### PR TITLE
🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -13,8 +13,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 3/25 | ⚙️ [periodic-cleanup] client: preserve live transcript during refresh [step 3/25] | Merged | [#1303](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1303) |
 | 4/25 | ⚙️ [periodic-cleanup] bridge: remove unused session paths and tracker state [step 4/25] | Merged | [#1305](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1305) |
 | 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | Merged | [#1308](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1308) |
-| 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | In review | [#1309](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1309) |
-| 7/25 | 🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25] | In progress (local, awaiting step 6 merge) | — |
+| 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | Merged | [#1309](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1309) |
+| 7/25 | 🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25] | In review | [#1311](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1311) |
 | 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | Proposed | — |
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Proposed | — |
 | 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -14,7 +14,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 4/25 | ⚙️ [periodic-cleanup] bridge: remove unused session paths and tracker state [step 4/25] | Merged | [#1305](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1305) |
 | 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | Merged | [#1308](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1308) |
 | 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | In review | [#1309](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1309) |
-| 7/25 | 🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25] | Proposed | — |
+| 7/25 | 🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25] | In progress (local, awaiting step 6 merge) | — |
 | 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | Proposed | — |
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Proposed | — |
 | 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | Proposed | — |
@@ -161,3 +161,17 @@ asked to start working the plan; steps execute in order from step 2.
   publication/generation checks. Orchestrator delivers status through
   `BridgeEventMapper.buildSessionStatusEvent`; the history listener ignores
   status and handoff payloads. The message variant follows in step 7.
+
+## Step 7 execution — 2026-09-05
+
+- `BridgeSseMessageUpdated.info` is a `PluginMessage`; ACP, Claude, Codex,
+  OpenCode and Pi emit typed envelopes (ACP and Codex stop building shared
+  messages internally). OpenCode drops an unknown message role at the plugin
+  boundary instead of relaying a raw payload.
+- `NormalizedMessageEvent` joins the normalized payload; the mapper converts
+  once through `toSharedMessage`, the orchestrator delivers it through
+  `BridgeEventMapper.buildMessageUpdatedEvent`, and the history listener stores
+  the same shared value with no decode/drop branch.
+- The residual session parse-failure log names the event type, error and stack
+  without dumping the payload. Failure-reporter failures are logged instead of
+  swallowed in the mapper, orchestrator and SSE manager.

--- a/bridge/app/lib/src/listeners/chat_history_listener.dart
+++ b/bridge/app/lib/src/listeners/chat_history_listener.dart
@@ -2,7 +2,6 @@ import "dart:async";
 
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart";
 
 import "../repositories/models/normalized_bridge_event.dart";
 import "../services/chat_history_service.dart";
@@ -49,22 +48,14 @@ class ChatHistoryListener({
       NormalizedOtherEvent(event: BridgeSseServerConnected()) => _chatHistoryService.invalidatePluginHistory(
         pluginId: pluginId,
       ),
-      NormalizedOtherEvent(event: BridgeSseMessageUpdated(:final info)) => _captureMessage(info: info),
+      NormalizedMessageEvent(:final message) => _chatHistoryService.captureMessage(
+        sessionId: message.sessionID,
+        message: message,
+      ),
       // A forced-stop handoff carries no finalized message, and a status
       // change stores nothing.
       NormalizedOtherEvent() || NormalizedStatusEvent() || NormalizedTerminalHandoff() => Future<void>.value(),
     };
-  }
-
-  Future<void> _captureMessage({required Map<String, dynamic> info}) async {
-    final Message message;
-    try {
-      message = Message.fromJson(info);
-    } on Object catch (error, stackTrace) {
-      Log.w("Ignoring an undecodable message event; it will not be stored", error, stackTrace);
-      return;
-    }
-    await _chatHistoryService.captureMessage(sessionId: message.sessionID, message: message);
   }
 
   /// Memoized so a second caller joins the same drain instead of returning

--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -1499,18 +1499,23 @@ class OrchestratorSession._({
     };
     final eventType = switch (payload) {
       NormalizedOtherEvent(:final event) => event.runtimeType,
-      NormalizedStatusEvent() => payload.runtimeType,
+      NormalizedStatusEvent() || NormalizedMessageEvent() => payload.runtimeType,
     };
     try {
       Log.v("[sse] plugin event arrived: $eventType");
       final BridgeSseEvent event;
       switch (payload) {
         case NormalizedStatusEvent(:final sessionId, :final status):
-          if (!_isCurrentSource(pluginId: pluginId, generation: generation, allowDuringStop: allowDuringStop)) return;
-          await _deliverSseEvent(
-            delivery: SseEventDelivery.uniform(
-              event: _mapper.buildSessionStatusEvent(sessionId: sessionId, status: status),
-            ),
+          await _deliverNormalized(
+            event: _mapper.buildSessionStatusEvent(sessionId: sessionId, status: status),
+            pluginId: pluginId,
+            generation: generation,
+            allowDuringStop: allowDuringStop,
+          );
+          return;
+        case NormalizedMessageEvent(:final message):
+          await _deliverNormalized(
+            event: _mapper.buildMessageUpdatedEvent(message: message),
             pluginId: pluginId,
             generation: generation,
             allowDuringStop: allowDuringStop,
@@ -1642,9 +1647,28 @@ class OrchestratorSession._({
               reason: "Failed to process SSE event",
               information: [eventType.toString()],
             )
-            .catchError((_) {}),
+            .catchError((Object reportError, StackTrace reportStackTrace) {
+              Log.w("[sse] failed to report processing failure", reportError, reportStackTrace);
+            }),
       );
     }
+  }
+
+  /// Delivers a public event built from an already-normalized shared value,
+  /// after the same current-source check the plugin-shaped path applies.
+  Future<void> _deliverNormalized({
+    required SesoriSseEvent event,
+    required String pluginId,
+    required int? generation,
+    required bool allowDuringStop,
+  }) async {
+    if (!_isCurrentSource(pluginId: pluginId, generation: generation, allowDuringStop: allowDuringStop)) return;
+    await _deliverSseEvent(
+      delivery: SseEventDelivery.uniform(event: event),
+      pluginId: pluginId,
+      generation: generation,
+      allowDuringStop: allowDuringStop,
+    );
   }
 
   /// Finalizes tool parts stranded by the ended turn and delivers each

--- a/bridge/app/lib/src/repositories/mappers/session_event_mapper.dart
+++ b/bridge/app/lib/src/repositories/mappers/session_event_mapper.dart
@@ -2,6 +2,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 
 import "../models/normalized_bridge_event.dart";
+import "plugin_message_mapper.dart";
 import "plugin_session_status_mapper.dart";
 
 class const SessionEventMapper() {
@@ -19,6 +20,9 @@ class const SessionEventMapper() {
     BridgeSseSessionStatus(:final sessionID, :final status) => NormalizedStatusEvent(
       sessionId: sessionID,
       status: status.toSharedSessionStatus(),
+    ),
+    BridgeSseMessageUpdated(:final info) => NormalizedMessageEvent(
+      message: info.toSharedMessage(sessionId: info.sessionID),
     ),
     _ => NormalizedOtherEvent(event: event),
   };
@@ -52,7 +56,7 @@ class const SessionEventMapper() {
       BridgeSseQueuedPromptsUpdated(:final sessionID) ||
       BridgeSseTodoUpdated(:final sessionID) => {sessionID},
       BridgeSseSessionError(:final sessionID) || BridgeSseTuiToastShow(:final sessionID) => {?sessionID},
-      BridgeSseMessageUpdated(:final info) => {Message.fromJson(info).sessionID},
+      BridgeSseMessageUpdated(:final info) => {info.sessionID},
       BridgeSseMessagePartUpdated(:final part) => {part.sessionID},
       BridgeSsePermissionAsked(:final sessionID, :final displaySessionId) ||
       BridgeSsePermissionReplied(:final sessionID, :final displaySessionId) ||
@@ -192,11 +196,9 @@ class const SessionEventMapper() {
         ),
         null => null,
       },
-      BridgeSseMessageUpdated(:final info) => switch (Message.fromJson(info)) {
-        final message => switch (mapped(message.sessionID)) {
-          final sessionId? => BridgeSseMessageUpdated(info: message.copyWith(sessionID: sessionId).toJson()),
-          null => null,
-        },
+      BridgeSseMessageUpdated(:final info) => switch (mapped(info.sessionID)) {
+        final sessionId? => BridgeSseMessageUpdated(info: info.copyWith(sessionID: sessionId)),
+        null => null,
       },
       BridgeSseMessageRemoved(:final sessionID, :final messageID) => switch (mapped(sessionID)) {
         final sessionId? => BridgeSseMessageRemoved(sessionID: sessionId, messageID: messageID),

--- a/bridge/app/lib/src/repositories/models/normalized_bridge_event.dart
+++ b/bridge/app/lib/src/repositories/models/normalized_bridge_event.dart
@@ -19,6 +19,9 @@ final class const NormalizedStatusEvent({
   required final SessionStatus status,
 }) extends NormalizedBridgePayload;
 
+/// A finalized message envelope, already carrying its bridge session id.
+final class const NormalizedMessageEvent({required final Message message}) extends NormalizedBridgePayload;
+
 /// An already id-normalized plugin event whose payload keeps its plugin shape.
 final class const NormalizedOtherEvent({required final BridgeSseEvent event}) extends NormalizedBridgePayload;
 

--- a/bridge/app/lib/src/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/sse/bridge_event_mapper.dart
@@ -62,7 +62,7 @@ class BridgeEventMapper({
             arguments: arguments,
             messageID: messageID,
           ),
-        BridgeSseMessageUpdated(:final info) => _tryParseSseEvent({"type": "message.updated", "info": info}),
+        BridgeSseMessageUpdated() => throw StateError("message updates are normalized before they reach the mapper"),
         BridgeSseMessageRemoved(:final sessionID, :final messageID) => SesoriSseEvent.messageRemoved(
           sessionID: sessionID,
           messageID: messageID,
@@ -192,7 +192,9 @@ class BridgeEventMapper({
               reason: "Failed to map SSE event",
               information: [event.runtimeType.toString()],
             )
-            .catchError((_) {}),
+            .catchError((Object reportError, StackTrace reportStackTrace) {
+              Log.w("[sse-mapper] failed to report mapping failure", reportError, reportStackTrace);
+            }),
       );
       return null;
     }
@@ -218,18 +220,26 @@ class BridgeEventMapper({
     return SesoriSseEvent.sessionStatus(sessionID: sessionId, status: status);
   }
 
+  /// Builds the public message event from the already-normalized shared message.
+  SesoriSseEvent buildMessageUpdatedEvent({required Message message}) {
+    return SesoriSseEvent.messageUpdated(info: message);
+  }
+
   /// Builds a projects summary event from already-remapped summary data
   /// (see `SessionRepository.getProjectActivitySummaries`).
   SesoriSseEvent buildProjectsSummaryEvent({required List<ProjectActivitySummary> projects}) {
     return SesoriSseEvent.projectsSummary(projects: projects);
   }
 
-  /// Attempts to parse an SSE event from a JSON payload.
+  /// Attempts to parse a session SSE event from its JSON payload.
+  ///
+  /// The payload carries the session's title and directory, so only the event
+  /// type is logged alongside the error.
   SesoriSseEvent? _tryParseSseEvent(Map<String, dynamic> payload) {
     try {
       return SesoriSseEvent.fromJson(payload);
-    } catch (e) {
-      Log.w("failed to parse SSE event from payload: $payload, error: $e");
+    } catch (e, st) {
+      Log.w("failed to parse SSE event ${payload["type"]}", e, st);
       return null;
     }
   }

--- a/bridge/app/lib/src/sse/sse_manager.dart
+++ b/bridge/app/lib/src/sse/sse_manager.dart
@@ -201,7 +201,9 @@ class SSEManager({
               reason: "Failed to send SSE event to phone",
               information: [event.runtimeType.toString(), "connID=$connID"],
             )
-            .catchError((_) {}),
+            .catchError((Object reportError, StackTrace reportStackTrace) {
+              Log.w("[sse] failed to report send failure", reportError, reportStackTrace);
+            }),
       );
     };
   }

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -276,14 +276,14 @@ void main() {
         .first;
 
     harness.plugins.single.emitEvent(
-      BridgeSseMessageUpdated(
-        info: const Message.user(
+      const BridgeSseMessageUpdated(
+        info: PluginMessage.user(
           promptId: null,
           id: "message",
           sessionID: "session",
           agent: null,
-          time: MessageTime(created: 1234, completed: null),
-        ).toJson(),
+          time: PluginMessageTime(created: 1234, completed: null),
+        ),
       ),
     );
 

--- a/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
+++ b/bridge/app/test/bridge/repositories/mappers/session_event_mapper_test.dart
@@ -16,13 +16,13 @@ void main() {
         sessionId: "backend-session",
         parentId: "backend-parent",
       );
-      final messageInfo = const Message.user(
+      const messageInfo = PluginMessage.user(
         promptId: null,
         id: "message",
         sessionID: "backend-session",
         agent: null,
         time: null,
-      ).toJson();
+      );
       const part = PluginMessagePart.text(
         id: "part",
         sessionID: "backend-session",
@@ -82,7 +82,7 @@ void main() {
         ),
         (
           name: "message updated",
-          event: BridgeSseMessageUpdated(info: messageInfo),
+          event: const BridgeSseMessageUpdated(info: messageInfo),
           expectedBackendIds: {"backend-session"},
         ),
         (

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -682,14 +682,14 @@ void main() {
           directory: "/repo",
         ),
       );
-      final message = BridgeSseMessageUpdated(
-        info: const Message.user(
+      const message = BridgeSseMessageUpdated(
+        info: PluginMessage.user(
           promptId: null,
           id: "backend-message",
           sessionID: "backend-root",
           agent: null,
           time: null,
-        ).toJson(),
+        ),
       );
       const part = BridgeSseMessagePartUpdated(
         part: PluginMessagePart.text(
@@ -739,7 +739,7 @@ void main() {
       expect(output, hasLength(5));
       expect(output.map((item) => item.generation), everyElement(1));
       expect(Session.fromJson((output[0].event as BridgeSseSessionCreated).info).id, "stable-root");
-      expect(Message.fromJson((output[1].event as BridgeSseMessageUpdated).info).sessionID, "stable-root");
+      expect((output[1].event as BridgeSseMessageUpdated).info.sessionID, "stable-root");
       expect((output[2].event as BridgeSseMessagePartUpdated).part.sessionID, "stable-root");
       expect((output[3].event as BridgeSseSessionStatus).sessionID, "stable-root");
       expect(output[4].event, isA<BridgeSseProjectUpdated>());

--- a/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
+++ b/bridge/app/test/bridge/sse/bridge_event_mapper_test.dart
@@ -73,28 +73,6 @@ void main() {
       );
     });
 
-    test("maps a system sender through the shared message update", () {
-      final result = mapEvent(
-        BridgeSseMessageUpdated(
-          info: const PluginMessage.assistant(
-            id: "m-system",
-            sessionID: "s1",
-            agent: null,
-            modelID: null,
-            providerID: null,
-            variant: null,
-            sender: PluginMessageSender.system,
-            time: null,
-          ).toJson(),
-        ),
-      );
-
-      expect(result, isA<SesoriMessageUpdated>());
-      final event = result! as SesoriMessageUpdated;
-      expect(event.info, isA<MessageAssistant>());
-      expect((event.info as MessageAssistant).sender, MessageSender.system);
-    });
-
     test("builds the public status event from the normalized shared status", () {
       const status = SessionStatus.retry(attempt: 1, message: "provider overloaded", next: 2000);
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -27,7 +27,7 @@ final class const AcpToolCallSessionFound({required final String sessionId}) ext
 /// `stopReason: end_turn` — indistinguishable from real assistant prose — so a
 /// backend that knows its own gate wording recognizes it (see
 /// [AcpEventMapper.classifyHaltNotice]) and it is surfaced as a
-/// [shared.Message.error] instead of quiet assistant text, giving the user an
+/// [PluginMessage.error] instead of quiet assistant text, giving the user an
 /// explicit "the turn did not run" signal. Classification carries no replacement
 /// message; the mapper always forwards the original backend text unchanged.
 class const AcpHaltNotice({
@@ -39,9 +39,10 @@ class const AcpHaltNotice({
 /// Translates ACP `session/update` notifications into bridge-neutral
 /// [BridgeSseEvent]s.
 ///
-/// Like the codex mapper, the `info` maps on session/message events MUST be
-/// sesori-schema JSON (parseable by `Message.fromJson` / `Session.fromJson`),
-/// so we build typed `sesori_shared` models and `.toJson()` them.
+/// Message envelopes are typed [PluginMessage] values; bridge core maps them to
+/// the shared model once. Session payloads are still sesori-schema JSON
+/// (parseable by `Session.fromJson`), so those are built as `sesori_shared`
+/// models and `.toJson()`-ed.
 ///
 /// ACP differs from codex's app-server protocol in two ways that shape this
 /// mapper:

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -281,16 +281,17 @@ class AcpEventMapper({
     required String sessionId,
     required String message,
   }) => BridgeSseMessageUpdated(
-    info: shared.Message.error(
+    info: PluginMessage.error(
       id: "${_fallbackTurnMessageId(sessionId)}-error",
       sessionID: sessionId,
       agent: pluginId,
       modelID: modelForSession(sessionId: sessionId),
       providerID: providerForSession(sessionId: sessionId),
+      variant: null,
       errorName: "ACP prompt failed",
       errorMessage: message,
       time: null,
-    ).toJson(),
+    ),
   );
 
   /// Emits complete snapshots for text and reasoning parts streamed during the
@@ -384,7 +385,7 @@ class AcpEventMapper({
     if (mutations.isEmpty) return const [];
     return [
       BridgeSseMessageUpdated(
-        info: _messageFor(_ChunkRole.user, messageId, sessionId, promptId: promptId, time: time).toJson(),
+        info: _messageFor(_ChunkRole.user, messageId, sessionId, promptId: promptId, time: time),
       ),
       for (final mutation in mutations)
         BridgeSseMessagePartUpdated(
@@ -777,7 +778,7 @@ class AcpEventMapper({
     if (started.add(identity.messageId)) {
       events.add(
         BridgeSseMessageUpdated(
-          info: _messageFor(_ChunkRole.assistant, identity.messageId, sessionId, promptId: null, time: time).toJson(),
+          info: _messageFor(_ChunkRole.assistant, identity.messageId, sessionId, promptId: null, time: time),
         ),
       );
     }
@@ -874,7 +875,7 @@ class AcpEventMapper({
     if (started.add(partId)) {
       if (started.add(messageId)) {
         events.add(
-          BridgeSseMessageUpdated(info: _messageFor(role, messageId, sessionId, promptId: null, time: time).toJson()),
+          BridgeSseMessageUpdated(info: _messageFor(role, messageId, sessionId, promptId: null, time: time)),
         );
       }
       events.add(
@@ -970,16 +971,17 @@ class AcpEventMapper({
     _closeCurrentIdlessAssistantContent(sessionId: sessionId);
     return [
       BridgeSseMessageUpdated(
-        info: shared.Message.error(
+        info: PluginMessage.error(
           id: messageId,
           sessionID: sessionId,
           agent: pluginId,
           modelID: modelForSession(sessionId: sessionId),
           providerID: providerForSession(sessionId: sessionId),
+          variant: null,
           errorName: notice.errorName,
           errorMessage: message,
-          time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
-        ).toJson(),
+          time: time,
+        ),
       ),
     ];
   }
@@ -1154,15 +1156,16 @@ class AcpEventMapper({
     required PluginMessageTime? time,
   }) {
     return BridgeSseMessageUpdated(
-      info: shared.Message.assistant(
+      info: PluginMessage.assistant(
         id: messageId,
         sessionID: sessionId,
         agent: pluginId,
         modelID: modelForSession(sessionId: sessionId),
         providerID: providerForSession(sessionId: sessionId),
-        sender: shared.MessageSender.agent,
-        time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
-      ).toJson(),
+        variant: null,
+        sender: PluginMessageSender.agent,
+        time: time,
+      ),
     );
   }
 
@@ -1195,7 +1198,7 @@ class AcpEventMapper({
     );
   }
 
-  shared.Message _messageFor(
+  PluginMessage _messageFor(
     _ChunkRole role,
     String messageId,
     String sessionId, {
@@ -1203,21 +1206,22 @@ class AcpEventMapper({
     required PluginMessageTime? time,
   }) {
     return switch (role) {
-      _ChunkRole.user => shared.Message.user(
+      _ChunkRole.user => PluginMessage.user(
         id: messageId,
         sessionID: sessionId,
         agent: null,
-        time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
+        time: time,
         promptId: promptId,
       ),
-      _ChunkRole.assistant => shared.Message.assistant(
+      _ChunkRole.assistant => PluginMessage.assistant(
         id: messageId,
         sessionID: sessionId,
         agent: pluginId,
         modelID: modelForSession(sessionId: sessionId),
         providerID: providerForSession(sessionId: sessionId),
-        sender: shared.MessageSender.agent,
-        time: time == null ? null : shared.MessageTime(created: time.created, completed: time.completed),
+        variant: null,
+        sender: PluginMessageSender.agent,
+        time: time,
       ),
     };
   }

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -49,8 +49,8 @@ void main() {
       );
 
       final updated = events.whereType<BridgeSseMessageUpdated>().single;
-      final message = shared.Message.fromJson(updated.info);
-      expect(message, isA<shared.MessageAssistant>());
+      final message = updated.info;
+      expect(message, isA<PluginMessageAssistant>());
 
       expect(events.whereType<BridgeSseMessagePartUpdated>(), hasLength(1));
       final delta = events.whereType<BridgeSseMessagePartDelta>().single;
@@ -70,7 +70,7 @@ void main() {
             "content": {"type": "text", "text": "reply"},
           }),
         );
-        return shared.Message.fromJson(events.whereType<BridgeSseMessageUpdated>().single.info).id;
+        return events.whereType<BridgeSseMessageUpdated>().single.info.id;
       }
 
       final beforeRestart = assistantId(target: mapper, promptId: "prompt-one");
@@ -424,10 +424,8 @@ void main() {
         ],
       );
 
-      final message = shared.Message.fromJson(
-        events.whereType<BridgeSseMessageUpdated>().single.info,
-      );
-      expect(message, isA<shared.MessageUser>());
+      final message = events.whereType<BridgeSseMessageUpdated>().single.info;
+      expect(message, isA<PluginMessageUser>());
       expect(
         events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.text),
         ["Hello", "Cursor"],
@@ -476,9 +474,7 @@ void main() {
         ],
       );
 
-      final message = shared.Message.fromJson(
-        events.whereType<BridgeSseMessageUpdated>().single.info,
-      );
+      final message = events.whereType<BridgeSseMessageUpdated>().single.info;
       final parts = events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part).toList();
       expect(message.id, "s1-initial-user");
       expect(parts.map((part) => part.id), ["s1-initial-user-text", "s1-initial-user-image-1"]);
@@ -535,12 +531,8 @@ void main() {
         }),
       );
 
-      final beforeId = shared.Message.fromJson(
-        beforeTool.whereType<BridgeSseMessageUpdated>().single.info,
-      ).id;
-      final afterId = shared.Message.fromJson(
-        afterTool.whereType<BridgeSseMessageUpdated>().single.info,
-      ).id;
+      final beforeId = beforeTool.whereType<BridgeSseMessageUpdated>().single.info.id;
+      final afterId = afterTool.whereType<BridgeSseMessageUpdated>().single.info.id;
       expect(afterId, isNot(beforeId));
       expect(
         afterTool.whereType<BridgeSseMessagePartDelta>().single.delta,
@@ -575,12 +567,8 @@ void main() {
         }),
       );
 
-      final beforeId = shared.Message.fromJson(
-        before.whereType<BridgeSseMessageUpdated>().single.info,
-      ).id;
-      final afterId = shared.Message.fromJson(
-        after.whereType<BridgeSseMessageUpdated>().single.info,
-      ).id;
+      final beforeId = before.whereType<BridgeSseMessageUpdated>().single.info.id;
+      final afterId = after.whereType<BridgeSseMessageUpdated>().single.info.id;
       expect(afterId, isNot(beforeId));
       expect(after.whereType<BridgeSseMessagePartUpdated>().single.part.type, PluginMessagePartType.file);
     });
@@ -596,7 +584,7 @@ void main() {
         }),
       );
       final updated = events.whereType<BridgeSseMessageUpdated>().single;
-      expect(shared.Message.fromJson(updated.info), isA<shared.MessageAssistant>());
+      expect(updated.info, isA<PluginMessageAssistant>());
       final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(part.type, PluginMessagePartType.tool);
       expect(part.tool, "read");
@@ -753,7 +741,7 @@ void main() {
         }, 20),
       );
       expect(
-        (updateEvents.whereType<BridgeSseMessageUpdated>().single.info["time"] as Map)["created"],
+        updateEvents.whereType<BridgeSseMessageUpdated>().single.info.time?.created,
         20,
       );
 
@@ -765,7 +753,7 @@ void main() {
         }, 10),
       );
       expect(
-        (callEvents.whereType<BridgeSseMessageUpdated>().single.info["time"] as Map)["created"],
+        callEvents.whereType<BridgeSseMessageUpdated>().single.info.time?.created,
         10,
       );
     });
@@ -965,7 +953,7 @@ void main() {
         }),
       );
       final firstEnvelope = first.whereType<BridgeSseMessageUpdated>().single;
-      final firstId = shared.Message.fromJson(firstEnvelope.info).id;
+      final firstId = firstEnvelope.info.id;
 
       // Same id, same role → same message, delta only.
       final more = mapper.map(
@@ -987,7 +975,7 @@ void main() {
         }),
       );
       final secondEnvelope = second.whereType<BridgeSseMessageUpdated>().single;
-      final secondId = shared.Message.fromJson(secondEnvelope.info).id;
+      final secondId = secondEnvelope.info.id;
       expect(secondId, isNot(firstId));
 
       // A later chunk for the FIRST message merges back into it (no envelope,
@@ -1290,8 +1278,7 @@ void main() {
           "content": {"type": "text", "text": "hi"},
         }),
       );
-      final message =
-          shared.Message.fromJson(events.whereType<BridgeSseMessageUpdated>().single.info) as shared.MessageAssistant;
+      final message = events.whereType<BridgeSseMessageUpdated>().single.info as PluginMessageAssistant;
       expect(message.modelID, "claude-opus-4-8");
       expect(message.providerID, "cursor");
     });
@@ -1329,11 +1316,9 @@ void main() {
         }),
       );
 
-      final message = shared.Message.fromJson(
-        events.whereType<BridgeSseMessageUpdated>().single.info,
-      );
-      expect(message, isA<shared.MessageError>());
-      expect((message as shared.MessageError).errorMessage, "\n\nHALT: fix it");
+      final message = events.whereType<BridgeSseMessageUpdated>().single.info;
+      expect(message, isA<PluginMessageError>());
+      expect((message as PluginMessageError).errorMessage, "\n\nHALT: fix it");
       // No assistant text part or delta — the notice rides in the error message.
       expect(events.whereType<BridgeSseMessagePartUpdated>(), isEmpty);
       expect(events.whereType<BridgeSseMessagePartDelta>(), isEmpty);
@@ -1383,8 +1368,8 @@ void main() {
       );
 
       expect(
-        shared.Message.fromJson(halt.whereType<BridgeSseMessageUpdated>().single.info),
-        isA<shared.MessageError>(),
+        halt.whereType<BridgeSseMessageUpdated>().single.info,
+        isA<PluginMessageError>(),
       );
     });
 
@@ -1409,15 +1394,11 @@ void main() {
         }),
       );
 
-      final beforeId = shared.Message.fromJson(
-        before.whereType<BridgeSseMessageUpdated>().single.info,
-      ).id;
+      final beforeId = before.whereType<BridgeSseMessageUpdated>().single.info.id;
       // The halt abandons the pre-halt envelope, so the post-halt chunk must
       // open a new one (its own envelope + a different message id), not append a
       // delta to the abandoned envelope.
-      final afterId = shared.Message.fromJson(
-        after.whereType<BridgeSseMessageUpdated>().single.info,
-      ).id;
+      final afterId = after.whereType<BridgeSseMessageUpdated>().single.info.id;
       expect(afterId, isNot(beforeId));
       expect(after.whereType<BridgeSseMessagePartDelta>().single.delta, "After");
     });
@@ -1453,10 +1434,8 @@ void main() {
         }),
       );
 
-      final message = shared.Message.fromJson(
-        events.whereType<BridgeSseMessageUpdated>().single.info,
-      );
-      expect(message, isA<shared.MessageAssistant>());
+      final message = events.whereType<BridgeSseMessageUpdated>().single.info;
+      expect(message, isA<PluginMessageAssistant>());
       expect(events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.type), [
         PluginMessagePartType.file,
         PluginMessagePartType.text,
@@ -1486,8 +1465,8 @@ void main() {
       );
 
       expect(
-        shared.Message.fromJson(text.whereType<BridgeSseMessageUpdated>().single.info),
-        isA<shared.MessageAssistant>(),
+        text.whereType<BridgeSseMessageUpdated>().single.info,
+        isA<PluginMessageAssistant>(),
       );
       expect(text.whereType<BridgeSseMessagePartDelta>().single.delta, "HALT: fix it");
       expect(image.whereType<BridgeSseMessageUpdated>(), isEmpty);
@@ -1502,10 +1481,8 @@ void main() {
           "content": {"type": "text", "text": "real answer"},
         }),
       );
-      final message = shared.Message.fromJson(
-        events.whereType<BridgeSseMessageUpdated>().single.info,
-      );
-      expect(message, isA<shared.MessageAssistant>());
+      final message = events.whereType<BridgeSseMessageUpdated>().single.info;
+      expect(message, isA<PluginMessageAssistant>());
       expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "real answer");
     });
   });

