### PR TITLE
⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -15,7 +15,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | Merged | [#1308](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1308) |
 | 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | Merged | [#1309](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1309) |
 | 7/25 | 🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25] | In review | [#1311](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1311) |
-| 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | Proposed | — |
+| 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | In progress (local, awaiting step 7 merge) | — |
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Proposed | — |
 | 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | Proposed | — |
 | 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | Proposed | — |
@@ -175,3 +175,15 @@ asked to start working the plan; steps execute in order from step 2.
 - The residual session parse-failure log names the event type, error and stack
   without dumping the payload. Failure-reporter failures are logged instead of
   swallowed in the mapper, orchestrator and SSE manager.
+
+## Step 8 execution — 2026-09-05
+
+- `SessionDao.getSessionIdsByBackendIds` projects backend id and stable id for
+  one plugin's requested ids; `SessionRepository.getSessionIdsByBackendIds`
+  returns `Map<String, String>` and both consumers (event translation, subtask
+  child remapping) use it. Full-record reads keep their existing callers.
+- `ProjectsDao.getActivityTimestamps` projects id and both activity columns for
+  requested ids; `ProjectRepository.getActivities` maps those rows without
+  `getAllProjects()`. Unused `getActivity` deleted. Empty inputs return empty at
+  the DAO. Real SQLite tests cover plugin isolation with a shared backend id,
+  missing ids, empty input and timestamp values.

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -14,8 +14,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 4/25 | ⚙️ [periodic-cleanup] bridge: remove unused session paths and tracker state [step 4/25] | Merged | [#1305](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1305) |
 | 5/25 | 🚧 [periodic-cleanup] bridge: remove unused options cache metadata [step 5/25] | Merged | [#1308](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1308) |
 | 6/25 | ⚙️ [periodic-cleanup] plugins: keep session status events typed [step 6/25] | Merged | [#1309](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1309) |
-| 7/25 | 🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25] | In review | [#1311](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1311) |
-| 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | In progress (local, awaiting step 7 merge) | — |
+| 7/25 | 🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25] | Merged | [#1311](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1311) |
+| 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | In review | [#1313](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1313) |
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Proposed | — |
 | 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | Proposed | — |
 | 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | Proposed | — |

--- a/bridge/app/lib/src/api/database/daos/projects_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/projects_dao.dart
@@ -12,6 +12,23 @@ class ProjectsDao(super.attachedDatabase) extends DatabaseAccessor<AppDatabase> 
     return await select(projectsTable).get();
   }
 
+  /// Creation and last-activity timestamps for [projectIds], keyed by id; an
+  /// id with no row is absent. Projects to the three columns the activity
+  /// reconciliation reads instead of loading every project row.
+  Future<Map<String, ({int createdAt, int updatedAt})>> getActivityTimestamps({required Set<String> projectIds}) async {
+    if (projectIds.isEmpty) return const {};
+    final query = selectOnly(projectsTable)
+      ..addColumns([projectsTable.projectId, projectsTable.createdAt, projectsTable.updatedAt])
+      ..where(projectsTable.projectId.isIn(projectIds));
+    final rows = await query.get();
+    return {
+      for (final row in rows)
+        if ((row.read(projectsTable.projectId), row.read(projectsTable.createdAt), row.read(projectsTable.updatedAt))
+            case (final projectId?, final createdAt?, final updatedAt?))
+          projectId: (createdAt: createdAt, updatedAt: updatedAt),
+    };
+  }
+
   /// Upserts the supplied rows without applying merge or import policy.
   Future<void> upsertProjectRows({required List<ProjectDto> rows}) async {
     if (rows.isEmpty) return;

--- a/bridge/app/lib/src/api/database/daos/projects_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/projects_dao.dart
@@ -13,8 +13,8 @@ class ProjectsDao(super.attachedDatabase) extends DatabaseAccessor<AppDatabase> 
   }
 
   /// Creation and last-activity timestamps for [projectIds], keyed by id; an
-  /// id with no row is absent. Projects to the three columns the activity
-  /// reconciliation reads instead of loading every project row.
+  /// id with no row is absent. The query selects only the three columns the
+  /// activity reconciliation reads instead of loading every project row.
   Future<Map<String, ({int createdAt, int updatedAt})>> getActivityTimestamps({required Set<String> projectIds}) async {
     if (projectIds.isEmpty) return const {};
     final query = selectOnly(projectsTable)

--- a/bridge/app/lib/src/api/database/daos/session_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/session_dao.dart
@@ -293,6 +293,28 @@ class SessionDao(super.attachedDatabase) extends DatabaseAccessor<AppDatabase> w
     return {for (final row in rows) row.backendSessionId: row};
   }
 
+  /// Stable ids for [backendSessionIds] of one plugin, keyed by backend id; a
+  /// backend id with no row is absent. Projects to the two id columns because
+  /// event translation and subtask remapping never read the rest of the row.
+  Future<Map<String, String>> getSessionIdsByBackendIds({
+    required String pluginId,
+    required List<String> backendSessionIds,
+  }) async {
+    if (backendSessionIds.isEmpty) return const {};
+    final query = selectOnly(sessionTable)
+      ..addColumns([sessionTable.backendSessionId, sessionTable.sessionId])
+      ..where(sessionTable.pluginId.equals(pluginId) & sessionTable.backendSessionId.isIn(backendSessionIds));
+    final rows = await query.get();
+    return {
+      for (final row in rows)
+        if ((row.read(sessionTable.backendSessionId), row.read(sessionTable.sessionId)) case (
+          final backendSessionId?,
+          final sessionId?,
+        ))
+          backendSessionId: sessionId,
+    };
+  }
+
   Future<Map<String, SessionDto>> getSessionsForPlugin({required String pluginId}) async {
     final rows = await (select(sessionTable)..where((table) => table.pluginId.equals(pluginId))).get();
     return {for (final row in rows) row.backendSessionId: row};

--- a/bridge/app/lib/src/repositories/project_repository.dart
+++ b/bridge/app/lib/src/repositories/project_repository.dart
@@ -238,15 +238,11 @@ class ProjectRepository({
   }
 
   Future<Map<String, ProjectTime>> getActivities({required Set<String> projectIds}) async {
-    final projects = await _projectsDao.getAllProjects();
+    final timestamps = await _projectsDao.getActivityTimestamps(projectIds: projectIds);
     return {
-      for (final project in projects)
-        if (projectIds.contains(project.projectId)) project.projectId: _mapActivity(project)!,
+      for (final entry in timestamps.entries)
+        entry.key: ProjectTime(created: entry.value.createdAt, updated: entry.value.updatedAt),
     };
-  }
-
-  Future<ProjectTime?> getActivity({required String projectId}) async {
-    return _mapActivity(await _projectsDao.getProject(projectId: projectId));
   }
 
   Future<void> writeActivity({required String projectId, required ProjectTime activity}) =>

--- a/bridge/app/lib/src/repositories/session_repository.dart
+++ b/bridge/app/lib/src/repositories/session_repository.dart
@@ -426,7 +426,7 @@ class SessionRepository({
           if (part case MessagePartSubtask(:final childSessionID)) ?childSessionID,
     };
     if (backendSessionIds.isEmpty) return messages;
-    final bindings = await getStoredSessionsByBackendIds(
+    final sessionIds = await getSessionIdsByBackendIds(
       pluginId: pluginId,
       backendSessionIds: backendSessionIds.toList(growable: false),
     );
@@ -437,7 +437,7 @@ class SessionRepository({
             for (final part in message.parts)
               switch (part) {
                 MessagePartSubtask(childSessionID: final backendSessionId?) => part.copyWith(
-                  childSessionID: bindings[backendSessionId]?.id,
+                  childSessionID: sessionIds[backendSessionId],
                 ),
                 _ => part,
               },
@@ -1236,17 +1236,13 @@ class SessionRepository({
     ))?.toStoredSession();
   }
 
-  Future<Map<String, StoredSession>> getStoredSessionsByBackendIds({
+  /// Stable session ids for [backendSessionIds] of [pluginId], keyed by backend
+  /// id. A backend id the bridge has not bound is absent.
+  Future<Map<String, String>> getSessionIdsByBackendIds({
     required String pluginId,
     required List<String> backendSessionIds,
-  }) async {
-    final rows = await _sessionDao.getSessionsByBackendIds(
-      pluginId: pluginId,
-      backendSessionIds: backendSessionIds,
-    );
-    return {
-      for (final entry in rows.entries) entry.key: entry.value.toStoredSession(),
-    };
+  }) {
+    return _sessionDao.getSessionIdsByBackendIds(pluginId: pluginId, backendSessionIds: backendSessionIds);
   }
 
   Future<StoredSession?> updateObservedSessionProjection({

--- a/bridge/app/lib/src/services/session_event_service.dart
+++ b/bridge/app/lib/src/services/session_event_service.dart
@@ -385,7 +385,7 @@ class SessionEventService({
     // delivery: an unbound one is translated to null instead of parking or
     // dropping the event that merely mentions it.
     final optionalBackendSessionIds = _eventMapper.optionalBackendSessionIds(event: source.event);
-    final bindings = await _sessionRepository.getStoredSessionsByBackendIds(
+    final bindings = await _sessionRepository.getSessionIdsByBackendIds(
       pluginId: source.pluginId,
       backendSessionIds: {...backendSessionIds, ...optionalBackendSessionIds}.toList(growable: false),
     );
@@ -419,12 +419,7 @@ class SessionEventService({
       }
       return null;
     }
-    final translated = _eventMapper.map(
-      event: source.event,
-      sessionIdsByBackendId: {
-        for (final entry in bindings.entries) entry.key: entry.value.id,
-      },
-    );
+    final translated = _eventMapper.map(event: source.event, sessionIdsByBackendId: bindings);
     if (!isCurrentEvent(
       pluginId: source.pluginId,
       generation: source.generation,

--- a/bridge/app/test/bridge/persistence/projects_dao_test.dart
+++ b/bridge/app/test/bridge/persistence/projects_dao_test.dart
@@ -300,6 +300,21 @@ void main() {
       });
     });
 
+    test("getActivityTimestamps returns the requested rows' timestamps only", () async {
+      await dao.setActivity(projectId: "/projects/a", createdAt: 10, updatedAt: 20);
+      await dao.setActivity(projectId: "/projects/b", createdAt: 30, updatedAt: 40);
+      await dao.setActivity(projectId: "/projects/c", createdAt: 50, updatedAt: 60);
+
+      expect(
+        await dao.getActivityTimestamps(projectIds: {"/projects/a", "/projects/c", "/projects/missing"}),
+        {
+          "/projects/a": (createdAt: 10, updatedAt: 20),
+          "/projects/c": (createdAt: 50, updatedAt: 60),
+        },
+      );
+      expect(await dao.getActivityTimestamps(projectIds: const {}), isEmpty);
+    });
+
     group("insertProjectsIfMissing", () {
       test("insertProjectsIfMissing inserts all missing projects in one batch", () async {
         await dao.insertProjectsIfMissing(projectIds: ["p1", "p2", "p3"]);

--- a/bridge/app/test/bridge/persistence/session_dao_test.dart
+++ b/bridge/app/test/bridge/persistence/session_dao_test.dart
@@ -157,6 +157,44 @@ void main() {
       );
     });
 
+    test("getSessionIdsByBackendIds projects requested bindings of one plugin only", () async {
+      await db.projectsDao.insertProjectsIfMissing(projectIds: ["/repo"]);
+      Future<void> insert({required String pluginId, required String sessionId, required String backendSessionId}) =>
+          dao.insertSession(
+            pluginId: pluginId,
+            preservePullRequestScope: false,
+            sessionId: sessionId,
+            backendSessionId: backendSessionId,
+            projectId: "/repo",
+            isDedicated: false,
+            createdAt: 100,
+            worktreePath: null,
+            branchName: null,
+            baseBranch: null,
+            baseCommit: null,
+            lastAgent: null,
+            lastAgentModel: null,
+          );
+      // Two plugins may reuse the same backend id; only the requested plugin's
+      // binding may answer.
+      await insert(pluginId: "opencode", sessionId: "stable-a", backendSessionId: "backend-shared");
+      await insert(pluginId: "codex", sessionId: "stable-b", backendSessionId: "backend-shared");
+      await insert(pluginId: "opencode", sessionId: "stable-c", backendSessionId: "backend-other");
+
+      expect(
+        await dao.getSessionIdsByBackendIds(
+          pluginId: "opencode",
+          backendSessionIds: ["backend-shared", "backend-missing"],
+        ),
+        {"backend-shared": "stable-a"},
+      );
+      expect(
+        await dao.getSessionIdsByBackendIds(pluginId: "codex", backendSessionIds: ["backend-shared"]),
+        {"backend-shared": "stable-b"},
+      );
+      expect(await dao.getSessionIdsByBackendIds(pluginId: "opencode", backendSessionIds: const []), isEmpty);
+    });
+
     test("archive clears prompt defaults while observed upsert preserves other bridge metadata", () async {
       await db.projectsDao.insertProjectsIfMissing(projectIds: ["/repo"]);
       await dao.insertSession(

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -503,7 +503,7 @@ class _NoopSessionRepository() implements SessionRepository {
   }) async => null;
 
   @override
-  Future<Map<String, StoredSession>> getStoredSessionsByBackendIds({
+  Future<Map<String, String>> getSessionIdsByBackendIds({
     required String pluginId,
     required List<String> backendSessionIds,
   }) async => const {};
@@ -954,7 +954,7 @@ class FakeSessionRepository({
   }) async => null;
 
   @override
-  Future<Map<String, StoredSession>> getStoredSessionsByBackendIds({
+  Future<Map<String, String>> getSessionIdsByBackendIds({
     required String pluginId,
     required List<String> backendSessionIds,
   }) async => const {};

--- a/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
@@ -353,8 +353,8 @@ void main() {
 
       expect(events, hasLength(4));
       final envelope = (events[0] as BridgeSseMessageUpdated).info;
-      expect(envelope["id"], "root-subagent-child");
-      expect(envelope["sessionID"], "root");
+      expect(envelope.id, "root-subagent-child");
+      expect(envelope.sessionID, "root");
       final child = (events[1] as BridgeSseSessionCreated).info;
       expect(child["id"], "child");
       expect(child["parentID"], "root");
@@ -363,7 +363,7 @@ void main() {
       expect((events[2] as BridgeSseSessionStatus).status, const PluginSessionStatus.busy());
       final tile = (events[3] as BridgeSseMessagePartUpdated).part as PluginMessagePartSubtask;
       expect(tile.id, "root-subagent-child-subtask");
-      expect(tile.messageID, envelope["id"]);
+      expect(tile.messageID, envelope.id);
       expect(tile.prompt, "Inspect the synthetic module");
       expect(tile.description, "Research child");
       expect(tile.agent, DeepSeekIdentity.id);
@@ -417,8 +417,8 @@ void main() {
         "grandchild",
       ]);
       final envelope = nested.whereType<BridgeSseMessageUpdated>().single.info;
-      expect(envelope["id"], "child-subagent-grandchild");
-      expect(envelope["sessionID"], "child");
+      expect(envelope.id, "child-subagent-grandchild");
+      expect(envelope.sessionID, "child");
       final tile = nested.whereType<BridgeSseMessagePartUpdated>().single.part as PluginMessagePartSubtask;
       expect(tile.sessionID, "child");
       expect(tile.id, "child-subagent-grandchild-subtask");
@@ -457,10 +457,10 @@ void main() {
         ),
       );
 
-      final message = events.whereType<BridgeSseMessageUpdated>().single.info;
-      expect(message["sessionID"], "child");
-      expect(message["modelID"], "deepseek-chat");
-      expect(message["providerID"], "deepseek");
+      final message = events.whereType<BridgeSseMessageUpdated>().single.info as PluginMessageAssistant;
+      expect(message.sessionID, "child");
+      expect(message.modelID, "deepseek-chat");
+      expect(message.providerID, "deepseek");
       final text = events.whereType<BridgeSseMessagePartUpdated>().single.part as PluginMessagePartText;
       expect(text.sessionID, "child");
       expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "Child reply");
@@ -483,7 +483,7 @@ void main() {
       );
 
       final message = events.whereType<BridgeSseMessageUpdated>().single.info;
-      expect(message["sessionID"], "child");
+      expect(message.sessionID, "child");
       final text = events.whereType<BridgeSseMessagePartUpdated>().single.part as PluginMessagePartText;
       expect(text.sessionID, "child");
       expect(events.whereType<BridgeSseMessagePartDelta>().single.delta, "Child reply");


### PR DESCRIPTION
## Complexity

⚙️ moderate — two new DAO projections, one repository method renamed and retyped with two production consumers, one unused repository method removed, and real SQLite tests.

## What

- `SessionDao.getSessionIdsByBackendIds` selects only backend id and stable id for one plugin's requested backend ids. `SessionRepository.getStoredSessionsByBackendIds`, which loaded full session records, is replaced by `getSessionIdsByBackendIds` returning a backend-id to stable-id map. Its two production consumers, event translation in `SessionEventService` and subtask child remapping in the repository, use it. The two test fakes follow. Full-record reads keep their other callers.
- `ProjectsDao.getActivityTimestamps` selects project id plus the created and updated columns for requested ids. `ProjectRepository.getActivities` maps those rows to `ProjectTime` without loading every project row. The unused `ProjectRepository.getActivity` is deleted. Empty inputs return an empty result at the DAO.
- Real SQLite DAO tests cover two plugins sharing a backend id, a missing id, empty input, and the timestamp values returned.

## Why

Step 8/25 of `.plan/active/periodic-cleanup`. Event translation only needs stable ids but decoded whole session rows, and activity reconciliation loaded the entire project table to pick a few timestamps. Both reads now fetch exactly what their callers use, with honestly named methods.

## Risk and test focus

Medium query risk, bridge only, no schema change. Impacted: plugin event id translation for every backend, subtask child-session references in loaded history, and project activity reconciliation. Most valuable checks: on a live backend, confirm events for a session and its child sessions still deliver, that a Claude or Codex subtask tile resolves its child link after a cold history load, and that project activity ordering updates after a turn. The generation fence around the awaited binding read is unchanged.

No public wire-contract or database change.

## Expected result

- User-visible: none.
- Database/persisted data: none; read-only projections.
- Internal: two narrower queries, one renamed repository method, one method removed. No latency claim is made without measurement.

## Verification

- `dart analyze` in `bridge/app`: no issues.
- `dart test` for the session and projects DAO suites, session and project repository suites, event service, project activity service, and dispatcher suites: 169 tests pass after rebasing onto merged main.
- Architecture implementation review (sub-agent, single commit): approved, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Step 8/25 of the periodic-cleanup bridge work: session and project reads now fetch only the columns their callers use — stable ids for event translation and child-session remapping, timestamps for activity reconciliation — instead of full rows. No schema, wire-contract, or user-visible change.

- `SessionRepository.getStoredSessionsByBackendIds` is replaced by `getSessionIdsByBackendIds`, which returns a backend-id to stable-id map; both production consumers use it.
- `ProjectsDao.getActivityTimestamps` selects only the id and timestamp columns, and `ProjectRepository.getActivities` maps those rows directly; the unused `getActivity` is removed.
- Real SQLite tests cover plugin isolation with a shared backend id, missing ids, empty input, and timestamp values; the DeepSeek subagent test now asserts typed message envelopes instead of map indexing.

<sup>Written for commit 445d4484c818e69d6e54f0b7ad0c370f862c3282. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

