### PR TITLE
⚙️ Show Codex subtasks inline with readable names

### DIFF
--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -145,8 +145,7 @@ sealed class CodexRolloutSessionMetadataPayloadDto with _$CodexRolloutSessionMet
     @JsonKey(name: "agent_path") required String? agentPath,
   }) = _CodexRolloutSessionMetadataPayloadDto;
 
-  factory fromJson(Map<String, dynamic> json) =>
-      _$CodexRolloutSessionMetadataPayloadDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) => _$CodexRolloutSessionMetadataPayloadDtoFromJson(json);
 }
 
 @Freezed(fromJson: true, toJson: false)
@@ -156,8 +155,7 @@ sealed class CodexRolloutTurnContextPayloadDto with _$CodexRolloutTurnContextPay
     @JsonKey(name: "reasoning_effort", fromJson: _stringOrNull) required String? effort,
   }) = _CodexRolloutTurnContextPayloadDto;
 
-  factory fromJson(Map<String, dynamic> json) =>
-      _$CodexRolloutTurnContextPayloadDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) => _$CodexRolloutTurnContextPayloadDtoFromJson(json);
 }
 
 String? _stringOrNull(Object? value) => value is String ? value : null;
@@ -168,8 +166,7 @@ sealed class CodexRolloutItemMetadataDto with _$CodexRolloutItemMetadataDto {
     @JsonKey(name: "turn_id") required String? turnId,
   }) = _CodexRolloutItemMetadataDto;
 
-  factory fromJson(Map<String, dynamic> json) =>
-      _$CodexRolloutItemMetadataDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) => _$CodexRolloutItemMetadataDtoFromJson(json);
 }
 
 @Freezed(
@@ -236,8 +233,7 @@ sealed class CodexRolloutResponseItemDto with _$CodexRolloutResponseItemDto {
 
   const factory unknown() = CodexRolloutUnknownResponseItemDto;
 
-  factory fromJson(Map<String, dynamic> json) =>
-      _$CodexRolloutResponseItemDtoFromJson(json);
+  factory fromJson(Map<String, dynamic> json) => _$CodexRolloutResponseItemDtoFromJson(json);
 }
 
 @Freezed(
@@ -340,6 +336,9 @@ sealed class CodexToolArgumentsDto with _$CodexToolArgumentsDto {
     @JsonKey(name: "file_path") required Object? filePath,
     required Object? query,
     @JsonKey(name: "cell_id") required Object? cellId,
+    @JsonKey(name: "task_name", fromJson: _stringOrNull) required String? taskName,
+    @JsonKey(fromJson: _stringOrNull) required String? message,
+    @JsonKey(name: "agent_type", fromJson: _stringOrNull) required String? agentType,
   }) = _CodexToolArgumentsDto;
 
   factory fromJson(Map<String, dynamic> json) => _$CodexToolArgumentsDtoFromJson(json);

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -3011,7 +3011,7 @@ as String?,
 /// @nodoc
 mixin _$CodexToolArgumentsDto {
 
- Object? get cmd; Object? get command; Object? get path;@JsonKey(name: "file_path") Object? get filePath; Object? get query;@JsonKey(name: "cell_id") Object? get cellId;
+ Object? get cmd; Object? get command; Object? get path;@JsonKey(name: "file_path") Object? get filePath; Object? get query;@JsonKey(name: "cell_id") Object? get cellId;@JsonKey(name: "task_name", fromJson: _stringOrNull) String? get taskName;@JsonKey(fromJson: _stringOrNull) String? get message;@JsonKey(name: "agent_type", fromJson: _stringOrNull) String? get agentType;
 /// Create a copy of CodexToolArgumentsDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -3022,16 +3022,16 @@ $CodexToolArgumentsDtoCopyWith<CodexToolArgumentsDto> get copyWith => _$CodexToo
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexToolArgumentsDto&&const DeepCollectionEquality().equals(other.cmd, cmd)&&const DeepCollectionEquality().equals(other.command, command)&&const DeepCollectionEquality().equals(other.path, path)&&const DeepCollectionEquality().equals(other.filePath, filePath)&&const DeepCollectionEquality().equals(other.query, query)&&const DeepCollectionEquality().equals(other.cellId, cellId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexToolArgumentsDto&&const DeepCollectionEquality().equals(other.cmd, cmd)&&const DeepCollectionEquality().equals(other.command, command)&&const DeepCollectionEquality().equals(other.path, path)&&const DeepCollectionEquality().equals(other.filePath, filePath)&&const DeepCollectionEquality().equals(other.query, query)&&const DeepCollectionEquality().equals(other.cellId, cellId)&&(identical(other.taskName, taskName) || other.taskName == taskName)&&(identical(other.message, message) || other.message == message)&&(identical(other.agentType, agentType) || other.agentType == agentType));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(cmd),const DeepCollectionEquality().hash(command),const DeepCollectionEquality().hash(path),const DeepCollectionEquality().hash(filePath),const DeepCollectionEquality().hash(query),const DeepCollectionEquality().hash(cellId));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(cmd),const DeepCollectionEquality().hash(command),const DeepCollectionEquality().hash(path),const DeepCollectionEquality().hash(filePath),const DeepCollectionEquality().hash(query),const DeepCollectionEquality().hash(cellId),taskName,message,agentType);
 
 @override
 String toString() {
-  return 'CodexToolArgumentsDto(cmd: $cmd, command: $command, path: $path, filePath: $filePath, query: $query, cellId: $cellId)';
+  return 'CodexToolArgumentsDto(cmd: $cmd, command: $command, path: $path, filePath: $filePath, query: $query, cellId: $cellId, taskName: $taskName, message: $message, agentType: $agentType)';
 }
 
 