--- a/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_history_replay_test.dart
@@ -406,7 +406,7 @@ void main() {
       });
 
       final replayed = (await loading).single;
-      expect(replayed.info.id, liveMessage.info["id"]);
+      expect(replayed.info.id, liveMessage.info.id);
       expect(replayed.parts.single.id, livePart.id);
       expect(replayed.parts.single.messageID, replayed.info.id);
     });

--- a/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_plugin_projects_test.dart
@@ -478,9 +478,9 @@ void main() {
       await pump();
 
       final inlineError = events.whereType<BridgeSseMessageUpdated>().singleWhere(
-        (event) => event.info["role"] == "error",
+        (event) => event.info is PluginMessageError,
       );
-      expect(inlineError.info["errorMessage"], "Agent is already processing.");
+      expect((inlineError.info as PluginMessageError).errorMessage, "Agent is already processing.");
       expect(
         events.whereType<BridgeSseSessionError>(),
         isNotEmpty,

--- a/bridge/sesori_plugin_acp/test/acp_session_options_service_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_options_service_test.dart
@@ -1,6 +1,5 @@
 import "package:acp_plugin/acp_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
 
 void main() {
@@ -21,12 +20,8 @@ void main() {
 
     final defaultEvents = mapper.map(_messageUpdate(sessionId: "other"));
     final overrideEvents = mapper.map(_messageUpdate(sessionId: "session"));
-    final defaultMessage = shared.Message.fromJson(
-      defaultEvents.whereType<BridgeSseMessageUpdated>().single.info,
-    ) as shared.MessageAssistant;
-    final overrideMessage = shared.Message.fromJson(
-      overrideEvents.whereType<BridgeSseMessageUpdated>().single.info,
-    ) as shared.MessageAssistant;
+    final defaultMessage = defaultEvents.whereType<BridgeSseMessageUpdated>().single.info as PluginMessageAssistant;
+    final overrideMessage = overrideEvents.whereType<BridgeSseMessageUpdated>().single.info as PluginMessageAssistant;
 
     expect((defaultMessage.modelID, defaultMessage.providerID), ("default-model", "provider"));
     expect((overrideMessage.modelID, overrideMessage.providerID), ("session-model", "session-provider"));

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -274,9 +274,15 @@ void main() {
       expect(
         emitted
             .whereType<BridgeSseMessageUpdated>()
-            .where((event) => event.info["promptId"] == firstId)
+            .where(
+              (event) => switch (event.info) {
+                PluginMessageUser(promptId: final id) => id == firstId,
+                _ => false,
+              },
+            )
             .single
-            .info["id"],
+            .info
+            .id,
         "$firstId-user",
       );
       respondTo(first, {"stopReason": "end_turn"});
@@ -291,8 +297,8 @@ void main() {
       final prompt = await waitForFrame("session/prompt");
 
       final message = emitted.whereType<BridgeSseMessageUpdated>().single;
-      expect(message.info["role"], "user");
-      expect(message.info["promptId"], promptId);
+      expect(message.info, isA<PluginMessageUser>());
+      expect((message.info as PluginMessageUser).promptId, promptId);
       expect(
         emitted.whereType<BridgeSseMessagePartUpdated>().single.part.text,
         "visible on dispatch",
@@ -317,7 +323,12 @@ void main() {
 
       expect((await plugin.getQueuedPrompts(sessionId: sessionId)).single.id, promptId);
       expect(
-        emitted.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == promptId),
+        emitted.whereType<BridgeSseMessageUpdated>().where(
+          (event) => switch (event.info) {
+            PluginMessageUser(promptId: final id) => id == promptId,
+            _ => false,
+          },
+        ),
         isEmpty,
       );
       expect(
@@ -335,9 +346,14 @@ void main() {
       expect(
         emitted
             .whereType<BridgeSseMessageUpdated>()
-            .singleWhere((event) => event.info["promptId"] == promptId)
-            .info["promptId"],
-        promptId,
+            .singleWhere(
+              (event) => switch (event.info) {
+                PluginMessageUser(promptId: final id) => id == promptId,
+                _ => false,
+              },
+            )
+            .info,
+        isA<PluginMessageUser>().having((info) => info.promptId, "promptId", promptId),
       );
       respondTo(prompt, {"stopReason": "end_turn"});
     });
@@ -371,9 +387,9 @@ void main() {
       }
 
       final messages = emitted.whereType<BridgeSseMessageUpdated>().toList();
-      expect(messages.map((event) => event.info["role"]), ["user", "assistant"]);
-      expect(messages.first.info["promptId"], promptId);
-      expect(messages.last.info["id"], "$promptId-user-assistant-a0");
+      expect(messages.map((event) => event.info.runtimeType), [PluginMessageUser, PluginMessageAssistant]);
+      expect((messages.first.info as PluginMessageUser).promptId, promptId);
+      expect(messages.last.info.id, "$promptId-user-assistant-a0");
 
       respondTo(prompt, {"stopReason": "end_turn"});
     });
@@ -423,7 +439,7 @@ void main() {
         await pump();
       }
 
-      final user = emitted.whereType<BridgeSseMessageUpdated>().singleWhere((event) => event.info["role"] == "user");
+      final user = emitted.whereType<BridgeSseMessageUpdated>().singleWhere((event) => event.info is PluginMessageUser);
       final tool = emitted.whereType<BridgeSseMessagePartUpdated>().singleWhere(
         (event) => event.part.type == PluginMessagePartType.tool,
       );
@@ -528,7 +544,7 @@ void main() {
       }
 
       final userIndex = emitted.indexWhere(
-        (event) => event is BridgeSseMessageUpdated && event.info["role"] == "user",
+        (event) => event is BridgeSseMessageUpdated && event.info is PluginMessageUser,
       );
       final childIndex = emitted.indexWhere(
         (event) => event is BridgeSseSessionCreated && event.info["id"] == "child",
@@ -717,9 +733,12 @@ void main() {
       await pump();
 
       final secondMessage = emitted.whereType<BridgeSseMessageUpdated>().singleWhere(
-        (event) => event.info["promptId"] == secondPromptId,
+        (event) => switch (event.info) {
+          PluginMessageUser(promptId: final id) => id == secondPromptId,
+          _ => false,
+        },
       );
-      expect((secondMessage.info["time"] as Map)["created"], greaterThan(queuedAt));
+      expect(secondMessage.info.time?.created, greaterThan(queuedAt));
 
       expect(firstPromptId, isNot(secondPromptId));
       respondTo(second, {"stopReason": "end_turn"});
@@ -740,7 +759,12 @@ void main() {
 
       expect(await plugin.getQueuedPrompts(sessionId: sessionId), isEmpty);
       expect(
-        emitted.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == promptId),
+        emitted.whereType<BridgeSseMessageUpdated>().where(
+          (event) => switch (event.info) {
+            PluginMessageUser(promptId: final id) => id == promptId,
+            _ => false,
+          },
+        ),
         isEmpty,
       );
       expect(emitted.whereType<BridgeSseSessionError>(), hasLength(1));
@@ -771,7 +795,7 @@ void main() {
       final created = emitted.whereType<BridgeSseSessionCreated>().single;
       expect(created.info["id"], "s1");
       final message = emitted.whereType<BridgeSseMessageUpdated>().single;
-      expect(message.info["role"], "user");
+      expect(message.info, isA<PluginMessageUser>());
       final part = emitted.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(part.text, "visible prompt");
       expect(part.text, isNot(contains("SYSTEM CONTEXT")));
@@ -859,7 +883,7 @@ void main() {
       await pump();
 
       final message = emitted.whereType<BridgeSseMessageUpdated>().single;
-      expect(message.info["role"], "user");
+      expect(message.info, isA<PluginMessageUser>());
       final part = emitted.whereType<BridgeSseMessagePartUpdated>().single.part;
       expect(part.text, "/review user arguments");
       expect(part.text, isNot(contains("SYSTEM CONTEXT")));
@@ -972,7 +996,12 @@ void main() {
       );
       expect((await plugin.getQueuedPrompts(sessionId: sessionId)).single.id, secondPromptId);
       expect(
-        emitted.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == secondPromptId),
+        emitted.whereType<BridgeSseMessageUpdated>().where(
+          (event) => switch (event.info) {
+            PluginMessageUser(promptId: final id) => id == secondPromptId,
+            _ => false,
+          },
+        ),
         isEmpty,
         reason: "an adapter-owned prompt must remain queued, not sent",
       );
@@ -987,9 +1016,14 @@ void main() {
       expect(
         emitted
             .whereType<BridgeSseMessageUpdated>()
-            .singleWhere((event) => event.info["promptId"] == secondPromptId)
-            .info["promptId"],
-        secondPromptId,
+            .singleWhere(
+              (event) => switch (event.info) {
+                PluginMessageUser(promptId: final id) => id == secondPromptId,
+                _ => false,
+              },
+            )
+            .info,
+        isA<PluginMessageUser>().having((info) => info.promptId, "promptId", secondPromptId),
       );
       expect(
         idleCount(),
@@ -1030,7 +1064,12 @@ void main() {
       }
       expect(frames("session/prompt"), hasLength(1));
       expect(
-        emitted.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == queuedPromptId),
+        emitted.whereType<BridgeSseMessageUpdated>().where(
+          (event) => switch (event.info) {
+            PluginMessageUser(promptId: final id) => id == queuedPromptId,
+            _ => false,
+          },
+        ),
         isEmpty,
       );
     });
@@ -1297,7 +1336,12 @@ void main() {
       expect(await plugin.getSessionStatuses(), isEmpty);
       expect(emitted.whereType<BridgeSseSessionIdle>(), isEmpty);
       expect(
-        emitted.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == promptId),
+        emitted.whereType<BridgeSseMessageUpdated>().where(
+          (event) => switch (event.info) {
+            PluginMessageUser(promptId: final id) => id == promptId,
+            _ => false,
+          },
+        ),
         isEmpty,
       );
       expect(emitted.whereType<BridgeSseQueuedPromptsUpdated>(), hasLength(queueUpdateCount));

--- a/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_event_dispatcher.dart
@@ -377,7 +377,7 @@ final class ClaudeEventDispatcher({
             errorName: error.name,
             errorMessage: error.message,
             time: _messageTime(message.timestamp),
-          ).toJson(),
+          ),
         ),
       ];
     }
@@ -403,7 +403,7 @@ final class ClaudeEventDispatcher({
           sessionId: sessionId,
           messageId: messageId,
           time: _messageTime(message.timestamp),
-        ).toJson(),
+        ),
       ),
     ];
     for (var offset = 0; offset < mapped.length; offset++) {
@@ -485,7 +485,7 @@ final class ClaudeEventDispatcher({
           agent: null,
           time: _messageTime(message.timestamp),
           promptId: promptId,
-        ).toJson(),
+        ),
       ),
       for (final part in parts) BridgeSseMessagePartUpdated(part: part),
     ];
@@ -581,7 +581,7 @@ final class ClaudeEventDispatcher({
           errorName: error.name,
           errorMessage: error.message,
           time: null,
-        ).toJson(),
+        ),
       ),
     ];
   }
