### PR TITLE
🌿 Name the session in completion push notifications

### DIFF
--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -342,6 +342,7 @@ class Orchestrator({
       completionNotifier: completionNotifier,
       contentBuilder: pushContentBuilder,
       dispatcher: pushDispatcher,
+      resolveSessionTitle: sessionRepository.getSessionTitle,
     );
     final maintenanceListener = MaintenancePushListener(
       tracker: pushTracker,

--- a/bridge/app/lib/src/push/completion_push_listener.dart
+++ b/bridge/app/lib/src/push/completion_push_listener.dart
@@ -2,6 +2,7 @@ import "dart:async";
 
 import "package:meta/meta.dart";
 import "package:rxdart/rxdart.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 import "package:sesori_shared/sesori_shared.dart";
 
 import "completion_notifier.dart";
@@ -14,6 +15,10 @@ class CompletionPushListener({
   required final CompletionNotifier _completionNotifier,
   required final PushNotificationContentBuilder _contentBuilder,
   required final PushDispatcher _dispatcher,
+  // The stored catalog title, not a tracker-cached one: the tracker forgets a
+  // root after it is pruned for idleness or the bridge restarts, which is
+  // exactly when a returning user prompts a long-idle session.
+  required final Future<String?> Function({required String sessionId}) _resolveSessionTitle,
 }) {
   final CompositeSubscription _subscriptions = CompositeSubscription();
   bool _isStarted = false;
@@ -48,12 +53,8 @@ class CompletionPushListener({
     _isStarted = true;
 
     _completionNotifier.completions
-        .listen((rootSessionId) {
-          final sessionTitle = _tracker.getSessionTitle(rootSessionId);
+        .listen((rootSessionId) async {
           final latestAssistantText = _tracker.getLatestAssistantText(rootSessionId);
-          final title = _contentBuilder.truncateTitle(
-            (sessionTitle == null || sessionTitle.trim().isEmpty) ? "Session completed" : sessionTitle,
-          );
           final body = _contentBuilder.truncateToWords(
             (latestAssistantText == null || latestAssistantText.trim().isEmpty)
                 ? "Task completed"
@@ -62,9 +63,15 @@ class CompletionPushListener({
           final projectId = _tracker.getSessionProjectId(sessionId: rootSessionId);
 
           _tracker.clearLatestAssistantTextForRootSubtree(rootSessionId: rootSessionId);
+          final sessionTitle = await _resolveSessionTitle(sessionId: rootSessionId).onError((error, stackTrace) {
+            Log.w("[push] failed to resolve title for session $rootSessionId", error, stackTrace);
+            return null;
+          });
           _dispatcher.dispatchCompletion(
             rootSessionId: rootSessionId,
-            title: title,
+            title: _contentBuilder.truncateTitle(
+              (sessionTitle == null || sessionTitle.trim().isEmpty) ? "Session completed" : sessionTitle,
+            ),
             body: body,
             projectId: projectId,
           );

--- a/bridge/app/lib/src/push/push_session_state_tracker.dart
+++ b/bridge/app/lib/src/push/push_session_state_tracker.dart
@@ -98,10 +98,6 @@ class PushSessionStateTracker({required final DateTime Function() _now}) {
     ).any((sessionState) => sessionState.previouslyBusy);
   }
 
-  String? getSessionTitle(String sessionId) {
-    return _sessions[sessionId]?.title;
-  }
-
   String? getSessionProjectId({required String sessionId}) {
     return _sessions[sessionId]?.projectId;
   }
@@ -517,7 +513,6 @@ class PushSessionStateTracker({required final DateTime Function() _now}) {
     }
 
     sessionState.parentId = nextParentId;
-    sessionState.title = session.title;
     sessionState.projectId = session.projectID;
 
     if (nextParentId != null) {
@@ -530,7 +525,6 @@ class PushSessionStateTracker({required final DateTime Function() _now}) {
 final class _PushTrackedSessionState() {
   String? parentId;
   String? projectId;
-  String? title;
   SessionStatus? status;
   bool previouslyBusy = false;
   final Set<String> childIds = <String>{};

--- a/bridge/app/lib/src/repositories/session_repository.dart
+++ b/bridge/app/lib/src/repositories/session_repository.dart
@@ -1226,6 +1226,14 @@ class SessionRepository({
     return (await _sessionDao.getSession(sessionId: sessionId))?.toStoredSession();
   }
 
+  /// The catalog title shown for [sessionId]: the bridge-owned copy when
+  /// present, otherwise the backend copy. Null when the session has no title
+  /// yet or is not stored.
+  Future<String?> getSessionTitle({required String sessionId}) async {
+    final row = await _sessionDao.getSession(sessionId: sessionId);
+    return row?.title ?? row?.catalogTitle;
+  }
+
   Future<StoredSession?> getStoredSessionByBackendId({
     required String pluginId,
     required String backendSessionId,

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -497,6 +497,9 @@ class _NoopSessionRepository() implements SessionRepository {
   Future<StoredSession?> getStoredSession({required String sessionId}) async => null;
 
   @override
+  Future<String?> getSessionTitle({required String sessionId}) async => null;
+
+  @override
   Future<StoredSession?> getStoredSessionByBackendId({
     required String pluginId,
     required String backendSessionId,
@@ -945,6 +948,12 @@ class FakeSessionRepository({
   @override
   Future<StoredSession?> getStoredSession({required String sessionId}) async {
     return (await _sessionDao.getSession(sessionId: sessionId))?.toStoredSession();
+  }
+
+  @override
+  Future<String?> getSessionTitle({required String sessionId}) async {
+    final row = await _sessionDao.getSession(sessionId: sessionId);
+    return row?.title ?? row?.catalogTitle;
   }
 
   @override

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -159,6 +159,7 @@ _createPushSubsystemForTest() {
       completionNotifier: completionNotifier,
       contentBuilder: const PushNotificationContentBuilder(),
       dispatcher: dispatcher,
+      resolveSessionTitle: ({required String sessionId}) async => null,
     ),
     maintenanceListener: MaintenancePushListener(
       tracker: tracker,

--- a/bridge/app/test/push/completion_push_listener_test.dart
+++ b/bridge/app/test/push/completion_push_listener_test.dart
@@ -97,8 +97,43 @@ void main() {
         ),
       );
 
-      expect(harness.tracker.getSessionTitle("session-a"), equals("Session A"));
+      expect(harness.tracker.getSessionProjectId(sessionId: "session-a"), equals("project-a"));
       expect(harness.dispatcher.immediateEvents, hasLength(2));
+    });
+
+    test("completion title comes from the stored session, not from tracked events", () {
+      fakeAsync((async) {
+        final harness = _newHarness(storedTitles: {"session-a": "Stored session title"});
+        harness.listener.start();
+
+        // No session created/updated event: the root was pruned for idleness or
+        // predates this bridge run, so only the stored title is left.
+        harness.listener.handleSseEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.busy()),
+        );
+        harness.listener.handleSseEvent(
+          const SesoriSseEvent.sessionStatus(sessionID: "session-a", status: SessionStatus.idle()),
+        );
+
+        async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
+
+        expect(harness.dispatcher.completionTitles, equals(["Stored session title"]));
+      });
+    });
+
+    test("completion falls back to a generic title for an untitled session", () {
+      fakeAsync((async) {
+        final harness = _newHarness();
+        harness.listener.start();
+
+        harness.emitCompletion(rootSessionId: "session-a");
+
+        async.elapse(const Duration(milliseconds: 500));
+        async.flushMicrotasks();
+
+        expect(harness.dispatcher.completionTitles, equals(["Session completed"]));
+      });
     });
 
     test("markSessionAborted updates abort suppression state", () {
@@ -200,7 +235,7 @@ class _Harness({
   }
 }
 
-_Harness _newHarness() {
+_Harness _newHarness({Map<String, String> storedTitles = const {}}) {
   final tracker = PushSessionStateTracker(now: DateTime.now);
   final notifier = CompletionNotifier(
     tracker: tracker,
@@ -212,6 +247,7 @@ _Harness _newHarness() {
     completionNotifier: notifier,
     contentBuilder: const PushNotificationContentBuilder(),
     dispatcher: dispatcher,
+    resolveSessionTitle: ({required String sessionId}) async => storedTitles[sessionId],
   );
   return _Harness(
     tracker: tracker,

--- a/bridge/app/test/push/push_dispatcher_test.dart
+++ b/bridge/app/test/push/push_dispatcher_test.dart
@@ -473,7 +473,7 @@ void main() {
 
         harness.completionListener.reset();
 
-        expect(harness.tracker.getSessionTitle("session-a"), isNull);
+        expect(harness.tracker.getSessionProjectId(sessionId: "session-a"), isNull);
         expect(harness.notifier.completionSentRootCount, equals(0));
         expect(harness.notifier.abortedRootCount, equals(0));
       });
@@ -522,6 +522,7 @@ _newHarness({
     completionNotifier: notifier,
     contentBuilder: contentBuilder,
     dispatcher: dispatcher,
+    resolveSessionTitle: ({required String sessionId}) async => null,
   );
   final maintenanceListener = MaintenancePushListener(
     tracker: resolvedTracker,

--- a/bridge/app/test/push/push_session_state_tracker_test.dart
+++ b/bridge/app/test/push/push_session_state_tracker_test.dart
@@ -72,24 +72,6 @@ void main() {
       expect(tracker.resolveRootSessionId("child"), equals("child"));
     });
 
-    test("tracks session titles from session created and updated", () {
-      final tracker = PushSessionStateTracker(now: DateTime.now);
-
-      tracker.handleEvent(
-        SesoriSseEvent.sessionCreated(
-          info: _session(id: "session-a", title: "Initial title"),
-        ),
-      );
-      expect(tracker.getSessionTitle("session-a"), equals("Initial title"));
-
-      tracker.handleEvent(
-        SesoriSseEvent.sessionUpdated(
-          info: _session(id: "session-a", title: "Updated title"),
-        ),
-      );
-      expect(tracker.getSessionTitle("session-a"), equals("Updated title"));
-    });
-
     test("tracks messageID to role from message updated events", () {
       final tracker = PushSessionStateTracker(now: DateTime.now);
 
@@ -427,20 +409,6 @@ void main() {
       expect(tracker.hasPendingInteraction("root"), isFalse);
     });
 
-    test("getSessionTitle returns cached title or null", () {
-      final tracker = PushSessionStateTracker(now: DateTime.now);
-
-      expect(tracker.getSessionTitle("missing"), isNull);
-
-      tracker.handleEvent(
-        SesoriSseEvent.sessionCreated(
-          info: _session(id: "session-a", title: "A title"),
-        ),
-      );
-
-      expect(tracker.getSessionTitle("session-a"), equals("A title"));
-    });
-
     test("getLatestAssistantText returns cached text or null", () {
       final tracker = PushSessionStateTracker(now: DateTime.now);
 
@@ -554,7 +522,6 @@ void main() {
 
       expect(tracker.isSessionGroupFullyIdle("root"), isTrue);
       expect(tracker.hasPendingInteraction("root"), isFalse);
-      expect(tracker.getSessionTitle("root"), isNull);
       expect(tracker.getLatestAssistantText("root"), isNull);
       expect(tracker.wasPreviouslyBusy("root"), isFalse);
       expect(tracker.resolveRootSessionId("child"), equals("child"));
@@ -582,7 +549,6 @@ void main() {
 
       expect(tracker.isSessionGroupFullyIdle("root"), isFalse);
       expect(tracker.hasPendingInteraction("root"), isTrue);
-      expect(tracker.getSessionTitle("root"), equals("Root title"));
     });
 
     test("cleans up session state on session deleted", () {
@@ -628,7 +594,6 @@ void main() {
 
       expect(tracker.isSessionGroupFullyIdle("root"), isTrue);
       expect(tracker.hasPendingInteraction("root"), isFalse);
-      expect(tracker.getSessionTitle("root"), isNull);
       expect(tracker.wasPreviouslyBusy("root"), isFalse);
       expect(tracker.resolveRootSessionId("child"), equals("child"));
     });

--- a/docs/regression/notifications.md
+++ b/docs/regression/notifications.md
@@ -55,7 +55,9 @@ external.
   cannot fail session work or desktop startup.
 - Mobile payloads carry category, event type, session and project identity, and user-visible event content. Question and
   permission bodies use backend text; update bodies may include the version; completion uses the bounded session title
-  and up to ten whitespace-delimited words of the latest assistant text.
+  and up to ten whitespace-delimited words of the latest assistant text. The completion title is read from the stored
+  session at send time, so a session whose in-memory push state was pruned for idleness or lost to a bridge restart
+  still names itself; only a session with no stored title falls back to generic completion copy.
 
 ## Regression Levels
 


### PR DESCRIPTION
## Complexity

Straightforward: the completion notification now reads the session title from
storage instead of an in-memory cache, and that cache is deleted.

## What

- `CompletionPushListener` resolves the completion title through a new
  `SessionRepository.getSessionTitle` (bridge-owned title, else catalog title)
  at send time.
- Removed the title field and `getSessionTitle` from `PushSessionStateTracker`;
  the DB is now the only source for it.
- A failed title read is logged and still sends the notification with the
  generic fallback.

## Why

The title came from the push tracker, which only learns one from a session
created/updated SSE event. Tracker state is pruned after 30 idle minutes
(`rootIdlePruneTtl`) and starts empty after every bridge restart, so prompting
a session that had been idle for a while produced "Session completed" instead
of its name — exactly the case where a returning user needs the name.

## Risk and test focus

Bridge-only; no database, wire contract, or client change. The completion
dispatch now awaits one indexed session row read before sending, so the push
is issued a microtask later; ordering with the debounced completion stream is
unchanged because the assistant-text snapshot and clear still happen
synchronously. Focus on completion notification titles for restarted or
long-idle sessions across harnesses.

## Expected result

A completion notification is titled with the session's title, whatever the
harness and however long the session was idle. Only a session with no stored
title falls back to "Session completed".

## Verification

- `dart test test/push test/bridge/runtime/bridge_runtime_builder_test.dart`
  (bridge/app) — passes, including two new tests: title from storage without
  any session event, and the untitled fallback.
- `dart analyze lib test` (bridge/app) — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completion push notifications now read the session title from the stored session at send time instead of the in-memory push tracker cache, so long-idle or bridge-restarted sessions keep their name instead of falling back to the generic "Session completed" title. Sessions with no stored title still fall back to generic copy, and a failed title read logs a warning and uses the same fallback.

- Removes the title field and `getSessionTitle` from `PushSessionStateTracker`; the stored session is now the only source for the title.
- Completion dispatch now awaits one indexed session row read before sending, so the push fires a microtask later; snapshot and clear of assistant text still happen synchronously.
- Bridge-only change; no database, wire contract, or client changes.

<sup>Written for commit ff843d47bdd58ef7ff727c68a53909b257a00704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

