### PR TITLE
⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -13,7 +13,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 3/25 | ⚙️ [periodic-cleanup] client: preserve live transcript during refresh [step 3/25] | Merged | [#1303](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1303) |
 | 4/25 | ⚙️ [periodic-cleanup] bridge: remove unused session paths and tracker state [step 4/25] | Merged | [#1305](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1305) |
 | 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | In review | [#1308](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1308) |
-| 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | Proposed | — |
+| 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | In progress (local, awaiting step 5 merge) | — |
 | 7/25 | 🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25] | Proposed | — |
 | 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | Proposed | — |
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Proposed | — |
@@ -147,3 +147,17 @@ asked to start working the plan; steps execute in order from step 2.
   242+/213-. Self-inclusive: the handwritten figure counts this tracker note as
   it stood at that head; this sentence adds a few lines more. Generators:
   build_runner, drift_dev schema dump/steps/generate.
+
+## Step 6 execution — 2026-09-05
+
+- `BridgeSseSessionStatus.status` is a `PluginSessionStatus`; every producer
+  (ACP shared tracker and plugin, Claude, Codex, OpenCode, Pi) emits the typed
+  value. OpenCode drops a status kind it does not recognise at the plugin
+  boundary instead of relaying an unparseable payload.
+- New `NormalizedBridgeEvent` sealed payload under `repositories/models/`:
+  status, other, and terminal-handoff (payload non-handoff by type).
+  `SessionEventMapper.normalize` is the single conversion, exposed through
+  `SessionEventService.toNormalized` and applied by the dispatcher after the
+  publication/generation checks. Orchestrator delivers status through
+  `BridgeEventMapper.buildSessionStatusEvent`; the history listener ignores
+  status and handoff payloads. The message variant follows in step 7.

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -12,8 +12,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 2/25 | ⚙️ [periodic-cleanup] client: preserve streamed text across refresh [step 2/25] | Merged | [#1299](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1299) |
 | 3/25 | ⚙️ [periodic-cleanup] client: preserve live transcript during refresh [step 3/25] | Merged | [#1303](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1303) |
 | 4/25 | ⚙️ [periodic-cleanup] bridge: remove unused session paths and tracker state [step 4/25] | Merged | [#1305](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1305) |
-| 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | In review | [#1308](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1308) |
-| 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | In progress (local, awaiting step 5 merge) | — |
+| 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | Merged | [#1308](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1308) |
+| 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | In review | [#1309](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1309) |
 | 7/25 | 🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25] | Proposed | — |
 | 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | Proposed | — |
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Proposed | — |

--- a/bridge/app/lib/src/listeners/chat_history_listener.dart
+++ b/bridge/app/lib/src/listeners/chat_history_listener.dart
@@ -4,6 +4,7 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../repositories/models/normalized_bridge_event.dart";
 import "../services/chat_history_service.dart";
 import "../services/session_event_dispatcher.dart";
 
@@ -43,11 +44,15 @@ class ChatHistoryListener({
     );
   }
 
-  Future<void> _capture({required String pluginId, required BridgeSseEvent event}) {
+  Future<void> _capture({required String pluginId, required NormalizedBridgeEvent event}) {
     return switch (event) {
-      BridgeSseServerConnected() => _chatHistoryService.invalidatePluginHistory(pluginId: pluginId),
-      BridgeSseMessageUpdated(:final info) => _captureMessage(info: info),
-      _ => Future<void>.value(),
+      NormalizedOtherEvent(event: BridgeSseServerConnected()) => _chatHistoryService.invalidatePluginHistory(
+        pluginId: pluginId,
+      ),
+      NormalizedOtherEvent(event: BridgeSseMessageUpdated(:final info)) => _captureMessage(info: info),
+      // A forced-stop handoff carries no finalized message, and a status
+      // change stores nothing.
+      NormalizedOtherEvent() || NormalizedStatusEvent() || NormalizedTerminalHandoff() => Future<void>.value(),
     };
   }
 

--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -63,6 +63,7 @@ import "repositories/filesystem_repository.dart";
 import "repositories/health_repository.dart";
 import "repositories/mappers/git_diff_output_mapper.dart";
 import "repositories/mappers/session_event_mapper.dart";
+import "repositories/models/normalized_bridge_event.dart";
 import "repositories/new_session_defaults_repository.dart";
 import "repositories/pending_interaction_support.dart";
 import "repositories/permission_repository.dart";
@@ -199,31 +200,30 @@ typedef OrchestratorComposition = ({
 /// Factory that creates [OrchestratorSession] instances with all runtime
 /// dependencies (room key, SSE manager) properly initialized.
 class Orchestrator({
-    required final BridgeConfig config,
-    required final RelayClient _client,
-    required final PluginLifecycleRepository _pluginLifecycleRepository,
-    required final PluginLifecycleService _pluginLifecycleService,
-    required final PluginRuntime _pluginRuntime,
-    required final BridgeSettingsRepository _bridgeSettingsRepository,
-    required final ServerClock _clock,
-    required final AppDatabase _database,
-    required final ChatHistoryDatabase _chatHistoryDatabase,
-    required final AttachmentSpillStorage _attachmentSpillStorage,
-    required final ArchivedSessionStorage _archivedSessionStorage,
-    required final http.Client _httpClient,
-    required final ProcessRunner _processRunner,
-    required final AccessTokenProvider _accessTokenProvider,
-    required final TokenRefresher _tokenRefresher,
-    required final BridgeRegistrationService _bridgeRegistrationService,
-    required final FailureReporter _failureReporter,
-    required final BridgeRestartService _restartService,
-    required final bool _filesystemAccessOk,
-    // Supervised mode only: owns the status-class pushes to the desktop GUI.
-    // Standalone has no control channel, so this is null there.
-    required final ControlStatusNotifier? _statusNotifier,
-    required final ReconnectBackoffPolicy _reconnectBackoff,
-  }) {
-
+  required final BridgeConfig config,
+  required final RelayClient _client,
+  required final PluginLifecycleRepository _pluginLifecycleRepository,
+  required final PluginLifecycleService _pluginLifecycleService,
+  required final PluginRuntime _pluginRuntime,
+  required final BridgeSettingsRepository _bridgeSettingsRepository,
+  required final ServerClock _clock,
+  required final AppDatabase _database,
+  required final ChatHistoryDatabase _chatHistoryDatabase,
+  required final AttachmentSpillStorage _attachmentSpillStorage,
+  required final ArchivedSessionStorage _archivedSessionStorage,
+  required final http.Client _httpClient,
+  required final ProcessRunner _processRunner,
+  required final AccessTokenProvider _accessTokenProvider,
+  required final TokenRefresher _tokenRefresher,
+  required final BridgeRegistrationService _bridgeRegistrationService,
+  required final FailureReporter _failureReporter,
+  required final BridgeRestartService _restartService,
+  required final bool _filesystemAccessOk,
+  // Supervised mode only: owns the status-class pushes to the desktop GUI.
+  // Standalone has no control channel, so this is null there.
+  required final ControlStatusNotifier? _statusNotifier,
+  required final ReconnectBackoffPolicy _reconnectBackoff,
+}) {
   /// Creates a new session with a fresh room key and SSE manager.
   OrchestratorComposition create() {
     final pluginComposition = _pluginLifecycleService.compositionView;
@@ -778,70 +778,73 @@ bool _gitPathExists({required String gitPath}) {
   return FileSystemEntity.typeSync(gitPath) != FileSystemEntityType.notFound;
 }
 
-enum OrchestratorSessionStartResult() { ready, cancelled }
+enum OrchestratorSessionStartResult() {
+  ready,
+  cancelled,
+}
 
 /// A running bridge session with immutable runtime state.
 ///
 /// Created by [Orchestrator.create]. Call [start] once, capture
 /// [waitUntilStopped] immediately, and use [cancel] to shut down gracefully.
 class OrchestratorSession._({
-    required final BridgeConfig config,
-    required final RelayClient _client,
-    required final Stream<NormalizedSourcedBridgeEvent> _pluginEvents,
-    required final PluginEventListener _pluginEventListener,
-    required final SessionBindingCommitListener _sessionBindingCommitListener,
-    required final SessionMutationListener _sessionMutationListener,
-    required final ChatHistoryListener _chatHistoryListener,
-    required final ChatHistoryActivityListener _chatHistoryActivityListener,
-    required final ChatHistoryService _chatHistoryService,
-    required final SessionOptionsCreationRefreshListener _sessionOptionsCreationRefreshListener,
-    required final SessionOptionsChangedRefreshListener _sessionOptionsChangedRefreshListener,
-    required final SessionOptionsService _sessionOptionsService,
-    required final SessionEventDispatcher _sessionEventDispatcher,
-    required final PluginRuntime _pluginRuntime,
-    required final CompletionPushListener _completionListener,
-    required final MaintenancePushListener _maintenanceListener,
-    required final AccessTokenProvider _accessTokenProvider,
-    required final TokenRefresher _tokenRefresher,
-    required final BridgeRegistrationService _bridgeRegistrationService,
-    required final SessionEncryptor _sessionEncryptor,
-    required final KeyExchangeManager _keyExchangeManager,
-    required final SSEManager _sseManager,
-    required final RoutedRequestDispatcher _routedRequestDispatcher,
-    required final BridgeEventMapper _mapper,
-    required final SessionPromptService _sessionPromptService,
-    required Stream<CatalogImportProgress> catalogImportProgress,
-    required Stream<SessionOptionsCacheUpdate> sessionOptionsCacheUpdates,
-    required Stream<String> pluginManagementSnapshotTokens,
-    required Stream<PluginInstallProgressUpdate> pluginInstallProgress,
-    required Stream<PluginAuthenticationProgressUpdate> pluginAuthenticationProgress,
-    required final StreamController<int> _bytesSentController,
-    required final StreamController<SesoriSseEvent> _localWireEventsController,
-    required final FailureReporter _failureReporter,
-    required final SessionRepository _sessionRepository,
-    required final PrSyncService _prSyncService,
-    required final ViewedProjectPrRefreshListener _viewedProjectPrRefreshListener,
-    required final PluginWarmupSettingListener _pluginWarmupSettingListener,
-    required final ViewedSessionPluginWarmupListener _viewedSessionPluginWarmupListener,
-    required final CurrentProjectGlossaryListener _currentProjectGlossaryListener,
-    required final ViewedProjectGlossaryListener _viewedProjectGlossaryListener,
-    required final ProjectGlossaryPopulationService _projectGlossaryPopulationService,
-    required final CurrentProjectService _currentProjectService,
-    required final SessionUnseenService _sessionUnseenService,
-    required final SessionViewTracker _sessionViewTracker,
-    required final ProjectViewTracker _projectViewTracker,
-    required final ProjectActivityService _projectActivityService,
-    required final PermissionAutoApprovalService _permissionAutoApprovalService,
-    required final YoloSettingsService _yoloSettingsService,
-    required final PendingInteractionService _pendingInteractionService,
-    required final SessionAbortService _sessionAbortService,
-    required final SessionOperationDispatcher _sessionOperationDispatcher,
-    required final SessionMutationDispatcher _sessionMutationDispatcher,
-    required final SessionCreationService _sessionCreationService,
-    required final BridgeRestartDispatcher _restartDispatcher,
-    required final ControlStatusNotifier? _statusNotifier,
-    required final ReconnectBackoffPolicy _reconnectBackoff,
-  }) {
+  required final BridgeConfig config,
+  required final RelayClient _client,
+  required final Stream<NormalizedSourcedBridgeEvent> _pluginEvents,
+  required final PluginEventListener _pluginEventListener,
+  required final SessionBindingCommitListener _sessionBindingCommitListener,
+  required final SessionMutationListener _sessionMutationListener,
+  required final ChatHistoryListener _chatHistoryListener,
+  required final ChatHistoryActivityListener _chatHistoryActivityListener,
+  required final ChatHistoryService _chatHistoryService,
+  required final SessionOptionsCreationRefreshListener _sessionOptionsCreationRefreshListener,
+  required final SessionOptionsChangedRefreshListener _sessionOptionsChangedRefreshListener,
+  required final SessionOptionsService _sessionOptionsService,
+  required final SessionEventDispatcher _sessionEventDispatcher,
+  required final PluginRuntime _pluginRuntime,
+  required final CompletionPushListener _completionListener,
+  required final MaintenancePushListener _maintenanceListener,
+  required final AccessTokenProvider _accessTokenProvider,
+  required final TokenRefresher _tokenRefresher,
+  required final BridgeRegistrationService _bridgeRegistrationService,
+  required final SessionEncryptor _sessionEncryptor,
+  required final KeyExchangeManager _keyExchangeManager,
+  required final SSEManager _sseManager,
+  required final RoutedRequestDispatcher _routedRequestDispatcher,
+  required final BridgeEventMapper _mapper,
+  required final SessionPromptService _sessionPromptService,
+  required Stream<CatalogImportProgress> catalogImportProgress,
+  required Stream<SessionOptionsCacheUpdate> sessionOptionsCacheUpdates,
+  required Stream<String> pluginManagementSnapshotTokens,
+  required Stream<PluginInstallProgressUpdate> pluginInstallProgress,
+  required Stream<PluginAuthenticationProgressUpdate> pluginAuthenticationProgress,
+  required final StreamController<int> _bytesSentController,
+  required final StreamController<SesoriSseEvent> _localWireEventsController,
+  required final FailureReporter _failureReporter,
+  required final SessionRepository _sessionRepository,
+  required final PrSyncService _prSyncService,
+  required final ViewedProjectPrRefreshListener _viewedProjectPrRefreshListener,
+  required final PluginWarmupSettingListener _pluginWarmupSettingListener,
+  required final ViewedSessionPluginWarmupListener _viewedSessionPluginWarmupListener,
+  required final CurrentProjectGlossaryListener _currentProjectGlossaryListener,
+  required final ViewedProjectGlossaryListener _viewedProjectGlossaryListener,
+  required final ProjectGlossaryPopulationService _projectGlossaryPopulationService,
+  required final CurrentProjectService _currentProjectService,
+  required final SessionUnseenService _sessionUnseenService,
+  required final SessionViewTracker _sessionViewTracker,
+  required final ProjectViewTracker _projectViewTracker,
+  required final ProjectActivityService _projectActivityService,
+  required final PermissionAutoApprovalService _permissionAutoApprovalService,
+  required final YoloSettingsService _yoloSettingsService,
+  required final PendingInteractionService _pendingInteractionService,
+  required final SessionAbortService _sessionAbortService,
+  required final SessionOperationDispatcher _sessionOperationDispatcher,
+  required final SessionMutationDispatcher _sessionMutationDispatcher,
+  required final SessionCreationService _sessionCreationService,
+  required final BridgeRestartDispatcher _restartDispatcher,
+  required final ControlStatusNotifier? _statusNotifier,
+  required final ReconnectBackoffPolicy _reconnectBackoff,
+}) {
   // ignore: cancel_subscriptions - cancelled by the failure-isolated session drain.
   final CompositeSubscription _subscriptions = CompositeSubscription();
   StreamSubscription<NormalizedSourcedBridgeEvent>? _normalizedEventSubscription;
@@ -1489,15 +1492,33 @@ class OrchestratorSession._({
   Future<void> _processPluginEvent(NormalizedSourcedBridgeEvent source) async {
     final pluginId = source.pluginId;
     final generation = source.generation;
-    final sourcedEvent = source.event;
     final allowDuringStop = source.allowDuringStop;
-    final terminalHandoff = sourcedEvent is BridgeSseTerminalHandoff;
-    final event = switch (sourcedEvent) {
-      BridgeSseTerminalHandoff(:final event) => event,
-      _ => sourcedEvent,
+    final (payload, terminalHandoff) = switch (source.event) {
+      NormalizedTerminalHandoff(:final payload) => (payload, true),
+      final NormalizedBridgePayload payload => (payload, false),
+    };
+    final eventType = switch (payload) {
+      NormalizedOtherEvent(:final event) => event.runtimeType,
+      NormalizedStatusEvent() => payload.runtimeType,
     };
     try {
-      Log.v("[sse] plugin event arrived: ${event.runtimeType}");
+      Log.v("[sse] plugin event arrived: $eventType");
+      final BridgeSseEvent event;
+      switch (payload) {
+        case NormalizedStatusEvent(:final sessionId, :final status):
+          if (!_isCurrentSource(pluginId: pluginId, generation: generation, allowDuringStop: allowDuringStop)) return;
+          await _deliverSseEvent(
+            delivery: SseEventDelivery.uniform(
+              event: _mapper.buildSessionStatusEvent(sessionId: sessionId, status: status),
+            ),
+            pluginId: pluginId,
+            generation: generation,
+            allowDuringStop: allowDuringStop,
+          );
+          return;
+        case NormalizedOtherEvent(event: final other):
+          event = other;
+      }
 
       if (event is BridgeSsePermissionReplied) {
         final wasAutoApproved = _permissionAutoApprovalService.consumeReply(
@@ -1610,16 +1631,16 @@ class OrchestratorSession._({
         );
       }
     } catch (e, st) {
-      Log.e("[sse] error processing event ${event.runtimeType}: $e\n$st");
+      Log.e("[sse] error processing event $eventType: $e\n$st");
       unawaited(
         _failureReporter
             .recordFailure(
               error: e,
               stackTrace: st,
-              uniqueIdentifier: "sse_event_processing:${event.runtimeType}",
+              uniqueIdentifier: "sse_event_processing:$eventType",
               fatal: false,
               reason: "Failed to process SSE event",
-              information: [event.runtimeType.toString()],
+              information: [eventType.toString()],
             )
             .catchError((_) {}),
       );
@@ -2552,14 +2573,15 @@ class OrchestratorSession._({
 /// milliseconds-order waits instead of real minutes; production uses
 /// [ReconnectBackoffPolicy.standard].
 class const ReconnectBackoffPolicy({
-    /// Backoff for a plain network drop (network blip, relay restart).
+  /// Backoff for a plain network drop (network blip, relay restart).
   required final Duration ordinaryInitial,
-    required final Duration ordinaryMax,
-    /// Backoff for a takeover drop, so two always-on bridges don't tight-loop
+  required final Duration ordinaryMax,
+
+  /// Backoff for a takeover drop, so two always-on bridges don't tight-loop
   /// kicking each other (ADR A22).
   required final Duration takeoverInitial,
-    required final Duration takeoverMax,
-  }) {
+  required final Duration takeoverMax,
+}) {
   static const ReconnectBackoffPolicy standard = ReconnectBackoffPolicy(
     ordinaryInitial: Duration(seconds: 1),
     ordinaryMax: Duration(seconds: 30),

--- a/bridge/app/lib/src/repositories/mappers/session_event_mapper.dart
+++ b/bridge/app/lib/src/repositories/mappers/session_event_mapper.dart
@@ -1,7 +1,28 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
+import "../models/normalized_bridge_event.dart";
+import "plugin_session_status_mapper.dart";
+
 class const SessionEventMapper() {
+  /// Converts an id-translated event into the value higher layers consume.
+  ///
+  /// The final step of normalization: payload kinds with a typed shared form
+  /// are mapped here, once, so delivery and storage never re-parse them.
+  NormalizedBridgeEvent normalize({required BridgeSseEvent event}) => switch (event) {
+    BridgeSseTerminalHandoff(:final event) => NormalizedTerminalHandoff(payload: _normalizePayload(event: event)),
+    _ => _normalizePayload(event: event),
+  };
+
+  NormalizedBridgePayload _normalizePayload({required BridgeSseEvent event}) => switch (event) {
+    BridgeSseTerminalHandoff() => throw StateError("terminal handoff must not wrap another terminal handoff"),
+    BridgeSseSessionStatus(:final sessionID, :final status) => NormalizedStatusEvent(
+      sessionId: sessionID,
+      status: status.toSharedSessionStatus(),
+    ),
+    _ => NormalizedOtherEvent(event: event),
+  };
+
   Session? sessionInfo({required BridgeSseEvent event}) {
     return switch (event) {
       BridgeSseTerminalHandoff(:final event) => sessionInfo(event: event),

--- a/bridge/app/lib/src/repositories/models/normalized_bridge_event.dart
+++ b/bridge/app/lib/src/repositories/models/normalized_bridge_event.dart
@@ -1,0 +1,29 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+/// A plugin event after the repository layer has translated its backend
+/// session ids to bridge session ids and mapped its payload to shared values.
+///
+/// Consumers above the repository read these values directly instead of
+/// re-parsing plugin payloads or calling repository mapping policy. Kinds not
+/// yet given a typed payload travel as [NormalizedOtherEvent]; that wrapper is
+/// produced only by the exhaustive normalizer and is not a fallback path.
+sealed class const NormalizedBridgeEvent();
+
+/// The payload variants a normalized event can carry.
+sealed class const NormalizedBridgePayload() extends NormalizedBridgeEvent;
+
+/// A session's status, for the bridge session [sessionId].
+final class const NormalizedStatusEvent({
+  required final String sessionId,
+  required final SessionStatus status,
+}) extends NormalizedBridgePayload;
+
+/// An already id-normalized plugin event whose payload keeps its plugin shape.
+final class const NormalizedOtherEvent({required final BridgeSseEvent event}) extends NormalizedBridgePayload;
+
+/// The normalized form of [BridgeSseTerminalHandoff]: reconciliation
+/// synthesized during a forced stop, carrying no stop-fence authority of its
+/// own. A handoff never wraps another handoff.
+final class const NormalizedTerminalHandoff({required final NormalizedBridgePayload payload})
+    extends NormalizedBridgeEvent;

--- a/bridge/app/lib/src/services/session_event_dispatcher.dart
+++ b/bridge/app/lib/src/services/session_event_dispatcher.dart
@@ -3,13 +3,14 @@ import "dart:async";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show KeyedParallelLock;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
+import "../repositories/models/normalized_bridge_event.dart";
 import "../repositories/session_repository.dart";
 import "session_event_service.dart";
 
 typedef NormalizedSourcedBridgeEvent = ({
   String pluginId,
   int? generation,
-  BridgeSseEvent event,
+  NormalizedBridgeEvent event,
   bool allowDuringStop,
   Completer<void>? terminalHandoffConsumed,
 });
@@ -131,7 +132,7 @@ class SessionEventDispatcher({required final SessionEventService _sessionEventSe
               _eventsController.add((
                 pluginId: pluginId,
                 generation: generation,
-                event: event,
+                event: _sessionEventService.toNormalized(event: event),
                 allowDuringStop: output.allowDuringStop,
                 terminalHandoffConsumed: output.terminalHandoffConsumed,
               ));

--- a/bridge/app/lib/src/services/session_event_service.dart
+++ b/bridge/app/lib/src/services/session_event_service.dart
@@ -4,6 +4,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/mappers/session_event_mapper.dart";
+import "../repositories/models/normalized_bridge_event.dart";
 import "../repositories/models/stored_session.dart";
 import "../repositories/session_repository.dart";
 import "../repositories/trackers/session_event_tracker.dart";
@@ -192,6 +193,10 @@ class SessionEventService({
     }
     return output;
   }
+
+  /// The value delivered to consumers for an event that passed identity,
+  /// enrichment, publication and generation checks.
+  NormalizedBridgeEvent toNormalized({required BridgeSseEvent event}) => _eventMapper.normalize(event: event);
 
   Future<bool> canPublish({required BridgeSseEvent event}) async {
     if (event is! BridgeSseSessionCreated && event is! BridgeSseSessionUpdated) return true;

--- a/bridge/app/lib/src/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/sse/bridge_event_mapper.dart
@@ -50,11 +50,7 @@ class BridgeEventMapper({
         BridgeSseSessionDiff(:final sessionID) => SesoriSseEvent.sessionDiff(sessionID: sessionID),
         BridgeSseSessionError(:final sessionID) => SesoriSseEvent.sessionError(sessionID: sessionID),
         BridgeSseSessionCompacted(:final sessionID) => SesoriSseEvent.sessionCompacted(sessionID: sessionID),
-        BridgeSseSessionStatus(:final sessionID, :final status) => _tryParseSseEvent({
-          "type": "session.status",
-          "sessionID": sessionID,
-          "status": status,
-        }),
+        BridgeSseSessionStatus() => throw StateError("session status is normalized before it reaches the mapper"),
         BridgeSseSessionIdle(:final sessionID) => SesoriSseEvent.sessionStatus(
           sessionID: sessionID,
           status: const SessionStatus.idle(),
@@ -215,6 +211,11 @@ class BridgeEventMapper({
 
   SesoriSseEvent buildMessagePartEvent({required MessagePart part}) {
     return SesoriSseEvent.messagePartUpdated(part: part);
+  }
+
+  /// Builds the public status event from the already-normalized shared status.
+  SesoriSseEvent buildSessionStatusEvent({required String sessionId, required SessionStatus status}) {
+    return SesoriSseEvent.sessionStatus(sessionID: sessionId, status: status);
   }
 
   /// Builds a projects summary event from already-remapped summary data

--- a/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
@@ -62,7 +62,7 @@ void main() {
         ),
         (
           name: "session status",
-          event: const BridgeSseSessionStatus(sessionID: "backend-session", status: {"type": "busy"}),
+          event: const BridgeSseSessionStatus(sessionID: "backend-session", status: PluginSessionStatus.busy()),
           expectedBackendIds: {"backend-session"},
         ),
         (

--- a/bridge/app/test/bridge/services/chat_history_capture_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_capture_test.dart
@@ -5,6 +5,7 @@ import "dart:typed_data";
 
 import "package:sesori_bridge/src/api/database/history/chat_history_database.dart";
 import "package:sesori_bridge/src/listeners/chat_history_listener.dart";
+import "package:sesori_bridge/src/repositories/models/normalized_bridge_event.dart";
 import "package:sesori_bridge/src/repositories/models/stored_session.dart";
 import "package:sesori_bridge/src/repositories/session_repository.dart";
 import "package:sesori_bridge/src/services/chat_history_reconcile_service.dart";
@@ -225,7 +226,7 @@ void main() {
       source.add((
         pluginId: "opencode",
         generation: 1,
-        event: const BridgeSseServerConnected(),
+        event: const NormalizedOtherEvent(event: BridgeSseServerConnected()),
         allowDuringStop: false,
         terminalHandoffConsumed: null,
       ));
@@ -246,12 +247,14 @@ void main() {
       source.add((
         pluginId: "opencode",
         generation: 1,
-        event: const BridgeSseMessagePartUpdated(
-          part: PluginMessagePart.text(
-            id: "p1",
-            sessionID: "ses_a",
-            messageID: "m1",
-            text: "one",
+        event: const NormalizedOtherEvent(
+          event: BridgeSseMessagePartUpdated(
+            part: PluginMessagePart.text(
+              id: "p1",
+              sessionID: "ses_a",
+              messageID: "m1",
+              text: "one",
+            ),
           ),
         ),
         allowDuringStop: false,
@@ -282,7 +285,7 @@ void main() {
       source.add((
         pluginId: "opencode",
         generation: 1,
-        event: const BridgeSseServerConnected(),
+        event: const NormalizedOtherEvent(event: BridgeSseServerConnected()),
         allowDuringStop: false,
         terminalHandoffConsumed: null,
       ));

--- a/bridge/app/test/bridge/services/session_event_dispatcher_test.dart
+++ b/bridge/app/test/bridge/services/session_event_dispatcher_test.dart
@@ -1,5 +1,7 @@
 import "dart:async";
 
+import "package:sesori_bridge/src/repositories/mappers/session_event_mapper.dart";
+import "package:sesori_bridge/src/repositories/models/normalized_bridge_event.dart";
 import "package:sesori_bridge/src/repositories/session_repository.dart";
 import "package:sesori_bridge/src/services/session_event_dispatcher.dart";
 import "package:sesori_bridge/src/services/session_event_service.dart";
@@ -61,7 +63,7 @@ void main() {
     await Future.wait([createdDispatch, deletedDispatch]);
     final output = await outputFuture;
     expect(output.single.pluginId, "plugin");
-    expect(output.single.event, isA<BridgeSseSessionDeleted>());
+    expect((output.single.event as NormalizedOtherEvent).event, isA<BridgeSseSessionDeleted>());
     await dispatcher.dispose();
   });
 
@@ -93,7 +95,7 @@ void main() {
     final output = await outputFuture;
     expect(output.pluginId, "plugin");
     expect(
-      output.event,
+      (output.event as NormalizedOtherEvent).event,
       isA<BridgeSseSessionUpdated>()
           .having((event) => event.titleChanged, "titleChanged", isTrue)
           .having((event) => event.info, "info", session.toJson()),
@@ -200,7 +202,7 @@ void main() {
     );
 
     final output = await outputFuture;
-    expect((output.single.event as BridgeSsePermissionAsked).requestID, "current");
+    expect(((output.single.event as NormalizedOtherEvent).event as BridgeSsePermissionAsked).requestID, "current");
     expect(output.single.generation, 2);
     await dispatcher.dispose();
   });
@@ -279,6 +281,10 @@ class _GatedSessionEventService({required final Future<void> _normalizeGate}) im
   }) {
     return (pluginId: pluginId, generation: generation, projectionUpdatedAt: 1, event: event);
   }
+
+  @override
+  NormalizedBridgeEvent toNormalized({required BridgeSseEvent event}) =>
+      const SessionEventMapper().normalize(event: event);
 
   @override
   Future<List<BridgeSseEvent>> normalize({

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -699,9 +699,9 @@ void main() {
           text: "visible prompt",
         ),
       );
-      final status = BridgeSseSessionStatus(
+      const status = BridgeSseSessionStatus(
         sessionID: "backend-root",
-        status: const SessionStatus.busy().toJson(),
+        status: PluginSessionStatus.busy(),
       );
 
       for (final (index, event) in [created, message, part, status].indexed) {

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -95,25 +95,13 @@ void main() {
       expect((event.info as MessageAssistant).sender, MessageSender.system);
     });
 
-    test("maps serialized plugin retry status through the shared SSE union", () {
-      final result = mapEvent(
-        BridgeSseSessionStatus(
-          sessionID: "s1",
-          status: const PluginSessionStatus.retry(
-            attempt: 1,
-            message: "provider overloaded",
-            next: 2000,
-          ).toJson(),
-        ),
-      );
+    test("builds the public status event from the normalized shared status", () {
+      const status = SessionStatus.retry(attempt: 1, message: "provider overloaded", next: 2000);
 
-      expect(result, isA<SesoriSessionStatus>());
-      final event = result! as SesoriSessionStatus;
+      final event = mapper.buildSessionStatusEvent(sessionId: "s1", status: status) as SesoriSessionStatus;
+
       expect(event.sessionID, "s1");
-      expect(
-        event.status,
-        const SessionStatus.retry(attempt: 1, message: "provider overloaded", next: 2000),
-      );
+      expect(event.status, status);
     });
 
     test("sends no wire event for a command catalog change", () {

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -4,7 +4,6 @@ import "dart:collection";
 import "package:path/path.dart" as p;
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 
 import "acp_approval_registry.dart";
 import "acp_command_listener.dart";
@@ -1331,7 +1330,7 @@ abstract class AcpPlugin({
       _eventBuffer.add(
         BridgeSseSessionStatus(
           sessionID: sessionId,
-          status: const shared.SessionStatus.busy().toJson(),
+          status: const PluginSessionStatus.busy(),
         ),
       );
       _eventBuffer.add(const BridgeSseProjectUpdated());

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
@@ -1,7 +1,6 @@
 import "dart:async";
 
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 
 /// A harness-reported sub-agent start. A [prompt] the harness does not carry
 /// is null and is filled from the child's own first user message; a harness
@@ -423,7 +422,7 @@ final class AcpChildSessionTracker() {
 
   BridgeSseSessionStatus _childStatus({required String childId, required bool busy}) => BridgeSseSessionStatus(
     sessionID: childId,
-    status: (busy ? const shared.SessionStatus.busy() : const shared.SessionStatus.idle()).toJson(),
+    status: busy ? const PluginSessionStatus.busy() : const PluginSessionStatus.idle(),
   );
 }
 

--- a/bridge/sesori_plugin_acp/test/acp_plugin_child_busy_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_child_busy_test.dart
@@ -1,7 +1,6 @@
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
 
 /// A running sub-agent keeps its root busy after the root's own turn settles:
@@ -153,7 +152,7 @@ void main() {
         (event) =>
             event is BridgeSseSessionStatus &&
             event.sessionID == "c2" &&
-            shared.SessionStatus.fromJson(event.status) == const shared.SessionStatus.idle(),
+            event.status == const PluginSessionStatus.idle(),
       );
       final rootIdleIndex = emitted.lastIndexWhere(
         (event) => event is BridgeSseSessionIdle && event.sessionID == sessionId,
@@ -358,7 +357,7 @@ void main() {
       expect(tile.childSessionID, "c1");
       expect(tile.taskState?.status, PluginToolStatus.cancelled);
       final childStatus = emitted.whereType<BridgeSseSessionStatus>().where((event) => event.sessionID == "c1").last;
-      expect(shared.SessionStatus.fromJson(childStatus.status), const shared.SessionStatus.idle());
+      expect(childStatus.status, const PluginSessionStatus.idle());
       expect(rootIdles(sessionId), hasLength(1));
       expect(await plugin.getSessionStatuses(), {sessionId: const PluginSessionStatus.idle()});
       expect(plugin.childSessionTracker.childStatuses, isEmpty);

--- a/bridge/sesori_plugin_acp/test/repositories/trackers/acp_child_session_tracker_test.dart
+++ b/bridge/sesori_plugin_acp/test/repositories/trackers/acp_child_session_tracker_test.dart
@@ -19,8 +19,7 @@ AcpChildSpawn _spawn({
 PluginMessagePartSubtask _subtaskPart(BridgeSseEvent event) =>
     (event as BridgeSseMessagePartUpdated).part as PluginMessagePartSubtask;
 
-shared.SessionStatus _status(BridgeSseEvent event) =>
-    shared.SessionStatus.fromJson((event as BridgeSseSessionStatus).status);
+PluginSessionStatus _status(BridgeSseEvent event) => (event as BridgeSseSessionStatus).status;
 
 void main() {
   group("AcpChildSessionTracker", () {
@@ -44,7 +43,7 @@ void main() {
       expect(created.parentID, "root");
       expect(created.directory, "/repo");
       expect(created.title, "Thing");
-      expect(_status(result.events[1]), const shared.SessionStatus.busy());
+      expect(_status(result.events[1]), const PluginSessionStatus.busy());
       expect(tracker.isChild(sessionId: "child"), isTrue);
       expect(tracker.childStatuses, {"child": const PluginSessionStatus.busy()});
       expect(tracker.busyChildIds(sessionId: "root"), {"child"});
@@ -99,7 +98,7 @@ void main() {
       expect(part.taskState?.status, PluginToolStatus.completed);
       expect(part.taskState?.output, hasLength(maxToolOutputLength));
       expect(part.taskState?.error, isNull);
-      expect(_status(events[1]), const shared.SessionStatus.idle());
+      expect(_status(events[1]), const PluginSessionStatus.idle());
       expect(tracker.childStatuses, {"child": const PluginSessionStatus.idle()});
       expect(tracker.busyChildIds(sessionId: "root"), isEmpty);
 
@@ -222,7 +221,7 @@ void main() {
         error: null,
       );
       expect(events, hasLength(1));
-      expect(_status(events.single), const shared.SessionStatus.idle());
+      expect(_status(events.single), const PluginSessionStatus.idle());
     });
 
     test("cancelled and failed finishes keep only the failure text", () {
@@ -423,7 +422,7 @@ void main() {
       final events = tracker.cancelAll();
       await pumpEventQueue();
       expect(_subtaskPart(events[0]).taskState?.status, PluginToolStatus.cancelled);
-      expect(_status(events[1]), const shared.SessionStatus.idle());
+      expect(_status(events[1]), const PluginSessionStatus.idle());
       expect(events, hasLength(2), reason: "the finished sibling is untouched");
       expect(tracker.hasBusyChildren, isFalse);
       expect(changes, 1);

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -1,5 +1,4 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 
 import "api/models/claude_stream_message.dart";
 import "models/claude_task_notification.dart";
@@ -549,11 +548,11 @@ final class ClaudeEventDispatcher({
     return [
       BridgeSseSessionStatus(
         sessionID: sessionId,
-        status: shared.SessionStatus.retry(
+        status: PluginSessionStatus.retry(
           attempt: attempt,
           message: _retryMessage(message),
           next: now.millisecondsSinceEpoch + delay,
-        ).toJson(),
+        ),
       ),
     ];
   }
@@ -684,7 +683,7 @@ PluginMessagePart _textPart({
 
 BridgeSseSessionStatus _childStatus({required String childId, required bool busy}) => BridgeSseSessionStatus(
   sessionID: childId,
-  status: (busy ? const shared.SessionStatus.busy() : const shared.SessionStatus.idle()).toJson(),
+  status: busy ? const PluginSessionStatus.busy() : const PluginSessionStatus.idle(),
 );
 
 Map<String, Object?>? _mapOrNull(Object? value) => value is Map ? value.cast<String, Object?>() : null;

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -4,7 +4,6 @@ import "dart:collection";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show PendingOperations;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 
 import "../api/models/claude_stream_message.dart";
 import "../claude_approval_registry.dart";
@@ -289,7 +288,7 @@ final class ClaudeSessionService({
     state.idleGeneration++;
     if (state.pending == 1) {
       _workState.set(PluginWorkState.busy);
-      _emit(BridgeSseSessionStatus(sessionID: sessionId, status: const shared.SessionStatus.busy().toJson()));
+      _emit(BridgeSseSessionStatus(sessionID: sessionId, status: const PluginSessionStatus.busy()));
       _emit(const BridgeSseProjectUpdated());
     }
   }
@@ -826,7 +825,7 @@ final class ClaudeSessionService({
         state.wakeupAt = null;
         state.idleGeneration++;
         _workState.set(PluginWorkState.busy);
-        _emit(BridgeSseSessionStatus(sessionID: sessionId, status: const shared.SessionStatus.busy().toJson()));
+        _emit(BridgeSseSessionStatus(sessionID: sessionId, status: const PluginSessionStatus.busy()));
         _emit(const BridgeSseProjectUpdated());
       case ClaudeResultMessage():
         if (state.selfStartedTurn != null) _endSelfStartedTurn(sessionId: sessionId, state: state);
@@ -841,7 +840,7 @@ final class ClaudeSessionService({
   void _settleRetry({required String sessionId, required ClaudeStreamMessage message}) {
     if (message is! ClaudeStreamEventMessage && message is! ClaudeAssistantMessage) return;
     if (_retryStatuses.remove(sessionId) == null) return;
-    _emit(BridgeSseSessionStatus(sessionID: sessionId, status: const shared.SessionStatus.busy().toJson()));
+    _emit(BridgeSseSessionStatus(sessionID: sessionId, status: const PluginSessionStatus.busy()));
   }
 
   void _endSelfStartedTurn({required String sessionId, required _SessionTurnState state}) {

--- a/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
@@ -676,7 +676,7 @@ void main() {
                 },
               ).single
               as BridgeSseSessionStatus;
-      final status = shared.SessionStatus.fromJson(retry.status) as shared.SessionStatusRetry;
+      final status = retry.status as PluginSessionStatusRetry;
       expect(status.attempt, 2);
       expect(status.message, "rate_limit");
       expect(status.next, inInclusiveRange(before + 5000, DateTime.now().millisecondsSinceEpoch + 5000));

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -651,7 +651,7 @@ void main() {
       final retry = (await harness.plugin.getSessionStatuses())[testSessionId]! as PluginSessionStatusRetry;
       expect(retry.attempt, 2);
       expect(retry.next, DateTime.utc(2026, 8, 11, 12).millisecondsSinceEpoch + 1000);
-      expect(events.whereType<BridgeSseSessionStatus>().last.status["next"], retry.next);
+      expect((events.whereType<BridgeSseSessionStatus>().last.status as PluginSessionStatusRetry).next, retry.next);
       expect(harness.plugin.getActiveSessionsSummary().single.activeSessions.single.isRetrying, isTrue);
 
       // The retried request streaming again is the recovery signal; the turn
@@ -670,8 +670,8 @@ void main() {
 
       expect((await harness.plugin.getSessionStatuses())[testSessionId], isA<PluginSessionStatusBusy>());
       expect(
-        shared.SessionStatus.fromJson(events.whereType<BridgeSseSessionStatus>().last.status),
-        isA<shared.SessionStatusBusy>(),
+        events.whereType<BridgeSseSessionStatus>().last.status,
+        isA<PluginSessionStatusBusy>(),
       );
       expect(harness.plugin.getActiveSessionsSummary().single.activeSessions.single.isRetrying, isFalse);
       await subscription.cancel();

--- a/bridge/sesori_plugin_claude/test/claude_subagent_child_sessions_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_subagent_child_sessions_test.dart
@@ -133,8 +133,8 @@ void main() {
       expect(created["directory"], "/workspace");
       expect(created["title"], "Say hi");
       expect(
-        shared.SessionStatus.fromJson((launched[1] as BridgeSseSessionStatus).status),
-        isA<shared.SessionStatusBusy>(),
+        (launched[1] as BridgeSseSessionStatus).status,
+        isA<PluginSessionStatusBusy>(),
       );
       expect(dispatcher.childSessionStatuses(), {_child: const PluginSessionStatus.busy()});
       expect(dispatcher.busyChildSessionIds(sessionId: _root), [_child]);
@@ -147,15 +147,15 @@ void main() {
       expect(finished.map((event) => event.runtimeType), [BridgeSseMessagePartUpdated, BridgeSseSessionStatus]);
       final idle = finished.last as BridgeSseSessionStatus;
       expect(idle.sessionID, _child);
-      expect(shared.SessionStatus.fromJson(idle.status), isA<shared.SessionStatusIdle>());
+      expect(idle.status, isA<PluginSessionStatusIdle>());
       expect(dispatcher.childSessionStatuses(), {_child: const PluginSessionStatus.idle()});
       expect(dispatcher.busyChildSessionIds(sessionId: _root), isEmpty);
 
       final resumed = dispatcher.map(message: ClaudeStreamMessage.parse(_taskStartedFrame()));
       expect(resumed.map((event) => event.runtimeType), [BridgeSseSessionStatus, BridgeSseMessagePartUpdated]);
       expect(
-        shared.SessionStatus.fromJson((resumed.first as BridgeSseSessionStatus).status),
-        isA<shared.SessionStatusBusy>(),
+        (resumed.first as BridgeSseSessionStatus).status,
+        isA<PluginSessionStatusBusy>(),
       );
       final resumedPart = (resumed.last as BridgeSseMessagePartUpdated).part as PluginMessagePartSubtask;
       expect(resumedPart.taskState?.status, PluginToolStatus.running);

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -194,7 +194,7 @@ class CodexEventMapper({
         return [
           BridgeSseSessionStatus(
             sessionID: threadId,
-            status: _codexStatusToSessionStatus(params["status"]).toJson(),
+            status: _codexStatusToSessionStatus(params["status"]),
           ),
         ];
 
@@ -208,7 +208,7 @@ class CodexEventMapper({
           ),
           BridgeSseSessionStatus(
             sessionID: threadId,
-            status: const shared.SessionStatus.busy().toJson(),
+            status: const PluginSessionStatus.busy(),
           ),
         ];
 
@@ -952,8 +952,8 @@ class CodexEventMapper({
   /// Maps a codex thread status object (`{type: idle|active, …}`) onto the
   /// sesori [shared.SessionStatus] union. Anything that is not explicitly
   /// `idle` is treated as busy.
-  shared.SessionStatus _codexStatusToSessionStatus(Object? raw) {
-    return isIdleThreadStatus(raw) ? const shared.SessionStatus.idle() : const shared.SessionStatus.busy();
+  PluginSessionStatus _codexStatusToSessionStatus(Object? raw) {
+    return isIdleThreadStatus(raw) ? const PluginSessionStatus.idle() : const PluginSessionStatus.busy();
   }
 
   /// Parses the direct and nested status shapes emitted by codex.

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -950,8 +950,8 @@ class CodexEventMapper({
   }
 
   /// Maps a codex thread status object (`{type: idle|active, …}`) onto the
-  /// sesori [shared.SessionStatus] union. Anything that is not explicitly
-  /// `idle` is treated as busy.
+  /// [PluginSessionStatus] union. Anything that is not explicitly `idle` is
+  /// treated as busy.
   PluginSessionStatus _codexStatusToSessionStatus(Object? raw) {
     return isIdleThreadStatus(raw) ? const PluginSessionStatus.idle() : const PluginSessionStatus.busy();
   }

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_session_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_session_mapper.dart
@@ -63,6 +63,6 @@ class const CodexSessionMapper() {
         parentSessionId: child.parentId,
       ).toJson(),
     ),
-    BridgeSseSessionStatus(sessionID: child.id, status: status.toJson()),
+    BridgeSseSessionStatus(sessionID: child.id, status: status),
   ];
 }

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -276,7 +276,7 @@ class CodexSessionService({
       if (sessionClosed && activityChanged && sessionId != null && _subAgentTracker.isChild(sessionId: sessionId))
         BridgeSseSessionStatus(
           sessionID: sessionId,
-          status: const PluginSessionStatus.idle().toJson(),
+          status: const PluginSessionStatus.idle(),
         ),
     ];
     final shouldDeferIdle =
@@ -410,7 +410,7 @@ class CodexSessionService({
   List<BridgeSseEvent> _rootIdleEvents({required String rootId}) => [
     BridgeSseSessionStatus(
       sessionID: rootId,
-      status: const PluginSessionStatus.idle().toJson(),
+      status: const PluginSessionStatus.idle(),
     ),
     BridgeSseSessionIdle(sessionID: rootId),
   ];

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -71,7 +71,7 @@ void main() {
         BridgeSseSessionStatus(:final sessionID, :final status) => {
           "type": "session.status",
           "sessionID": sessionID,
-          "status": status,
+          "status": status.toJson(),
         },
         BridgeSseMessageUpdated(:final info) => {"type": "message.updated", "info": info},
         _ => throw ArgumentError("parseAsSesori: unhandled ${event.runtimeType}"),
@@ -287,7 +287,7 @@ void main() {
 
       final status = events.whereType<BridgeSseSessionStatus>().single;
       expect(status.sessionID, "t-activity");
-      expect(shared.SessionStatus.fromJson(status.status), isA<shared.SessionStatusBusy>());
+      expect(status.status, isA<PluginSessionStatusBusy>());
       expect(parseAsSesori(status), isA<shared.SesoriSessionStatus>());
     });
 
@@ -356,12 +356,12 @@ void main() {
       );
 
       expect(
-        shared.SessionStatus.fromJson((active.single as BridgeSseSessionStatus).status),
-        isA<shared.SessionStatusBusy>(),
+        (active.single as BridgeSseSessionStatus).status,
+        isA<PluginSessionStatusBusy>(),
       );
       expect(
-        shared.SessionStatus.fromJson((idle.single as BridgeSseSessionStatus).status),
-        isA<shared.SessionStatusIdle>(),
+        (idle.single as BridgeSseSessionStatus).status,
+        isA<PluginSessionStatusIdle>(),
       );
     });
 

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -331,8 +331,7 @@ void main() {
         model: null,
       );
       final idle = plugin.events.firstWhere(
-        (event) =>
-            event is BridgeSseSessionStatus && shared.SessionStatus.fromJson(event.status) is shared.SessionStatusIdle,
+        (event) => event is BridgeSseSessionStatus && event.status is PluginSessionStatusIdle,
       );
       fake.pushNotification("thread/status/changed", {
         "threadId": "t-compact",
@@ -2728,8 +2727,8 @@ void main() {
       expect(fake.sentParamsFor("thread/read"), {"threadId": "child-1", "includeTurns": false});
       await Future<void>.delayed(Duration.zero);
       expect(
-        events.whereType<BridgeSseSessionStatus>().where((event) => event.sessionID == "child-1").last.status["type"],
-        "busy",
+        events.whereType<BridgeSseSessionStatus>().where((event) => event.sessionID == "child-1").last.status,
+        const PluginSessionStatus.busy(),
         reason: "the started activity supersedes Codex's pre-start idle status",
       );
       var statuses = await plugin.getSessionStatuses();
@@ -2989,7 +2988,9 @@ void main() {
       final childBusy = plugin.events
           .where(
             (event) =>
-                event is BridgeSseSessionStatus && event.sessionID == "child-1" && event.status["type"] == "busy",
+                event is BridgeSseSessionStatus &&
+                event.sessionID == "child-1" &&
+                event.status is PluginSessionStatusBusy,
           )
           .first;
       fake.pushNotification("item/started", {

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_sessions_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_sessions_test.dart
@@ -271,7 +271,7 @@ void main() {
       expect(session.parentID, "root-1");
       expect(session.title, "Raman");
       final announcedStatus = announcement.events.last as BridgeSseSessionStatus;
-      expect(announcedStatus.status["type"], "busy");
+      expect(announcedStatus.status, const PluginSessionStatus.busy());
       expect(
         await service.handleSubAgentStarted(
           childThreadId: "child-1",
@@ -486,9 +486,9 @@ void main() {
         activityChanged: true,
         sessionClosed: false,
         events: [
-          BridgeSseSessionStatus(
+          const BridgeSseSessionStatus(
             sessionID: "root-1",
-            status: const PluginSessionStatus.idle().toJson(),
+            status: PluginSessionStatus.idle(),
           ),
           const BridgeSseSessionIdle(sessionID: "root-1"),
         ],

--- a/bridge/sesori_plugin_grok/test/grok_event_mapper_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_event_mapper_test.dart
@@ -72,7 +72,7 @@ void main() {
       expect(created.directory, "/project");
       expect(created.projectID, "/project");
       expect(created.title, "Synthetic child task");
-      expect(shared.SessionStatus.fromJson((spawned[1] as BridgeSseSessionStatus).status), const shared.SessionStatus.busy());
+      expect((spawned[1] as BridgeSseSessionStatus).status, const PluginSessionStatus.busy());
       expect(tracker.busyChildIds(sessionId: _root), {_child});
       expect(tracker.runningChildren(sessionId: _root).single.isBackground, isFalse);
 
@@ -185,7 +185,7 @@ void main() {
       expect(tile.messageID, _tileMessageId);
       expect(tile.taskState?.status, PluginToolStatus.completed);
       expect(tile.taskState?.output, "synthetic final text");
-      expect(shared.SessionStatus.fromJson((events[1] as BridgeSseSessionStatus).status), const shared.SessionStatus.idle());
+      expect((events[1] as BridgeSseSessionStatus).status, const PluginSessionStatus.idle());
       expect(tracker.childStatuses, {_child: const PluginSessionStatus.idle()});
       expect(tracker.hasRootHold(sessionId: _root), isTrue);
 

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -2,6 +2,7 @@ import "models/plugin_agent.dart";
 import "models/plugin_message.dart";
 import "models/plugin_pending_question.dart";
 import "models/plugin_queued_prompt.dart";
+import "models/plugin_session_status.dart";
 
 sealed class const BridgeSseEvent();
 
@@ -52,10 +53,7 @@ class const BridgeSseSessionError({required final String? sessionID}) extends Br
 
 class const BridgeSseSessionCompacted({required final String sessionID}) extends BridgeSseEvent;
 
-/// [status] uses the shared session-status JSON shape with a `type` discriminator.
-/// `PluginSessionStatus.toJson()` produces that shape for plugin-owned status.
-// ignore: no_slop_linter/prefer_specific_type, SSE payload values are heterogeneous
-class const BridgeSseSessionStatus({required final String sessionID, required final Map<String, dynamic> status})
+class const BridgeSseSessionStatus({required final String sessionID, required final PluginSessionStatus status})
     extends BridgeSseEvent;
 
 class const BridgeSseSessionIdle({required final String sessionID}) extends BridgeSseEvent;

--- a/bridge/sesori_plugin_opencode/lib/src/plugin_model_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/plugin_model_mapper.dart
@@ -51,18 +51,10 @@ class const PluginModelMapper({
     );
   }
 
+  /// A catalog read treats a status kind this plugin does not know as idle: a
+  /// listed session must still render with some status.
   PluginSessionStatus mapSessionStatus(SessionStatus status) {
-    return switch (status) {
-      SessionStatusIdle() => const PluginSessionStatus.idle(),
-      SessionStatusBusy() => const PluginSessionStatus.busy(),
-      SessionStatusRetry(:final attempt, :final message, :final next) => PluginSessionStatus.retry(
-        attempt: attempt,
-        message: message,
-        next: next,
-      ),
-      SessionStatusUnknown() => const PluginSessionStatus.idle(),
-      _ => const PluginSessionStatus.idle(),
-    };
+    return knownPluginSessionStatus(status) ?? const PluginSessionStatus.idle();
   }
 
   PluginAgent mapAgent(Agent agent) {
@@ -147,3 +139,18 @@ class const PluginModelMapper({
     return segments.isEmpty ? null : segments.last;
   }
 }
+
+/// The plugin status for an OpenCode status of a known kind, or null for a kind
+/// this plugin does not know. Callers decide what an unknown kind means at
+/// their boundary.
+PluginSessionStatus? knownPluginSessionStatus(SessionStatus status) => switch (status) {
+  SessionStatusIdle() => const PluginSessionStatus.idle(),
+  SessionStatusBusy() => const PluginSessionStatus.busy(),
+  SessionStatusRetry(:final attempt, :final message, :final next) => PluginSessionStatus.retry(
+    attempt: attempt,
+    message: message,
+    next: next,
+  ),
+  SessionStatusUnknown() => null,
+  _ => null,
+};

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
@@ -4,6 +4,7 @@ import "assistant_message_mapper.dart";
 import "message_part_mapper.dart";
 import "models/openapi/assistant_message.g.dart";
 import "models/openapi/message.g.dart";
+import "models/openapi/session_status.g.dart";
 import "models/openapi/user_message.g.dart";
 import "models/sse_event_data.g.dart";
 import "question_info_mapper.dart";
@@ -21,6 +22,18 @@ class SseEventMapper({final AssistantMessageMapper _assistantMessageMapper = con
   /// encode to a map; the fallback only covers an unknown variant whose raw
   /// payload is not a map.
   static Map<String, dynamic> _asMap(Object? json) => json is Map<String, dynamic> ? json : const <String, dynamic>{};
+
+  static PluginSessionStatus? _pluginStatus(SessionStatus status) => switch (status) {
+    SessionStatusIdle() => const PluginSessionStatus.idle(),
+    SessionStatusBusy() => const PluginSessionStatus.busy(),
+    SessionStatusRetry(:final attempt, :final message, :final next) => PluginSessionStatus.retry(
+      attempt: attempt,
+      message: message,
+      next: next,
+    ),
+    SessionStatusUnknown() => null,
+    _ => null,
+  };
 
   /// Normalizes a `message.updated` payload into the shared-`Message` JSON
   /// shape the phone parses, mirroring the REST load path
@@ -72,10 +85,12 @@ class SseEventMapper({final AssistantMessageMapper _assistantMessageMapper = con
       ),
       SseSessionError(:final sessionID) => BridgeSseSessionError(sessionID: sessionID),
       SseSessionCompacted(:final sessionID) => BridgeSseSessionCompacted(sessionID: sessionID),
-      SseSessionStatus(:final sessionID, :final status) => BridgeSseSessionStatus(
-        sessionID: sessionID,
-        status: _asMap(status.toJson()),
-      ),
+      SseSessionStatus(:final sessionID, :final status) => switch (_pluginStatus(status)) {
+        final pluginStatus? => BridgeSseSessionStatus(sessionID: sessionID, status: pluginStatus),
+        // A status kind this plugin does not know carries nothing the bridge
+        // can deliver; the event is dropped here instead of at the relay.
+        null => null,
+      },
       // COMPATIBILITY 2026-05-18 (v0.7.0): Older OpenCode runtimes emit session.idle. Remove this branch and manifest variant when those runtimes are unsupported.
       SseSessionIdle(:final sessionID) => BridgeSseSessionIdle(sessionID: sessionID),
       SseCommandExecuted(:final name, :final sessionID, :final arguments, :final messageID) => BridgeSseCommandExecuted(

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
@@ -4,9 +4,9 @@ import "assistant_message_mapper.dart";
 import "message_part_mapper.dart";
 import "models/openapi/assistant_message.g.dart";
 import "models/openapi/message.g.dart";
-import "models/openapi/session_status.g.dart";
 import "models/openapi/user_message.g.dart";
 import "models/sse_event_data.g.dart";
+import "plugin_model_mapper.dart";
 import "question_info_mapper.dart";
 
 /// Maps OpenCode SSE events and message parts to plugin interface types.
@@ -22,18 +22,6 @@ class SseEventMapper({final AssistantMessageMapper _assistantMessageMapper = con
   /// encode to a map; the fallback only covers an unknown variant whose raw
   /// payload is not a map.
   static Map<String, dynamic> _asMap(Object? json) => json is Map<String, dynamic> ? json : const <String, dynamic>{};
-
-  static PluginSessionStatus? _pluginStatus(SessionStatus status) => switch (status) {
-    SessionStatusIdle() => const PluginSessionStatus.idle(),
-    SessionStatusBusy() => const PluginSessionStatus.busy(),
-    SessionStatusRetry(:final attempt, :final message, :final next) => PluginSessionStatus.retry(
-      attempt: attempt,
-      message: message,
-      next: next,
-    ),
-    SessionStatusUnknown() => null,
-    _ => null,
-  };
 
   /// Normalizes a `message.updated` payload into the shared-`Message` JSON
   /// shape the phone parses, mirroring the REST load path
@@ -85,7 +73,7 @@ class SseEventMapper({final AssistantMessageMapper _assistantMessageMapper = con
       ),
       SseSessionError(:final sessionID) => BridgeSseSessionError(sessionID: sessionID),
       SseSessionCompacted(:final sessionID) => BridgeSseSessionCompacted(sessionID: sessionID),
-      SseSessionStatus(:final sessionID, :final status) => switch (_pluginStatus(status)) {
+      SseSessionStatus(:final sessionID, :final status) => switch (knownPluginSessionStatus(status)) {
         final pluginStatus? => BridgeSseSessionStatus(sessionID: sessionID, status: pluginStatus),
         // A status kind this plugin does not know carries nothing the bridge
         // can deliver; the event is dropped here instead of at the relay.

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -6,7 +6,10 @@ import "package:opencode_plugin/opencode_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
-enum _OptionDiscoveryRequest() { agents, providers }
+enum _OptionDiscoveryRequest() {
+  agents,
+  providers,
+}
 
 /// Waits until [count] events of type [T] have been delivered, or fails.
 ///
@@ -501,7 +504,7 @@ void main() {
     for (final testCase in staleSelectionCases) {
       test("classifies a removed ${testCase.name} after a generic reservation failure", () async {
         final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
-      await plugin.initialize();
+        await plugin.initialize();
         addTearDown(plugin.dispose);
         await server.waitForSseConnection();
         server
@@ -1089,7 +1092,7 @@ void main() {
         }
         if (event is BridgeSseSessionStatus &&
             event.sessionID == "s-root" &&
-            event.status["type"] == "idle" &&
+            event.status is PluginSessionStatusIdle &&
             !idleEvent.isCompleted) {
           idleEvent.complete();
         }
@@ -1288,7 +1291,7 @@ void main() {
     group("renameSession", () {
       test("sends PATCH with title body and returns updated session", () async {
         final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
-      await plugin.initialize();
+        await plugin.initialize();
         await server.waitForSseConnection();
         server.requestLog.clear();
 
@@ -1303,7 +1306,7 @@ void main() {
     group("archiveSession", () {
       test("sends PATCH with time.archived body", () async {
         final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
-      await plugin.initialize();
+        await plugin.initialize();
         await server.waitForSseConnection();
         server.requestLog.clear();
 
@@ -1321,7 +1324,7 @@ void main() {
     group("renameProject", () {
       test("resolves worktree to project UUID then sends PATCH with name", () async {
         final plugin = OpenCodePlugin(serverUrl: server.baseUrl);
-      await plugin.initialize();
+        await plugin.initialize();
         await server.waitForSseConnection();
         server.requestLog.clear();
 

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -1,5 +1,4 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 
 import "../api/models/pi_assistant_delta.dart";
 import "../api/models/pi_event.dart";
@@ -623,16 +622,7 @@ final class PiEventDispatcher({
   List<BridgeSseEvent> _status({required String sessionId, required PiEvent event, required DateTime? now}) {
     final status = sessionStatusFor(event: event, now: now);
     if (status == null) return const [];
-    final sharedStatus = switch (status) {
-      PluginSessionStatusIdle() => const shared.SessionStatus.idle(),
-      PluginSessionStatusBusy() => const shared.SessionStatus.busy(),
-      PluginSessionStatusRetry(:final attempt, :final message, :final next) => shared.SessionStatus.retry(
-        attempt: attempt,
-        message: message,
-        next: next,
-      ),
-    };
-    return [BridgeSseSessionStatus(sessionID: sessionId, status: sharedStatus.toJson())];
+    return [BridgeSseSessionStatus(sessionID: sessionId, status: status)];
   }
 
   List<BridgeSseEvent> _compactionStart({

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -4,7 +4,6 @@ import "dart:collection";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show PendingOperations;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 
 import "../api/models/pi_event.dart";
 import "../api/models/pi_extension_ui_request.dart";
@@ -25,7 +24,11 @@ final class const PiTurnCancelledException({required final String sessionId}) im
   String toString() => "Pi turn was cancelled";
 }
 
-enum _PiQueueState() { visible, released, cancelled }
+enum _PiQueueState() {
+  visible,
+  released,
+  cancelled,
+}
 
 final class _PiSessionTurnState({required final String initialDirectory}) {
   /// See [recentPromptIds]. 64 comfortably exceeds any realistic gap between
@@ -71,8 +74,7 @@ final class _PiSessionTurnState({required final String initialDirectory}) {
   bool isAdmitted({required String promptId}) =>
       turns.any(
         (turn) =>
-            turn.promptId == promptId &&
-            (turn is! _PiQueuedPromptTurn || turn.queueState != _PiQueueState.cancelled),
+            turn.promptId == promptId && (turn is! _PiQueuedPromptTurn || turn.queueState != _PiQueueState.cancelled),
       ) ||
       recentPromptIds.contains(promptId);
 
@@ -214,10 +216,7 @@ final class PiSessionService({
       return true;
     }
     final index = state.queue.indexWhere(
-      (turn) =>
-          turn is _PiQueuedPromptTurn &&
-          turn.promptId == promptId &&
-          turn.queueState == _PiQueueState.visible,
+      (turn) => turn is _PiQueuedPromptTurn && turn.promptId == promptId && turn.queueState == _PiQueueState.visible,
     );
     if (index == -1) return false;
     final turn = state.queue.removeAt(index) as _PiQueuedPromptTurn;
@@ -470,7 +469,7 @@ final class PiSessionService({
       _emit(
         BridgeSseSessionStatus(
           sessionID: sessionId,
-          status: const shared.SessionStatus.busy().toJson(),
+          status: const PluginSessionStatus.busy(),
         ),
       );
       _emit(const BridgeSseProjectUpdated());
@@ -785,7 +784,7 @@ final class PiSessionService({
     _emit(
       BridgeSseSessionStatus(
         sessionID: sessionId,
-        status: const shared.SessionStatus.busy().toJson(),
+        status: const PluginSessionStatus.busy(),
       ),
     );
     _emit(const BridgeSseProjectUpdated());
@@ -797,7 +796,7 @@ final class PiSessionService({
     _emit(
       BridgeSseSessionStatus(
         sessionID: sessionId,
-        status: const shared.SessionStatus.idle().toJson(),
+        status: const PluginSessionStatus.idle(),
       ),
     );
     _emit(BridgeSseSessionIdle(sessionID: sessionId));
@@ -847,7 +846,7 @@ final class PiSessionService({
       _emit(
         BridgeSseSessionStatus(
           sessionID: exit.sessionId,
-          status: const shared.SessionStatus.idle().toJson(),
+          status: const PluginSessionStatus.idle(),
         ),
       );
       _emit(BridgeSseSessionError(sessionID: exit.sessionId));
@@ -952,7 +951,7 @@ final class PiSessionService({
         _emit(
           BridgeSseSessionStatus(
             sessionID: sessionId,
-            status: const shared.SessionStatus.busy().toJson(),
+            status: const PluginSessionStatus.busy(),
           ),
         );
         _emit(const BridgeSseProjectUpdated());
@@ -963,7 +962,7 @@ final class PiSessionService({
     _emit(
       BridgeSseSessionStatus(
         sessionID: sessionId,
-        status: const shared.SessionStatus.idle().toJson(),
+        status: const PluginSessionStatus.idle(),
       ),
     );
     _emit(BridgeSseSessionIdle(sessionID: sessionId));
@@ -1083,7 +1082,7 @@ final class PiSessionService({
     _emit(
       BridgeSseSessionStatus(
         sessionID: sessionId,
-        status: const shared.SessionStatus.idle().toJson(),
+        status: const PluginSessionStatus.idle(),
       ),
     );
     _emit(BridgeSseSessionIdle(sessionID: sessionId));
@@ -1100,8 +1099,7 @@ final class PiSessionService({
       };
       if (activeSessionIds.isEmpty) return const <String>{};
       await Future.wait([
-        for (final sessionId in activeSessionIds)
-          _abort(sessionId: sessionId, processExitIsExpected: true),
+        for (final sessionId in activeSessionIds) _abort(sessionId: sessionId, processExitIsExpected: true),
       ]);
       if (currentWorkState != PluginWorkState.idle) {
         await workState.firstWhere((state) => state == PluginWorkState.idle);
@@ -1176,10 +1174,7 @@ final class PiSessionService({
     if (idleTimeout == null) return;
     unawaited(() async {
       await _clock.delay(duration: idleTimeout);
-      if (_disposed ||
-          !identical(_sessions[sessionId], state) ||
-          state.hasWork ||
-          state.idleGeneration != generation) {
+      if (_disposed || !identical(_sessions[sessionId], state) || state.hasWork || state.idleGeneration != generation) {
         return;
       }
       _extensionUi.cancelForOwner(sessionId: sessionId, processGeneration: null);

--- a/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
@@ -712,16 +712,14 @@ void main() {
     );
     final settled = dispatcher.map(sessionId: sessionId, event: _event("agent_settled"));
 
-    expect((retry.single as BridgeSseSessionStatus).status, {
-      "attempt": 2,
-      "message": "provider overloaded",
-      "next": 1500,
-      "type": "retry",
-    });
+    expect(
+      (retry.single as BridgeSseSessionStatus).status,
+      const PluginSessionStatus.retry(attempt: 2, message: "provider overloaded", next: 1500),
+    );
     expect(agentEnd, isEmpty);
-    expect((autoRetryResumed.single as BridgeSseSessionStatus).status, {"type": "busy"});
-    expect((summarizationResumed.single as BridgeSseSessionStatus).status, {"type": "busy"});
-    expect(compacting.whereType<BridgeSseSessionStatus>().single.status, {"type": "busy"});
+    expect((autoRetryResumed.single as BridgeSseSessionStatus).status, const PluginSessionStatus.busy());
+    expect((summarizationResumed.single as BridgeSseSessionStatus).status, const PluginSessionStatus.busy());
+    expect(compacting.whereType<BridgeSseSessionStatus>().single.status, const PluginSessionStatus.busy());
     final runningMessage = compacting.whereType<BridgeSseMessageUpdated>().single;
     expect(runningMessage.info["id"], "pi:session:compaction:compaction:1");
     final runningPart = compacting.whereType<BridgeSseMessagePartUpdated>().single.part;

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -684,8 +684,8 @@ void main() {
       (event) => event.info["promptId"] == "prompt-5",
     );
     final emptyQueue = events.whereType<BridgeSseQueuedPromptsUpdated>().last;
-    expect(statuses.first.status["type"], "busy");
-    expect(statuses.last.status["type"], "idle");
+    expect(statuses.first.status, const PluginSessionStatus.busy());
+    expect(statuses.last.status, const PluginSessionStatus.idle());
     expect(userMessage.info["role"], "user");
     expect(events.indexOf(userMessage), lessThan(events.indexOf(emptyQueue)));
     expect(events.indexOf(statuses.last), lessThan(idleIndex));
@@ -1037,7 +1037,7 @@ void main() {
     process.emit(frame: {"type": "agent_settled"});
     final nextModel = await _waitForNthCommand(process: process, type: "set_model", count: 2);
     expect(service.sessionStatuses["session"], const PluginSessionStatus.busy());
-    expect(events.whereType<BridgeSseSessionStatus>().last.status["type"], "busy");
+    expect(events.whereType<BridgeSseSessionStatus>().last.status, const PluginSessionStatus.busy());
 
     process.emitResponse(id: nextModel["id"]! as String, command: "set_model");
     final nextPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
@@ -1862,8 +1862,8 @@ void main() {
       containsAllInOrder(["[PR Monitor] report", "Handled report"]),
     );
     expect(
-      events.whereType<BridgeSseSessionStatus>().map((event) => event.status["type"]),
-      ["busy", "idle"],
+      events.whereType<BridgeSseSessionStatus>().map((event) => event.status),
+      [const PluginSessionStatus.busy(), const PluginSessionStatus.idle()],
     );
     expect(events.whereType<BridgeSseSessionIdle>(), hasLength(1));
     expect(service.currentWorkState, PluginWorkState.idle);


### PR DESCRIPTION
## Complexity

⚙️ moderate — one plugin-interface field type change propagated through six producer packages, plus a new normalized payload seam across the bridge's event dispatcher, orchestrator, and history listener.

## What

- `BridgeSseSessionStatus.status` is now a `PluginSessionStatus` instead of a JSON map. Every producer emits its existing typed status directly: the shared ACP plugin and child tracker (Copilot, DeepSeek, Grok, Hermes, Cursor), Claude, Codex, OpenCode, and Pi. OpenCode maps its own generated status type and drops an unrecognised kind at the plugin boundary instead of relaying an unparseable payload. Retry attempt, message, and next values are preserved.
- New sealed `NormalizedBridgeEvent` under `bridge/app/lib/src/repositories/models/`: `NormalizedStatusEvent` (stable session id plus shared `SessionStatus`), `NormalizedOtherEvent` (the remaining id-normalized event), and `NormalizedTerminalHandoff`, whose payload type cannot itself be a handoff.
- `SessionEventMapper.normalize` is the single conversion, using the existing status mapper extension. `SessionEventService.toNormalized` exposes it and `SessionEventDispatcher` applies it after the publication and generation checks, so the normalized stream now carries these values for plugin, binding-commit, and local events alike.
- The orchestrator delivers status through `BridgeEventMapper.buildSessionStatusEvent` from the shared value and routes other events through its existing path. The history listener matches the other-event wrapper. `BridgeEventMapper.map` no longer re-parses a status payload through JSON.
- Tests across the app and every affected plugin now assert typed statuses. The message variant follows in step 7.

## Why

Step 6/25 of `.plan/active/periodic-cleanup`. Plugins serialised a typed status to JSON only for the bridge to re-parse it before serialising again for the client. Keeping the value typed removes that round trip and the failure branch it created, without changing what clients receive.

## Risk and test focus

Medium cross-plugin mapping risk, bridge only. Impacted: `session.status` delivery for every backend, including retry status from Claude and Pi, child-session busy/idle from the ACP tracker, Claude, and Codex, and forced-stop terminal handoffs. Most valuable checks: a headless bridge with one live streaming backend shows busy, idle, and (where the backend produces it) retry status on a client with the same fields as before; a sub-agent child goes busy and idle; a forced stop still settles the session.

No public wire-contract change: the `session.status` event shape sent to clients is unchanged. No database change.

## Expected result

- User-visible: none. Status transitions look the same on every surface.
- Database/persisted data: none.
- Internal: one interface field typed, one new sealed model file, one conversion seam; plugins drop their shared-model import for status construction.

## Verification

- `dart analyze` for the whole `bridge/` workspace: no issues.
- `dart test`: app event mapper, event service, dispatcher, history capture, bridge event mapper, and plugin event listener suites; ACP, Claude, Codex, Grok, OpenCode, and Pi suites that assert status events. All pass after rebasing onto merged main.
- Architecture implementation review (sub-agent, single commit): approved, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps session status events typed from plugin to client. Plugins previously serialized their typed status to JSON and the bridge re-parsed it before serializing again; now `BridgeSseSessionStatus.status` carries a `PluginSessionStatus` and the bridge maps it to the shared status once, removing that round trip and the failure branch it created. The wire contract is unchanged: clients receive the same `session.status` events as before.

**Refactors**
- New sealed `NormalizedBridgeEvent` splits events into status, other-event, and terminal-handoff payloads; `SessionEventMapper.normalize` is the single conversion, applied after the dispatcher's publication and generation checks.
- The orchestrator delivers status from the shared value, and the history listener reads the other-event wrapper.
- OpenCode shares the known-status conversion between its live SSE and catalog read paths, and drops an unrecognized status kind at the plugin boundary instead of relaying an unparseable payload.
- No wire or database change; no user-visible behavior change, and retry attempt, message, and next values are preserved. Typed message events follow in step 7.

<sup>Written for commit bd65f7486489558e2795177f5e09d9191a523fb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