@@ -606,7 +606,7 @@ final class ClaudeEventDispatcher({
     _announcedMessageIds[sessionId] = messageId;
     return [
       BridgeSseMessageUpdated(
-        info: _assistantMessage(sessionId: sessionId, messageId: messageId).toJson(),
+        info: _assistantMessage(sessionId: sessionId, messageId: messageId),
       ),
     ];
   }

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -708,7 +708,7 @@ final class ClaudePlugin({
           agent: null,
           time: PluginMessageTime(created: now, completed: now),
           promptId: promptId,
-        ).toJson(),
+        ),
       ),
     );
     _eventBuffer.add(

--- a/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_event_dispatcher_test.dart
@@ -1,6 +1,5 @@
 import "package:claude_plugin/claude_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
 
 void main() {
@@ -21,7 +20,7 @@ void main() {
         tools: ClaudeToolTracker(),
         catalogModelId: ({required apiModel}) => apiModel == "claude-opus-5" ? "opus[1m]" : null,
       );
-      Map<String, Object?> assistantAfterText({required String messageId}) {
+      PluginMessage assistantAfterText({required String messageId}) {
         _map(
           mapper,
           _stream(
@@ -45,14 +44,14 @@ void main() {
       }
 
       mapper.beginTurn(sessionId: "session-1", directory: "/tmp/project", model: "fable", variant: "high");
-      final selected = assistantAfterText(messageId: "msg-1");
-      expect(selected["modelID"], "fable");
-      expect(selected["variant"], "high");
+      final selected = assistantAfterText(messageId: "msg-1") as PluginMessageAssistant;
+      expect(selected.modelID, "fable");
+      expect(selected.variant, "high");
 
       mapper.beginTurn(sessionId: "session-1", directory: "/tmp/project", model: null, variant: null);
-      final mapped = assistantAfterText(messageId: "msg-2");
-      expect(mapped["modelID"], "opus[1m]");
-      expect(mapped["variant"], isNull);
+      final mapped = assistantAfterText(messageId: "msg-2") as PluginMessageAssistant;
+      expect(mapped.modelID, "opus[1m]");
+      expect(mapped.variant, isNull);
     });
 
     test("creates an assistant when its first visible block starts", () {
@@ -97,9 +96,9 @@ void main() {
       );
 
       expect(started, isEmpty);
-      final info = shared.Message.fromJson((textStart.first as BridgeSseMessageUpdated).info);
-      expect(info, isA<shared.MessageAssistant>());
-      final assistant = info as shared.MessageAssistant;
+      final info = (textStart.first as BridgeSseMessageUpdated).info;
+      expect(info, isA<PluginMessageAssistant>());
+      final assistant = info as PluginMessageAssistant;
       expect(assistant.id, "msg-1");
       expect(assistant.agent, "claude");
       expect(assistant.modelID, "claude-opus-5");
@@ -393,7 +392,7 @@ void main() {
 
       expect(assistant, isEmpty);
       expect(user, isEmpty);
-      expect((shared.Message.fromJson(error.info) as shared.MessageError).modelID, "claude-opus-5");
+      expect((error.info as PluginMessageError).modelID, "claude-opus-5");
     });
 
     test("keeps a prompt that merely mentions internal command markers", () {
@@ -407,7 +406,7 @@ void main() {
         ),
       );
 
-      expect((mentioned.first as BridgeSseMessageUpdated).info["id"], "user-mention");
+      expect((mentioned.first as BridgeSseMessageUpdated).info.id, "user-mention");
       expect(
         (mentioned.last as BridgeSseMessagePartUpdated).part.text,
         "What does <command-name> mean in <local-command-stdout> output?",
@@ -580,7 +579,7 @@ void main() {
         ),
       );
 
-      final user = shared.Message.fromJson((visible.first as BridgeSseMessageUpdated).info) as shared.MessageUser;
+      final user = (visible.first as BridgeSseMessageUpdated).info as PluginMessageUser;
       expect(user.id, "user-frame");
       expect(user.time?.created, DateTime.utc(2026, 8, 10, 10).millisecondsSinceEpoch);
       expect((visible.last as BridgeSseMessagePartUpdated).part.id, "user-frame-block-0");
@@ -608,7 +607,7 @@ void main() {
         ),
       );
 
-      expect((replayed.first as BridgeSseMessageUpdated).info["id"], "replay-frame");
+      expect((replayed.first as BridgeSseMessageUpdated).info.id, "replay-frame");
       expect((replayed.last as BridgeSseMessagePartUpdated).part.text, "authored follow-up");
       expect(contextOnly, isEmpty);
     });
@@ -647,9 +646,9 @@ void main() {
         },
       );
 
-      final info = shared.Message.fromJson((assistantEvents.single as BridgeSseMessageUpdated).info);
-      expect(info, isA<shared.MessageError>());
-      final error = info as shared.MessageError;
+      final info = (assistantEvents.single as BridgeSseMessageUpdated).info;
+      expect(info, isA<PluginMessageError>());
+      final error = info as PluginMessageError;
       expect(error.id, "synthetic-error-message");
       expect(error.errorName, "api_error");
       expect(error.errorMessage, "You've hit your session limit");
@@ -697,7 +696,7 @@ void main() {
                 },
               ).single
               as BridgeSseMessageUpdated;
-      final info = shared.Message.fromJson(error.info) as shared.MessageError;
+      final info = error.info as PluginMessageError;
       expect(info.errorName, "api_error");
       expect(info.errorMessage, "  raw backend detail must be forwarded  ");
       expect(info.modelID, "claude-opus-5");
@@ -717,7 +716,7 @@ void main() {
                 },
               ).single
               as BridgeSseMessageUpdated;