@@ -3042,7 +3042,7 @@ abstract mixin class $CodexToolArgumentsDtoCopyWith<$Res>  {
   factory $CodexToolArgumentsDtoCopyWith(CodexToolArgumentsDto value, $Res Function(CodexToolArgumentsDto) _then) = _$CodexToolArgumentsDtoCopyWithImpl;
 @useResult
 $Res call({
- Object? cmd, Object? command, Object? path,@JsonKey(name: "file_path") Object? filePath, Object? query,@JsonKey(name: "cell_id") Object? cellId
+ Object? cmd, Object? command, Object? path,@JsonKey(name: "file_path") Object? filePath, Object? query,@JsonKey(name: "cell_id") Object? cellId,@JsonKey(name: "task_name", fromJson: _stringOrNull) String? taskName,@JsonKey(fromJson: _stringOrNull) String? message,@JsonKey(name: "agent_type", fromJson: _stringOrNull) String? agentType
 });
 
 
@@ -3059,9 +3059,12 @@ class _$CodexToolArgumentsDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexToolArgumentsDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? cmd = freezed,Object? command = freezed,Object? path = freezed,Object? filePath = freezed,Object? query = freezed,Object? cellId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? cmd = freezed,Object? command = freezed,Object? path = freezed,Object? filePath = freezed,Object? query = freezed,Object? cellId = freezed,Object? taskName = freezed,Object? message = freezed,Object? agentType = freezed,}) {
   return _then(CodexToolArgumentsDto(
-cmd: freezed == cmd ? _self.cmd : cmd ,command: freezed == command ? _self.command : command ,path: freezed == path ? _self.path : path ,filePath: freezed == filePath ? _self.filePath : filePath ,query: freezed == query ? _self.query : query ,cellId: freezed == cellId ? _self.cellId : cellId ,
+cmd: freezed == cmd ? _self.cmd : cmd ,command: freezed == command ? _self.command : command ,path: freezed == path ? _self.path : path ,filePath: freezed == filePath ? _self.filePath : filePath ,query: freezed == query ? _self.query : query ,cellId: freezed == cellId ? _self.cellId : cellId ,taskName: freezed == taskName ? _self.taskName : taskName // ignore: cast_nullable_to_non_nullable
+as String?,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String?,agentType: freezed == agentType ? _self.agentType : agentType // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 
@@ -3073,7 +3076,7 @@ cmd: freezed == cmd ? _self.cmd : cmd ,command: freezed == command ? _self.comma
 @JsonSerializable(createToJson: false)
 
 class _CodexToolArgumentsDto implements CodexToolArgumentsDto {
-  const _CodexToolArgumentsDto({required this.cmd, required this.command, required this.path, @JsonKey(name: "file_path") required this.filePath, required this.query, @JsonKey(name: "cell_id") required this.cellId});
+  const _CodexToolArgumentsDto({required this.cmd, required this.command, required this.path, @JsonKey(name: "file_path") required this.filePath, required this.query, @JsonKey(name: "cell_id") required this.cellId, @JsonKey(name: "task_name", fromJson: _stringOrNull) required this.taskName, @JsonKey(fromJson: _stringOrNull) required this.message, @JsonKey(name: "agent_type", fromJson: _stringOrNull) required this.agentType});
   factory _CodexToolArgumentsDto.fromJson(Map<String, dynamic> json) => _$CodexToolArgumentsDtoFromJson(json);
 
 @override final  Object? cmd;
@@ -3082,6 +3085,9 @@ class _CodexToolArgumentsDto implements CodexToolArgumentsDto {
 @override@JsonKey(name: "file_path") final  Object? filePath;
 @override final  Object? query;
 @override@JsonKey(name: "cell_id") final  Object? cellId;
+@override@JsonKey(name: "task_name", fromJson: _stringOrNull) final  String? taskName;
+@override@JsonKey(fromJson: _stringOrNull) final  String? message;
+@override@JsonKey(name: "agent_type", fromJson: _stringOrNull) final  String? agentType;
 
 /// Create a copy of CodexToolArgumentsDto
 /// with the given fields replaced by the non-null parameter values.
@@ -3093,16 +3099,16 @@ _$CodexToolArgumentsDtoCopyWith<_CodexToolArgumentsDto> get copyWith => __$Codex
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexToolArgumentsDto&&const DeepCollectionEquality().equals(other.cmd, cmd)&&const DeepCollectionEquality().equals(other.command, command)&&const DeepCollectionEquality().equals(other.path, path)&&const DeepCollectionEquality().equals(other.filePath, filePath)&&const DeepCollectionEquality().equals(other.query, query)&&const DeepCollectionEquality().equals(other.cellId, cellId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexToolArgumentsDto&&const DeepCollectionEquality().equals(other.cmd, cmd)&&const DeepCollectionEquality().equals(other.command, command)&&const DeepCollectionEquality().equals(other.path, path)&&const DeepCollectionEquality().equals(other.filePath, filePath)&&const DeepCollectionEquality().equals(other.query, query)&&const DeepCollectionEquality().equals(other.cellId, cellId)&&(identical(other.taskName, taskName) || other.taskName == taskName)&&(identical(other.message, message) || other.message == message)&&(identical(other.agentType, agentType) || other.agentType == agentType));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(cmd),const DeepCollectionEquality().hash(command),const DeepCollectionEquality().hash(path),const DeepCollectionEquality().hash(filePath),const DeepCollectionEquality().hash(query),const DeepCollectionEquality().hash(cellId));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(cmd),const DeepCollectionEquality().hash(command),const DeepCollectionEquality().hash(path),const DeepCollectionEquality().hash(filePath),const DeepCollectionEquality().hash(query),const DeepCollectionEquality().hash(cellId),taskName,message,agentType);
 
 @override
 String toString() {
-  return 'CodexToolArgumentsDto(cmd: $cmd, command: $command, path: $path, filePath: $filePath, query: $query, cellId: $cellId)';
+  return 'CodexToolArgumentsDto(cmd: $cmd, command: $command, path: $path, filePath: $filePath, query: $query, cellId: $cellId, taskName: $taskName, message: $message, agentType: $agentType)';
 }
 
 
@@ -3113,7 +3119,7 @@ abstract mixin class _$CodexToolArgumentsDtoCopyWith<$Res> implements $CodexTool
   factory _$CodexToolArgumentsDtoCopyWith(_CodexToolArgumentsDto value, $Res Function(_CodexToolArgumentsDto) _then) = __$CodexToolArgumentsDtoCopyWithImpl;
 @override @useResult
 $Res call({
- Object? cmd, Object? command, Object? path,@JsonKey(name: "file_path") Object? filePath, Object? query,@JsonKey(name: "cell_id") Object? cellId
+ Object? cmd, Object? command, Object? path,@JsonKey(name: "file_path") Object? filePath, Object? query,@JsonKey(name: "cell_id") Object? cellId,@JsonKey(name: "task_name", fromJson: _stringOrNull) String? taskName,@JsonKey(fromJson: _stringOrNull) String? message,@JsonKey(name: "agent_type", fromJson: _stringOrNull) String? agentType
 });
 
 
@@ -3130,9 +3136,12 @@ class __$CodexToolArgumentsDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexToolArgumentsDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? cmd = freezed,Object? command = freezed,Object? path = freezed,Object? filePath = freezed,Object? query = freezed,Object? cellId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? cmd = freezed,Object? command = freezed,Object? path = freezed,Object? filePath = freezed,Object? query = freezed,Object? cellId = freezed,Object? taskName = freezed,Object? message = freezed,Object? agentType = freezed,}) {
   return _then(_CodexToolArgumentsDto(
-cmd: freezed == cmd ? _self.cmd : cmd ,command: freezed == command ? _self.command : command ,path: freezed == path ? _self.path : path ,filePath: freezed == filePath ? _self.filePath : filePath ,query: freezed == query ? _self.query : query ,cellId: freezed == cellId ? _self.cellId : cellId ,
+cmd: freezed == cmd ? _self.cmd : cmd ,command: freezed == command ? _self.command : command ,path: freezed == path ? _self.path : path ,filePath: freezed == filePath ? _self.filePath : filePath ,query: freezed == query ? _self.query : query ,cellId: freezed == cellId ? _self.cellId : cellId ,taskName: freezed == taskName ? _self.taskName : taskName // ignore: cast_nullable_to_non_nullable
+as String?,message: freezed == message ? _self.message : message // ignore: cast_nullable_to_non_nullable
+as String?,agentType: freezed == agentType ? _self.agentType : agentType // ignore: cast_nullable_to_non_nullable
+as String?,
   ));
 }
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -324,4 +324,7 @@ _CodexToolArgumentsDto _$CodexToolArgumentsDtoFromJson(Map json) =>
       filePath: json['file_path'],
       query: json['query'],
       cellId: json['cell_id'],
+      taskName: _stringOrNull(json['task_name']),
+      message: _stringOrNull(json['message']),
+      agentType: _stringOrNull(json['agent_type']),
     );

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -8,6 +8,7 @@ import "codex_app_server_client.dart";
 import "codex_config_reader.dart";
 import "repositories/mappers/codex_image_attachment_mapper.dart";
 import "repositories/mappers/codex_rollout_tool_mapper.dart";
+import "repositories/mappers/codex_tool_part_mapper.dart";
 import "repositories/mappers/codex_user_content_mapper.dart";
 import "repositories/models/codex_projected_tool.dart";
 import "repositories/models/codex_thread_record.dart";