-      final multipleInfo = shared.Message.fromJson(multipleErrors.info) as shared.MessageError;
+      final multipleInfo = multipleErrors.info as PluginMessageError;
       expect(multipleInfo.errorMessage, "first backend error\nsecond backend error");
     });
 
@@ -748,9 +747,7 @@ void main() {
         ),
         ..._map(mapper, _user(uuid: "result-frame", content: resultContent)),
       ];
-      final liveInfo = shared.Message.fromJson(
-        liveEvents.whereType<BridgeSseMessageUpdated>().last.info,
-      );
+      final liveInfo = liveEvents.whereType<BridgeSseMessageUpdated>().last.info;
       final liveParts = <String, PluginMessagePart>{
         for (final event in liveEvents.whereType<BridgeSseMessagePartUpdated>()) event.part.id: event.part,
       };

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -136,9 +136,9 @@ void main() {
       expect(visibleParts.single.part.text, "visible prompt");
       expect(visibleParts.single.part.messageID, "replay-user-1");
       final user = events.whereType<BridgeSseMessageUpdated>().where(
-        (event) => event.info["role"] == "user",
+        (event) => event.info is PluginMessageUser,
       );
-      expect(user.single.info["id"], "replay-user-1");
+      expect(user.single.info.id, "replay-user-1");
       await subscription.cancel();
     });
 
@@ -316,7 +316,7 @@ void main() {
       );
       expect(visible.single.part.messageID, "replay-user-2");
       final message = events.whereType<BridgeSseMessageUpdated>().where(
-        (event) => event.info["id"] == "replay-user-2" && event.info["role"] == "user",
+        (event) => event.info.id == "replay-user-2" && event.info is PluginMessageUser,
       );
       expect(message, hasLength(1));
       await subscription.cancel();
@@ -350,9 +350,9 @@ void main() {
       await pump();
 
       final user = events.whereType<BridgeSseMessageUpdated>().singleWhere(
-        (event) => event.info["id"] == "echo-image",
+        (event) => event.info.id == "echo-image",
       );
-      expect(user.info["promptId"], "prm_image");
+      expect((user.info as PluginMessageUser).promptId, "prm_image");
       expect(
         events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.type),
         containsAll([
@@ -399,10 +399,10 @@ void main() {
       await pump();
 
       final messageIndex = events.indexWhere(
-        (event) => event is BridgeSseMessageUpdated && event.info["id"] == "replay-steer",
+        (event) => event is BridgeSseMessageUpdated && event.info.id == "replay-steer",
       );
       final message = events[messageIndex] as BridgeSseMessageUpdated;
-      expect(message.info["promptId"], "prm_steer");
+      expect((message.info as PluginMessageUser).promptId, "prm_steer");
       final emptyQueueIndex = events.indexWhere(
         (event) => event is BridgeSseQueuedPromptsUpdated && event.prompts.isEmpty,
       );
@@ -443,7 +443,12 @@ void main() {
 
       final messageIndex = events.indexWhere(
         (event) =>
-            event is BridgeSseMessageUpdated && event.info["role"] == "user" && event.info["promptId"] == "prm_cmd",
+            event is BridgeSseMessageUpdated &&
+            event.info is PluginMessageUser &&
+            switch (event.info) {
+              PluginMessageUser(promptId: final id) => id == "prm_cmd",
+              _ => false,
+            },
       );
       expect(messageIndex, greaterThanOrEqualTo(0));
       final emptyQueueIndex = events.indexWhere(
@@ -483,7 +488,12 @@ void main() {
       await pump();
 
       expect(
-        events.whereType<BridgeSseMessageUpdated>().where((event) => event.info["promptId"] == "prm_unmappable"),
+        events.whereType<BridgeSseMessageUpdated>().where(
+          (event) => switch (event.info) {
+            PluginMessageUser(promptId: final id) => id == "prm_unmappable",
+            _ => false,
+          },
+        ),
         isEmpty,
       );
       final queued = await harness.plugin.getQueuedPrompts(sessionId: testSessionId);
@@ -520,9 +530,9 @@ void main() {
 
       // A buffered frame delivered while abort clears the queue must not
       // inherit the aborted turn's identity.
-      final lateEchoes = events.whereType<BridgeSseMessageUpdated>().where((event) => event.info["id"] == "late-echo");
+      final lateEchoes = events.whereType<BridgeSseMessageUpdated>().where((event) => event.info.id == "late-echo");
       expect(lateEchoes, hasLength(1));
-      expect(lateEchoes.single.info["promptId"], isNull);
+      expect((lateEchoes.single.info as PluginMessageUser).promptId, isNull);
       await subscription.cancel();
     });
 
@@ -721,7 +731,7 @@ void main() {
       await pump();
 
       final errorEvent = events.whereType<BridgeSseMessageUpdated>().last;
-      final error = shared.Message.fromJson(errorEvent.info) as shared.MessageError;
+      final error = errorEvent.info as PluginMessageError;
       expect(error.errorName, "api_error");
       expect(error.errorMessage, "Claude Code could not complete the API request (HTTP 500).");
       expect(
@@ -809,7 +819,7 @@ void main() {
 
       final errors = events
           .whereType<BridgeSseMessageUpdated>()
-          .map((event) => shared.Message.fromJson(event.info))
+          .map((event) => event.info)
           .whereType<shared.MessageError>();
       expect(errors, isEmpty);
       await subscription.cancel();

--- a/bridge/sesori_plugin_claude/test/claude_subagent_child_sessions_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_subagent_child_sessions_test.dart
@@ -4,7 +4,6 @@ import "dart:io";
 import "package:claude_plugin/claude_plugin.dart";
 import "package:path/path.dart" as p;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
 
 const _root = "11111111-2222-4333-8444-555555555555";
@@ -177,7 +176,7 @@ void main() {
 
       expect(early, isEmpty, reason: "no child session exists before the sub-agent id is known");
       expect(routed.map((event) => event.runtimeType), [BridgeSseMessageUpdated, BridgeSseMessagePartUpdated]);
-      expect(shared.Message.fromJson((routed[0] as BridgeSseMessageUpdated).info).sessionID, _child);
+      expect((routed[0] as BridgeSseMessageUpdated).info.sessionID, _child);
       final part = (routed[1] as BridgeSseMessagePartUpdated).part;
       expect(part.sessionID, _child);
       expect(part.text, "hi");

--- a/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart
@@ -67,7 +67,7 @@ class CodexEventMapper({
   /// Live app-server updates carry item lifecycle timestamps separately from
   /// the item itself. Retain them so completion and canonical tool upserts do
   /// not replace a timestamped message envelope with an undated one.
-  final Map<({String threadId, String itemId}), shared.MessageTime> _itemTimes = {};
+  final Map<({String threadId, String itemId}), PluginMessageTime> _itemTimes = {};
 
   /// Records the model codex resolved for [threadId] so subsequent
   /// live-streamed assistant messages are stamped with the model actually in
@@ -222,7 +222,7 @@ class CodexEventMapper({
             timestampSeconds: turn?["completedAt"],
           ),
           if (_turnErrorMessage(threadId: threadId, turn: turn) case final errorMessage?)
-            BridgeSseMessageUpdated(info: errorMessage.toJson()),
+            BridgeSseMessageUpdated(info: errorMessage),
           BridgeSseSessionIdle(sessionID: threadId),
         ];
 
@@ -328,7 +328,7 @@ class CodexEventMapper({
       errorName: "CodexError",
       errorMessage: message,
       time: _rolloutMessageTime(timestamp),
-    ).toJson(),
+    ),
   );
 
   /// Renders a complete repository-owned canonical tool upsert.
@@ -342,7 +342,7 @@ class CodexEventMapper({
     title: tool.title,
     status: tool.status,
     output: tool.output,
-    time: _sharedMessageTime(tool.time),
+    time: tool.time,
     attachments: tool.attachments,
   );
 
@@ -474,11 +474,11 @@ class CodexEventMapper({
         return _userMessageEvents(
           threadId: threadId,
           itemId: itemId,
-          message: shared.Message.user(
+          message: PluginMessage.user(
             id: itemId,
             sessionID: threadId,
             agent: null,
-            time: time == null ? null : shared.MessageTime(created: time.created, completed: null),
+            time: time == null ? null : PluginMessageTime(created: time.created, completed: null),
             // Codex echoes the id the bridge sent with turn/start, so an
             // item caused by a bridge send names its prompt; one typed in the
             // Codex CLI carries none.
@@ -580,7 +580,7 @@ class CodexEventMapper({
     required String itemId,
     required String tool,
     required PluginToolStatus status,
-    required shared.MessageTime? time,
+    required PluginMessageTime? time,
     required List<PluginMessageAttachment> attachments,
     String? title,
     String? output,
@@ -588,7 +588,7 @@ class CodexEventMapper({
   }) {
     return [
       BridgeSseMessageUpdated(
-        info: _assistantMessage(itemId: itemId, threadId: threadId, time: time).toJson(),
+        info: _assistantMessage(itemId: itemId, threadId: threadId, time: time),
       ),
       BridgeSseMessagePartUpdated(
         part: PluginMessagePart.tool(
@@ -712,23 +712,24 @@ class CodexEventMapper({
   /// responses), falling back to the global config model when unknown. Provider
   /// comes from the thread's `thread/started.modelProvider`. The persisted
   /// rollout path is authoritative on re-fetch.
-  shared.Message _assistantMessage({
+  PluginMessage _assistantMessage({
     required String itemId,
     required String threadId,
-    required shared.MessageTime? time,
+    required PluginMessageTime? time,
   }) {
-    return shared.Message.assistant(
+    return PluginMessage.assistant(
       id: itemId,
       sessionID: threadId,
       agent: "codex",
       modelID: _threadModel[threadId] ?? config.model,
       providerID: _threadProvider[threadId] ?? config.modelProvider ?? "openai",
-      sender: shared.MessageSender.agent,
+      variant: null,
+      sender: PluginMessageSender.agent,
       time: time,
     );
   }
 
-  shared.MessageTime? _recordAppServerItemTime({
+  PluginMessageTime? _recordAppServerItemTime({
     required Map<String, dynamic> params,
     required String threadId,
     required String? itemId,
@@ -739,7 +740,7 @@ class CodexEventMapper({
     final previous = _itemTimes[key];
     final created = _milliseconds(params["startedAtMs"]) ?? previous?.created;
     if (created == null) return previous;
-    final time = shared.MessageTime(
+    final time = PluginMessageTime(
       created: created,
       completed: completed ? _milliseconds(params["completedAtMs"]) ?? previous?.completed : previous?.completed,
     );
@@ -772,13 +773,6 @@ class CodexEventMapper({
 
   int? _secondsToMilliseconds(Object? value) => value is num ? (value * Duration.millisecondsPerSecond).round() : null;
 
-  shared.MessageTime? _sharedMessageTime(PluginMessageTime? time) => time == null
-      ? null
-      : shared.MessageTime(
-          created: time.created,
-          completed: time.completed,
-        );
-
   void _forgetItemTimes(String threadId) => _itemTimes.removeWhere((key, _) => key.threadId == threadId);
 
   /// Emits the message envelope and its (single) content part. The part id
@@ -787,13 +781,13 @@ class CodexEventMapper({
   List<BridgeSseEvent> _messageEvents({
     required String threadId,
     required String itemId,
-    required shared.Message message,
+    required PluginMessage message,
     required PluginMessagePartType partType,
     required String partSuffix,
     required String? text,
   }) {
     return [
-      BridgeSseMessageUpdated(info: message.toJson()),
+      BridgeSseMessageUpdated(info: message),
       _messagePartEvent(
         threadId: threadId,
         itemId: itemId,
@@ -808,12 +802,12 @@ class CodexEventMapper({
   List<BridgeSseEvent> _userMessageEvents({
     required String threadId,
     required String itemId,
-    required shared.Message message,
+    required PluginMessage message,
     required String? text,
     required List<PluginMessageAttachment> attachments,
   }) {
     return [
-      BridgeSseMessageUpdated(info: message.toJson()),
+      BridgeSseMessageUpdated(info: message),
       if (text != null)
         _messagePartEvent(
           threadId: threadId,

--- a/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_event_mapper_test.dart
@@ -73,7 +73,7 @@ void main() {
           "sessionID": sessionID,
           "status": status.toJson(),
         },
-        BridgeSseMessageUpdated(:final info) => {"type": "message.updated", "info": info},
+        BridgeSseMessageUpdated(:final info) => {"type": "message.updated", "info": info.toJson()},
         _ => throw ArgumentError("parseAsSesori: unhandled ${event.runtimeType}"),
       };
       return shared.SesoriSseEvent.fromJson(payload);
@@ -385,8 +385,8 @@ void main() {
 
       expect(events, hasLength(2));
       final message = events[0] as BridgeSseMessageUpdated;
-      final parsed = shared.Message.fromJson(message.info);
-      expect(parsed, isA<shared.MessageUser>());
+      final parsed = message.info;
+      expect(parsed, isA<PluginMessageUser>());
       expect(parsed.id, "i-user");
       expect(parsed.sessionID, "t-1");
       expect(parseAsSesori(message), isA<shared.SesoriMessageUpdated>());
@@ -417,8 +417,8 @@ void main() {
         ),
       );
 
-      final parsed = shared.Message.fromJson((events[0] as BridgeSseMessageUpdated).info);
-      expect((parsed as shared.MessageUser).promptId, "prm_1");
+      final parsed = (events[0] as BridgeSseMessageUpdated).info;
+      expect((parsed as PluginMessageUser).promptId, "prm_1");
     });
 
     test("item userMessage typed in the codex CLI stays unattributed", () {
@@ -439,8 +439,8 @@ void main() {
         ),
       );
 
-      final parsed = shared.Message.fromJson((events[0] as BridgeSseMessageUpdated).info);
-      expect((parsed as shared.MessageUser).promptId, isNull);
+      final parsed = (events[0] as BridgeSseMessageUpdated).info;
+      expect((parsed as PluginMessageUser).promptId, isNull);
     });
 
     test("item userMessage hides bridge context while preserving authored content", () {
@@ -476,7 +476,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       );
 
       expect(events, hasLength(3));
-      final user = shared.Message.fromJson((events.first as BridgeSseMessageUpdated).info) as shared.MessageUser;
+      final user = (events.first as BridgeSseMessageUpdated).info as PluginMessageUser;
       expect(user.promptId, "prm_user_content");
       final parts = events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part).toList();
       expect(parts.first.type, PluginMessagePartType.text);
@@ -703,16 +703,16 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
         ),
       );
 
-      final startedUser = shared.Message.fromJson((userStarted.first as BridgeSseMessageUpdated).info);
-      final completedUser = shared.Message.fromJson((userCompleted.first as BridgeSseMessageUpdated).info);
-      final startedAssistant = shared.Message.fromJson((assistantStarted.first as BridgeSseMessageUpdated).info);
-      final completedAssistant = shared.Message.fromJson((assistantCompleted.first as BridgeSseMessageUpdated).info);
-      expect(startedUser.time, const shared.MessageTime(created: 1779293100123, completed: null));
+      final startedUser = (userStarted.first as BridgeSseMessageUpdated).info;
+      final completedUser = (userCompleted.first as BridgeSseMessageUpdated).info;
+      final startedAssistant = (assistantStarted.first as BridgeSseMessageUpdated).info;
+      final completedAssistant = (assistantCompleted.first as BridgeSseMessageUpdated).info;
+      expect(startedUser.time, const PluginMessageTime(created: 1779293100123, completed: null));
       expect(completedUser.time, startedUser.time);
-      expect(startedAssistant.time, const shared.MessageTime(created: 1779293101000, completed: null));
+      expect(startedAssistant.time, const PluginMessageTime(created: 1779293101000, completed: null));
       expect(
         completedAssistant.time,
-        const shared.MessageTime(created: 1779293101000, completed: 1779293102000),
+        const PluginMessageTime(created: 1779293101000, completed: 1779293102000),
       );
     });
 
@@ -760,8 +760,8 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       );
 
       expect(
-        shared.Message.fromJson((completed.first as BridgeSseMessageUpdated).info).time,
-        const shared.MessageTime(created: 1779293103000, completed: 1779293104000),
+        (completed.first as BridgeSseMessageUpdated).info.time,
+        const PluginMessageTime(created: 1779293103000, completed: 1779293104000),
       );
     });
 
@@ -789,8 +789,8 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
 
       expect(started, hasLength(2));
       expect(
-        shared.Message.fromJson((started[0] as BridgeSseMessageUpdated).info),
-        isA<shared.MessageAssistant>(),
+        (started[0] as BridgeSseMessageUpdated).info,
+        isA<PluginMessageAssistant>(),
       );
       final startedPart = (started[1] as BridgeSseMessagePartUpdated).part;
       expect(startedPart.tool, "compact");
@@ -825,7 +825,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       );
 
       expect(events, hasLength(2));
-      expect(shared.Message.fromJson((events[0] as BridgeSseMessageUpdated).info), isA<shared.MessageAssistant>());
+      expect((events[0] as BridgeSseMessageUpdated).info, isA<PluginMessageAssistant>());
       final part = (events[1] as BridgeSseMessagePartUpdated).part;
       expect(part.type, PluginMessagePartType.text);
       expect(part.text, "Hi. What do you need changed?");
@@ -862,11 +862,9 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
         ),
       );
 
-      final message = shared.Message.fromJson(
-        (events[0] as BridgeSseMessageUpdated).info,
-      );
-      expect(message, isA<shared.MessageAssistant>());
-      final assistant = message as shared.MessageAssistant;
+      final message = (events[0] as BridgeSseMessageUpdated).info;
+      expect(message, isA<PluginMessageAssistant>());
+      final assistant = message as PluginMessageAssistant;
       expect(assistant.agent, equals("codex"));
       expect(assistant.providerID, equals("openai"));
       expect(assistant.modelID, equals("gpt-5.5"));
@@ -904,9 +902,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
           },
         ),
       );
-      final assistant = shared.Message.fromJson(
-        (events[0] as BridgeSseMessageUpdated).info,
-      ) as shared.MessageAssistant;
+      final assistant = (events[0] as BridgeSseMessageUpdated).info as PluginMessageAssistant;
       expect(assistant.modelID, equals("gpt-5.4-mini"));
       expect(assistant.providerID, equals("openai"));
 
@@ -921,9 +917,7 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
           },
         ),
       );
-      final assistant2 = shared.Message.fromJson(
-        (events2[0] as BridgeSseMessageUpdated).info,
-      ) as shared.MessageAssistant;
+      final assistant2 = (events2[0] as BridgeSseMessageUpdated).info as PluginMessageAssistant;
       expect(assistant2.modelID, equals("gpt-5.5"));
     });
 
@@ -971,8 +965,8 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
 
       expect(events, hasLength(2));
       expect(
-        shared.Message.fromJson((events[0] as BridgeSseMessageUpdated).info),
-        isA<shared.MessageAssistant>(),
+        (events[0] as BridgeSseMessageUpdated).info,
+        isA<PluginMessageAssistant>(),
       );
       final part = (events[1] as BridgeSseMessagePartUpdated).part;
       expect(part.type, PluginMessagePartType.tool);
@@ -1065,8 +1059,8 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
         "/usr/bin/false",
       );
       expect(
-        shared.Message.fromJson((running[0] as BridgeSseMessageUpdated).info).time,
-        shared.MessageTime(created: DateTime.utc(2026, 7, 23, 8).millisecondsSinceEpoch, completed: null),
+        (running[0] as BridgeSseMessageUpdated).info.time,
+        PluginMessageTime(created: DateTime.utc(2026, 7, 23, 8).millisecondsSinceEpoch, completed: null),
       );
       final rawPart = (completed[1] as BridgeSseMessagePartUpdated).part;
       final latePart = (lateItem[1] as BridgeSseMessagePartUpdated).part;
@@ -1345,8 +1339,8 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       final part = (events[1] as BridgeSseMessagePartUpdated).part;
       expect(part.state.status, PluginToolStatus.completed);
       expect(
-        shared.Message.fromJson((events[0] as BridgeSseMessageUpdated).info).time,
-        const shared.MessageTime(created: 1779293200000, completed: 1779293201000),
+        (events[0] as BridgeSseMessageUpdated).info.time,
+        const PluginMessageTime(created: 1779293200000, completed: 1779293201000),
       );
       rolloutLifecycle.clearRolloutTurn(threadId: "t-completed");
     });
@@ -1895,12 +1889,12 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
 
       expect(events, hasLength(3));
       final event = events[1] as BridgeSseMessageUpdated;
-      final message = shared.Message.fromJson(event.info) as shared.MessageError;
+      final message = event.info as PluginMessageError;
       expect(message.id, "u-quota");
       expect(message.sessionID, "t-quota");
       expect(message.errorName, "CodexError");
       expect(message.errorMessage, "You've hit your usage limit.");
-      expect(message.time, const shared.MessageTime(created: 1700000010000, completed: 1700000010000));
+      expect(message.time, const PluginMessageTime(created: 1700000010000, completed: 1700000010000));
       expect(parseAsSesori(event), isA<shared.SesoriMessageUpdated>());
     });
 

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -829,7 +829,7 @@ void main() {
       await Future<void>.delayed(Duration.zero);
 
       final messageEvent = events.whereType<BridgeSseMessageUpdated>().single;
-      final message = shared.Message.fromJson(messageEvent.info) as shared.MessageAssistant;
+      final message = messageEvent.info as PluginMessageAssistant;
       expect(message.modelID, "gpt-session");
     });
 
@@ -1125,9 +1125,9 @@ void main() {
       final visibleError = plugin.events
           .where((event) => event is BridgeSseMessageUpdated)
           .cast<BridgeSseMessageUpdated>()
-          .map((event) => shared.Message.fromJson(event.info))
-          .where((message) => message is shared.MessageError)
-          .cast<shared.MessageError>()
+          .map((event) => event.info)
+          .where((message) => message is PluginMessageError)
+          .cast<PluginMessageError>()
           .first;
       fake.pushNotification("error", {
         "threadId": "t-terminal",
@@ -1730,19 +1730,19 @@ void main() {
       final errorIndex = emittedEvents.indexWhere(
         (event) =>
             event is BridgeSseMessageUpdated &&
-            switch (shared.Message.fromJson(event.info)) {
-              shared.MessageError(errorMessage: "You've hit your usage limit.") => true,
+            switch (event.info) {
+              PluginMessageError(errorMessage: "You've hit your usage limit.") => true,
               _ => false,
             },
       );
       final idleIndex = emittedEvents.indexWhere((event) => event is BridgeSseSessionIdle);
       expect(errorIndex, greaterThanOrEqualTo(0));
       expect(idleIndex, greaterThan(errorIndex));
-      final error = shared.Message.fromJson((emittedEvents[errorIndex] as BridgeSseMessageUpdated).info);
+      final error = (emittedEvents[errorIndex] as BridgeSseMessageUpdated).info;
       expect(error.id, "u-failed");
       expect(
         error.time,
-        shared.MessageTime(
+        PluginMessageTime(
           created: DateTime.utc(2026, 8, 20, 8, 0, 5).millisecondsSinceEpoch,
           completed: null,
         ),

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -5,7 +5,6 @@ import "package:acp_plugin/acp_plugin.dart";
 import "package:cursor_plugin/cursor_plugin.dart";
 import "package:cursor_plugin/src/repositories/cursor_generated_image_reader.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
-import "package:sesori_shared/sesori_shared.dart" as shared;
 import "package:test/test.dart";
 
 void main() {
@@ -326,12 +325,10 @@ void main() {
           },
         ),
       );
-      final message = shared.Message.fromJson(
-        events.whereType<BridgeSseMessageUpdated>().single.info,
-      );
-      expect(message, isA<shared.MessageError>());
+      final message = events.whereType<BridgeSseMessageUpdated>().single.info;
+      expect(message, isA<PluginMessageError>());
       expect(
-        (message as shared.MessageError).errorMessage,
+        (message as PluginMessageError).errorMessage,
         "\n\nCheck your settings to continue",
       );
       expect(events.whereType<BridgeSseMessagePartDelta>(), isEmpty);

--- a/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
@@ -29,44 +29,56 @@ void main() {
   );
 
   int? liveCreated(List<BridgeSseEvent> events) =>
-      (events.whereType<BridgeSseMessageUpdated>().single.info["time"] as Map?)?["created"] as int?;
+      events.whereType<BridgeSseMessageUpdated>().single.info.time?.created;
 
   test("live assistant and tool envelopes use DeepSeek metadata time", () {
     expect(
-      liveCreated(mapper.map(notification({
-        "sessionUpdate": "agent_message_chunk",
-        "messageId": "a1",
-        "content": {"type": "text", "text": "hello"},
-      }, 10))),
+      liveCreated(
+        mapper.map(
+          notification({
+            "sessionUpdate": "agent_message_chunk",
+            "messageId": "a1",
+            "content": {"type": "text", "text": "hello"},
+          }, 10),
+        ),
+      ),
       10,
     );
     expect(
-      liveCreated(mapper.map(notification({
-        "sessionUpdate": "tool_call",
-        "toolCallId": "t1",
-        "kind": "read",
-      }, 20))),
+      liveCreated(
+        mapper.map(
+          notification({
+            "sessionUpdate": "tool_call",
+            "toolCallId": "t1",
+            "kind": "read",
+          }, 20),
+        ),
+      ),
       20,
     );
   });
 
   test("local initial and queued users use accepted creation times", () {
     expect(
-      liveCreated(mapper.mapInitialPrompt(
-        sessionId: "s1",
-        parts: const [PluginPromptPart.text(text: "initial")],
-        createdAtMs: 30,
-      )),
+      liveCreated(
+        mapper.mapInitialPrompt(
+          sessionId: "s1",
+          parts: const [PluginPromptPart.text(text: "initial")],
+          createdAtMs: 30,
+        ),
+      ),
       30,
     );
     expect(
-      liveCreated(mapper.mapSentPrompt(
-        sessionId: "s1",
-        messageId: "queued-user",
-        promptId: "queued",
-        parts: const [PluginPromptPart.text(text: "queued")],
-        createdAtMs: 40,
-      )),
+      liveCreated(
+        mapper.mapSentPrompt(
+          sessionId: "s1",
+          messageId: "queued-user",
+          promptId: "queued",
+          parts: const [PluginPromptPart.text(text: "queued")],
+          createdAtMs: 40,
+        ),
+      ),
       40,
     );
   });
@@ -80,31 +92,41 @@ void main() {
       messageTimeResolver: ({required params}) => parser.parse(params),
       haltClassifier: null,
     );
-    collector.consume(notification({
-      "sessionUpdate": "user_message_chunk",
-      "messageId": "u1",
-      "content": {"type": "text", "text": "user"},
-    }, 30).params);
-    collector.consume(notification({
-      "sessionUpdate": "agent_message_chunk",
-      "messageId": "a1",
-      "content": {"type": "text", "text": "first"},
-    }, 20).params);
-    collector.consume(notification({
-      "sessionUpdate": "agent_message_chunk",
-      "messageId": "a1",
-      "content": {"type": "text", "text": "later"},
-    }, 50).params);
-    collector.consume(notification({
-      "sessionUpdate": "tool_call",
-      "toolCallId": "t1",
-      "kind": "read",
-    }, 10).params);
-    collector.consume(notification({
-      "sessionUpdate": "tool_call_update",
-      "toolCallId": "t1",
-      "status": "completed",
-    }, 60).params);
+    collector.consume(
+      notification({
+        "sessionUpdate": "user_message_chunk",
+        "messageId": "u1",
+        "content": {"type": "text", "text": "user"},
+      }, 30).params,
+    );
+    collector.consume(
+      notification({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "a1",
+        "content": {"type": "text", "text": "first"},
+      }, 20).params,
+    );
+    collector.consume(
+      notification({
+        "sessionUpdate": "agent_message_chunk",
+        "messageId": "a1",
+        "content": {"type": "text", "text": "later"},
+      }, 50).params,
+    );
+    collector.consume(
+      notification({
+        "sessionUpdate": "tool_call",
+        "toolCallId": "t1",
+        "kind": "read",
+      }, 10).params,
+    );
+    collector.consume(
+      notification({
+        "sessionUpdate": "tool_call_update",
+        "toolCallId": "t1",
+        "status": "completed",
+      }, 60).params,
+    );
 
     final messages = collector.build();
     expect(messages.map((message) => message.info.time?.created), [30, 10]);
@@ -120,17 +142,22 @@ void main() {
       haltClassifier: classifier,
     );
     final halted = collector(({required text}) => const AcpHaltNotice(errorName: "halt"));
-    halted.consume(notification({
-      "sessionUpdate": "agent_message_chunk",
-      "content": {"type": "text", "text": "halt"},
-    }, 70).params);
+    halted.consume(
+      notification({
+        "sessionUpdate": "agent_message_chunk",
+        "content": {"type": "text", "text": "halt"},
+      }, 70).params,
+    );
     expect(halted.build().single.info.time?.created, 70);
     expect(halted.build().single.info.toJson()["errorName"], "halt");
 
-    final old = collector(null)..consume(notification({
-      "sessionUpdate": "agent_message_chunk",
-      "content": {"type": "text", "text": "old"},
-    }).params);
+    final old = collector(null)
+      ..consume(
+        notification({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "old"},
+        }).params,
+      );
     expect(old.build().single.info.time, isNull);
   });
 }

--- a/bridge/sesori_plugin_grok/test/grok_event_mapper_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_event_mapper_test.dart
@@ -77,8 +77,8 @@ void main() {
       expect(tracker.runningChildren(sessionId: _root).single.isBackground, isFalse);
 
       final prompted = mapper.map(_fixture("subagent_child_prompt.json"));
-      final envelope = shared.Message.fromJson(prompted.whereType<BridgeSseMessageUpdated>().single.info);
-      expect(envelope, isA<shared.MessageAssistant>());
+      final envelope = prompted.whereType<BridgeSseMessageUpdated>().single.info;
+      expect(envelope, isA<PluginMessageAssistant>());
       expect(envelope.id, _tileMessageId);
       expect(envelope.sessionID, _root);
       final tile = _subtask(prompted.whereType<BridgeSseMessagePartUpdated>().single);

--- a/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_sse_event.dart
@@ -76,8 +76,7 @@ class const BridgeSseQueuedPromptsUpdated({
   required final List<PluginQueuedPrompt> prompts,
 }) extends BridgeSseEvent;
 
-// ignore: no_slop_linter/prefer_specific_type, SSE payload values are heterogeneous
-class const BridgeSseMessageUpdated({required final Map<String, dynamic> info}) extends BridgeSseEvent;
+class const BridgeSseMessageUpdated({required final PluginMessage info}) extends BridgeSseEvent;
 
 class const BridgeSseMessageRemoved({required final String sessionID, required final String messageID})
     extends BridgeSseEvent;

--- a/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_test.dart
@@ -289,9 +289,14 @@ void main() {
       expect(
         events
             .whereType<BridgeSseMessageUpdated>()
-            .singleWhere((event) => event.info["promptId"] == "prompt-2")
-            .info["role"],
-        "user",
+            .singleWhere(
+              (event) => switch (event.info) {
+                PluginMessageUser(promptId: final id) => id == "prompt-2",
+                _ => false,
+              },
+            )
+            .info,
+        isA<PluginMessageUser>(),
       );
       respond(replacement, {"stopReason": "end_turn"});
     });
@@ -420,7 +425,8 @@ void main() {
         PluginMessagePartType.text,
         PluginMessagePartType.file,
       ]);
-      final image = (messages.last.parts.last as PluginMessagePartFile).attachment as PluginMessageAttachmentInlineImage;
+      final image =
+          (messages.last.parts.last as PluginMessagePartFile).attachment as PluginMessageAttachmentInlineImage;
       expect(image.base64, "AQ==");
       expect(image.filename, "history.webp");
       expect(image.toString(), isNot(contains("/private/")));

--- a/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse_event_mapper.dart
@@ -17,20 +17,13 @@ class SseEventMapper({final AssistantMessageMapper _assistantMessageMapper = con
   final MessagePartMapper _messagePartMapper = const MessagePartMapper();
   final QuestionInfoMapper _questionInfoMapper = const QuestionInfoMapper();
 
-  /// Narrows a union's `Object? toJson()` result to the JSON map the bridge
-  /// model carries — without a null-assertion (`!`). Known variants always
-  /// encode to a map; the fallback only covers an unknown variant whose raw
-  /// payload is not a map.
-  static Map<String, dynamic> _asMap(Object? json) => json is Map<String, dynamic> ? json : const <String, dynamic>{};
-
-  /// Normalizes a `message.updated` payload into the shared-`Message` JSON
-  /// shape the phone parses, mirroring the REST load path
-  /// ([PluginModelMapper.mapMessageWithParts]). Crucially this collapses an
-  /// errored assistant message (`role: "assistant"` + `error`) into the
-  /// `role: "error"` shape via [AssistantMessageMapper]; forwarding the raw
-  /// OpenCode payload would keep `role: "assistant"` and the phone would drop
-  /// the error, leaving a blank turn until the session is re-opened.
-  Map<String, dynamic> _mapMessageInfo(Message info, {required String? promptId}) {
+  /// Maps a `message.updated` payload to its plugin envelope, mirroring the
+  /// REST load path ([PluginModelMapper.mapMessageWithParts]). Crucially this
+  /// collapses an errored assistant message (`role: "assistant"` + `error`)
+  /// into the error envelope via [AssistantMessageMapper]; forwarding it as an
+  /// assistant message would leave a blank turn on the phone until the session
+  /// is re-opened.
+  PluginMessage? _mapMessageInfo(Message info, {required String? promptId}) {
     final pluginMessage = switch (info) {
       UserMessage(:final id, :final sessionID, :final agent, :final time) => PluginMessage.user(
         id: id,
@@ -42,12 +35,11 @@ class SseEventMapper({final AssistantMessageMapper _assistantMessageMapper = con
         promptId: promptId,
       ),
       AssistantMessage() => _assistantMessageMapper.map(info),
-      // Unknown roles from a newer OpenCode server: fall through to the raw
-      // payload below so the phone can still attempt to decode it.
+      // Unknown roles from a newer OpenCode server have no plugin shape the
+      // bridge can deliver; the event is dropped here.
       _ => null,
     };
-    if (pluginMessage == null) return _asMap(info.toJson());
-    return _asMap(pluginMessage.toJson());
+    return pluginMessage;
   }
 
   /// Maps an [SseEventData] to a [BridgeSseEvent], or null if the event
@@ -87,7 +79,10 @@ class SseEventMapper({final AssistantMessageMapper _assistantMessageMapper = con
         arguments: arguments,
         messageID: messageID,
       ),
-      SseMessageUpdated(:final info) => BridgeSseMessageUpdated(info: _mapMessageInfo(info, promptId: promptId)),
+      SseMessageUpdated(:final info) => switch (_mapMessageInfo(info, promptId: promptId)) {
+        final message? => BridgeSseMessageUpdated(info: message),
+        null => null,
+      },
       SseMessageRemoved(:final sessionID, :final messageID) => BridgeSseMessageRemoved(
         sessionID: sessionID,
         messageID: messageID,

--- a/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_plugin_impl_test.dart
@@ -353,9 +353,9 @@ void main() {
 
       final stamped = events.whereType<BridgeSseMessageUpdated>().toList();
       expect(stamped, hasLength(3));
-      expect(stamped[0].info["promptId"], equals("prm_1"));
-      expect(stamped[1].info["promptId"], equals("prm_1"));
-      expect(stamped[2].info.containsKey("promptId"), isFalse);
+      expect((stamped[0].info as PluginMessageUser).promptId, equals("prm_1"));
+      expect((stamped[1].info as PluginMessageUser).promptId, equals("prm_1"));
+      expect((stamped[2].info as PluginMessageUser).promptId, isNull);
     });
 
     test("sendPrompt marks an accepted turn busy before SSE arrives", () async {
@@ -662,7 +662,7 @@ void main() {
       await _awaitEvents<BridgeSseMessageUpdated>(events, count: 2);
 
       expect(
-        events.whereType<BridgeSseMessageUpdated>().map((event) => event.info["promptId"]),
+        events.whereType<BridgeSseMessageUpdated>().map((event) => (event.info as PluginMessageUser).promptId),
         equals(["prompt-1", "prompt-1"]),
       );
       server.holdCommand!.complete();
@@ -713,7 +713,7 @@ void main() {
       await _awaitEvents<BridgeSseMessageUpdated>(events, count: 1);
 
       final echoed = events.whereType<BridgeSseMessageUpdated>().single;
-      expect(echoed.info.containsKey("promptId"), isFalse);
+      expect((echoed.info as PluginMessageUser).promptId, isNull);
     });
 
     test("bare compact reuses a correlated server message and native compaction part", () async {
@@ -785,7 +785,7 @@ void main() {
       await _awaitEvents<BridgeSseMessageUpdated>(events, count: 1);
 
       final compactEcho = events.whereType<BridgeSseMessageUpdated>().single;
-      expect(compactEcho.info["promptId"], equals("prompt-compact"));
+      expect((compactEcho.info as PluginMessageUser).promptId, equals("prompt-compact"));
     });
 
     test("compact guidance is persisted before reserving the marker", () async {

--- a/bridge/sesori_plugin_opencode/test/sse_event_mapper_test.dart
+++ b/bridge/sesori_plugin_opencode/test/sse_event_mapper_test.dart
@@ -70,9 +70,9 @@ void main() {
       // The phone parses this via the shared `Message.fromJson` `role`
       // discriminator, so a live error must arrive as `role: "error"` with
       // flat error fields — not as `role: "assistant"` with the error dropped.
-      expect(event.info["role"], equals("error"));
-      expect(event.info["errorName"], equals("ProviderAuthError"));
-      expect(event.info["errorMessage"], equals("invalid api key"));
+      expect(event.info, isA<PluginMessageError>());
+      expect((event.info as PluginMessageError).errorName, equals("ProviderAuthError"));
+      expect((event.info as PluginMessageError).errorMessage, equals("invalid api key"));
     });
 
     test("maps a live non-errored assistant message.updated to the assistant role", () {
@@ -80,8 +80,7 @@ void main() {
 
       expect(result, isA<BridgeSseMessageUpdated>());
       final event = result! as BridgeSseMessageUpdated;
-      expect(event.info["role"], equals("assistant"));
-      expect(event.info.containsKey("errorName"), isFalse);
+      expect(event.info, isA<PluginMessageAssistant>());
     });
 
     test("maps session.created using provided canonical projectID", () {
@@ -136,13 +135,13 @@ void main() {
         promptId: "prm_1",
       );
 
-      expect((result! as BridgeSseMessageUpdated).info["promptId"], equals("prm_1"));
+      expect(((result! as BridgeSseMessageUpdated).info as PluginMessageUser).promptId, equals("prm_1"));
     });
 
     test("leaves a user message with no resolved prompt unattributed", () {
       final result = mapper.map(SseEventData.messageUpdated(info: _userMessage(id: "msg-from-tui")));
 
-      expect((result! as BridgeSseMessageUpdated).info.containsKey("promptId"), isFalse);
+      expect(((result! as BridgeSseMessageUpdated).info as PluginMessageUser).promptId, isNull);
     });
   });
 }

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -169,7 +169,7 @@ final class PiEventDispatcher({
     return mapped == null
         ? const []
         : [
-            BridgeSseMessageUpdated(info: mapped.info.toJson()),
+            BridgeSseMessageUpdated(info: mapped.info),
             for (final part in mapped.parts) BridgeSseMessagePartUpdated(part: part),
           ];
   }
@@ -299,7 +299,7 @@ final class PiEventDispatcher({
       ];
     }
     return [
-      BridgeSseMessageUpdated(info: mapped.info.toJson()),
+      BridgeSseMessageUpdated(info: mapped.info),
       for (final partId in removedPartIds)
         BridgeSseMessagePartRemoved(sessionID: sessionId, messageID: messageId, partID: partId),
       for (final part in parts) BridgeSseMessagePartUpdated(part: part),
@@ -328,7 +328,7 @@ final class PiEventDispatcher({
     );
     final mapped = _historyMapper.mapBashExecution(sessionId: sessionId, messageId: messageId, message: message);
     return [
-      BridgeSseMessageUpdated(info: mapped.info.toJson()),
+      BridgeSseMessageUpdated(info: mapped.info),
       for (final part in mapped.parts) BridgeSseMessagePartUpdated(part: part),
     ];
   }
@@ -363,7 +363,7 @@ final class PiEventDispatcher({
     );
     if (mapped == null) return const [];
     return [
-      BridgeSseMessageUpdated(info: mapped.info.toJson()),
+      BridgeSseMessageUpdated(info: mapped.info),
       for (final part in mapped.parts) BridgeSseMessagePartUpdated(part: part),
     ];
   }
@@ -383,7 +383,7 @@ final class PiEventDispatcher({
     );
     if (mapped == null) return const [];
     return [
-      BridgeSseMessageUpdated(info: mapped.info.toJson()),
+      BridgeSseMessageUpdated(info: mapped.info),
       for (final part in mapped.parts) BridgeSseMessagePartUpdated(part: part),
     ];
   }
@@ -635,7 +635,7 @@ final class PiEventDispatcher({
     final mapped = _historyMapper.mapRunningCompaction(sessionId: sessionId, messageId: messageId);
     return [
       ..._status(sessionId: sessionId, event: event, now: now),
-      BridgeSseMessageUpdated(info: mapped.info.toJson()),
+      BridgeSseMessageUpdated(info: mapped.info),
       for (final part in mapped.parts) BridgeSseMessagePartUpdated(part: part),
     ];
   }
@@ -680,7 +680,7 @@ final class PiEventDispatcher({
     final mapped = _historyMapper.mapCompaction(sessionId: sessionId, messageId: messageId);
     return [
       BridgeSseSessionCompacted(sessionID: sessionId),
-      BridgeSseMessageUpdated(info: mapped.info.toJson()),
+      BridgeSseMessageUpdated(info: mapped.info),
       for (final part in mapped.parts) BridgeSseMessagePartUpdated(part: part),
     ];
   }
@@ -710,7 +710,7 @@ final class PiEventDispatcher({
     if (messageId == null || message == null) return const [];
     state.announced = true;
     final mapped = _historyMapper.mapAssistantMessage(sessionId: sessionId, messageId: messageId, message: message);
-    return [BridgeSseMessageUpdated(info: mapped.info.toJson())];
+    return [BridgeSseMessageUpdated(info: mapped.info)];
   }
 
   _SessionState _session(String sessionId) => _sessions.putIfAbsent(

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_session_service.dart
@@ -727,8 +727,10 @@ final class PiSessionService({
               (mapped is BridgeSseSessionStatus || mapped is BridgeSseSessionIdle);
           if (!serviceOwnsLifecycle) _emit(mapped);
           if (mapped is! BridgeSseMessageUpdated) continue;
-          final promptId = mapped.info["promptId"];
-          if (promptId is! String) continue;
+          final info = mapped.info;
+          if (info is! PluginMessageUser) continue;
+          final promptId = info.promptId;
+          if (promptId == null) continue;
           final correlated = _turnForPrompt(state: state, promptId: promptId);
           if (correlated == null) continue;
           correlated.userMessageEmitted = true;
@@ -989,7 +991,10 @@ final class PiSessionService({
     );
     mappedEvents.forEach(_emit);
     turn.userMessageEmitted = mappedEvents.any(
-      (mapped) => mapped is BridgeSseMessageUpdated && mapped.info["promptId"] == turn.promptId,
+      (mapped) => switch (mapped) {
+        BridgeSseMessageUpdated(info: PluginMessageUser(:final promptId)) => promptId == turn.promptId,
+        _ => false,
+      },
     );
   }
 

--- a/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
@@ -86,7 +86,7 @@ void main() {
           identities: PiMessageIdentityBuilder(pluginId: "pi", sessionId: sessionId),
         )
         .single;
-    expect((finalEvents.first as BridgeSseMessageUpdated).info, replay.info.toJson());
+    expect((finalEvents.first as BridgeSseMessageUpdated).info, replay.info);
     expect(finalEvents.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part), replay.parts);
   });
 
@@ -254,11 +254,11 @@ void main() {
       }),
     );
 
-    expect((firstUser.first as BridgeSseMessageUpdated).info["promptId"], "prompt-1");
+    expect(((firstUser.first as BridgeSseMessageUpdated).info as PluginMessageUser).promptId, "prompt-1");
     expect(firstUser.whereType<BridgeSseMessagePartUpdated>().single.part.text, "first");
     expect(beforeSteer.whereType<BridgeSseMessagePartDelta>().single.messageID, "pi:session:assistant:100:1");
     expect(afterSteer.whereType<BridgeSseMessagePartDelta>().single.messageID, "pi:session:assistant:100:1");
-    expect((steeringUser.first as BridgeSseMessageUpdated).info["promptId"], "prompt-2");
+    expect(((steeringUser.first as BridgeSseMessageUpdated).info as PluginMessageUser).promptId, "prompt-2");
     expect(steeringUser.whereType<BridgeSseMessagePartUpdated>().single.part.text, "second");
   });
 
@@ -288,7 +288,7 @@ void main() {
         )
         .single;
 
-    expect((live.first as BridgeSseMessageUpdated).info, replay.info.toJson());
+    expect((live.first as BridgeSseMessageUpdated).info, replay.info);
     expect(live.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part), replay.parts);
   });
 
@@ -328,7 +328,7 @@ void main() {
         )
         .single;
 
-    expect((live.first as BridgeSseMessageUpdated).info, replay.info.toJson());
+    expect((live.first as BridgeSseMessageUpdated).info, replay.info);
     expect(live.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part), replay.parts);
   });
 
@@ -552,9 +552,12 @@ void main() {
           )
           .single;
 
-      expect((live.single as BridgeSseMessageUpdated).info, replay.info.toJson());
+      expect((live.single as BridgeSseMessageUpdated).info, replay.info);
       if (reason == "error") {
-        expect((live.single as BridgeSseMessageUpdated).info["errorMessage"], "private provider detail");
+        expect(
+          ((live.single as BridgeSseMessageUpdated).info as PluginMessageError).errorMessage,
+          "private provider detail",
+        );
       }
     }
   });
@@ -638,7 +641,7 @@ void main() {
       }),
     );
 
-    expect(events.whereType<BridgeSseMessageUpdated>().single.info["id"] as String, contains(":bashExecution:5:1"));
+    expect(events.whereType<BridgeSseMessageUpdated>().single.info.id, contains(":bashExecution:5:1"));
     final part = events.whereType<BridgeSseMessagePartUpdated>().single.part;
     expect(part.tool, "bash");
     expect(part.state.title, "pwd");
@@ -676,7 +679,7 @@ void main() {
       }),
     );
 
-    expect(events.whereType<BridgeSseMessageUpdated>().single.info["id"], "pi:session:custom:6:2");
+    expect(events.whereType<BridgeSseMessageUpdated>().single.info.id, "pi:session:custom:6:2");
     expect(events.whereType<BridgeSseMessagePartUpdated>().single.part.text, "Extension result");
   });
 
@@ -721,12 +724,12 @@ void main() {
     expect((summarizationResumed.single as BridgeSseSessionStatus).status, const PluginSessionStatus.busy());
     expect(compacting.whereType<BridgeSseSessionStatus>().single.status, const PluginSessionStatus.busy());
     final runningMessage = compacting.whereType<BridgeSseMessageUpdated>().single;
-    expect(runningMessage.info["id"], "pi:session:compaction:compaction:1");
+    expect(runningMessage.info.id, "pi:session:compaction:compaction:1");
     final runningPart = compacting.whereType<BridgeSseMessagePartUpdated>().single.part;
     expect(runningPart.state.status, PluginToolStatus.running);
     expect(runningPart.state.title, "Compacting context");
     expect(compacted.whereType<BridgeSseSessionCompacted>(), hasLength(1));
-    expect(compacted.whereType<BridgeSseMessageUpdated>().single.info["id"], runningMessage.info["id"]);
+    expect(compacted.whereType<BridgeSseMessageUpdated>().single.info.id, runningMessage.info.id);
     final completedPart = compacted.whereType<BridgeSseMessagePartUpdated>().single.part;
     expect(completedPart.id, runningPart.id);
     expect(completedPart.state.status, PluginToolStatus.completed);
@@ -769,8 +772,8 @@ void main() {
 
     expect(compacted.whereType<BridgeSseSessionCompacted>(), hasLength(1));
     expect(
-      compacted.whereType<BridgeSseMessageUpdated>().single.info["id"],
-      compacting.whereType<BridgeSseMessageUpdated>().single.info["id"],
+      compacted.whereType<BridgeSseMessageUpdated>().single.info.id,
+      compacting.whereType<BridgeSseMessageUpdated>().single.info.id,
     );
     expect(
       compacted.whereType<BridgeSseMessagePartUpdated>().single.part.state.status,
@@ -783,7 +786,7 @@ void main() {
       sessionId: sessionId,
       event: _event("compaction_start", {"reason": "threshold"}),
     );
-    final messageId = compacting.whereType<BridgeSseMessageUpdated>().single.info["id"];
+    final messageId = compacting.whereType<BridgeSseMessageUpdated>().single.info.id;
 
     final failed = dispatcher.map(
       sessionId: sessionId,
@@ -801,7 +804,7 @@ void main() {
 
     expect(failed.whereType<BridgeSseMessageRemoved>().single.messageID, messageId);
     expect(failed.whereType<BridgeSseSessionError>(), hasLength(1));
-    expect(restarted.whereType<BridgeSseMessageUpdated>().single.info["id"], messageId);
+    expect(restarted.whereType<BridgeSseMessageUpdated>().single.info.id, messageId);
   });
 
   test("running compaction identity survives history hydration before completion", () {
@@ -809,7 +812,7 @@ void main() {
       sessionId: sessionId,
       event: _event("compaction_start", {"reason": "threshold"}),
     );
-    final messageId = compacting.whereType<BridgeSseMessageUpdated>().single.info["id"];
+    final messageId = compacting.whereType<BridgeSseMessageUpdated>().single.info.id;
     identities.hydrate<void>(sessionId: sessionId, map: (_) {});
 
     final compacted = dispatcher.map(
@@ -821,8 +824,8 @@ void main() {
       event: _event("compaction_start", {"reason": "threshold"}),
     );
 
-    expect(compacted.whereType<BridgeSseMessageUpdated>().single.info["id"], messageId);
-    expect(next.whereType<BridgeSseMessageUpdated>().single.info["id"], "pi:session:compaction:compaction:2");
+    expect(compacted.whereType<BridgeSseMessageUpdated>().single.info.id, messageId);
+    expect(next.whereType<BridgeSseMessageUpdated>().single.info.id, "pi:session:compaction:compaction:2");
   });
 
   test("interleaved sessions and unknown variants keep state isolated", () {
@@ -899,10 +902,10 @@ void main() {
       event: _event("compaction_end", {"aborted": false, "willRetry": false}),
     );
 
-    expect(finalized.whereType<BridgeSseMessageUpdated>().single.info["id"], "pi:session:assistant:10:2");
+    expect(finalized.whereType<BridgeSseMessageUpdated>().single.info.id, "pi:session:assistant:10:2");
     expect(finalized.whereType<BridgeSseMessagePartRemoved>().single.partID, "pi:session:assistant:10:2-block-1");
     expect(
-      compacted.whereType<BridgeSseMessageUpdated>().single.info["id"],
+      compacted.whereType<BridgeSseMessageUpdated>().single.info.id,
       "pi:session:compaction:compaction:2",
     );
   });

--- a/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_impl_test.dart
@@ -212,7 +212,7 @@ void main() {
       await idle;
 
       expect(events.whereType<BridgeSseSessionCompacted>(), hasLength(1));
-      expect(events.whereType<BridgeSseMessageUpdated>().first.info["promptId"], "prompt-compact");
+      expect((events.whereType<BridgeSseMessageUpdated>().first.info as PluginMessageUser).promptId, "prompt-compact");
       final visibleText = events
           .whereType<BridgeSseMessagePartUpdated>()
           .where((event) => event.part.type == PluginMessagePartType.text)
@@ -245,7 +245,12 @@ void main() {
       final process = await harness.nextSessionProcess();
       final request = await waitForCommand(process: process, type: "compact");
       final runningUpdate = harness.plugin.events.firstWhere(
-        (event) => event is BridgeSseMessageUpdated && event.info["promptId"] == null,
+        (event) =>
+            event is BridgeSseMessageUpdated &&
+            switch (event.info) {
+              PluginMessageUser(promptId: final id) => id == null,
+              PluginMessageAssistant() || PluginMessageError() => true,
+            },
       );
       process.emit(frame: {"type": "compaction_start", "reason": "manual"});
       await accepted;
@@ -257,7 +262,7 @@ void main() {
       process.emitFailure(id: request["id"]! as String, command: "compact", error: "compaction failed");
 
       final removedEvent = await removed;
-      expect((removedEvent as BridgeSseMessageRemoved).messageID, running.info["id"]);
+      expect((removedEvent as BridgeSseMessageRemoved).messageID, running.info.id);
       await Future.wait([failed, idle]);
       expect(harness.plugin.getActiveSessionsSummary(), isEmpty);
     });

--- a/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_session_service_test.dart
@@ -681,12 +681,15 @@ void main() {
     final statuses = events.whereType<BridgeSseSessionStatus>().toList();
     final idleIndex = events.indexWhere((event) => event is BridgeSseSessionIdle);
     final userMessage = events.whereType<BridgeSseMessageUpdated>().singleWhere(
-      (event) => event.info["promptId"] == "prompt-5",
+      (event) => switch (event.info) {
+        PluginMessageUser(promptId: final id) => id == "prompt-5",
+        _ => false,
+      },
     );
     final emptyQueue = events.whereType<BridgeSseQueuedPromptsUpdated>().last;
     expect(statuses.first.status, const PluginSessionStatus.busy());
     expect(statuses.last.status, const PluginSessionStatus.idle());
-    expect(userMessage.info["role"], "user");
+    expect(userMessage.info, isA<PluginMessageUser>());
     expect(events.indexOf(userMessage), lessThan(events.indexOf(emptyQueue)));
     expect(events.indexOf(statuses.last), lessThan(idleIndex));
   });
@@ -838,7 +841,7 @@ void main() {
     expect(
       events
           .whereType<BridgeSseMessageUpdated>()
-          .map((event) => event.info["promptId"])
+          .map((event) => (event.info as PluginMessageUser).promptId)
           .where((promptId) => promptId == "prompt-8" || promptId == "prompt-9"),
       ["prompt-8", "prompt-9"],
     );
@@ -1239,10 +1242,10 @@ void main() {
 
     final userMessages = events
         .whereType<BridgeSseMessageUpdated>()
-        .where((event) => event.info["role"] == "user")
+        .where((event) => event.info is PluginMessageUser)
         .toList();
     expect(userMessages, hasLength(1));
-    expect(userMessages.single.info["promptId"], "image-only");
+    expect((userMessages.single.info as PluginMessageUser).promptId, "image-only");
   });
 
   test("command rejects busy, accepts dialog-first, and uses no-run state barrier", () async {
@@ -1435,7 +1438,7 @@ void main() {
     await waitForCommand(process: process, type: "prompt");
     process.emit(frame: {"type": "compaction_start", "reason": "threshold"});
     await _waitForEventCount<BridgeSseMessageUpdated>(events: events, count: 1);
-    final messageId = events.whereType<BridgeSseMessageUpdated>().single.info["id"];
+    final messageId = events.whereType<BridgeSseMessageUpdated>().single.info.id;
 
     process.exit(code: 9);
 
@@ -1473,14 +1476,14 @@ void main() {
     expect(service.sessionStatuses["session"], const PluginSessionStatus.busy());
     final runningMessage = events.whereType<BridgeSseMessageUpdated>().single;
     final runningPart = events.whereType<BridgeSseMessagePartUpdated>().single.part;
-    expect(runningPart.messageID, runningMessage.info["id"]);
+    expect(runningPart.messageID, runningMessage.info.id);
     expect(runningPart.state.status, PluginToolStatus.running);
     expect(runningPart.state.title, "Compacting context");
 
     process.emit(frame: {"type": "compaction_end", "aborted": false, "willRetry": false});
     await pump();
 
-    expect(events.whereType<BridgeSseMessageUpdated>().last.info["id"], runningMessage.info["id"]);
+    expect(events.whereType<BridgeSseMessageUpdated>().last.info.id, runningMessage.info.id);
     final completedPart = events.whereType<BridgeSseMessagePartUpdated>().last.part;
     expect(completedPart.id, runningPart.id);
     expect(completedPart.state.status, PluginToolStatus.completed);
@@ -1695,7 +1698,7 @@ void main() {
     process.emit(frame: {"type": "agent_start"});
     process.emit(frame: {"type": "compaction_start", "reason": "threshold"});
     await _waitForEventCount<BridgeSseMessageUpdated>(events: events, count: 1);
-    final compactionMessageId = events.whereType<BridgeSseMessageUpdated>().single.info["id"];
+    final compactionMessageId = events.whereType<BridgeSseMessageUpdated>().single.info.id;
     final steeringPrompt = await _waitForNthCommand(process: process, type: "prompt", count: 2);
     expect(steeringPrompt["message"], "queued");
     expect(steeringPrompt["streamingBehavior"], "steer");
@@ -1855,8 +1858,11 @@ void main() {
     await _waitForEventCount<BridgeSseMessageUpdated>(events: events, count: 2);
 
     final messageInfos = events.whereType<BridgeSseMessageUpdated>().map((event) => event.info).toList();
-    expect(messageInfos.map((info) => info["role"]), ["assistant", "assistant"]);
-    expect(messageInfos.map((info) => info["sender"]), ["system", "agent"]);
+    expect(messageInfos.map((info) => info.runtimeType), [PluginMessageAssistant, PluginMessageAssistant]);
+    expect(
+      messageInfos.map((info) => (info as PluginMessageAssistant).sender),
+      [PluginMessageSender.system, PluginMessageSender.agent],
+    );
     expect(
       events.whereType<BridgeSseMessagePartUpdated>().map((event) => event.part.text),
       containsAllInOrder(["[PR Monitor] report", "Handled report"]),


### PR DESCRIPTION
## Complexity

🚧 complex — a plugin-interface payload type change across five producer packages that feeds the transcript store, a new normalized payload variant consumed by delivery and history, and about 150 test sites rewritten from map access to typed access.

## What

- `BridgeSseMessageUpdated.info` is now a `PluginMessage` instead of a JSON map. ACP, Claude, Codex, OpenCode, and Pi emit their typed envelope directly. ACP and Codex previously built shared `Message` values and serialized them; they now build `PluginMessage` values, and Codex tracks item times as `PluginMessageTime`. OpenCode drops a message role it does not recognise at the plugin boundary instead of relaying a raw payload.
- `NormalizedMessageEvent` joins the sealed normalized payload. `SessionEventMapper` reads the session id from the typed envelope, remaps it with `copyWith`, and converts once through the existing `toSharedMessage` extension. The orchestrator delivers it through `BridgeEventMapper.buildMessageUpdatedEvent`, and `ChatHistoryListener` stores that same shared value, so stored and delivered messages cannot disagree. The listener's JSON decode/drop branch is gone.
- The residual session parse-failure log now names the event type with the error and stack, without dumping the payload. Failure-reporter failures in the SSE mapper, orchestrator, and SSE manager are logged instead of swallowed.
- Tests across the app and every affected plugin assert typed envelopes. Filters over mixed message lists use type-safe pattern matching so non-user envelopes are skipped rather than cast.

## Why

Step 7/25 of `.plan/active/periodic-cleanup`. Plugins serialised typed messages to JSON, the bridge parsed them back to remap ids and re-serialised them, and the history listener parsed them a third time with a decode failure branch that could silently drop a message from storage. One typed value end to end removes the round trips and the branch.

## Risk and test focus

High persisted-content sensitivity, bridge only, no schema change. Impacted: message envelopes for every backend on the live path and in the transcript store; user, assistant, and error metadata, sender, prompt id, time, provider and model, and stable ids. Most valuable checks: on a live backend, send a prompt and confirm the user echo and assistant envelope render with the same metadata as before; force a provider error and confirm the error envelope; reopen the session cold and confirm the stored transcript matches what was delivered live.

No public wire-contract change: the `message.updated` event shape sent to clients is unchanged. No database change.

## Expected result

- User-visible: none. Messages render with the same metadata on every surface.
- Database/persisted data: none. Stored envelopes are the same shared values delivered live.
- Internal: one interface field typed, one new payload variant, one shared delivery helper in the orchestrator, plugin producers drop their shared-model message construction.

## Verification

- `dart analyze` for the whole `bridge/` workspace: no issues.
- `dart test`: app event mapper, event service, dispatcher, history capture, bridge event mapper, orchestrator emit, and plugin event listener suites; ACP, Claude, Codex, Cursor, DeepSeek, Grok, OMP, OpenCode, and Pi suites that assert message events. All pass after rebasing onto merged main.
- Architecture implementation review (sub-agent, single commit): approved, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps message events typed end to end so stored and delivered messages can no longer disagree.

- `BridgeSseMessageUpdated.info` is now a `PluginMessage` instead of a JSON map; ACP, Claude, Codex, OpenCode, and Pi emit their typed envelope directly.
- Message updates are normalized once into a shared `Message`, and the same value drives both delivery and transcript storage, removing the history listener's decode/drop branch.
- The residual session parse-failure log now records the event type, error, and stack without dumping the payload; failure-reporter failures are logged instead of swallowed.
- OpenCode drops a message role it doesn't recognize at the plugin boundary instead of relaying raw payload.
- No wire-contract, database, or user-visible change.

<sup>Written for commit efcdc0407a3355dae2a73df266231029ebb8a7db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