@@ -335,16 +336,19 @@ class CodexEventMapper({
   List<BridgeSseEvent> mapProjectedTool({
     required String threadId,
     required CodexProjectedTool tool,
-  }) => _toolItemEvents(
-    threadId: threadId,
-    itemId: tool.canonicalId,
-    tool: tool.tool,
-    title: tool.title,
-    status: tool.status,
-    output: tool.output,
-    time: _sharedMessageTime(tool.time),
-    attachments: tool.attachments,
-  );
+    required List<CodexThreadRecord> children,
+  }) => [
+    BridgeSseMessageUpdated(
+      info: _assistantMessage(
+        itemId: tool.canonicalId,
+        threadId: threadId,
+        time: _sharedMessageTime(tool.time),
+      ).toJson(),
+    ),
+    BridgeSseMessagePartUpdated(
+      part: const CodexToolPartMapper().map(sessionId: threadId, tool: tool, children: children),
+    ),
+  ];
 
   /// `item/*/delta` notifications stream text into an already-known part.
   List<BridgeSseEvent> _deltaEvent({

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -322,18 +322,30 @@ class CodexPlugin._({
       return;
     }
     if (_isSupersededTurnLifecycleNotification(notification)) return;
-    if (_subAgentItemParser.parse(notification: notification) case CodexSubAgentActivity(
+    final subAgentItem = _subAgentItemParser.parse(notification: notification);
+    if (subAgentItem case CodexSubAgentActivity(
       lifecycle: CodexCorrelatableItemLifecycle.started,
       kind: CodexSubAgentActivityKind.started,
       threadId: final parentId,
       :final agentThreadId,
       :final agentPath,
     )) {
-      await _announceSubAgentThread(
+      final announced = await _announceSubAgentThread(
         parentId: parentId,
         childId: agentThreadId,
         agentPath: agentPath,
       );
+      if (announced) {
+        _rolloutTailer.drain(sessionId: parentId);
+        final tool = _toolLifecycleTracker.observeSubAgentStarted(event: subAgentItem);
+        _eventMapper
+            .mapProjectedTool(
+              threadId: parentId,
+              tool: tool,
+              children: _sessionService.knownChildThreads(sessionId: parentId),
+            )
+            .forEach(_eventBuffer.add);
+      }
     }
     final command = _commandExecutionParser.parse(
       notification: notification,
@@ -367,6 +379,7 @@ class CodexPlugin._({
             .mapProjectedTool(
               threadId: threadId,
               tool: tool,
+              children: _sessionService.knownChildThreads(sessionId: threadId),
             )
             .forEach(_eventBuffer.add);
       }
@@ -406,6 +419,7 @@ class CodexPlugin._({
         : _eventMapper.mapProjectedTool(
             threadId: mappedThreadId!,
             tool: projectedTool,
+            children: _sessionService.knownChildThreads(sessionId: mappedThreadId),
           );
     _sessionService
         .coordinateSessionEvents(
@@ -424,12 +438,12 @@ class CodexPlugin._({
   /// Dispatches the typed activity fact to Layer 3 and buffers the ordered
   /// child-session events it returns. Generic mapper context remains shared
   /// with every live thread so later child events keep their model and project.
-  Future<void> _announceSubAgentThread({
+  Future<bool> _announceSubAgentThread({
     required String parentId,
     required String childId,
     required String? agentPath,
   }) async {
-    if (_deletedThreadIds.contains(parentId) || _deletedThreadIds.contains(childId)) return;
+    if (_deletedThreadIds.contains(parentId) || _deletedThreadIds.contains(childId)) return false;
     // The child's `thread/status/changed` normally precedes the activity item;
     // preserve it when present and otherwise announce the child as idle.
     final status = _sessionStatuses[childId] ?? const PluginSessionStatus.idle();
@@ -440,7 +454,7 @@ class CodexPlugin._({
       agentPath: agentPath,
       status: status,
     );
-    if (announcement == null) return;
+    if (announcement == null) return false;
     final child = announcement.child;
     _sessionStatuses[childId] = announcement.status;
     _eventMapper.setThreadTime(child);
@@ -450,6 +464,7 @@ class CodexPlugin._({
     if (directory != null) _recordThreadDirectory(childId, directory);
     announcement.events.forEach(_eventBuffer.add);
     _syncWorkState();
+    return true;
   }
 
   CodexImageGenerationItemDto? _parseImageGeneration({
@@ -478,6 +493,7 @@ class CodexPlugin._({
           .mapProjectedTool(
             threadId: append.sessionId,
             tool: tool,
+            children: _sessionService.knownChildThreads(sessionId: append.sessionId),
           )
           .forEach(_eventBuffer.add);
     }
@@ -1046,7 +1062,13 @@ class CodexPlugin._({
       );
     }
     for (final tool in _toolLifecycleTracker.observeTerminalNotification(notification: terminal)) {
-      _eventMapper.mapProjectedTool(threadId: sessionId, tool: tool).forEach(_eventBuffer.add);
+      _eventMapper
+          .mapProjectedTool(
+            threadId: sessionId,
+            tool: tool,
+            children: _sessionService.knownChildThreads(sessionId: sessionId),
+          )
+          .forEach(_eventBuffer.add);
     }
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
@@ -6,6 +6,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, 
 
 import "../api/codex_rollout_api.dart";
 import "../api/models/codex_rollout_dto.dart";
+import "mappers/codex_sub_agent_name_mapper.dart";
 import "models/codex_session_record.dart";
 
 /// Layer-2 aggregation, mapping, selection, and deletion for the rollout catalog.
@@ -54,6 +55,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
           modelProvider: metadata?.modelProvider,
           model: metadata?.model,
           agentNickname: metadata?.agentNickname,
+          agentPath: metadata?.agentPath,
           parentId: metadata?.parentId,
         ),
       );
@@ -296,6 +298,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
     String? cliVersion;
     String? model;
     String? agentNickname;
+    String? agentPath;
     String? parentId;
     for (final line in lines) {
       switch (line) {
@@ -314,6 +317,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
           if (payload.threadSource == CodexRolloutThreadSource.subagent) {
             parentId = payload.parentThreadId;
             agentNickname = payload.agentNickname;
+            agentPath = payload.agentPath;
           }
         case CodexRolloutTurnContextLineDto(:final payload):
           final candidate = payload.model;
@@ -334,6 +338,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
       model: model,
       cliVersion: cliVersion,
       agentNickname: agentNickname,
+      agentPath: agentPath,
       parentId: parentId,
     );
   }
@@ -349,7 +354,13 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
       projectID: directory,
       directory: directory,
       parentID: record.parentId,
-      title: _usefulText(record.threadName) ?? _usefulText(record.agentNickname),
+      title: record.parentId == null
+          ? _usefulText(record.threadName)
+          : const CodexSubAgentNameMapper().map(
+              name: record.threadName,
+              nickname: record.agentNickname,
+              agentPath: record.agentPath,
+            ),
       time: created == null || updated == null
           ? null
           : PluginSessionTime(
@@ -388,5 +399,6 @@ class const _CodexSessionMetadata({
   required final String? model,
   required final String? cliVersion,
   required final String? agentNickname,
+  required final String? agentPath,
   required final String? parentId,
 });

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -6,11 +6,20 @@ import "../codex_config_reader.dart";
 import "../models/codex_replay_tool_disposition.dart";
 import "codex_tool_lifecycle_tracker.dart";
 import "mappers/codex_rollout_tool_mapper.dart";
+import "mappers/codex_tool_part_mapper.dart";
 import "mappers/codex_user_content_mapper.dart";
 import "models/codex_projected_tool.dart";
+import "models/codex_thread_record.dart";
 
 final class CodexPreparedMessageRead({required Iterable<CodexRolloutLineDto> lines}) {
   final List<CodexRolloutLineDto> _lines = List.unmodifiable(lines);
+
+  bool get hasSubtasks => _lines.any(
+    (line) => switch (line) {
+      CodexRolloutResponseItemLineDto(payload: CodexRolloutFunctionCallDto(name: "spawn_agent")) => true,
+      _ => false,
+    },
+  );
 }
 
 /// Layer-2 mapping from typed rollout transcript DTOs to plugin messages.
@@ -22,6 +31,7 @@ class CodexMessageRepository({
   List<PluginMessageWithParts> readMessages({
     required String rolloutPath,
     required String sessionId,
+    required List<CodexThreadRecord> children,
     required CodexReplayToolDisposition replayToolDisposition,
     required Map<String, PluginToolStatus> structuredToolStatusByCallId,
     CodexConfigDefaults config = const CodexConfigDefaults.empty(),
@@ -32,6 +42,7 @@ class CodexMessageRepository({
         sessionId: sessionId,
       ),
       sessionId: sessionId,
+      children: children,
       replayToolDisposition: replayToolDisposition,
       structuredToolStatusByCallId: structuredToolStatusByCallId,
       config: config,
@@ -108,6 +119,7 @@ class CodexMessageRepository({
   List<PluginMessageWithParts> projectMessages({
     required CodexPreparedMessageRead read,
     required String sessionId,
+    required List<CodexThreadRecord> children,
     required CodexReplayToolDisposition replayToolDisposition,
     required Map<String, PluginToolStatus> structuredToolStatusByCallId,
     CodexConfigDefaults config = const CodexConfigDefaults.empty(),
@@ -154,15 +166,24 @@ class CodexMessageRepository({
               time: _messageTimeFrom(timestamp),
             )
           : messages[existingIndex]!.info;
-      final message = _toolMessage(
-        messageId: tool.canonicalId,
-        sessionId: sessionId,
+      final message = PluginMessageWithParts(
         info: info,
-        tool: tool.tool,
-        title: tool.title,
-        status: structuredToolStatusByCallId[tool.canonicalId] ?? tool.status,
-        output: tool.output,
-        attachments: tool.attachments,
+        parts: [
+          const CodexToolPartMapper().map(
+            sessionId: sessionId,
+            children: children,
+            tool: CodexProjectedTool(
+              canonicalId: tool.canonicalId,
+              tool: tool.tool,
+              presentation: tool.presentation,
+              title: tool.title,
+              status: structuredToolStatusByCallId[tool.canonicalId] ?? tool.status,
+              output: tool.output,
+              time: tool.time,
+              attachments: tool.attachments,
+            ),
+          ),
+        ],
       );
       if (existingIndex == null) {
         toolMessageIndexById[tool.canonicalId] = messages.length;

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
@@ -157,6 +157,7 @@ class CodexThreadRepository({required final CodexAppServerApi _appServerApi}) {
       modelProvider: _usefulText(thread.modelProvider) ?? _usefulText(dto.modelProvider),
       parentId: _subAgentParentId(thread: thread),
       agentNickname: _usefulText(thread.agentNickname),
+      agentPath: null,
     );
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
@@ -5,6 +5,7 @@ import "../api/models/codex_correlatable_item_event_dto.dart";
 import "../api/models/codex_file_change_dto.dart";
 import "../api/models/codex_image_bearing_item_dto.dart";
 import "../api/models/codex_rollout_dto.dart";
+import "../api/models/codex_sub_agent_item_event_dto.dart";
 import "../codex_app_server_client.dart";
 import "../models/codex_replay_tool_disposition.dart";
 import "mappers/codex_rollout_tool_mapper.dart";
@@ -21,6 +22,35 @@ class CodexToolLifecycleTracker({
 }) {
   final Map<String, _ThreadToolLifecycle> _threads = {};
   final Map<String, Map<String, _TrackedTool>> _retainedCommandsByThread = {};
+
+  CodexProjectedTool observeSubAgentStarted({required CodexSubAgentActivity event}) {
+    final thread = _threads.putIfAbsent(event.threadId, _ThreadToolLifecycle.new);
+    final tool = thread.tools.putIfAbsent(
+      event.itemId,
+      () => _TrackedTool(
+        id: event.itemId,
+        tool: "spawn_agent",
+        presentation: CodexSubtaskPresentation(
+          taskName: event.agentPath,
+          prompt: null,
+          agent: "codex",
+          childSessionId: event.agentThreadId,
+        ),
+        title: null,
+        turnId: event.turnId,
+        chronologySegment: thread.chronologySegment,
+        isRolloutCall: true,
+      ),
+    );
+    final previous = tool.presentation;
+    tool.presentation = CodexSubtaskPresentation(
+      taskName: previous is CodexSubtaskPresentation ? previous.taskName ?? event.agentPath : event.agentPath,
+      prompt: previous is CodexSubtaskPresentation ? previous.prompt : null,
+      agent: previous is CodexSubtaskPresentation ? previous.agent : "codex",
+      childSessionId: event.agentThreadId,
+    );
+    return tool.snapshot();
+  }
 
   /// Applies one typed rollout record and returns complete canonical upserts.
   List<CodexProjectedTool> observeRolloutLine({
@@ -179,6 +209,7 @@ class CodexToolLifecycleTracker({
         () => _TrackedTool(
           id: generationId,
           tool: "image_generation",
+          presentation: const CodexOrdinaryToolPresentation(),
           title: null,
           turnId: turnId,
           chronologySegment: thread.chronologySegment,
@@ -355,6 +386,7 @@ class CodexToolLifecycleTracker({
         () => _TrackedTool(
           id: id,
           tool: "image_generation",
+          presentation: const CodexOrdinaryToolPresentation(),
           title: null,
           turnId: null,
           chronologySegment: thread.chronologySegment,
@@ -402,6 +434,7 @@ class CodexToolLifecycleTracker({
         () => _TrackedTool(
           id: call.id,
           tool: call.tool,
+          presentation: call.presentation,
           title: call.title,
           turnId: effectiveTurnId,
           chronologySegment: thread.chronologySegment,
@@ -410,6 +443,15 @@ class CodexToolLifecycleTracker({
       );
       tool.time ??= time;
       tool.title ??= call.title;
+      if (call.presentation case final CodexSubtaskPresentation input) {
+        final previous = tool.presentation;
+        tool.presentation = CodexSubtaskPresentation(
+          taskName: input.taskName,
+          prompt: input.prompt,
+          agent: input.agent,
+          childSessionId: previous is CodexSubtaskPresentation ? previous.childSessionId : null,
+        );
+      }
       if (fileChangePatch != null) {
         tool.rolloutOutput ??= _rolloutToolMapper.clipOutput(fileChangePatch);
         thread.codeModeFileCallIds.add(call.id);
@@ -533,6 +575,7 @@ class CodexToolLifecycleTracker({
       () => _TrackedTool(
         id: id,
         tool: "image_generation",
+        presentation: const CodexOrdinaryToolPresentation(),
         title: null,
         turnId: null,
         chronologySegment: thread.chronologySegment,
@@ -827,6 +870,7 @@ class _ThreadToolLifecycle() {
 class _TrackedTool({
   required final String id,
   required final String tool,
+  required var CodexToolPresentation presentation,
   required var String? title,
   required var String? turnId,
   required final int chronologySegment,
@@ -843,6 +887,7 @@ class _TrackedTool({
   CodexProjectedTool snapshot() => CodexProjectedTool(
     canonicalId: id,
     tool: tool,
+    presentation: presentation,
     title: title,
     status: status,
     output: rolloutOutput ?? appServerOutput,

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -5,6 +5,7 @@ import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
 
 import "../../api/models/codex_image_bearing_item_dto.dart";
 import "../../api/models/codex_rollout_dto.dart";
+import "../models/codex_projected_tool.dart";
 import "codex_image_attachment_mapper.dart";
 
 class const CodexRolloutToolCall({
@@ -12,6 +13,7 @@ class const CodexRolloutToolCall({
   required final String? turnId,
   required final String tool,
   required final String? title,
+  required final CodexToolPresentation presentation,
 });
 
 sealed class const CodexRolloutToolResult({
@@ -327,12 +329,21 @@ class const CodexRolloutToolMapper({
     final usefulId = _usefulText(callId) ?? _usefulText(id);
     if (usefulId == null) return null;
     final usefulName = _usefulText(name) ?? "tool";
+    final arguments = usefulName == "spawn_agent" ? _tryDecodeToolArguments(raw: input) : null;
     final fileChangePatch = usefulName.toLowerCase() == "exec" ? _codeModeFileChangePatch(input: input) : null;
     return CodexRolloutToolCall(
       id: usefulId,
       turnId: _usefulText(turnId),
       tool: fileChangePatch == null ? normalizeToolName(usefulName) : "edit",
       title: fileChangePatch == null ? toolCallTitle(input) : _fileChangeTitle(patch: fileChangePatch),
+      presentation: usefulName == "spawn_agent"
+          ? CodexSubtaskPresentation(
+              taskName: _usefulText(arguments?.taskName),
+              prompt: _usefulText(arguments?.message),
+              agent: _usefulText(arguments?.agentType) ?? "codex",
+              childSessionId: null,
+            )
+          : const CodexOrdinaryToolPresentation(),
     );
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_session_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_session_mapper.dart
@@ -42,7 +42,7 @@ class const CodexSessionMapper() {
       projectID: directory,
       directory: directory,
       parentID: parentSessionId,
-      title: record.parentId == null
+      title: parentSessionId == null
           ? record.name
           : const CodexSubAgentNameMapper().map(
               name: record.name,

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_session_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_session_mapper.dart
@@ -3,6 +3,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../models/codex_session_record.dart";
 import "../models/codex_thread_record.dart";
+import "codex_sub_agent_name_mapper.dart";
 
 /// Pure Layer-2 projections among normalized Codex records and bridge session
 /// contracts and lifecycle events.
@@ -20,6 +21,7 @@ class const CodexSessionMapper() {
     modelProvider: record.modelProvider,
     parentId: record.parentId,
     agentNickname: _usefulText(record.agentNickname),
+    agentPath: _usefulText(record.agentPath),
   );
 
   String? _usefulText(String? value) {
@@ -40,7 +42,13 @@ class const CodexSessionMapper() {
       projectID: directory,
       directory: directory,
       parentID: parentSessionId,
-      title: record.name,
+      title: record.parentId == null
+          ? record.name
+          : const CodexSubAgentNameMapper().map(
+              name: record.name,
+              nickname: record.agentNickname,
+              agentPath: record.agentPath,
+            ),
       time: created == null || updated == null
           ? null
           : PluginSessionTime(

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_sub_agent_name_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_sub_agent_name_mapper.dart
@@ -1,0 +1,21 @@
+/// Display names for Codex's machine-oriented task paths. Raw paths stay on
+/// the records so presentation never changes child identity or matching.
+class const CodexSubAgentNameMapper() {
+  String? map({required String? name, required String? nickname, required String? agentPath}) {
+    final preferred = _usefulText(value: nickname) ?? _usefulText(value: name);
+    if (preferred != null && !preferred.startsWith("/root/")) return preferred;
+    final path = preferred ?? _usefulText(value: agentPath);
+    if (path == null) return null;
+    final leaf = path.split("/").last;
+    final suffix = RegExp(r"^(.+)_([0-9]+)$").firstMatch(leaf);
+    final words = (suffix?.group(1) ?? leaf).replaceAll("_", " ");
+    if (words.isEmpty) return path;
+    final label = "${words[0].toUpperCase()}${words.substring(1)}";
+    return suffix == null ? label : "$label · ${suffix.group(2)}";
+  }
+}
+
+String? _usefulText({required String? value}) {
+  final trimmed = value?.trim();
+  return trimmed == null || trimmed.isEmpty ? null : trimmed;
+}

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_tool_part_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_tool_part_mapper.dart
@@ -1,0 +1,64 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../models/codex_projected_tool.dart";
+import "../models/codex_thread_record.dart";
+import "codex_sub_agent_name_mapper.dart";
+
+/// One part projection for live tool upserts and saved transcript replay.
+class const CodexToolPartMapper() {
+  PluginMessagePart map({
+    required String sessionId,
+    required CodexProjectedTool tool,
+    required List<CodexThreadRecord> children,
+  }) {
+    final state = PluginToolState(
+      status: tool.status,
+      title: tool.title,
+      output: tool.output,
+      error: tool.status == PluginToolStatus.error ? tool.output : null,
+      attachments: tool.attachments,
+    );
+    switch (tool.presentation) {
+      case CodexOrdinaryToolPresentation():
+        return PluginMessagePart.tool(
+          id: "${tool.canonicalId}-tool",
+          sessionID: sessionId,
+          messageID: tool.canonicalId,
+          tool: tool.tool,
+          state: state,
+        );
+      case CodexSubtaskPresentation(:final taskName, :final prompt, :final agent, :final childSessionId):
+        CodexThreadRecord? child;
+        for (final candidate in children) {
+          if (childSessionId != null
+              ? candidate.id == childSessionId
+              : taskName != null &&
+                    candidate.agentPath != null &&
+                    (candidate.agentPath == taskName || candidate.agentPath!.split("/").last == taskName)) {
+            child = candidate;
+            break;
+          }
+        }
+        final title =
+            const CodexSubAgentNameMapper().map(
+              name: child?.name,
+              nickname: child?.agentNickname,
+              agentPath: child?.agentPath ?? taskName,
+            ) ??
+            "Subtask";
+        final targetId = childSessionId ?? child?.id;
+        return PluginMessagePart.subtask(
+          id: "${tool.canonicalId}-tool",
+          sessionID: sessionId,
+          messageID: tool.canonicalId,
+          description: title,
+          prompt: prompt ?? title,
+          agent: agent,
+          childSessionID: targetId,
+          // A completed spawn only launched the child. The shared tile follows
+          // that child's session status, including work after the parent ends.
+          taskState: targetId == null ? state : null,
+        );
+    }
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_projected_tool.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_projected_tool.dart
@@ -4,6 +4,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 final class CodexProjectedTool({
   required final String canonicalId,
   required final String tool,
+  required final CodexToolPresentation presentation,
   required final String? title,
   required final PluginToolStatus status,
   required final String? output,
@@ -12,3 +13,16 @@ final class CodexProjectedTool({
 }) {
   final List<PluginMessageAttachment> attachments = List.unmodifiable(attachments);
 }
+
+sealed class const CodexToolPresentation();
+
+final class const CodexOrdinaryToolPresentation() extends CodexToolPresentation;
+
+/// Spawn input and its child identity, enriched when Codex announces the child.
+/// The spawn tool's completion is separate from that child's work lifecycle.
+final class const CodexSubtaskPresentation({
+  required final String? taskName,
+  required final String? prompt,
+  required final String agent,
+  required final String? childSessionId,
+}) extends CodexToolPresentation;

--- a/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_session_record.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_session_record.dart
@@ -9,6 +9,7 @@ class const CodexSessionRecord({
   required final String? modelProvider,
   required final String? model,
   required final String? agentNickname,
+  required final String? agentPath,
 
   /// The parent thread of a sub-agent rollout (`session_meta.parent_thread_id`
   /// with `thread_source: subagent`); `null` for a root rollout.

--- a/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_thread_record.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_thread_record.dart
@@ -12,4 +12,5 @@ class const CodexThreadRecord({
 
   /// Codex's generated nickname for a sub-agent thread; `null` for a root.
   required final String? agentNickname,
+  required final String? agentPath,
 });

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -19,6 +19,7 @@ import "../repositories/models/codex_thread_record.dart";
 
 final class const CodexSessionMessageRead._({
   required final CodexPreparedMessageRead _messages,
+  required final List<CodexThreadRecord> _children,
   required final Map<String, PluginToolStatus> _structuredToolStatusByCallId,
   required final CodexConfigDefaults _config,
 });
@@ -134,6 +135,9 @@ class CodexSessionService({
   void _recordPersistedChild({required CodexSessionRecord record}) =>
       _subAgentTracker.record(child: _sessionMapper.mapPersistedThread(record: record));
 
+  List<CodexThreadRecord> knownChildThreads({required String sessionId}) =>
+      _subAgentTracker.childrenOf(parentId: sessionId);
+
   /// Resolves and records a child named by `subAgentActivity started`, then
   /// maps its ordered creation/status events. A repeated activity returns
   /// `null` and never announces the child twice.
@@ -168,6 +172,7 @@ class CodexSessionService({
           modelProvider: null,
           parentId: parentThreadId,
           agentNickname: null,
+          agentPath: agentPath,
         );
     if (trackedChild == null && !_subAgentTracker.record(child: child)) {
       _announcedSubAgentThreadIds.remove(childThreadId);
@@ -204,6 +209,7 @@ class CodexSessionService({
         modelProvider: read.modelProvider,
         parentId: parentThreadId,
         agentNickname: read.agentNickname,
+        agentPath: agentPath ?? trackedChild?.agentPath,
       );
       _subAgentTracker.replaceChild(child: child);
     }
@@ -735,6 +741,13 @@ class CodexSessionService({
   }) async {
     final path = _catalogRepository.findRolloutPath(sessionId: sessionId);
     if (path == null) return null;
+    final messages = _messageRepository.prepareMessageRead(rolloutPath: path, sessionId: sessionId);
+    final children = messages.hasSubtasks
+        ? [
+            for (final record in await _catalogRepository.listSessionRecordsInIsolate())
+              if (record.parentId == sessionId) _sessionMapper.mapPersistedThread(record: record),
+          ]
+        : const <CodexThreadRecord>[];
     Map<String, PluginToolStatus> structuredToolStatusByCallId;
     try {
       structuredToolStatusByCallId = await _toolOutcomeRepository.readStatuses(
@@ -749,10 +762,8 @@ class CodexSessionService({
       structuredToolStatusByCallId = const {};
     }
     return CodexSessionMessageRead._(
-      messages: _messageRepository.prepareMessageRead(
-        rolloutPath: path,
-        sessionId: sessionId,
-      ),
+      messages: messages,
+      children: children,
       structuredToolStatusByCallId: structuredToolStatusByCallId,
       config: _metadataRepository.readConfigDefaults(),
     );
@@ -766,6 +777,10 @@ class CodexSessionService({
     return _messageRepository.projectMessages(
       read: read._messages,
       sessionId: sessionId,
+      children: [
+        ...knownChildThreads(sessionId: sessionId),
+        ...read._children,
+      ],
       replayToolDisposition: switch (sessionStatus) {
         PluginSessionStatusIdle() => CodexReplayToolDisposition.terminalize,
         PluginSessionStatusBusy() || PluginSessionStatusRetry() => CodexReplayToolDisposition.preserveRunning,

--- a/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_catalog_repository_test.dart
@@ -288,6 +288,7 @@ CodexSessionRecord _record({
   modelProvider: "openai",
   model: "gpt-5.4-codex",
   agentNickname: null,
+  agentPath: null,
 );
 
 class _StubCodexCatalogRepository(final List<CodexSessionRecord> records) extends CodexCatalogRepository {

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -1999,7 +1999,7 @@ class _ToolLifecycleHarness({
     final events = <BridgeSseEvent>[];
     for (final tool in _toolTracker.observeRolloutLine(threadId: threadId, line: line)) {
       events.addAll(
-        _eventMapper.mapProjectedTool(threadId: threadId, tool: tool),
+        _eventMapper.mapProjectedTool(threadId: threadId, tool: tool, children: const []),
       );
     }
     return events;
@@ -2030,7 +2030,7 @@ class _ToolLifecycleHarness({
     if (tool == null || threadId is! String) {
       return _eventMapper.map(notification);
     }
-    return _eventMapper.mapProjectedTool(threadId: threadId, tool: tool);
+    return _eventMapper.mapProjectedTool(threadId: threadId, tool: tool, children: const []);
   }
 
   void clearRolloutTurn({required String threadId}) {

--- a/bridge/sesori_plugin_codex/test/codex_inline_subtask_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_inline_subtask_test.dart
@@ -1,0 +1,267 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:codex_plugin/src/api/codex_rollout_api.dart";
+import "package:codex_plugin/src/api/models/codex_correlatable_item_event_dto.dart";
+import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
+import "package:codex_plugin/src/api/models/codex_sub_agent_item_dto.dart";
+import "package:codex_plugin/src/api/models/codex_sub_agent_item_event_dto.dart";
+import "package:codex_plugin/src/models/codex_replay_tool_disposition.dart";
+import "package:codex_plugin/src/repositories/codex_message_repository.dart";
+import "package:codex_plugin/src/repositories/codex_tool_lifecycle_tracker.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_image_attachment_mapper.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_rollout_tool_mapper.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_sub_agent_name_mapper.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_tool_part_mapper.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_user_content_mapper.dart";
+import "package:codex_plugin/src/repositories/models/codex_projected_tool.dart";
+import "package:codex_plugin/src/repositories/models/codex_thread_record.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+import "support/codex_plugin_test_factory.dart";
+
+void main() {
+  const names = CodexSubAgentNameMapper();
+  const rolloutMapper = CodexRolloutToolMapper(imageAttachmentMapper: CodexImageAttachmentMapper());
+  const parts = CodexToolPartMapper();
+
+  test("formats task paths while preserving readable titles and nicknames", () {
+    expect(
+      names.map(name: null, nickname: null, agentPath: "/root/architecture_review_1271"),
+      "Architecture review · 1271",
+    );
+    expect(names.map(name: "/root/parent/check_ci_2", nickname: null, agentPath: null), "Check ci · 2");
+    expect(names.map(name: null, nickname: null, agentPath: "review_api"), "Review api");
+    expect(
+      names.map(name: "Review API behavior", nickname: null, agentPath: "/root/review_api"),
+      "Review API behavior",
+    );
+    expect(names.map(name: "/root/review_api", nickname: "Raman", agentPath: "/root/review_api"), "Raman");
+    expect(names.map(name: null, nickname: null, agentPath: null), isNull);
+  });
+
+  for (final activityFirst in [false, true]) {
+    test("one navigable subtask survives spawn completion (activity first: $activityFirst)", () {
+      final tracker = CodexToolLifecycleTracker(rolloutToolMapper: rolloutMapper);
+      final upserts = <PluginMessagePart>[];
+      void render({required CodexProjectedTool tool}) => upserts.add(
+        parts.map(
+          sessionId: "root-1",
+          tool: tool,
+          children: [_child(nickname: null)],
+        ),
+      );
+      void spawn() {
+        for (final tool in tracker.observeRolloutLine(threadId: "root-1", line: _spawn())) {
+          render(tool: tool);
+        }
+      }
+
+      void activity() => render(tool: tracker.observeSubAgentStarted(event: _activity));
+      if (activityFirst) {
+        activity();
+        spawn();
+      } else {
+        spawn();
+        activity();
+      }
+      for (final line in [_spawnResult(), _parentComplete()]) {
+        for (final tool in tracker.observeRolloutLine(threadId: "root-1", line: line)) {
+          render(tool: tool);
+        }
+      }
+      expect(upserts.map((part) => part.id).toSet(), {"call-spawn-tool"});
+      expect(upserts, everyElement(isA<PluginMessagePartSubtask>()));
+      final task = upserts.last as PluginMessagePartSubtask;
+      expect(task.childSessionID, "child-1");
+      expect(task.description, "Architecture review · 1271");
+      expect(task.prompt, "Review the proposed architecture.");
+      expect(task.taskState, isNull, reason: "the running child owns status after the parent completes");
+    });
+  }
+
+  test("activity alone creates a linked card before rollout enrichment is available", () {
+    final tracker = CodexToolLifecycleTracker(rolloutToolMapper: rolloutMapper);
+    final part = parts.map(
+      sessionId: "root-1",
+      tool: tracker.observeSubAgentStarted(event: _activity),
+      children: [_child(nickname: null)],
+    ) as PluginMessagePartSubtask;
+    expect(part.childSessionID, "child-1");
+    expect(part.description, "Architecture review · 1271");
+    expect(part.taskState, isNull);
+  });
+
+  test("history resolves the raw task path even when the displayed child nickname differs", () {
+    final repository = CodexMessageRepository(
+      rolloutApi: CodexRolloutApi(environment: const {}),
+      rolloutToolMapper: rolloutMapper,
+      userContentMapper: const CodexUserContentMapper(),
+    );
+    final read = CodexPreparedMessageRead(lines: [_spawn(), _spawnResult(), _parentComplete()]);
+    expect(read.hasSubtasks, isTrue);
+    final messages = repository.projectMessages(
+      read: read,
+      sessionId: "root-1",
+      children: [_child(nickname: "Raman")],
+      replayToolDisposition: CodexReplayToolDisposition.terminalize,
+      structuredToolStatusByCallId: const {},
+    );
+    final task = messages.single.parts.single as PluginMessagePartSubtask;
+    expect(task.id, "call-spawn-tool");
+    expect(task.description, "Raman");
+    expect(task.childSessionID, "child-1");
+    expect(task.taskState, isNull);
+  });
+
+  test("an interrupted launch without a child retains its explicit failure state", () {
+    final repository = CodexMessageRepository(
+      rolloutApi: CodexRolloutApi(environment: const {}),
+      rolloutToolMapper: rolloutMapper,
+      userContentMapper: const CodexUserContentMapper(),
+    );
+    final messages = repository.projectMessages(
+      read: CodexPreparedMessageRead(
+        lines: [
+          _spawn(),
+          _line(
+            type: "event_msg",
+            payload: {
+              "type": "turn_aborted",
+              "turn_id": "turn-1",
+              "reason": "interrupted",
+            },
+          ),
+        ],
+      ),
+      sessionId: "root-1",
+      children: const [],
+      replayToolDisposition: CodexReplayToolDisposition.terminalize,
+      structuredToolStatusByCallId: const {},
+    );
+    final task = messages.single.parts.single as PluginMessagePartSubtask;
+    expect(task.childSessionID, isNull);
+    expect(task.taskState?.status, PluginToolStatus.error);
+  });
+
+  test("a fresh plugin resolves inline history and task-widget titles from persisted metadata", () async {
+    final home = Directory.systemTemp.createTempSync("codex-inline-");
+    addTearDown(() => home.deleteSync(recursive: true));
+    final sessions = Directory("${home.path}/sessions")..createSync();
+    const parentId = "019a0000-1111-2222-3333-aaaaaaaaaaaa";
+    const childId = "019a0000-1111-2222-3333-aaaaaaaaaaab";
+    for (final id in [parentId, childId]) {
+      final records = [
+        {
+          "type": "session_meta",
+          "payload": {
+            "id": id,
+            "cwd": "/repo",
+            "timestamp": "2026-09-05T12:00:00Z",
+            if (id == childId) ...{
+              "parent_thread_id": parentId,
+              "thread_source": "subagent",
+              "agent_path": "/root/architecture_review_1271",
+            },
+          },
+        },
+        if (id == parentId) ...[
+          {
+            "type": "response_item",
+            "payload": {
+              "type": "function_call",
+              "call_id": "call-spawn",
+              "name": "spawn_agent",
+              "arguments": jsonEncode({"task_name": "architecture_review_1271", "message": "Review the architecture."}),
+            },
+          },
+          {
+            "type": "response_item",
+            "payload": {
+              "type": "function_call_output",
+              "call_id": "call-spawn",
+              "output": jsonEncode({"task_name": "/root/architecture_review_1271"}),
+            },
+          },
+        ],
+      ];
+      File("${sessions.path}/rollout-2026-09-05T12-00-00-$id.jsonl")
+          .writeAsStringSync("${records.map(jsonEncode).join("\n")}\n");
+    }
+    final plugin = createInjectedCodexPlugin(
+      serverUrl: "ws://127.0.0.1:0",
+      environment: {"CODEX_HOME": home.path},
+      projectCwd: "/repo",
+      clientFactory: null,
+      keepaliveInterval: const Duration(seconds: 30),
+    );
+    addTearDown(plugin.dispose);
+    final messages = await plugin.getSessionMessages(parentId);
+    final task = messages.single.parts.single as PluginMessagePartSubtask;
+    final children = await plugin.getChildSessions(parentId);
+    expect(task.childSessionID, childId);
+    expect(task.description, "Architecture review · 1271");
+    expect(task.description, children.single.title);
+    expect(task.taskState, isNull);
+  });
+}
+
+const _activity = CodexSubAgentActivity(
+  lifecycle: CodexCorrelatableItemLifecycle.started,
+  threadId: "root-1",
+  turnId: "turn-1",
+  itemId: "call-spawn",
+  kind: CodexSubAgentActivityKind.started,
+  agentThreadId: "child-1",
+  agentPath: "/root/architecture_review_1271",
+);
+
+CodexThreadRecord _child({required String? nickname}) => CodexThreadRecord(
+  id: "child-1",
+  name: null,
+  directory: "/repo",
+  createdAt: null,
+  updatedAt: null,
+  model: null,
+  modelProvider: null,
+  parentId: "root-1",
+  agentNickname: nickname,
+  agentPath: "/root/architecture_review_1271",
+);
+
+CodexRolloutLineDto _spawn() => _line(
+  type: "response_item",
+  payload: {
+    "type": "function_call",
+    "call_id": "call-spawn",
+    "name": "spawn_agent",
+    "arguments": jsonEncode({"task_name": "architecture_review_1271", "message": "Review the proposed architecture."}),
+    "internal_chat_message_metadata_passthrough": {"turn_id": "turn-1"},
+  },
+);
+
+CodexRolloutLineDto _spawnResult() => _line(
+  type: "response_item",
+  payload: {
+    "type": "function_call_output",
+    "call_id": "call-spawn",
+    "output": jsonEncode({"task_name": "/root/architecture_review_1271"}),
+  },
+);
+
+CodexRolloutLineDto _parentComplete() => _line(
+  type: "event_msg",
+  payload: {
+    "type": "task_complete",
+    "turn_id": "turn-1",
+    "last_agent_message": "Done",
+  },
+);
+
+CodexRolloutLineDto _line({required String type, required Map<String, Object?> payload}) =>
+    CodexRolloutLineDto.fromJson({
+      "timestamp": "2026-09-05T12:00:00Z",
+      "type": type,
+      "payload": payload,
+    });

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -2727,6 +2727,15 @@ void main() {
       expect(childSession.projectID, "/work/other");
       expect(fake.sentParamsFor("thread/read"), {"threadId": "child-1", "includeTurns": false});
       await Future<void>.delayed(Duration.zero);
+      final inlineTask = events
+          .whereType<BridgeSseMessagePartUpdated>()
+          .map((event) => event.part)
+          .whereType<PluginMessagePartSubtask>()
+          .single;
+      expect(inlineTask.messageID, "call_spawn");
+      expect(inlineTask.description, "Raman");
+      expect(inlineTask.childSessionID, "child-1");
+      expect(inlineTask.taskState, isNull);
       expect(
         events.whereType<BridgeSseSessionStatus>().where((event) => event.sessionID == "child-1").last.status["type"],
         "busy",

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -967,6 +967,7 @@ void main() {
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-aaaaaaaaaaaa",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1053,6 +1054,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-aaaaaaaaaaab",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1109,6 +1111,7 @@ authored arguments
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-aaaaaaaaaaad",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1158,6 +1161,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-aaaaaaaaaaae",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1204,6 +1208,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-aaaaaaaaaaac",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1241,6 +1246,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: sessionId,
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1373,6 +1379,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-ccccccccccc1",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1449,6 +1456,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-ccccccccccc2",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1489,6 +1497,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-cccccccccccc",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1537,12 +1546,14 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final firstRead = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-iiiiiiiiiiii",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
       final secondRead = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-iiiiiiiiiiii",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1600,12 +1611,14 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final busyMessages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-iiiiiiiiii99",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.preserveRunning,
         structuredToolStatusByCallId: const {},
       );
       final idleMessages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-iiiiiiiiii99",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1657,6 +1670,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-iiiiiiiiiii2",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1703,6 +1717,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-iiiiiiiiiii3",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1743,6 +1758,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-iiiiiiiiiii4",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -1759,6 +1775,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
         () => messageRepository.readMessages(
           rolloutPath: path,
           sessionId: sessionId,
+          children: const [],
           replayToolDisposition: CodexReplayToolDisposition.terminalize,
           structuredToolStatusByCallId: const {},
         ),
@@ -1827,6 +1844,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-bbbbbbbbbbbb",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {
           "c2": PluginToolStatus.error,
@@ -2059,12 +2077,14 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-ccccccccccc2",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.preserveRunning,
         structuredToolStatusByCallId: const {},
       );
       final idleMessages = messageRepository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-ccccccccccc2",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -2174,6 +2194,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
         messages = messageRepository.readMessages(
           rolloutPath: path,
           sessionId: "019a0000-1111-2222-3333-bbbbbbbbbbbb",
+          children: const [],
           replayToolDisposition: CodexReplayToolDisposition.terminalize,
           structuredToolStatusByCallId: const {},
         );
@@ -2234,6 +2255,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
           .readMessages(
             rolloutPath: path,
             sessionId: "019a0000-1111-2222-3333-cccccccccccc",
+            children: const [],
             replayToolDisposition: CodexReplayToolDisposition.terminalize,
             structuredToolStatusByCallId: const {},
           )
@@ -2494,6 +2516,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = repository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-dddddddddddd",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
       );
@@ -2540,6 +2563,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final messages = repository.readMessages(
         rolloutPath: path,
         sessionId: "019a0000-1111-2222-3333-eeeeeeeeeeee",
+        children: const [],
         replayToolDisposition: CodexReplayToolDisposition.terminalize,
         structuredToolStatusByCallId: const {},
         config: const CodexConfigDefaults(

--- a/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
@@ -468,6 +468,7 @@ class _RecordingMessageRepository() extends CodexMessageRepository {
   List<PluginMessageWithParts> projectMessages({
     required CodexPreparedMessageRead read,
     required String sessionId,
+    required List<CodexThreadRecord> children,
     required CodexReplayToolDisposition replayToolDisposition,
     required Map<String, PluginToolStatus> structuredToolStatusByCallId,
     CodexConfigDefaults config = const CodexConfigDefaults.empty(),
@@ -570,6 +571,7 @@ class _StubThreadRepository() extends CodexThreadRepository {
       modelProvider: null,
       parentId: null,
       agentNickname: null,
+      agentPath: null,
     );
   }
 

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_sessions_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_sessions_test.dart
@@ -44,6 +44,7 @@ void main() {
         modelProvider: null,
         model: null,
         agentNickname: agentNickname,
+        agentPath: null,
         parentId: "root-1",
       );
       const mapper = CodexSessionMapper();
@@ -82,6 +83,7 @@ void main() {
       expect(records["01a06259-6e4f-77f2-8bc7-000000000001"]?.parentId, isNull);
       expect(records["01a06259-6e4f-77f2-8bc7-000000000002"]?.parentId, "01a06259-6e4f-77f2-8bc7-000000000001");
       expect(records["01a06259-6e4f-77f2-8bc7-000000000002"]?.agentNickname, "Raman");
+      expect(records["01a06259-6e4f-77f2-8bc7-000000000002"]?.agentPath, "/root/sleep_then_done");
       expect(
         records["01a06259-6e4f-77f2-8bc7-000000000003"]?.parentId,
         isNull,
@@ -242,6 +244,7 @@ void main() {
           modelProvider: "openai",
           parentId: null,
           agentNickname: "Raman",
+          agentPath: null,
         ),
       );
       final service = _newService(
@@ -697,6 +700,7 @@ CodexThreadRecord _liveChild({required String id, required String parentId}) => 
   modelProvider: null,
   parentId: parentId,
   agentNickname: "Hooke",
+  agentPath: null,
 );
 
 CodexSessionRecord _record({required String id, required String? cwd, required String? parentId}) => CodexSessionRecord(
@@ -710,6 +714,7 @@ CodexSessionRecord _record({required String id, required String? cwd, required S
   modelProvider: "openai",
   model: null,
   agentNickname: null,
+  agentPath: null,
   parentId: parentId,
 );
 

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -31,7 +31,7 @@ listed variant when no default is declared) and models in plugin-defined order.
 
 | Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |
 |---|---|---|---|---|---|---|---|---|---|---|
-| Sub-agents rendered as inline subtask tiles | ✅ | ✅ | ⬜³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
+| Sub-agents rendered as inline subtask tiles | ✅ | ✅ | ✅³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
 | Sub-agent transcripts exposed as child sessions | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
 | Scoped stop: confirmation while sub-agents run, `stop` cancels them all | ✅ | ✅ | ⬜³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
 | Stop the sub-agents only while the main agent is idle (`stop`) | ✅ | ✅ | ⬜³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
@@ -53,7 +53,13 @@ announces itself through the parent's `subAgentActivity started`
 (`agentThreadId`) and `thread/status/changed`, never `thread/started`;
 `receiverThreadIds` stays empty. Sesori exposes the verified child thread and
 persisted rollout under its direct parent and rolls running descendants into
-the root's busy state. `turn/interrupt` works per child thread with its
+the root's busy state. Spawn calls appear as inline subtask tiles both live
+and in saved history, linked to the child thread; the tile follows the child's
+session status instead of treating spawn completion as task completion.
+Raw task-path fallbacks are formatted for display (for example,
+`/root/architecture_review_1271` becomes `Architecture review · 1271`), while
+raw paths remain the identity used to match saved spawn calls to children.
+`turn/interrupt` works per child thread with its
 `turnId`, and interrupting the parent leaves children running, so
 main-agent-only is supportable.
 

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -60,6 +60,16 @@ defaults and queued client sends coherent.
   client user-message id in either case. The bridge keeps the authoritative
   active turn until its terminal event even when an older app server returns a
   separate submission id for the steering request.
+- Codex spawn calls render as one inline subtask card in the parent chat as
+  well as a child in the tasks widget, on phone and desktop. Cards open the
+  correct child transcript and survive history reload. A linked card follows
+  the child's session status; completing the spawn call or the parent turn
+  must not stop its spinner while the child runs. Readable child nicknames and
+  titles are preserved; raw path fallbacks such as
+  `/root/architecture_review_1271` display as `Architecture review · 1271`.
+  Matching uses the raw task path under the direct parent, not the formatted
+  label. An interrupted launch that never creates a child retains its own
+  terminal tool status.
 - A Codex root remains effectively busy after its own turn completes while any
   tracked descendant turn is running. The root's idle status and completion
   signal are deferred and released exactly once after the last child settles;
@@ -445,6 +455,10 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   shows a transient idle between the task notification and its wake-up turn; a
   `<task-notification>` envelope renders as a user bubble, or a prompt that
   quotes the envelope disappears; sub-agent text appears in the root transcript.
+- A Codex spawn is absent from the parent chat, appears twice as both a tool
+  and a subtask, loses its child link after reload, or stops spinning just
+  because the spawn call returned. Machine task paths appear unformatted, or
+  formatting changes which child a card opens.
 - A Codex root reports idle while a child is starting or still runs, never
   releases its deferred idle after the child settles, emits completion more
   than once, omits a busy child id, omits an awaiting-input root after reconnect,


### PR DESCRIPTION
## Complexity
⚙️ Moderate: joins live child announcements and saved spawn calls through the existing Codex tool projection.

## What
Render Codex spawn calls as clickable inline subtask cards, alongside the tasks widget, on phone and desktop. Format raw fallback names such as `/root/architecture_review_1271` as **Architecture review · 1271**, preserving readable nicknames and titles.

## Why
Codex subtasks were discoverable through the tasks widget but lacked the inline representation already available for Claude Code. Raw agent paths also made task names difficult to read.

## Risk and test focus
Keep one card per spawn across live updates and replay, retain the correct child link, and follow the child session's running status after the spawn call or parent turn completes. Exact raw paths remain the matching identity. Changes stay inside the Codex plugin and reuse the existing shared subtask contract and UI. No database schema or transport-contract changes.

## Expected result
A running Codex subtask appears in both the chat and tasks widget with a readable title. Its inline card opens the child transcript and remains linked after reopening the session.

## Verification
- Owning Codex package analysis passed with `--fatal-infos`.
- 249 focused tests passed across live events, history, tool lifecycle, session service, and catalog mapping.
- All seven inline-subtask tests passed, including the final fresh-plugin history/catalog integration case (250 unique tests across the focused runs).
- DTOs regenerated with the pinned Dart toolchain; whitespace validation passed.
- Architecture plan and implementation reviews approved.
