### PR TITLE
🚧 [managed-runtime-auto-upgrade] runtime: select supported managed versions and sweep by ownership [step 2/5]

### DIFF
--- a/.plan/active/managed-runtime-auto-upgrade/PLAN.md
+++ b/.plan/active/managed-runtime-auto-upgrade/PLAN.md
@@ -130,9 +130,18 @@ provider configuration, session history, or a running session's executable.
 - `ManagedRuntimeInventory` gains
   `List<RuntimeVersion> installedVersions({required String stateDirectory})`:
   version directory names under `<stateDirectory>/<runtimeId>/` that parse with
-  `manifest.parseVersion`, sorted descending. `hasSupersededVersion` becomes a
-  one-line derivation. Unparseable names are ignored; read errors log and yield
-  an empty list, as today.
+  `manifest.parseInstalledVersion`, sorted descending. `hasSupersededVersion`
+  becomes a one-line derivation. Unparseable names are ignored; read errors log
+  and yield an empty list, as today.
+- `RuntimeManifest.parseInstalledVersion` is new, defaulting to `parseVersion`.
+  `parseVersion` parses a token of `--version` output, and OMP's requires an
+  `omp/` prefix so an unrelated semver token in that output is not mistaken for
+  the runtime version. Directory names carry the bare version, so OMP overrides
+  the new method. Without the split, OMP silently never finds a superseded
+  managed version — a latent bug this plan would otherwise make load-bearing.
+- `RuntimeManifest.managedBinaryPath` takes a `version` instead of assuming the
+  pinned one, so ordered candidate probing reuses it rather than repeating the
+  `<stateDirectory>/<runtimeId>/<version>/<binaryFileName>` layout.
 - `ManagedRuntimeSelectionService` takes the inventory and drops
   `managedVersionPolicy`. Managed candidates are probed in order: the pinned
   version directory, then every other installed version `>= minPathVersion`
@@ -184,10 +193,13 @@ provider configuration, session history, or a running session's executable.
   `bool needsManagedRuntimeUpgrade({required PluginConfig config, required
   String stateDirectory})`, default `false`, sync and disk-only. The
   descriptor is the single owner of the decision: each managed descriptor
-  returns `_supportsManagedInstall(config) &&
-  inventory.hasSupersededVersion(stateDirectory)`, which already folds in the
-  explicit-binary and platform gates behind its `install` capability. The
-  lifecycle service does not re-check the capability.
+  returns `managementCapabilities(config).contains(install) &&
+  inventory.hasSupersededVersion(stateDirectory)`. The capability is the gate
+  rather than each descriptor's private `_supportsManagedInstall`, because
+  OpenCode additionally drops `install` in attach mode
+  (`--opencode-no-auto-start`) — where Sesori does not own the runtime — and the
+  private helper does not capture that. The lifecycle service does not re-check
+  the capability.
 
 ### 3. Startup trigger (`bridge/app`)
 
@@ -279,7 +291,10 @@ implementation appears to need any of these, stop and ask.
 ## Cleanup Assessment
 
 - `ManagedRuntimeVersionPolicy` and its `select` parameter are removed in
-  Step 2, along with the selection test "applies exact or minimum policy".
+  Step 2, along with the selection test "applies exact or minimum policy". The
+  provision-service test "does not accept a managed runtime with a different
+  version" is replaced by a below-minimum rejection, which is what the single
+  remaining rule asserts.
 - The provision-notice message that names `bundledVersion` for an older
   managed runtime is corrected in Step 2.
 - The "This bridge needs a newer X. Install it from Sesori" hints in OpenCode,

--- a/.plan/active/managed-runtime-auto-upgrade/TRACKER.md
+++ b/.plan/active/managed-runtime-auto-upgrade/TRACKER.md
@@ -2,8 +2,8 @@
 
 | Step | PR title | Status | PR | Notes |
 |---|---|---|---|---|
-| 1/5 | 🌱 [managed-runtime-auto-upgrade] docs: plan automatic managed runtime upgrades [step 1/5] | This PR | — | |
-| 2/5 | 🚧 [managed-runtime-auto-upgrade] runtime: select supported managed versions and sweep by ownership [step 2/5] | Planned | — | |
+| 1/5 | 🌱 [managed-runtime-auto-upgrade] docs: plan automatic managed runtime upgrades [step 1/5] | Merged | #1312 | |
+| 2/5 | 🚧 [managed-runtime-auto-upgrade] runtime: select supported managed versions and sweep by ownership [step 2/5] | This PR | — | Two plan deviations, both recorded in `PLAN.md`: the upgrade gate is the `install` capability (OpenCode drops it in attach mode), and `RuntimeManifest.parseInstalledVersion` splits directory-name parsing from `--version` token parsing so OMP's `omp/` prefix stops hiding its superseded versions. |
 | 3/5 | ⚙️ [managed-runtime-auto-upgrade] bridge: upgrade superseded managed runtimes on startup [step 3/5] | Planned | — | |
 | 4/5 | 🌱 [managed-runtime-auto-upgrade] docs: reconcile runtime upgrade regression coverage [step 4/5] | Planned | — | |
 | 5/5 | 🌿 [managed-runtime-auto-upgrade] verify: run runtime upgrade coverage and retire the plan [step 5/5] | Planned | — | |

--- a/bridge/app/lib/src/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/runtime/plugin_runtime.dart
@@ -229,6 +229,10 @@ class PluginRuntime({
   /// state — the caller re-inspects setup after a terminal [ProvisionReady].
   /// A shutdown aborts the install cooperatively via the returned stream's
   /// abort signal.
+  ///
+  /// An install may overlap a generation running from an older managed runtime
+  /// version, so the descriptor also receives the slot's live in-use fact to
+  /// gate its cleanup.
   Stream<RuntimeProvisionProgress> installRuntime({required String pluginId}) async* {
     final slot = _requireSlot(pluginId);
     if (_shuttingDown) {
@@ -244,6 +248,7 @@ class PluginRuntime({
         environment: _environment,
         stateDirectory: slot.registration.stateDirectory,
         startAborted: abortController.signal,
+        runtimeInUse: _SlotRuntimeInUseSignal(slot: slot),
       );
     } finally {
       _installAbortControllers.remove(abortController);
@@ -1850,6 +1855,17 @@ class _PluginRuntimeSlot({required final PluginRuntimeRegistration registration}
   StreamSubscription<BridgeSseEvent>? eventSubscription;
   bool allowPendingInputResolutionsDuringStop = false;
   final Set<Future<void> Function()> operationStreamCancellations = <Future<void> Function()>{};
+}
+
+/// Reports a slot's live generation to an in-flight managed-runtime install.
+///
+/// Read on each access rather than captured: a generation can start or stop
+/// while a download runs, and the installer only cares about the moment it
+/// decides whether to sweep. A starting generation counts — it has already
+/// resolved the binary path it will launch.
+class const _SlotRuntimeInUseSignal({required final _PluginRuntimeSlot _slot}) implements RuntimeInUseSignal {
+  @override
+  bool get isInUse => _slot.plugin != null || _slot.startFuture != null;
 }
 
 class _PluginRuntimeAuthentication({

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -78,7 +78,7 @@ void main() {
     final runtime = _runtime(
       factory: _FakeGenerationFactory(startGate: Future<void>.value()),
       descriptor: _FakeDescriptor(
-        install: (startAborted) async* {
+        install: (startAborted, runtimeInUse) async* {
           yield const ProvisionResolving();
           await installGate.future;
           if (startAborted.isAborted) throw const PluginStartAbortedException();
@@ -96,6 +96,32 @@ void main() {
     runtime.beginShutdown();
     installGate.complete();
     await expectLater(done, throwsA(isA<PluginStartAbortedException>()));
+  });
+
+  test("installRuntime reports a live generation to the descriptor", () async {
+    final installGate = Completer<void>();
+    final inUseReadings = <bool>[];
+    final factory = _FakeGenerationFactory(startGate: Future<void>.value());
+    final runtime = _runtime(
+      factory: factory,
+      descriptor: _FakeDescriptor(
+        install: (startAborted, runtimeInUse) async* {
+          inUseReadings.add(runtimeInUse.isInUse);
+          await installGate.future;
+          inUseReadings.add(runtimeInUse.isInUse);
+          yield const ProvisionReady(binaryPath: "/managed/one");
+        },
+      ),
+    );
+    addTearDown(runtime.dispose);
+
+    final done = runtime.installRuntime(pluginId: "one").drain<void>();
+    await _waitUntil(() => inUseReadings.isNotEmpty);
+    await runtime.start(pluginId: "one");
+    installGate.complete();
+    await done;
+
+    expect(inUseReadings, [false, true], reason: "the signal is read live, not captured at install start");
   });
 
   test("installRuntime fails immediately while shutting down", () async {
@@ -1947,7 +1973,8 @@ class _FakeGenerationFactory({
 
 class const _FakeDescriptor({
   final Future<PluginSetupStatus> Function()? inspect,
-  final Stream<RuntimeProvisionProgress> Function(StartAbortSignal startAborted)? install,
+  final Stream<RuntimeProvisionProgress> Function(StartAbortSignal startAborted, RuntimeInUseSignal runtimeInUse)?
+  install,
 }) extends BridgePluginDescriptor {
   @override
   String get id => "one";
@@ -1981,6 +2008,7 @@ class const _FakeDescriptor({
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal startAborted,
+    required RuntimeInUseSignal runtimeInUse,
   }) {
     final handler = install;
     if (handler == null) {
@@ -1990,9 +2018,10 @@ class const _FakeDescriptor({
         environment: environment,
         stateDirectory: stateDirectory,
         startAborted: startAborted,
+        runtimeInUse: runtimeInUse,
       );
     }
-    return handler(startAborted);
+    return handler(startAborted, runtimeInUse);
   }
 
   @override

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -230,13 +230,13 @@ class const CodexPluginDescriptor({
         manifest: manifest,
         probeTimeout: _versionProbeTimeout,
       ),
+      inventory: const ManagedRuntimeInventory(manifest: manifest),
     ).select(
       explicitExecutablePath: _explicitBin(config),
       fallbackExecutableCandidates: _desktopCandidates(environment: environment),
       environment: environment,
       stateDirectory: stateDirectory,
       abortSignal: abortSignal,
-      managedVersionPolicy: ManagedRuntimeVersionPolicy.exact,
     );
   }
 
@@ -265,12 +265,21 @@ class const CodexPluginDescriptor({
   }
 
   @override
+  bool needsManagedRuntimeUpgrade({required PluginConfig config, required String stateDirectory}) {
+    if (!managementCapabilities(config: config).contains(PluginControlCapability.install)) return false;
+    return const ManagedRuntimeInventory(
+      manifest: CodexRuntimeManifest(),
+    ).hasSupersededVersion(stateDirectory: stateDirectory);
+  }
+
+  @override
   Stream<RuntimeProvisionProgress> installRuntime({
     required PluginConfig config,
     required HostProcessService processes,
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal startAborted,
+    required RuntimeInUseSignal runtimeInUse,
   }) async* {
     const manifest = CodexRuntimeManifest();
     final commandExecutor = HostProcessCommandExecutor(
@@ -301,6 +310,7 @@ class const CodexPluginDescriptor({
         environment: environment,
         stateDirectory: stateDirectory,
         startAborted: startAborted,
+        runtimeInUse: runtimeInUse,
       );
     } finally {
       httpClient.close();
@@ -432,6 +442,7 @@ class const CodexPluginDescriptor({
           manifest: manifest,
           probeTimeout: _versionProbeTimeout,
         ),
+        inventory: const ManagedRuntimeInventory(manifest: manifest),
       ),
       fallbackExecutableCandidates: _desktopCandidates(environment: host.environment),
     ).provision(host: host, explicitExecutablePath: null);

--- a/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart
@@ -3,10 +3,58 @@ import "dart:convert";
 import "dart:io";
 
 import "package:codex_plugin/codex_plugin.dart";
+import "package:path/path.dart" as p;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 import "package:test/test.dart";
 
 void main() {
+  group("CodexPluginDescriptor.needsManagedRuntimeUpgrade", () {
+    const descriptor = CodexPluginDescriptor(desktopAppCliCandidates: []);
+    const config = PluginConfig(values: {"port": null, "bin": "codex"});
+    late Directory stateDir;
+
+    setUp(() async {
+      stateDir = await Directory.systemTemp.createTemp("codex-upgrade");
+    });
+
+    tearDown(() async {
+      if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+    });
+
+    void installedVersion(String version) {
+      Directory(p.join(stateDir.path, const CodexRuntimeManifest().runtimeId, version)).createSync(recursive: true);
+    }
+
+    test("declines without any managed runtime on disk", () {
+      expect(descriptor.needsManagedRuntimeUpgrade(config: config, stateDirectory: stateDir.path), isFalse);
+    });
+
+    test("declines when only the pinned version is installed", () {
+      installedVersion(const CodexRuntimeManifest().bundledVersion.raw);
+
+      expect(descriptor.needsManagedRuntimeUpgrade(config: config, stateDirectory: stateDir.path), isFalse);
+    });
+
+    test("asks for an upgrade when a superseded version is installed", () {
+      installedVersion("0.140.0");
+
+      expect(descriptor.needsManagedRuntimeUpgrade(config: config, stateDirectory: stateDir.path), isTrue);
+    });
+
+    test("declines with an explicit binary override", () {
+      installedVersion("0.140.0");
+
+      expect(
+        descriptor.needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {"port": null, "bin": "/opt/codex/bin/codex"}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group("CodexPluginDescriptor.inspectSetup", () {
     const stateDirectory = "/state";
     const config = PluginConfig(values: {"port": null, "bin": "codex"});
@@ -98,9 +146,80 @@ void main() {
       expect(result, isA<PluginSetupRuntimeMissing>());
     });
 
+    test("recognizes a superseded but still supported managed runtime", () async {
+      final stateDir = await Directory.systemTemp.createTemp("codex-setup");
+      addTearDown(() async {
+        if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+      });
+      const manifest = CodexRuntimeManifest();
+      final supersededVersion = SemanticRuntimeVersion.parse(value: "0.140.0");
+      Directory(p.join(stateDir.path, manifest.runtimeId, supersededVersion.raw)).createSync(recursive: true);
+      final supersededPath = manifest.managedBinaryPath(stateDirectory: stateDir.path, version: supersededVersion);
+      final processes = _ProbeProcessService(
+        spawnOutcomes: [
+          const ProcessException("codex", ["--version"], "missing", 2),
+          ProcessException(
+            manifest.managedBinaryPath(stateDirectory: stateDir.path, version: manifest.bundledVersion),
+            const ["--version"],
+            "missing",
+            2,
+          ),
+          _ProbeProcess(
+            pid: 5,
+            stdoutBytes: utf8.encode("codex 0.140.0\n"),
+            exitCode: Future<int>.value(0),
+          ),
+          _ProbeProcess(
+            pid: 6,
+            stdoutBytes: utf8.encode("Logged in using ChatGPT\n"),
+            exitCode: Future<int>.value(0),
+          ),
+        ],
+      );
+
+      final result = await descriptor.inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDir.path,
+      );
+
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.140.0"));
+      expect(processes.spawnedExecutables.last, supersededPath);
+    });
+
+    test("ignores a managed runtime below the minimum supported version", () async {
+      final stateDir = await Directory.systemTemp.createTemp("codex-setup");
+      addTearDown(() async {
+        if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+      });
+      const manifest = CodexRuntimeManifest();
+      Directory(p.join(stateDir.path, manifest.runtimeId, "0.138.0")).createSync(recursive: true);
+      final processes = _ProbeProcessService(
+        spawnError: const ProcessException("codex", ["--version"], "missing", 2),
+      );
+
+      final result = await descriptor.inspectSetup(
+        config: config,
+        processes: processes,
+        environment: const <String, String>{},
+        stateDirectory: stateDir.path,
+      );
+
+      expect(result, isA<PluginSetupRuntimeMissing>());
+      expect(
+        processes.spawnedExecutables,
+        isNot(contains(contains("0.138.0"))),
+        reason: "an obsolete managed version is never a selection candidate",
+      );
+    });
+
     test("recognizes and authenticates a previously installed managed runtime", () async {
       const manifest = CodexRuntimeManifest();
-      final managedBinaryPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
+      final managedBinaryPath = manifest.managedBinaryPath(
+        stateDirectory: stateDirectory,
+        version: manifest.bundledVersion,
+      );
       final processes = _ProbeProcessService(
         spawnOutcomes: [
           const ProcessException("codex", ["--version"], "missing", 2),
@@ -165,7 +284,10 @@ void main() {
 
     test("reports an indeterminate desktop-app fallback probe", () async {
       const manifest = CodexRuntimeManifest();
-      final managedBinaryPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
+      final managedBinaryPath = manifest.managedBinaryPath(
+        stateDirectory: stateDirectory,
+        version: manifest.bundledVersion,
+      );
       const appCli = "/Applications/ChatGPT.app/Contents/Resources/codex";
       final processes = _ProbeProcessService(
         spawnOutcomes: [
@@ -195,7 +317,10 @@ void main() {
 
     test("keeps an indeterminate PATH probe when desktop fallbacks are absent", () async {
       const manifest = CodexRuntimeManifest();
-      final managedBinaryPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
+      final managedBinaryPath = manifest.managedBinaryPath(
+        stateDirectory: stateDirectory,
+        version: manifest.bundledVersion,
+      );
       const appCli = "/Applications/ChatGPT.app/Contents/Resources/codex";
       final processes = _ProbeProcessService(
         spawnOutcomes: [
@@ -224,7 +349,10 @@ void main() {
 
     test("skips an outdated desktop-app CLI in favor of the managed runtime", () async {
       const manifest = CodexRuntimeManifest();
-      final managedBinaryPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
+      final managedBinaryPath = manifest.managedBinaryPath(
+        stateDirectory: stateDirectory,
+        version: manifest.bundledVersion,
+      );
       const appCli = "/Applications/ChatGPT.app/Contents/Resources/codex";
       final processes = _ProbeProcessService(
         spawnOutcomes: [

--- a/bridge/sesori_plugin_copilot/lib/src/runtime/copilot_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_copilot/lib/src/runtime/copilot_plugin_descriptor.dart
@@ -100,6 +100,14 @@ final class const CopilotPluginDescriptor({
   }
 
   @override
+  bool needsManagedRuntimeUpgrade({required PluginConfig config, required String stateDirectory}) {
+    if (!managementCapabilities(config: config).contains(PluginControlCapability.install)) return false;
+    return const ManagedRuntimeInventory(
+      manifest: CopilotRuntimeManifest(),
+    ).hasSupersededVersion(stateDirectory: stateDirectory);
+  }
+
+  @override
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
     const manifest = CopilotRuntimeManifest();
     yield* ManagedRuntimeProvisionService(
@@ -107,6 +115,7 @@ final class const CopilotPluginDescriptor({
       selectionService: ManagedRuntimeSelectionService(
         manifest: manifest,
         versionValidator: _versionValidator(processes: host.processes),
+        inventory: const ManagedRuntimeInventory(manifest: manifest),
       ),
       fallbackExecutableCandidates: const [],
     ).provision(
@@ -122,6 +131,7 @@ final class const CopilotPluginDescriptor({
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal startAborted,
+    required RuntimeInUseSignal runtimeInUse,
   }) async* {
     const manifest = CopilotRuntimeManifest();
     final commandExecutor = HostProcessCommandExecutor(
@@ -152,6 +162,7 @@ final class const CopilotPluginDescriptor({
         environment: environment,
         stateDirectory: stateDirectory,
         startAborted: startAborted,
+        runtimeInUse: runtimeInUse,
       );
     } finally {
       httpClient.close();
@@ -171,13 +182,13 @@ final class const CopilotPluginDescriptor({
         await ManagedRuntimeSelectionService(
           manifest: manifest,
           versionValidator: _versionValidator(processes: processes),
+          inventory: const ManagedRuntimeInventory(manifest: manifest),
         ).select(
           explicitExecutablePath: explicitBin,
           fallbackExecutableCandidates: const [],
           environment: environment,
           stateDirectory: stateDirectory,
           abortSignal: StartAbortSignal.never,
-          managedVersionPolicy: ManagedRuntimeVersionPolicy.exact,
         );
     return switch (selection) {
       ManagedRuntimeSelected(:final version) => PluginSetupReady.versioned(runtimeVersion: version.raw),

--- a/bridge/sesori_plugin_copilot/test/copilot_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_copilot/test/copilot_plugin_descriptor_test.dart
@@ -6,6 +6,59 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 void main() {
+  group("CopilotPluginDescriptor.needsManagedRuntimeUpgrade", () {
+    final descriptor = CopilotPluginDescriptor.production();
+    late Directory stateDir;
+
+    setUp(() async {
+      stateDir = await Directory.systemTemp.createTemp("copilot-upgrade");
+    });
+
+    tearDown(() async {
+      if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+    });
+
+    void installedVersion(String version) {
+      Directory("${stateDir.path}/${const CopilotRuntimeManifest().runtimeId}/$version").createSync(recursive: true);
+    }
+
+    test("declines without a superseded managed runtime", () {
+      installedVersion(const CopilotRuntimeManifest().bundledVersion.raw);
+
+      expect(
+        descriptor.needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {CopilotPluginDescriptor.binOption: "copilot"}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+
+    test("asks for an upgrade when a superseded version is installed", () {
+      installedVersion("1.0.79");
+
+      expect(
+        descriptor.needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {CopilotPluginDescriptor.binOption: "copilot"}),
+          stateDirectory: stateDir.path,
+        ),
+        isTrue,
+      );
+    });
+
+    test("declines with an explicit binary override", () {
+      installedVersion("1.0.79");
+
+      expect(
+        descriptor.needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {CopilotPluginDescriptor.binOption: "/custom/copilot"}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   const defaultConfig = PluginConfig(values: {CopilotPluginDescriptor.binOption: "copilot"});
 
   test("offers managed install only for automatic runtime selection", () {
@@ -60,6 +113,7 @@ void main() {
             environment: const {},
             stateDirectory: "/state",
             startAborted: controller.signal,
+            runtimeInUse: RuntimeInUseSignal.never,
           )
           .toList(),
       throwsA(isA<PluginStartAbortedException>()),

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -182,10 +182,19 @@ class const CursorPluginDescriptor({
           processes: host.processes,
           maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
         ),
+        inventory: const ManagedRuntimeInventory(manifest: manifest),
       ),
       // Cursor has no desktop-app-bundled CLI to fall back to.
       fallbackExecutableCandidates: const [],
     );
+  }
+
+  @override
+  bool needsManagedRuntimeUpgrade({required PluginConfig config, required String stateDirectory}) {
+    if (!managementCapabilities(config: config).contains(PluginControlCapability.install)) return false;
+    return const ManagedRuntimeInventory(
+      manifest: CursorRuntimeManifest(),
+    ).hasSupersededVersion(stateDirectory: stateDirectory);
   }
 
   @override
@@ -195,6 +204,7 @@ class const CursorPluginDescriptor({
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal startAborted,
+    required RuntimeInUseSignal runtimeInUse,
   }) async* {
     const manifest = CursorRuntimeManifest();
     final commandExecutor = HostProcessCommandExecutor(
@@ -224,6 +234,7 @@ class const CursorPluginDescriptor({
         environment: environment,
         stateDirectory: stateDirectory,
         startAborted: startAborted,
+        runtimeInUse: runtimeInUse,
       );
     } finally {
       httpClient.close();
@@ -255,20 +266,21 @@ class const CursorPluginDescriptor({
     required String stateDirectory,
   }) async {
     final explicitBin = _explicitBin(config);
-    final selection = await ManagedRuntimeSelectionService(
-      manifest: const CursorRuntimeManifest(),
-      versionValidator: _versionValidatorFor(
-        processes: processes,
-        maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
-      ),
-    ).select(
-      explicitExecutablePath: explicitBin,
-      fallbackExecutableCandidates: const [],
-      environment: environment,
-      stateDirectory: stateDirectory,
-      abortSignal: StartAbortSignal.never,
-      managedVersionPolicy: ManagedRuntimeVersionPolicy.minimum,
-    );
+    final selection =
+        await ManagedRuntimeSelectionService(
+          manifest: const CursorRuntimeManifest(),
+          versionValidator: _versionValidatorFor(
+            processes: processes,
+            maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+          ),
+          inventory: const ManagedRuntimeInventory(manifest: CursorRuntimeManifest()),
+        ).select(
+          explicitExecutablePath: explicitBin,
+          fallbackExecutableCandidates: const [],
+          environment: environment,
+          stateDirectory: stateDirectory,
+          abortSignal: StartAbortSignal.never,
+        );
 
     /// What to tell the user when nothing usable was found and Sesori can
     /// install the runtime itself.
@@ -296,8 +308,8 @@ class const CursorPluginDescriptor({
           ),
         };
       }
-      if (selection.primaryRejection case ManagedRuntimeProbeRejected(outcome: RuntimeProbeMissing()) ||
-          ManagedRuntimeVersionRejected()) {
+      if (selection.primaryRejection
+          case ManagedRuntimeProbeRejected(outcome: RuntimeProbeMissing()) || ManagedRuntimeVersionRejected()) {
         return PluginSetupRuntimeMissing(actionHint: missingRuntimeHint());
       }
       return const PluginSetupUnknown(

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_descriptor_availability_test.dart
@@ -5,11 +5,64 @@ import "dart:io";
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:cursor_plugin/cursor_plugin.dart";
+import "package:path/path.dart" as p;
 import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 void main() {
+  group("CursorPluginDescriptor.needsManagedRuntimeUpgrade", () {
+    const config = PluginConfig(
+      values: {
+        CursorPluginDescriptor.binOption: "cursor-agent",
+        CursorPluginDescriptor.apiEndpointOption: null,
+      },
+    );
+    late Directory stateDir;
+
+    setUp(() async {
+      stateDir = await Directory.systemTemp.createTemp("cursor-upgrade");
+    });
+
+    tearDown(() async {
+      if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+    });
+
+    void installedVersion(String version) {
+      Directory(p.join(stateDir.path, const CursorRuntimeManifest().runtimeId, version)).createSync(recursive: true);
+    }
+
+    test("declines without a superseded managed runtime", () {
+      installedVersion(const CursorRuntimeManifest().bundledVersion.raw);
+
+      expect(
+        const CursorPluginDescriptor().needsManagedRuntimeUpgrade(config: config, stateDirectory: stateDir.path),
+        isFalse,
+      );
+    });
+
+    test("asks for an upgrade when a superseded version is installed", () {
+      installedVersion("2026.07.20-abc1234");
+
+      expect(
+        const CursorPluginDescriptor().needsManagedRuntimeUpgrade(config: config, stateDirectory: stateDir.path),
+        isTrue,
+      );
+    });
+
+    test("declines with an explicit binary override", () {
+      installedVersion("2026.07.20-abc1234");
+
+      expect(
+        const CursorPluginDescriptor().needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {"bin": "/custom/cursor-agent", "api-endpoint": null}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group("CursorPluginDescriptor.inspectSetup", () {
     const stateDirectory = "/state";
     const config = PluginConfig(
@@ -176,7 +229,10 @@ void main() {
 
     test("reports the managed runtime version selected after PATH is missing", () async {
       const manifest = CursorRuntimeManifest();
-      final managedBinaryPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
+      final managedBinaryPath = manifest.managedBinaryPath(
+        stateDirectory: stateDirectory,
+        version: manifest.bundledVersion,
+      );
       final processes = _ProbeProcessService(
         spawnOutcomes: [
           const ProcessException("cursor-agent", ["--version"], "missing", 2),

--- a/bridge/sesori_plugin_cursor/test/runtime/cursor_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_cursor/test/runtime/cursor_runtime_manifest_test.dart
@@ -71,7 +71,7 @@ void main() {
 
   test("managed binaries live under a version-scoped directory", () {
     expect(
-      manifest.managedBinaryPath(stateDirectory: "/state"),
+      manifest.managedBinaryPath(stateDirectory: "/state", version: manifest.bundledVersion),
       "/state/cursor/2026.08.11-e8db854/cursor-agent",
     );
   });

--- a/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
@@ -82,6 +82,14 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
   }
 
   @override
+  bool needsManagedRuntimeUpgrade({required PluginConfig config, required String stateDirectory}) {
+    if (!managementCapabilities(config: config).contains(PluginControlCapability.install)) return false;
+    return const ManagedRuntimeInventory(
+      manifest: DeepSeekRuntimeManifest(),
+    ).hasSupersededVersion(stateDirectory: stateDirectory);
+  }
+
+  @override
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
     const manifest = DeepSeekRuntimeManifest();
     yield* ManagedRuntimeProvisionService(
@@ -89,6 +97,7 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
       selectionService: ManagedRuntimeSelectionService(
         manifest: manifest,
         versionValidator: _versionValidator(processes: host.processes),
+        inventory: const ManagedRuntimeInventory(manifest: manifest),
       ),
       fallbackExecutableCandidates: const [],
     ).provision(
@@ -104,6 +113,7 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal startAborted,
+    required RuntimeInUseSignal runtimeInUse,
   }) async* {
     const manifest = DeepSeekRuntimeManifest();
     final commandExecutor = _executor(processes);
@@ -126,6 +136,7 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
         environment: environment,
         stateDirectory: stateDirectory,
         startAborted: startAborted,
+        runtimeInUse: runtimeInUse,
       );
     } finally {
       httpClient.close();
@@ -145,13 +156,13 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
         await ManagedRuntimeSelectionService(
           manifest: manifest,
           versionValidator: _versionValidator(processes: processes),
+          inventory: const ManagedRuntimeInventory(manifest: manifest),
         ).select(
           explicitExecutablePath: explicit,
           fallbackExecutableCandidates: const [],
           environment: environment,
           stateDirectory: stateDirectory,
           abortSignal: StartAbortSignal.never,
-          managedVersionPolicy: ManagedRuntimeVersionPolicy.exact,
         );
     switch (selection) {
       case ManagedRuntimeSelected(:final binaryPath, :final version):

--- a/bridge/sesori_plugin_deepseek/test/deepseek_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_plugin_descriptor_test.dart
@@ -8,6 +8,58 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 void main() {
+  group("DeepSeekPluginDescriptor.needsManagedRuntimeUpgrade", () {
+    late Directory stateDir;
+
+    setUp(() async {
+      stateDir = await Directory.systemTemp.createTemp("deepseek-upgrade");
+    });
+
+    tearDown(() async {
+      if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+    });
+
+    void installedVersion(String version) {
+      Directory("${stateDir.path}/${const DeepSeekRuntimeManifest().runtimeId}/$version").createSync(recursive: true);
+    }
+
+    test("declines without a superseded managed runtime", () {
+      installedVersion(const DeepSeekRuntimeManifest().bundledVersion.raw);
+
+      expect(
+        const DeepSeekPluginDescriptor().needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {DeepSeekPluginDescriptor.binOption: DeepSeekBinary.defaultBinary}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+
+    test("asks for an upgrade when a superseded version is installed", () {
+      installedVersion("0.1.2");
+
+      expect(
+        const DeepSeekPluginDescriptor().needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {DeepSeekPluginDescriptor.binOption: DeepSeekBinary.defaultBinary}),
+          stateDirectory: stateDir.path,
+        ),
+        isTrue,
+      );
+    });
+
+    test("declines with an explicit binary override", () {
+      installedVersion("0.1.2");
+
+      expect(
+        const DeepSeekPluginDescriptor().needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {DeepSeekPluginDescriptor.binOption: "/custom/deepseek"}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   const config = PluginConfig(values: {DeepSeekPluginDescriptor.binOption: DeepSeekBinary.defaultBinary});
 
   test("descriptor declares managed installation when no explicit path is configured", () {

--- a/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
+++ b/bridge/sesori_plugin_interface/lib/sesori_plugin_interface.dart
@@ -25,6 +25,7 @@ export "src/lifecycle/plugin_state_storage.dart";
 export "src/lifecycle/plugin_status.dart";
 export "src/lifecycle/plugin_status_controller.dart";
 export "src/lifecycle/plugin_work_state.dart";
+export "src/lifecycle/runtime_in_use_signal.dart";
 export "src/lifecycle/runtime_provision_progress.dart";
 export "src/lifecycle/start_abort_signal.dart";
 export "src/lifecycle/steady_plugin_lifecycle.dart";

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/bridge_plugin_descriptor.dart
@@ -12,6 +12,7 @@ import "plugin_residency_policy.dart";
 import "plugin_session_options_scope.dart";
 import "plugin_setup_status.dart";
 import "plugin_state_storage.dart";
+import "runtime_in_use_signal.dart";
 import "runtime_provision_progress.dart";
 import "start_abort_signal.dart";
 
@@ -114,6 +115,10 @@ abstract class const BridgePluginDescriptor() {
   /// to sweep superseded managed versions after success. It must never touch
   /// files outside the plugin's managed runtime area or start the backend.
   ///
+  /// The plugin may already be running from an older supported managed version
+  /// while this install downloads its replacement; [runtimeInUse] reports that
+  /// at sweep time so the sweep leaves a live generation's directory alone.
+  ///
   /// The stream's final event is terminal: [ProvisionReady] carries the
   /// installed binary path, [ProvisionFailed] a sanitized user-facing message
   /// (no local paths or raw command output). Long phases must observe
@@ -128,11 +133,26 @@ abstract class const BridgePluginDescriptor() {
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal startAborted,
+    required RuntimeInUseSignal runtimeInUse,
   }) {
     return Stream<RuntimeProvisionProgress>.value(
       ProvisionFailed(message: "$displayName does not support installing a managed runtime."),
     );
   }
+
+  /// Whether a bridge start should install this plugin's pinned managed runtime
+  /// in the background because Sesori already manages an older one.
+  ///
+  /// True only when the plugin can install a managed runtime under [config] and
+  /// a managed version directory other than the pinned target exists under
+  /// [stateDirectory]. A machine that has never installed through Sesori keeps
+  /// the explicit Install command. Synchronous and disk-only: no probing, no
+  /// process spawning, no network. The default declines, which suits every
+  /// plugin without a managed runtime.
+  bool needsManagedRuntimeUpgrade({
+    required PluginConfig config,
+    required String stateDirectory,
+  }) => false;
 
   /// Resolves an already-present backend runtime and reports progress.
   ///

--- a/bridge/sesori_plugin_interface/lib/src/lifecycle/runtime_in_use_signal.dart
+++ b/bridge/sesori_plugin_interface/lib/src/lifecycle/runtime_in_use_signal.dart
@@ -1,0 +1,23 @@
+/// Read side of "this plugin currently has a live generation", owned by the
+/// bridge.
+///
+/// A managed-runtime install can run while the plugin is started on an older
+/// managed version that is still supported, so the post-install sweep must not
+/// delete the directory the running executable was launched from. The
+/// installer reads this at sweep time — never caches it — and leaves a
+/// still-used version directory for a later install to reclaim.
+///
+/// Like `StartAbortSignal`, this is bridge-owned live state handed to plugin
+/// code as a narrow read-only fact rather than as a raw callback.
+abstract class const RuntimeInUseSignal() {
+  /// A signal for callers with no generation to protect (tests, tools).
+  static const RuntimeInUseSignal never = _NeverInUseSignal();
+
+  /// Whether the plugin has a live or starting generation. Cheap to poll.
+  bool get isInUse;
+}
+
+final class const _NeverInUseSignal() implements RuntimeInUseSignal {
+  @override
+  bool get isInUse => false;
+}

--- a/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_interface/test/lifecycle/bridge_plugin_descriptor_test.dart
@@ -58,12 +58,22 @@ void main() {
             environment: const {},
             stateDirectory: '/state',
             startAborted: StartAbortSignal.never,
+            runtimeInUse: RuntimeInUseSignal.never,
           )
           .toList();
 
       expect(events, hasLength(1));
       expect(events.single, isA<ProvisionFailed>());
       expect((events.single as ProvisionFailed).message, contains('does not support installing'));
+    });
+
+    test('the default descriptor never asks for a managed runtime upgrade', () {
+      const descriptor = _MinimalDescriptor();
+
+      expect(
+        descriptor.needsManagedRuntimeUpgrade(config: const PluginConfig.empty(), stateDirectory: '/state'),
+        isFalse,
+      );
     });
 
     test('a descriptor can reject configuration with PluginConfigException', () {

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
@@ -116,6 +116,14 @@ final class const OmpPluginDescriptor({
   }
 
   @override
+  bool needsManagedRuntimeUpgrade({required PluginConfig config, required String stateDirectory}) {
+    if (!managementCapabilities(config: config).contains(PluginControlCapability.install)) return false;
+    return const ManagedRuntimeInventory(
+      manifest: OmpRuntimeManifest(),
+    ).hasSupersededVersion(stateDirectory: stateDirectory);
+  }
+
+  @override
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
     if (_explicitBin(host.config) != null) return;
     const manifest = OmpRuntimeManifest();
@@ -124,6 +132,7 @@ final class const OmpPluginDescriptor({
       selectionService: ManagedRuntimeSelectionService(
         manifest: manifest,
         versionValidator: _versionValidator(processes: host.processes),
+        inventory: const ManagedRuntimeInventory(manifest: manifest),
       ),
       fallbackExecutableCandidates: const [],
     ).provision(host: host, explicitExecutablePath: null);
@@ -136,6 +145,7 @@ final class const OmpPluginDescriptor({
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal startAborted,
+    required RuntimeInUseSignal runtimeInUse,
   }) async* {
     const manifest = OmpRuntimeManifest();
     final commandExecutor = HostProcessCommandExecutor(
@@ -166,6 +176,7 @@ final class const OmpPluginDescriptor({
         environment: environment,
         stateDirectory: stateDirectory,
         startAborted: startAborted,
+        runtimeInUse: runtimeInUse,
       );
     } finally {
       httpClient.close();
@@ -181,17 +192,18 @@ final class const OmpPluginDescriptor({
   }) async {
     const manifest = OmpRuntimeManifest();
     final explicitBin = _explicitBin(config);
-    final selection = await ManagedRuntimeSelectionService(
-      manifest: manifest,
-      versionValidator: _versionValidator(processes: processes),
-    ).select(
-      explicitExecutablePath: explicitBin,
-      fallbackExecutableCandidates: const [],
-      environment: environment,
-      stateDirectory: stateDirectory,
-      abortSignal: StartAbortSignal.never,
-      managedVersionPolicy: ManagedRuntimeVersionPolicy.exact,
-    );
+    final selection =
+        await ManagedRuntimeSelectionService(
+          manifest: manifest,
+          versionValidator: _versionValidator(processes: processes),
+          inventory: const ManagedRuntimeInventory(manifest: manifest),
+        ).select(
+          explicitExecutablePath: explicitBin,
+          fallbackExecutableCandidates: const [],
+          environment: environment,
+          stateDirectory: stateDirectory,
+          abortSignal: StartAbortSignal.never,
+        );
     if (selection case ManagedRuntimeSelected(:final version)) {
       return PluginSetupReady.versioned(runtimeVersion: version.raw);
     }
@@ -210,8 +222,7 @@ final class const OmpPluginDescriptor({
       };
     }
     final automatic = notSelected as ManagedRuntimeAutomaticNotSelected;
-    if (_isUnknownRejection(automatic.primaryRejection) ||
-        _isUnknownRejection(automatic.managedRejection)) {
+    if (_isUnknownRejection(automatic.primaryRejection) || _isUnknownRejection(automatic.managedRejection)) {
       return const PluginSetupUnknown(
         actionHint: "Oh My Pi setup could not be determined. Verify the local CLI and retry.",
       );

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_runtime_manifest.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_runtime_manifest.dart
@@ -83,6 +83,12 @@ class const OmpRuntimeManifest() extends RuntimeManifest {
     return SemanticRuntimeVersion.tryParse(value: value.substring(4));
   }
 
+  /// `omp --version` prints `omp/<semver>` and the prefix is required so an
+  /// unrelated semver token in that output is not mistaken for the runtime
+  /// version. Version directories carry the bare semver, so they parse here.
+  @override
+  RuntimeVersion? parseInstalledVersion({required String value}) => SemanticRuntimeVersion.tryParse(value: value);
+
   @override
   RuntimeAsset? assetFor({required PlatformTarget target}) {
     if (target.os == PlatformOs.linux) return null;

--- a/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
@@ -28,6 +28,58 @@ OmpRuntimeAssetService _runtimeAssets({
 );
 
 void main() {
+  group("OmpPluginDescriptor.needsManagedRuntimeUpgrade", () {
+    late Directory stateDir;
+
+    setUp(() async {
+      stateDir = await Directory.systemTemp.createTemp("omp-upgrade");
+    });
+
+    tearDown(() async {
+      if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+    });
+
+    void installedVersion(String version) {
+      Directory("${stateDir.path}/${const OmpRuntimeManifest().runtimeId}/$version").createSync(recursive: true);
+    }
+
+    test("declines without a superseded managed runtime", () {
+      installedVersion(const OmpRuntimeManifest().bundledVersion.raw);
+
+      expect(
+        OmpPluginDescriptor.production().needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {OmpPluginDescriptor.binOption: "omp"}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+
+    test("asks for an upgrade when a superseded version is installed", () {
+      installedVersion("17.3.0");
+
+      expect(
+        OmpPluginDescriptor.production().needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {OmpPluginDescriptor.binOption: "omp"}),
+          stateDirectory: stateDir.path,
+        ),
+        isTrue,
+      );
+    });
+
+    test("declines with an explicit binary override", () {
+      installedVersion("17.3.0");
+
+      expect(
+        OmpPluginDescriptor.production().needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {OmpPluginDescriptor.binOption: "/custom/omp"}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   const config = PluginConfig(values: {OmpPluginDescriptor.binOption: "omp"});
 
   group("OmpPluginDescriptor setup", () {

--- a/bridge/sesori_plugin_omp/test/omp_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_runtime_manifest_test.dart
@@ -20,6 +20,13 @@ void main() {
     expect(manifest.parseVersion(value: "omp/not-a-version"), isNull);
   });
 
+  test("parses bare version directory names the installer writes", () {
+    // `omp --version` prints `omp/<semver>`, but version directories carry the
+    // bare version, so the two parsers are deliberately different.
+    expect(manifest.parseInstalledVersion(value: "17.3.8")?.raw, "17.3.8");
+    expect(manifest.parseInstalledVersion(value: ".sesori-runtime-staging"), isNull);
+  });
+
   test("maps all seven official direct binary assets", () {
     final assets = <RuntimeAsset>[
       manifest.assetFor(

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -269,12 +269,21 @@ class const OpenCodePluginDescriptor({
   }
 
   @override
+  bool needsManagedRuntimeUpgrade({required PluginConfig config, required String stateDirectory}) {
+    if (!managementCapabilities(config: config).contains(PluginControlCapability.install)) return false;
+    return const ManagedRuntimeInventory(
+      manifest: OpenCodeRuntimeManifest(),
+    ).hasSupersededVersion(stateDirectory: stateDirectory);
+  }
+
+  @override
   Stream<RuntimeProvisionProgress> installRuntime({
     required PluginConfig config,
     required HostProcessService processes,
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal startAborted,
+    required RuntimeInUseSignal runtimeInUse,
   }) async* {
     const manifest = OpenCodeRuntimeManifest();
     final commandExecutor = HostProcessCommandExecutor(
@@ -305,6 +314,7 @@ class const OpenCodePluginDescriptor({
         environment: environment,
         stateDirectory: stateDirectory,
         startAborted: startAborted,
+        runtimeInUse: runtimeInUse,
       );
     } finally {
       httpClient.close();
@@ -340,21 +350,22 @@ class const OpenCodePluginDescriptor({
           : "Install OpenCode from Sesori, or install it locally and retry setup detection.";
     }
 
-    final selection = await ManagedRuntimeSelectionService(
-      manifest: manifest,
-      versionValidator: RuntimeVersionValidator(
-        commandExecutor: executor,
-        manifest: manifest,
-        probeTimeout: _versionProbeTimeout,
-      ),
-    ).select(
-      explicitExecutablePath: explicitBin,
-      fallbackExecutableCandidates: const [],
-      environment: environment,
-      stateDirectory: stateDirectory,
-      abortSignal: StartAbortSignal.never,
-      managedVersionPolicy: ManagedRuntimeVersionPolicy.exact,
-    );
+    final selection =
+        await ManagedRuntimeSelectionService(
+          manifest: manifest,
+          versionValidator: RuntimeVersionValidator(
+            commandExecutor: executor,
+            manifest: manifest,
+            probeTimeout: _versionProbeTimeout,
+          ),
+          inventory: const ManagedRuntimeInventory(manifest: manifest),
+        ).select(
+          explicitExecutablePath: explicitBin,
+          fallbackExecutableCandidates: const [],
+          environment: environment,
+          stateDirectory: stateDirectory,
+          abortSignal: StartAbortSignal.never,
+        );
     if (selection case ManagedRuntimeSelected(:final version)) {
       return PluginSetupReady.versioned(runtimeVersion: version.raw);
     }
@@ -430,6 +441,7 @@ class const OpenCodePluginDescriptor({
           manifest: manifest,
           probeTimeout: _versionProbeTimeout,
         ),
+        inventory: const ManagedRuntimeInventory(manifest: manifest),
       ),
       // OpenCode has no desktop app bundling a CLI.
       fallbackExecutableCandidates: const [],

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_availability_test.dart
@@ -84,7 +84,10 @@ void main() {
 
     test("recognizes a previously installed managed runtime when PATH is missing", () async {
       const manifest = OpenCodeRuntimeManifest();
-      final managedBinaryPath = manifest.managedBinaryPath(stateDirectory: stateDirectory);
+      final managedBinaryPath = manifest.managedBinaryPath(
+        stateDirectory: stateDirectory,
+        version: manifest.bundledVersion,
+      );
       final processes = _ProbeProcessService(
         spawnOutcomes: [
           const ProcessException("opencode", ["--version"], "missing", 2),

--- a/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_opencode/test/runtime/open_code_plugin_descriptor_test.dart
@@ -8,10 +8,66 @@ import "package:http/testing.dart";
 import "package:opencode_plugin/src/runtime/open_code_managed_api.dart";
 import "package:opencode_plugin/src/runtime/open_code_ownership_record.dart";
 import "package:opencode_plugin/src/runtime/open_code_plugin_descriptor.dart";
+import "package:opencode_plugin/src/runtime/open_code_runtime_manifest.dart";
+import "package:path/path.dart" as p;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 void main() {
+  group("OpenCodePluginDescriptor.needsManagedRuntimeUpgrade", () {
+    const descriptor = OpenCodePluginDescriptor();
+    const config = PluginConfig(values: {"no-auto-start": false, "bin": null});
+    late Directory stateDir;
+
+    setUp(() async {
+      stateDir = await Directory.systemTemp.createTemp("opencode-upgrade");
+    });
+
+    tearDown(() async {
+      if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+    });
+
+    void installedVersion(String version) {
+      Directory(p.join(stateDir.path, const OpenCodeRuntimeManifest().runtimeId, version)).createSync(recursive: true);
+    }
+
+    test("declines without a superseded managed runtime", () {
+      installedVersion(const OpenCodeRuntimeManifest().bundledVersion.raw);
+
+      expect(descriptor.needsManagedRuntimeUpgrade(config: config, stateDirectory: stateDir.path), isFalse);
+    });
+
+    test("asks for an upgrade when a superseded version is installed", () {
+      installedVersion("1.17.9");
+
+      expect(descriptor.needsManagedRuntimeUpgrade(config: config, stateDirectory: stateDir.path), isTrue);
+    });
+
+    test("declines with an explicit binary override", () {
+      installedVersion("1.17.9");
+
+      expect(
+        descriptor.needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {"no-auto-start": false, "bin": "/custom/opencode"}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+
+    test("declines in attach mode, where Sesori does not own the runtime", () {
+      installedVersion("1.17.9");
+
+      expect(
+        descriptor.needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {"no-auto-start": true, "bin": null}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group("OpenCodePluginDescriptor static surface", () {
     const descriptor = OpenCodePluginDescriptor();
 

--- a/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
@@ -133,6 +133,14 @@ final class const PiPluginDescriptor({
   }
 
   @override
+  bool needsManagedRuntimeUpgrade({required PluginConfig config, required String stateDirectory}) {
+    if (!managementCapabilities(config: config).contains(PluginControlCapability.install)) return false;
+    return const ManagedRuntimeInventory(
+      manifest: PiRuntimeManifest(),
+    ).hasSupersededVersion(stateDirectory: stateDirectory);
+  }
+
+  @override
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
     if (_explicitBin(host.config) != null) return;
     const manifest = PiRuntimeManifest();
@@ -141,6 +149,7 @@ final class const PiPluginDescriptor({
       selectionService: ManagedRuntimeSelectionService(
         manifest: manifest,
         versionValidator: _versionValidator(processes: host.processes),
+        inventory: const ManagedRuntimeInventory(manifest: manifest),
       ),
       fallbackExecutableCandidates: const [],
     ).provision(host: host, explicitExecutablePath: null);
@@ -153,6 +162,7 @@ final class const PiPluginDescriptor({
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal startAborted,
+    required RuntimeInUseSignal runtimeInUse,
   }) async* {
     const manifest = PiRuntimeManifest();
     final commandExecutor = HostProcessCommandExecutor(
@@ -179,6 +189,7 @@ final class const PiPluginDescriptor({
         environment: environment,
         stateDirectory: stateDirectory,
         startAborted: startAborted,
+        runtimeInUse: runtimeInUse,
       );
     } finally {
       httpClient.close();
@@ -194,17 +205,18 @@ final class const PiPluginDescriptor({
   }) async {
     const manifest = PiRuntimeManifest();
     final explicitBin = _explicitBin(config);
-    final selection = await ManagedRuntimeSelectionService(
-      manifest: manifest,
-      versionValidator: _versionValidator(processes: processes),
-    ).select(
-      explicitExecutablePath: explicitBin,
-      fallbackExecutableCandidates: const [],
-      environment: environment,
-      stateDirectory: stateDirectory,
-      abortSignal: StartAbortSignal.never,
-      managedVersionPolicy: ManagedRuntimeVersionPolicy.exact,
-    );
+    final selection =
+        await ManagedRuntimeSelectionService(
+          manifest: manifest,
+          versionValidator: _versionValidator(processes: processes),
+          inventory: const ManagedRuntimeInventory(manifest: manifest),
+        ).select(
+          explicitExecutablePath: explicitBin,
+          fallbackExecutableCandidates: const [],
+          environment: environment,
+          stateDirectory: stateDirectory,
+          abortSignal: StartAbortSignal.never,
+        );
     if (selection is ManagedRuntimeSelected) return const PluginSetupReady();
     final notSelected = selection as ManagedRuntimeNotSelected;
     if (explicitBin != null) {
@@ -221,8 +233,7 @@ final class const PiPluginDescriptor({
       };
     }
     final automatic = notSelected as ManagedRuntimeAutomaticNotSelected;
-    if (_isUnknownRejection(automatic.primaryRejection) ||
-        _isUnknownRejection(automatic.managedRejection)) {
+    if (_isUnknownRejection(automatic.primaryRejection) || _isUnknownRejection(automatic.managedRejection)) {
       return const PluginSetupUnknown(
         actionHint: "Pi setup could not be determined. Verify the local CLI and retry.",
       );

--- a/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
@@ -2,12 +2,65 @@ import "dart:async";
 import "dart:convert";
 import "dart:io";
 
+import "package:path/path.dart" as p;
 import "package:pi_plugin/pi_plugin.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
 void main() {
+  group("PiPluginDescriptor.needsManagedRuntimeUpgrade", () {
+    late Directory stateDir;
+
+    setUp(() async {
+      stateDir = await Directory.systemTemp.createTemp("pi-upgrade");
+    });
+
+    tearDown(() async {
+      if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+    });
+
+    void installedVersion(String version) {
+      Directory(p.join(stateDir.path, const PiRuntimeManifest().runtimeId, version)).createSync(recursive: true);
+    }
+
+    test("declines without a superseded managed runtime", () {
+      installedVersion(const PiRuntimeManifest().bundledVersion.raw);
+
+      expect(
+        PiPluginDescriptor.production().needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {PiPluginDescriptor.binOption: null}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+
+    test("asks for an upgrade when a superseded version is installed", () {
+      installedVersion("0.84.2");
+
+      expect(
+        PiPluginDescriptor.production().needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {PiPluginDescriptor.binOption: null}),
+          stateDirectory: stateDir.path,
+        ),
+        isTrue,
+      );
+    });
+
+    test("declines with an explicit binary override", () {
+      installedVersion("0.84.2");
+
+      expect(
+        PiPluginDescriptor.production().needsManagedRuntimeUpgrade(
+          config: const PluginConfig(values: {PiPluginDescriptor.binOption: "/custom/pi"}),
+          stateDirectory: stateDir.path,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group("PiPluginDescriptor setup", () {
     test("declares Pi capabilities without registering it", () {
       final descriptor = PiPluginDescriptor.production();

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_cleaner.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_cleaner.dart
@@ -3,18 +3,20 @@ import "dart:io";
 import "package:path/path.dart" as p;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
-/// Removes superseded managed runtime version directories.
+/// Removes managed runtime version directories the caller no longer wants.
 ///
-/// A managed runtime is laid out as `<managedDir>/<version>/<binary>`. After the
-/// pinned version is healthy, older version directories are dead weight from a
-/// previous bridge release's bundled runtime; this sweeps them, keeping only the
-/// version currently in use so a running runtime is never deleted.
+/// A managed runtime is laid out as `<managedDir>/<version>/<binary>`. Older
+/// version directories are dead weight from a previous bridge release's bundled
+/// runtime, but which ones are safe to remove depends on where the install is:
+/// an obsolete version can go before the download starts, while a still-usable
+/// one must survive until its replacement is verified and no generation runs
+/// from it. The caller owns that decision through [keep].
 class ManagedRuntimeCleaner({required final String _runtimeId}) {
-  /// Deletes every immediate subdirectory of [managedDir] except [keepVersion].
+  /// Deletes every immediate subdirectory of [managedDir] that [keep] rejects.
   /// Best-effort: a directory that cannot be removed is logged and skipped.
   Future<void> sweep({
     required String managedDir,
-    required String keepVersion,
+    required bool Function({required String versionName}) keep,
   }) async {
     final Directory dir = Directory(managedDir);
     if (!dir.existsSync()) {
@@ -36,7 +38,7 @@ class ManagedRuntimeCleaner({required final String _runtimeId}) {
         continue;
       }
       final String name = p.basename(entity.path);
-      if (name == keepVersion) {
+      if (keep(versionName: name)) {
         continue;
       }
       try {

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_install_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_install_service.dart
@@ -7,6 +7,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
         ProvisionFailed,
         ProvisionReady,
         ProvisionResolving,
+        RuntimeInUseSignal,
         RuntimeProvisionProgress,
         StartAbortSignal;
 
@@ -23,8 +24,14 @@ import "runtime_version_validator.dart";
 /// (which only resolves already-present runtimes): it selects the platform
 /// asset, reuses a healthy existing install, otherwise downloads, verifies,
 /// extracts, and places the binary via [RuntimeInstallService], probes the
-/// result actually runs, and sweeps superseded managed versions before
-/// reporting the terminal event (a consumer may unsubscribe on that event).
+/// result actually runs, and sweeps managed versions before reporting the
+/// terminal event (a consumer may unsubscribe on that event).
+///
+/// The sweep runs in two stages because the plugin may be running from an older
+/// managed version while this install downloads its replacement. Versions below
+/// [RuntimeManifest.minPathVersion] can never be selected, so they go before the
+/// download starts; the rest go once the pinned version is verified, minus any
+/// still-supported version that a live generation could be running from.
 ///
 /// Terminal events are [ProvisionReady] (the installed binary path) or
 /// [ProvisionFailed] with a sanitized user-facing message. An abort surfaces
@@ -40,6 +47,7 @@ class ManagedRuntimeInstallService({
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal startAborted,
+    required RuntimeInUseSignal runtimeInUse,
   }) async* {
     _throwIfAborted(startAborted: startAborted);
     yield const ProvisionResolving();
@@ -47,6 +55,28 @@ class ManagedRuntimeInstallService({
     final String id = _manifest.runtimeId;
     final String name = _manifest.displayName;
     final RuntimeVersion bundled = _manifest.bundledVersion;
+    final String managedDir = p.join(stateDirectory, id);
+
+    bool keepUntilInstalled({required String versionName}) {
+      final RuntimeVersion? version = _manifest.parseInstalledVersion(value: versionName);
+      // Not a managed version directory (installer staging, stray names): the
+      // post-install sweep owns those.
+      if (version == null) return true;
+      return version.compareTo(_manifest.minPathVersion) >= 0;
+    }
+
+    bool keepAfterInstall({required String versionName}) {
+      if (versionName == bundled.raw) return true;
+      // A generation started before this install may still be running from a
+      // supported older version; leave its directory for a later install to
+      // reclaim rather than deleting the executable out from under it.
+      if (!runtimeInUse.isInUse) return false;
+      return keepUntilInstalled(versionName: versionName);
+    }
+
+    // Obsolete versions are unselectable whether or not this install succeeds,
+    // so they go before any bandwidth is spent.
+    await _cleaner.sweep(managedDir: managedDir, keep: keepUntilInstalled);
 
     final PlatformTarget target;
     try {
@@ -79,7 +109,6 @@ class ManagedRuntimeInstallService({
       return;
     }
 
-    final String managedDir = p.join(stateDirectory, id);
     final String versionDir = p.join(managedDir, bundled.raw);
     final String binaryPath = p.join(versionDir, _manifest.binaryFileName);
 
@@ -100,7 +129,7 @@ class ManagedRuntimeInstallService({
         // Sweep before the terminal event: consumers may stop listening as
         // soon as ProvisionReady arrives, which would cancel this stream and
         // leave superseded version directories behind.
-        await _cleaner.sweep(managedDir: managedDir, keepVersion: bundled.raw);
+        await _cleaner.sweep(managedDir: managedDir, keep: keepAfterInstall);
         yield ProvisionReady(binaryPath: binaryPath);
         return;
       }
@@ -155,7 +184,7 @@ class ManagedRuntimeInstallService({
     Log.i("[$id] installed managed $name ${bundled.toString()}");
     // Sweep before the terminal event: consumers may stop listening as soon as
     // ProvisionReady arrives, which would cancel this stream mid-sweep.
-    await _cleaner.sweep(managedDir: managedDir, keepVersion: bundled.raw);
+    await _cleaner.sweep(managedDir: managedDir, keep: keepAfterInstall);
     yield ProvisionReady(binaryPath: binaryPath);
   }
 

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_inventory.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_inventory.dart
@@ -4,47 +4,54 @@ import "package:path/path.dart" as p;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "runtime_manifest.dart";
+import "runtime_version.dart";
 
-/// Reports whether a managed runtime directory holds a version other than the
-/// one currently pinned.
+/// Reports which managed runtime versions are present on disk.
 ///
 /// Managed runtimes are laid out as `<stateDirectory>/<runtimeId>/<version>/`,
 /// so a bridge update that pins a newer version simply stops finding the old
-/// one: setup reports the runtime as missing even though a previous version is
-/// still on disk. Descriptors use this to tell the two cases apart — nothing
-/// installed at all versus a superseded install — so the user is told the
-/// runtime needs updating rather than being told to install it by hand.
+/// one at the pinned path. Selection uses this to fall back to an older but
+/// still supported version, and descriptors use it to tell "nothing installed"
+/// apart from "superseded install" for wording and for the startup upgrade.
 ///
 /// Read-only: it never deletes or repairs anything. Sweeping superseded
 /// versions remains [ManagedRuntimeCleaner]'s job during an install.
 class const ManagedRuntimeInventory({required final RuntimeManifest _manifest}) {
-  /// Whether a managed version directory other than the pinned
-  /// [RuntimeManifest.bundledVersion] exists under [stateDirectory].
+  /// Managed versions installed under [stateDirectory], newest first.
   ///
-  /// Only the directory name is inspected; the binary inside is not probed,
-  /// because this decides wording, not whether the runtime can run.
-  bool hasSupersededVersion({required String stateDirectory}) {
+  /// Only directory names are inspected; no binary is probed. Names that do not
+  /// parse as this runtime's version (installer staging, stray directories) are
+  /// ignored, and an unreadable managed directory yields an empty list.
+  List<RuntimeVersion> installedVersions({required String stateDirectory}) {
     final managedDir = Directory(p.join(stateDirectory, _manifest.runtimeId));
-    if (!managedDir.existsSync()) return false;
+    if (!managedDir.existsSync()) return const [];
 
-    final pinned = _manifest.bundledVersion.raw;
+    final List<FileSystemEntity> entries;
     try {
-      return managedDir.listSync(followLinks: false).any(
-        (entity) {
-          if (entity is! Directory) return false;
-          final name = p.basename(entity.path);
-          return name != pinned && _manifest.parseVersion(value: name) != null;
-        },
-      );
+      entries = managedDir.listSync(followLinks: false);
     } on Object catch (error, stackTrace) {
-      // Wording-only input: an unreadable directory falls back to the generic
-      // hint rather than failing setup inspection.
+      // Advisory input: an unreadable directory reads as "nothing managed here"
+      // rather than failing setup inspection or an install.
       Log.w(
         "[${_manifest.runtimeId}] could not inspect managed runtime dir '${managedDir.path}'",
         error,
         stackTrace,
       );
-      return false;
+      return const [];
     }
+
+    final versions = [
+      for (final entity in entries)
+        if (entity is Directory) ?_manifest.parseInstalledVersion(value: p.basename(entity.path)),
+    ];
+    versions.sort((a, b) => b.compareTo(a));
+    return List<RuntimeVersion>.unmodifiable(versions);
+  }
+
+  /// Whether a managed version directory other than the pinned
+  /// [RuntimeManifest.bundledVersion] exists under [stateDirectory].
+  bool hasSupersededVersion({required String stateDirectory}) {
+    final pinned = _manifest.bundledVersion.raw;
+    return installedVersions(stateDirectory: stateDirectory).any((version) => version.raw != pinned);
   }
 }

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_provision_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_provision_service.dart
@@ -16,8 +16,9 @@ import "runtime_manifest.dart";
 ///
 /// Precedence is a sufficiently recent PATH runtime, then the first
 /// sufficiently recent fallback executable candidate (e.g. a CLI bundled by a
-/// backend's desktop app, enumerated by the owning plugin), then the pinned
-/// managed runtime when that exact version is already present and runnable.
+/// backend's desktop app, enumerated by the owning plugin), then the newest
+/// installed managed runtime that is still at or above the minimum, preferring
+/// the pinned version.
 class ManagedRuntimeProvisionService({
   required final RuntimeManifest _manifest,
   required final ManagedRuntimeSelectionService _selectionService,
@@ -27,21 +28,22 @@ class ManagedRuntimeProvisionService({
   /// harmlessly.
   required final List<String> _fallbackExecutableCandidates,
 }) {
-  Stream<RuntimeProvisionProgress> provision({required PluginHost host, required String? explicitExecutablePath}) async* {
+  Stream<RuntimeProvisionProgress> provision({
+    required PluginHost host,
+    required String? explicitExecutablePath,
+  }) async* {
     if (host.startAborted.isAborted) throw const PluginStartAbortedException();
     yield const ProvisionResolving();
 
     final id = _manifest.runtimeId;
     final name = _manifest.displayName;
     final minimum = _manifest.minPathVersion;
-    final bundled = _manifest.bundledVersion;
     final selection = await _selectionService.select(
       explicitExecutablePath: explicitExecutablePath,
       fallbackExecutableCandidates: _fallbackExecutableCandidates,
       environment: host.environment,
       stateDirectory: host.stateDirectory,
       abortSignal: host.startAborted,
-      managedVersionPolicy: ManagedRuntimeVersionPolicy.exact,
     );
     if (selection case ManagedRuntimeSelected(
       :final binaryPath,
@@ -52,7 +54,7 @@ class ManagedRuntimeProvisionService({
         yield ProvisionNotice(
           message:
               "Installed $name ${rejectedPathVersion.toString()} is older than the minimum supported ${minimum.toString()}; "
-              "using the existing managed $name ${bundled.toString()} instead.",
+              "using the existing managed $name ${version.toString()} instead.",
         );
       }
       Log.i("[$id] using ${source.name} $name ${version.toString()}");
@@ -65,5 +67,4 @@ class ManagedRuntimeProvisionService({
           "No usable existing $name runtime was found. Install $name locally and retry: ${_manifest.installDocsUrl}",
     );
   }
-
 }

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_selection_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_selection_service.dart
@@ -1,12 +1,17 @@
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginStartAbortedException, StartAbortSignal;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show PluginStartAbortedException, StartAbortSignal;
 
+import "managed_runtime_inventory.dart";
 import "runtime_manifest.dart";
 import "runtime_version.dart";
 import "runtime_version_validator.dart";
 
-enum ManagedRuntimeSource() { explicit, path, fallback, managed }
-
-enum ManagedRuntimeVersionPolicy() { minimum, exact }
+enum ManagedRuntimeSource() {
+  explicit,
+  path,
+  fallback,
+  managed,
+}
 
 sealed class const ManagedRuntimeRejection();
 
@@ -75,6 +80,7 @@ final class const ManagedRuntimeAutomaticNotSelected({
 class ManagedRuntimeSelectionService({
   required final RuntimeManifest _manifest,
   required final RuntimeVersionValidator _versionValidator,
+  required final ManagedRuntimeInventory _inventory,
 }) {
   Future<ManagedRuntimeSelection> select({
     required String? explicitExecutablePath,
@@ -82,7 +88,6 @@ class ManagedRuntimeSelectionService({
     required Map<String, String> environment,
     required String stateDirectory,
     required StartAbortSignal abortSignal,
-    required ManagedRuntimeVersionPolicy managedVersionPolicy,
   }) async {
     _throwIfAborted(abortSignal);
     if (explicitExecutablePath != null) {
@@ -143,29 +148,65 @@ class ManagedRuntimeSelectionService({
       }
     }
 
-    final managedPath = _manifest.managedBinaryPath(stateDirectory: stateDirectory);
-    final managedProbe = await _probe(
-      executable: managedPath,
+    // The pinned version is preferred, then any older managed version that is
+    // still at or above the minimum — a bridge update that raises the target
+    // leaves the previous install usable until its replacement is downloaded.
+    final pinnedPath = _manifest.managedBinaryPath(
+      stateDirectory: stateDirectory,
+      version: _manifest.bundledVersion,
+    );
+    final pinnedProbe = await _probe(
+      executable: pinnedPath,
       environment: environment,
       abortSignal: abortSignal,
     );
-    if (managedProbe case RuntimeProbeReady(:final version) when _acceptsManagedVersion(
-      version: version,
-      policy: managedVersionPolicy,
-    )) {
+    if (pinnedProbe case RuntimeProbeReady(:final version) when _isSupported(version: version)) {
       return ManagedRuntimeManagedSelected(
-        binaryPath: managedPath,
+        binaryPath: pinnedPath,
         version: version,
         rejectedPathVersion: pathVersion,
       );
+    }
+    final pinnedRejection = _rejectionFor(probe: pinnedProbe);
+
+    ManagedRuntimeRejection? supersededRejection;
+    for (final candidate in _supersededCandidates(stateDirectory: stateDirectory)) {
+      final candidatePath = _manifest.managedBinaryPath(stateDirectory: stateDirectory, version: candidate);
+      final probe = await _probe(
+        executable: candidatePath,
+        environment: environment,
+        abortSignal: abortSignal,
+      );
+      if (probe case RuntimeProbeReady(:final version) when _isSupported(version: version)) {
+        return ManagedRuntimeManagedSelected(
+          binaryPath: candidatePath,
+          version: version,
+          rejectedPathVersion: pathVersion,
+        );
+      }
+      final rejection = _rejectionFor(probe: probe);
+      if (supersededRejection == null && !_isMissingRejection(rejection: rejection)) {
+        supersededRejection = rejection;
+      }
     }
 
     return ManagedRuntimeAutomaticNotSelected(
       primaryRejection: _isMissingRejection(rejection: pathRejection)
           ? fallbackRejection ?? pathRejection
           : pathRejection,
-      managedRejection: _rejectionFor(probe: managedProbe),
+      managedRejection: _isMissingRejection(rejection: pinnedRejection)
+          ? supersededRejection ?? pinnedRejection
+          : pinnedRejection,
     );
+  }
+
+  /// Installed managed versions other than the pinned one that are still
+  /// supported, newest first.
+  Iterable<RuntimeVersion> _supersededCandidates({required String stateDirectory}) {
+    final pinned = _manifest.bundledVersion.raw;
+    return _inventory
+        .installedVersions(stateDirectory: stateDirectory)
+        .where((version) => version.raw != pinned && _isSupported(version: version));
   }
 
   Future<RuntimeProbeOutcome> _probe({
@@ -188,12 +229,7 @@ class ManagedRuntimeSelectionService({
   bool _isMissingRejection({required ManagedRuntimeRejection rejection}) =>
       rejection is ManagedRuntimeProbeRejected && rejection.outcome is RuntimeProbeMissing;
 
-  bool _acceptsManagedVersion({required RuntimeVersion version, required ManagedRuntimeVersionPolicy policy}) {
-    return switch (policy) {
-      ManagedRuntimeVersionPolicy.minimum => version.compareTo(_manifest.minPathVersion) >= 0,
-      ManagedRuntimeVersionPolicy.exact => version.compareTo(_manifest.bundledVersion) == 0,
-    };
-  }
+  bool _isSupported({required RuntimeVersion version}) => version.compareTo(_manifest.minPathVersion) >= 0;
 
   void _throwIfAborted(StartAbortSignal abortSignal) {
     if (abortSignal.isAborted) throw const PluginStartAbortedException();

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_install_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_install_service.dart
@@ -32,11 +32,12 @@ class const RuntimeInstallException(final String message) implements Exception {
 /// SHA-256) is written last, so an
 /// interrupted install leaves no sentinel and is cleanly redone next attempt.
 /// No lock is required: single-live-bridge enforcement covers cross-process
-/// overlap, callers gate concurrent same-plugin work (setup-blocked plugins
-/// cannot start, and management commands are serialized per plugin), the
-/// binary lands via atomic rename, and the sentinel is written last — so any
-/// residual race self-heals on the next attempt. Staging paths are fixed and
-/// self-healing.
+/// overlap, callers gate concurrent same-plugin work (management commands are
+/// serialized per plugin), the binary lands via atomic rename, and the sentinel
+/// is written last — so any residual race self-heals on the next attempt.
+/// Staging paths are fixed and self-healing. The plugin may be running from an
+/// older managed version directory throughout; placement only ever touches the
+/// pinned version directory and this runtime's staging paths.
 class RuntimeInstallService({
   required final BinaryDownloadClient _downloadClient,
   required final ChecksumValidator _checksumValidator,

--- a/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_manifest.dart
@@ -74,7 +74,10 @@ abstract class const RuntimeManifest() {
   /// version directory (platform-aware, e.g. `opencode` or `bin/codex.exe`).
   String get binaryFileName;
 
-  /// Minimum pre-installed (PATH) version the bridge will use as-is.
+  /// Minimum version the bridge will use as-is, for a pre-installed (PATH)
+  /// runtime and for a managed one alike: a managed version at or above it stays
+  /// usable while a newer [bundledVersion] downloads, and one below it is never
+  /// selected.
   RuntimeVersion get minPathVersion;
 
   /// The exact version the managed runtime installs.
@@ -84,6 +87,14 @@ abstract class const RuntimeManifest() {
   /// scheme. Keeping this with the pins guarantees probes and comparisons use
   /// one scheme per runtime.
   RuntimeVersion? parseVersion({required String value});
+
+  /// Parses a managed version directory name under the runtime's state root.
+  ///
+  /// The installer names those directories with [RuntimeVersion.raw], so the
+  /// default reuses [parseVersion]. Override when [parseVersion] requires a
+  /// publisher-specific `--version` token (a prefix, a label) that an on-disk
+  /// directory name does not carry.
+  RuntimeVersion? parseInstalledVersion({required String value}) => parseVersion(value: value);
 
   /// The pinned asset for [target], or `null` when the platform is unsupported
   /// or requires asynchronous host-specific selection by the installer's
@@ -100,10 +111,10 @@ abstract class const RuntimeManifest() {
   String githubReleaseAssetUrl({required String repository, required String tag, required RuntimeAsset asset}) =>
       "https://github.com/$repository/releases/download/$tag/${asset.assetName}";
 
-  /// Expected path of this manifest's pinned managed binary under a plugin
-  /// state root. Computing the path is read-only and does not imply that the
-  /// runtime is installed or valid.
-  String managedBinaryPath({required String stateDirectory}) {
-    return p.join(stateDirectory, runtimeId, bundledVersion.raw, binaryFileName);
+  /// Expected path of this manifest's managed binary for [version] under a
+  /// plugin state root. Computing the path is read-only and does not imply that
+  /// the runtime is installed or valid.
+  String managedBinaryPath({required String stateDirectory, required RuntimeVersion version}) {
+    return p.join(stateDirectory, runtimeId, version.raw, binaryFileName);
   }
 }

--- a/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_cleaner_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_cleaner_test.dart
@@ -23,30 +23,50 @@ void main() {
       File(p.join(dir.path, "opencode")).writeAsStringSync("binary");
     }
 
-    test("removes superseded version dirs and keeps the kept one", () async {
+    bool Function({required String versionName}) keepOnly(String version) {
+      return ({required versionName}) => versionName == version;
+    }
+
+    test("removes every version dir the predicate rejects", () async {
       makeVersionDir("0.9.0");
       makeVersionDir("1.0.0");
       makeVersionDir("1.17.9");
 
-      await ManagedRuntimeCleaner(runtimeId: "opencode").sweep(managedDir: managedDir.path, keepVersion: "1.17.9");
+      await ManagedRuntimeCleaner(
+        runtimeId: "opencode",
+      ).sweep(managedDir: managedDir.path, keep: keepOnly("1.17.9"));
 
       expect(Directory(p.join(managedDir.path, "1.17.9")).existsSync(), isTrue);
       expect(Directory(p.join(managedDir.path, "1.0.0")).existsSync(), isFalse);
       expect(Directory(p.join(managedDir.path, "0.9.0")).existsSync(), isFalse);
     });
 
+    test("keeps every version dir the predicate accepts", () async {
+      makeVersionDir("1.0.0");
+      makeVersionDir("1.17.9");
+
+      await ManagedRuntimeCleaner(
+        runtimeId: "opencode",
+      ).sweep(managedDir: managedDir.path, keep: ({required versionName}) => versionName != "1.0.0");
+
+      expect(Directory(p.join(managedDir.path, "1.17.9")).existsSync(), isTrue);
+      expect(Directory(p.join(managedDir.path, "1.0.0")).existsSync(), isFalse);
+    });
+
     test("leaves stray files alone, only sweeps directories", () async {
       makeVersionDir("1.17.9");
       File(p.join(managedDir.path, ".sesori-runtime-download")).writeAsStringSync("partial");
 
-      await ManagedRuntimeCleaner(runtimeId: "opencode").sweep(managedDir: managedDir.path, keepVersion: "1.17.9");
+      await ManagedRuntimeCleaner(
+        runtimeId: "opencode",
+      ).sweep(managedDir: managedDir.path, keep: keepOnly("1.17.9"));
 
       expect(File(p.join(managedDir.path, ".sesori-runtime-download")).existsSync(), isTrue);
     });
 
     test("is a no-op when the managed dir does not exist", () async {
       final missing = p.join(managedDir.path, "does-not-exist");
-      await ManagedRuntimeCleaner(runtimeId: "opencode").sweep(managedDir: missing, keepVersion: "1.17.9");
+      await ManagedRuntimeCleaner(runtimeId: "opencode").sweep(managedDir: missing, keep: keepOnly("1.17.9"));
       // No throw is the assertion.
       expect(Directory(missing).existsSync(), isFalse);
     });

--- a/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_install_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_install_service_test.dart
@@ -38,6 +38,9 @@ class const _StubManifest({required final bool hasAsset}) implements RuntimeMani
   RuntimeVersion? parseVersion({required String value}) => SemanticRuntimeVersion.tryParse(value: value);
 
   @override
+  RuntimeVersion? parseInstalledVersion({required String value}) => parseVersion(value: value);
+
+  @override
   RuntimeAsset? assetFor({required PlatformTarget target}) => hasAsset ? _asset : null;
 
   @override
@@ -51,9 +54,14 @@ class const _StubManifest({required final bool hasAsset}) implements RuntimeMani
       "https://github.com/$repository/releases/download/$tag/${asset.assetName}";
 
   @override
-  String managedBinaryPath({required String stateDirectory}) {
-    return p.join(stateDirectory, runtimeId, bundledVersion.toString(), binaryFileName);
+  String managedBinaryPath({required String stateDirectory, required RuntimeVersion version}) {
+    return p.join(stateDirectory, runtimeId, version.raw, binaryFileName);
   }
+}
+
+class const _StubInUseSignal({required final bool _inUse}) implements RuntimeInUseSignal {
+  @override
+  bool get isInUse => _inUse;
 }
 
 class _FakeValidator({required final RuntimeVersion? managedVersion}) implements RuntimeVersionValidator {
@@ -65,9 +73,7 @@ class _FakeValidator({required final RuntimeVersion? managedVersion}) implements
     required Map<String, String>? environment,
   }) async {
     detectedExecutables.add(executable);
-    return managedVersion == null
-        ? const RuntimeProbeUnrecognized()
-        : RuntimeProbeReady(version: managedVersion!);
+    return managedVersion == null ? const RuntimeProbeUnrecognized() : RuntimeProbeReady(version: managedVersion!);
   }
 
   @override
@@ -83,9 +89,10 @@ class _FakeValidator({required final RuntimeVersion? managedVersion}) implements
   RuntimeVersion? parseVersionOutput({required String output}) => SemanticRuntimeVersion.tryParse(value: output);
 }
 
-class const _FakeDownloadClient() implements BinaryDownloadClient {
+class const _FakeDownloadClient({required final void Function()? _onDownload}) implements BinaryDownloadClient {
   @override
   Stream<DownloadProgress> download({required String url, required String destinationPath}) async* {
+    _onDownload?.call();
     File(destinationPath).writeAsBytesSync(const [1, 2, 3, 4]);
     yield const DownloadProgress(receivedBytes: 4, totalBytes: 4);
   }
@@ -143,13 +150,14 @@ void main() {
     bool checksumValid = true,
     RuntimeVersion? managedVersion,
     RuntimeAssetResolver? assetResolver,
+    void Function()? onDownload,
   }) {
     final manifest = _StubManifest(hasAsset: hasAsset);
     return ManagedRuntimeInstallService(
       manifest: manifest,
       versionValidator: _FakeValidator(managedVersion: managedVersion),
       installService: RuntimeInstallService(
-        downloadClient: const _FakeDownloadClient(),
+        downloadClient: _FakeDownloadClient(onDownload: onDownload),
         checksumValidator: _FakeChecksumValidator(valid: checksumValid),
         archiveExtractor: const _FakeArchiveExtractor(),
         commandExecutor: _FakeCommandExecutor(),
@@ -160,10 +168,29 @@ void main() {
     );
   }
 
-  Future<List<RuntimeProvisionProgress>> install(ManagedRuntimeInstallService service) {
+  Future<List<RuntimeProvisionProgress>> install(
+    ManagedRuntimeInstallService service, {
+    RuntimeInUseSignal runtimeInUse = RuntimeInUseSignal.never,
+  }) {
     return service
-        .install(environment: const {}, stateDirectory: stateDir.path, startAborted: StartAbortSignal.never)
+        .install(
+          environment: const {},
+          stateDirectory: stateDir.path,
+          startAborted: StartAbortSignal.never,
+          runtimeInUse: runtimeInUse,
+        )
         .toList();
+  }
+
+  Directory versionDir(String version) =>
+      Directory(p.join(stateDir.path, "opencode", version))..createSync(recursive: true);
+
+  /// Writes a healthy pinned install so the service takes its already-installed
+  /// short-circuit instead of downloading.
+  void installPinned() {
+    final dir = versionDir("1.17.9");
+    File(p.join(dir.path, "opencode")).writeAsStringSync("BINARY");
+    File(p.join(dir.path, RuntimeInstallService.sentinelFileName)).writeAsStringSync("abc123");
   }
 
   test("installs, probes the placed binary, and ends ready", () async {
@@ -204,13 +231,21 @@ void main() {
     final aborted = StartAbortController();
     final resolverStarted = Completer<void>();
     final resolverMayFail = Completer<void>();
-    final events = build(
-      assetResolver: ({required target}) async {
-        resolverStarted.complete();
-        await resolverMayFail.future;
-        throw StateError("resolver stopped");
-      },
-    ).install(environment: const {}, stateDirectory: stateDir.path, startAborted: aborted.signal).toList();
+    final events =
+        build(
+              assetResolver: ({required target}) async {
+                resolverStarted.complete();
+                await resolverMayFail.future;
+                throw StateError("resolver stopped");
+              },
+            )
+            .install(
+              environment: const {},
+              stateDirectory: stateDir.path,
+              startAborted: aborted.signal,
+              runtimeInUse: RuntimeInUseSignal.never,
+            )
+            .toList();
 
     await resolverStarted.future;
     aborted.abort();
@@ -236,7 +271,7 @@ void main() {
   });
 
   test("sweeps superseded managed versions after a healthy install", () async {
-    final staleDir = Directory(p.join(stateDir.path, "opencode", "1.0.0"))..createSync(recursive: true);
+    final staleDir = versionDir("1.0.0");
 
     await install(build(managedVersion: SemanticRuntimeVersion.parse(value: "1.17.9")));
 
@@ -244,14 +279,104 @@ void main() {
     expect(Directory(p.join(stateDir.path, "opencode", "1.17.9")).existsSync(), isTrue);
   });
 
+  test("removes below-minimum versions before the download starts", () async {
+    final obsoleteDir = versionDir("0.9.0");
+    final supportedDir = versionDir("1.5.0");
+    var downloaded = false;
+    final service = build(
+      managedVersion: SemanticRuntimeVersion.parse(value: "1.17.9"),
+      onDownload: () {
+        downloaded = true;
+        expect(obsoleteDir.existsSync(), isFalse, reason: "an obsolete version goes before bandwidth is spent");
+        expect(
+          supportedDir.existsSync(),
+          isTrue,
+          reason: "a supported version stays usable until the replacement lands",
+        );
+      },
+    );
+
+    await install(service);
+
+    expect(downloaded, isTrue);
+    expect(supportedDir.existsSync(), isFalse);
+  });
+
+  test("removes an obsolete version even when the install then fails", () async {
+    final obsoleteDir = versionDir("0.9.0");
+
+    final events = await install(build(checksumValid: false));
+
+    expect(events.last, isA<ProvisionFailed>());
+    expect(obsoleteDir.existsSync(), isFalse);
+  });
+
+  test("keeps an unparseable directory until the post-install sweep", () async {
+    final stagingDir = versionDir(".sesori-runtime-staging");
+    var stagingPresentAtDownload = false;
+    final service = build(
+      managedVersion: SemanticRuntimeVersion.parse(value: "1.17.9"),
+      onDownload: () => stagingPresentAtDownload = stagingDir.existsSync(),
+    );
+
+    await install(service);
+
+    expect(stagingPresentAtDownload, isTrue);
+    expect(stagingDir.existsSync(), isFalse);
+  });
+
+  test("keeps a supported superseded version while a generation is running", () async {
+    final supportedDir = versionDir("1.5.0");
+    final obsoleteDir = versionDir("0.9.0");
+
+    await install(
+      build(managedVersion: SemanticRuntimeVersion.parse(value: "1.17.9")),
+      runtimeInUse: const _StubInUseSignal(inUse: true),
+    );
+
+    expect(supportedDir.existsSync(), isTrue);
+    expect(obsoleteDir.existsSync(), isFalse);
+  });
+
+  test("keeps a supported superseded version on the already-installed path too", () async {
+    final supportedDir = versionDir("1.5.0");
+    installPinned();
+
+    final events = await install(
+      build(managedVersion: SemanticRuntimeVersion.parse(value: "1.17.9")),
+      runtimeInUse: const _StubInUseSignal(inUse: true),
+    );
+
+    expect(events.whereType<ProvisionDownloading>(), isEmpty);
+    expect(events.last, isA<ProvisionReady>());
+    expect(supportedDir.existsSync(), isTrue);
+  });
+
+  test("reclaims a supported superseded version once no generation is running", () async {
+    final supportedDir = versionDir("1.5.0");
+    installPinned();
+
+    await install(
+      build(managedVersion: SemanticRuntimeVersion.parse(value: "1.17.9")),
+      runtimeInUse: const _StubInUseSignal(inUse: false),
+    );
+
+    expect(supportedDir.existsSync(), isFalse);
+  });
+
   test("sweeps before the terminal event so an unsubscribing consumer cannot skip cleanup", () async {
-    final staleDir = Directory(p.join(stateDir.path, "opencode", "1.0.0"))..createSync(recursive: true);
+    final staleDir = versionDir("1.0.0");
     final flow = build(managedVersion: SemanticRuntimeVersion.parse(value: "1.17.9"));
 
     // Mirrors the lifecycle service, which stops listening at the terminal
     // event so the phone is not held up by post-install housekeeping.
     await flow
-        .install(environment: const {}, stateDirectory: stateDir.path, startAborted: StartAbortSignal.never)
+        .install(
+          environment: const {},
+          stateDirectory: stateDir.path,
+          startAborted: StartAbortSignal.never,
+          runtimeInUse: RuntimeInUseSignal.never,
+        )
         .firstWhere((event) => event is ProvisionReady || event is ProvisionFailed);
 
     expect(staleDir.existsSync(), isFalse);

--- a/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_inventory_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_inventory_test.dart
@@ -89,4 +89,20 @@ void main() {
 
     expect(inventory.hasSupersededVersion(stateDirectory: stateDir.path), isFalse);
   });
+
+  test("lists installed versions newest first", () {
+    versionDir("1.16.0");
+    versionDir("1.17.9");
+    versionDir("0.9.0");
+    versionDir(".sesori-runtime-staging");
+
+    expect(
+      inventory.installedVersions(stateDirectory: stateDir.path).map((version) => version.raw),
+      ["1.17.9", "1.16.0", "0.9.0"],
+    );
+  });
+
+  test("lists nothing when the managed directory does not exist", () {
+    expect(inventory.installedVersions(stateDirectory: stateDir.path), isEmpty);
+  });
 }

--- a/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_provision_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_provision_service_test.dart
@@ -40,6 +40,9 @@ class const _StubManifest() implements RuntimeManifest {
   RuntimeVersion? parseVersion({required String value}) => SemanticRuntimeVersion.tryParse(value: value);
 
   @override
+  RuntimeVersion? parseInstalledVersion({required String value}) => parseVersion(value: value);
+
+  @override
   RuntimeAsset? assetFor({required PlatformTarget target}) => _asset;
 
   @override
@@ -53,8 +56,8 @@ class const _StubManifest() implements RuntimeManifest {
       "https://github.com/$repository/releases/download/$tag/${asset.assetName}";
 
   @override
-  String managedBinaryPath({required String stateDirectory}) {
-    return p.join(stateDirectory, runtimeId, bundledVersion.toString(), binaryFileName);
+  String managedBinaryPath({required String stateDirectory, required RuntimeVersion version}) {
+    return p.join(stateDirectory, runtimeId, version.raw, binaryFileName);
   }
 }
 
@@ -113,8 +116,21 @@ class const _FakeHost({
 }
 
 void main() {
-  const stateDirectory = "/state";
-  final managedBinaryPath = p.join(stateDirectory, "opencode", "1.17.9", "opencode");
+  late Directory stateDir;
+
+  setUp(() async {
+    stateDir = await Directory.systemTemp.createTemp("managed-provision");
+  });
+
+  tearDown(() async {
+    if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+  });
+
+  String managedBinaryPathFor(String version) => p.join(stateDir.path, "opencode", version, "opencode");
+
+  void installedVersionDir(String version) {
+    Directory(p.join(stateDir.path, "opencode", version)).createSync(recursive: true);
+  }
 
   Future<List<RuntimeProvisionProgress>> resolve({
     required RuntimeVersion? pathVersion,
@@ -131,12 +147,13 @@ void main() {
               managedVersion: managedVersion,
               candidateVersions: candidateVersions,
             ),
+            inventory: const ManagedRuntimeInventory(manifest: _StubManifest()),
           ),
           fallbackExecutableCandidates: fallbackCandidates,
         )
         .provision(
           host: _FakeHost(
-            stateDirectory: stateDirectory,
+            stateDirectory: stateDir.path,
             abortSignal: StartAbortSignal.never,
           ),
           explicitExecutablePath: null,
@@ -161,7 +178,7 @@ void main() {
       managedVersion: SemanticRuntimeVersion.parse(value: "1.17.9"),
     );
 
-    expect((events.last as ProvisionReady).binaryPath, managedBinaryPath);
+    expect((events.last as ProvisionReady).binaryPath, managedBinaryPathFor("1.17.9"));
     expect(events.whereType<ProvisionNotice>(), isEmpty);
   });
 
@@ -172,7 +189,7 @@ void main() {
     );
 
     expect(events.whereType<ProvisionNotice>(), hasLength(1));
-    expect((events.last as ProvisionReady).binaryPath, managedBinaryPath);
+    expect((events.last as ProvisionReady).binaryPath, managedBinaryPathFor("1.17.9"));
   });
 
   test("uses a sufficiently recent fallback candidate when PATH is absent", () async {
@@ -200,17 +217,31 @@ void main() {
       },
     );
 
-    expect((events.last as ProvisionReady).binaryPath, managedBinaryPath);
+    expect((events.last as ProvisionReady).binaryPath, managedBinaryPathFor("1.17.9"));
   });
 
-  test("does not accept a managed runtime with a different version", () async {
+  test("does not accept a managed runtime below the minimum", () async {
     final events = await resolve(
       pathVersion: null,
-      managedVersion: SemanticRuntimeVersion.parse(value: "1.0.0"),
+      managedVersion: SemanticRuntimeVersion.parse(value: "0.9.0"),
     );
 
     expect(events.last, isA<ProvisionFailed>());
     expect((events.last as ProvisionFailed).message, contains("Install OpenCode locally"));
+  });
+
+  test("names the selected managed version when falling back from an outdated PATH runtime", () async {
+    installedVersionDir("1.5.0");
+    final events = await resolve(
+      pathVersion: SemanticRuntimeVersion.parse(value: "0.9.0"),
+      managedVersion: SemanticRuntimeVersion.parse(value: "1.5.0"),
+      candidateVersions: {managedBinaryPathFor("1.17.9"): null},
+    );
+
+    expect((events.last as ProvisionReady).binaryPath, managedBinaryPathFor("1.5.0"));
+    final notice = events.whereType<ProvisionNotice>().single;
+    expect(notice.message, contains("managed OpenCode 1.5.0"));
+    expect(notice.message, isNot(contains("1.17.9")));
   });
 
   test("never installs when no existing runtime is usable", () async {
@@ -230,10 +261,11 @@ void main() {
           selectionService: ManagedRuntimeSelectionService(
             manifest: const _StubManifest(),
             versionValidator: validator,
+            inventory: const ManagedRuntimeInventory(manifest: _StubManifest()),
           ),
           fallbackExecutableCandidates: const [],
         ).provision(
-          host: _FakeHost(stateDirectory: stateDirectory, abortSignal: abort.signal),
+          host: _FakeHost(stateDirectory: stateDir.path, abortSignal: abort.signal),
           explicitExecutablePath: null,
         );
 
@@ -256,10 +288,11 @@ void main() {
           selectionService: ManagedRuntimeSelectionService(
             manifest: const _StubManifest(),
             versionValidator: validator,
+            inventory: const ManagedRuntimeInventory(manifest: _StubManifest()),
           ),
           fallbackExecutableCandidates: const [],
         ).provision(
-          host: _FakeHost(stateDirectory: stateDirectory, abortSignal: abort.signal),
+          host: _FakeHost(stateDirectory: stateDir.path, abortSignal: abort.signal),
           explicitExecutablePath: null,
         );
 

--- a/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_selection_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/provisioning/managed_runtime_selection_service_test.dart
@@ -75,27 +75,42 @@ class _Validator({
 
 void main() {
   const manifest = _Manifest();
-  const stateDirectory = "/state";
-  final managedPath = p.join(stateDirectory, "runtime", "2.0.0", "runtime");
+  late Directory stateDir;
   RuntimeVersion version(String value) => SemanticRuntimeVersion.parse(value: value);
+
+  setUp(() async {
+    stateDir = await Directory.systemTemp.createTemp("managed-selection");
+  });
+
+  tearDown(() async {
+    if (stateDir.existsSync()) await stateDir.delete(recursive: true);
+  });
+
+  /// Creates the on-disk version directory the inventory reports; the probe
+  /// outcome for its binary still decides whether the candidate is selected.
+  String installed(String value) {
+    Directory(p.join(stateDir.path, "runtime", value)).createSync(recursive: true);
+    return p.join(stateDir.path, "runtime", value, "runtime");
+  }
+
+  String managedPathFor(String value) => p.join(stateDir.path, "runtime", value, "runtime");
 
   Future<ManagedRuntimeSelection> select({
     required _Validator validator,
     String? explicitExecutablePath,
     List<String> fallbackExecutableCandidates = const [],
-    ManagedRuntimeVersionPolicy managedVersionPolicy = ManagedRuntimeVersionPolicy.exact,
     required StartAbortSignal abortSignal,
   }) {
     return ManagedRuntimeSelectionService(
       manifest: manifest,
       versionValidator: validator,
+      inventory: const ManagedRuntimeInventory(manifest: manifest),
     ).select(
       explicitExecutablePath: explicitExecutablePath,
       fallbackExecutableCandidates: fallbackExecutableCandidates,
       environment: const {"PATH": "/bin"},
-      stateDirectory: stateDirectory,
+      stateDirectory: stateDir.path,
       abortSignal: abortSignal,
-      managedVersionPolicy: managedVersionPolicy,
     );
   }
 
@@ -127,7 +142,7 @@ void main() {
         "runtime": RuntimeProbeReady(version: version("0.9.0")),
         "/old/runtime": RuntimeProbeReady(version: version("0.8.0")),
         "/desktop/runtime": RuntimeProbeReady(version: version("1.5.0")),
-        managedPath: RuntimeProbeReady(version: version("2.0.0")),
+        managedPathFor("2.0.0"): RuntimeProbeReady(version: version("2.0.0")),
       },
       onProbe: null,
     );
@@ -146,26 +161,117 @@ void main() {
     expect(validator.probes, ["runtime", "/old/runtime", "/desktop/runtime"]);
   });
 
-  test("applies exact or minimum policy to the managed runtime", () async {
-    _Validator validator() => _Validator(
+  test("accepts any managed version at or above the minimum", () async {
+    final validator = _Validator(
       outcomes: {
-        managedPath: RuntimeProbeReady(version: version("2.1.0")),
+        managedPathFor("2.0.0"): RuntimeProbeReady(version: version("2.1.0")),
       },
       onProbe: null,
     );
 
-    final exact = await select(validator: validator(), abortSignal: StartAbortSignal.never);
-    expect(exact, isA<ManagedRuntimeNotSelected>());
+    final result = await select(validator: validator, abortSignal: StartAbortSignal.never);
 
-    final minimum = await select(
-      validator: validator(),
-      managedVersionPolicy: ManagedRuntimeVersionPolicy.minimum,
+    expect(result, isA<ManagedRuntimeManagedSelected>());
+    expect((result as ManagedRuntimeSelected).version.raw, "2.1.0");
+  });
+
+  test("prefers the pinned managed version over a newer installed one", () async {
+    installed("1.5.0");
+    installed("2.0.0");
+    final validator = _Validator(
+      outcomes: {
+        managedPathFor("2.0.0"): RuntimeProbeReady(version: version("2.0.0")),
+        managedPathFor("1.5.0"): RuntimeProbeReady(version: version("1.5.0")),
+      },
+      onProbe: null,
+    );
+
+    final result = await select(validator: validator, abortSignal: StartAbortSignal.never);
+
+    expect((result as ManagedRuntimeSelected).binaryPath, managedPathFor("2.0.0"));
+    expect(validator.probes, isNot(contains(managedPathFor("1.5.0"))));
+  });
+
+  test("falls back to the highest supported version when the pinned one is absent", () async {
+    installed("1.0.0");
+    installed("1.5.0");
+    final validator = _Validator(
+      outcomes: {
+        managedPathFor("1.5.0"): RuntimeProbeReady(version: version("1.5.0")),
+        managedPathFor("1.0.0"): RuntimeProbeReady(version: version("1.0.0")),
+      },
+      onProbe: null,
+    );
+
+    final result = await select(validator: validator, abortSignal: StartAbortSignal.never);
+
+    final selected = result as ManagedRuntimeManagedSelected;
+    expect(selected.binaryPath, managedPathFor("1.5.0"));
+    expect(selected.version.raw, "1.5.0");
+    expect(validator.probes, isNot(contains(managedPathFor("1.0.0"))));
+  });
+
+  test("accepts an installed version equal to the minimum", () async {
+    installed("1.0.0");
+    final validator = _Validator(
+      outcomes: {
+        managedPathFor("1.0.0"): RuntimeProbeReady(version: version("1.0.0")),
+      },
+      onProbe: null,
+    );
+
+    final result = await select(validator: validator, abortSignal: StartAbortSignal.never);
+
+    expect((result as ManagedRuntimeSelected).version.raw, "1.0.0");
+  });
+
+  test("skips an unrunnable superseded version and takes the next one down", () async {
+    installed("1.9.0");
+    installed("1.5.0");
+    final validator = _Validator(
+      outcomes: {
+        managedPathFor("1.9.0"): const RuntimeProbeNonZeroExit(exitCode: 1),
+        managedPathFor("1.5.0"): RuntimeProbeReady(version: version("1.5.0")),
+      },
+      onProbe: null,
+    );
+
+    final result = await select(validator: validator, abortSignal: StartAbortSignal.never);
+
+    expect((result as ManagedRuntimeSelected).binaryPath, managedPathFor("1.5.0"));
+  });
+
+  test("never probes a below-minimum or unparseable managed directory", () async {
+    installed("0.9.0");
+    installed(".sesori-runtime-staging");
+    final validator = _Validator(
+      outcomes: {
+        managedPathFor("0.9.0"): RuntimeProbeReady(version: version("0.9.0")),
+      },
+      onProbe: null,
+    );
+
+    final result = await select(validator: validator, abortSignal: StartAbortSignal.never);
+
+    expect(result, isA<ManagedRuntimeNotSelected>());
+    expect(validator.probes, ["runtime", managedPathFor("2.0.0")]);
+  });
+
+  test("prefers an informative superseded rejection over a missing pinned one", () async {
+    installed("1.5.0");
+    const supersededFailure = RuntimeProbeUnrecognized();
+    final result = await select(
+      validator: _Validator(
+        outcomes: {
+          managedPathFor("1.5.0"): supersededFailure,
+        },
+        onProbe: null,
+      ),
       abortSignal: StartAbortSignal.never,
     );
-    expect(minimum, isA<ManagedRuntimeSelected>());
-    expect(minimum, isA<ManagedRuntimeManagedSelected>());
-    final selected = minimum as ManagedRuntimeSelected;
-    expect(selected.version.raw, "2.1.0");
+
+    final automatic = result as ManagedRuntimeAutomaticNotSelected;
+    expect((automatic.managedRejection as ManagedRuntimeProbeRejected).outcome, same(supersededFailure));
   });
 
   test("preserves PATH and managed rejection details", () async {
@@ -175,7 +281,7 @@ void main() {
       validator: _Validator(
         outcomes: {
           "runtime": pathFailure,
-          managedPath: managedFailure,
+          managedPathFor("2.0.0"): managedFailure,
         },
         onProbe: null,
       ),


### PR DESCRIPTION
## Complexity

🚧 complex — one plugin-interface parameter forces lockstep changes across seven
managed descriptors, and the install path gains an ownership-aware two-stage
cleanup that must not delete a runtime a live generation is executing.

## What

Step 2/5 of `.plan/active/managed-runtime-auto-upgrade`, covering Design §1 and
§2. No startup trigger yet — that is Step 3.

- `ManagedRuntimeSelectionService` probes the pinned managed version first, then
  every other installed version at or above `minPathVersion`, newest first.
  `ManagedRuntimeVersionPolicy` is deleted: with an ordered candidate list the
  exact/minimum distinction had no consumer left.
- `ManagedRuntimeInventory.installedVersions` lists managed version directories
  newest first; `hasSupersededVersion` derives from it.
- `ManagedRuntimeCleaner.sweep` takes a `keep` predicate instead of a single
  kept version, so the caller owns cleanup policy and the cleaner stays
  mechanism.
- `ManagedRuntimeInstallService` sweeps in two stages: versions below the
  minimum go before the download starts (they are unselectable either way), and
  everything else goes once the pinned version is verified — minus any
  still-supported version a live generation could be running from.
- New `RuntimeInUseSignal` in `sesori_plugin_interface`, mirroring
  `StartAbortSignal`: a read-only `bool get isInUse` the installer reads at sweep
  time. Its only production implementation is private to `PluginRuntime` and
  reads the slot on each access.
- `BridgePluginDescriptor` gains `installRuntime(runtimeInUse:)` and a
  `needsManagedRuntimeUpgrade` default of `false`; all seven managed descriptors
  (OpenCode, Codex, Cursor, Copilot, Pi, OMP, DeepSeek) update in lockstep.
- The managed-runtime provision notice now names the version actually selected
  instead of `bundledVersion`, which was wrong for exactly the case this series
  introduces.

Two deliberate deviations from the plan text, both recorded in `PLAN.md`:

1. `needsManagedRuntimeUpgrade` gates on
   `managementCapabilities(config).contains(install)` rather than each
   descriptor's private `_supportsManagedInstall`. OpenCode additionally drops
   `install` in attach mode (`--opencode-no-auto-start`), and OMP's private
   helper takes no config at all, so the plan's literal formula would have
   auto-upgraded runtimes Sesori does not own.
2. New `RuntimeManifest.parseInstalledVersion` (defaults to `parseVersion`,
   overridden only by OMP). `parseVersion` parses a token of `--version` output
   and OMP's requires an `omp/` prefix so an unrelated semver token is not
   mistaken for the runtime version — meaning it can never parse a version
   *directory* name. `hasSupersededVersion` was therefore silently always false
   for OMP; harmless while it only picked hint wording, but this change would
   have made OMP the one harness that never falls back and never upgrades.

`RuntimeManifest.managedBinaryPath` now takes the version instead of assuming
the pinned one, so ordered candidate probing reuses it rather than repeating the
`<stateDirectory>/<runtimeId>/<version>/<binaryFileName>` layout a third time.

## Why

Raising a harness's pinned managed runtime currently makes setup report the
harness as runtime-missing until the user presses Install, even when the managed
version already on disk satisfies the minimum. This step makes an older
supported managed version selectable and makes the installer safe to run while
the plugin is executing from one, which is the precondition for the background
startup upgrade in Step 3.

## Risk and test focus

Moderate risk, confined to managed-runtime resolution and cleanup. No wire,
database, persisted-state, or client change; PATH installs, explicit
`--<plugin>-bin` binaries, credentials, and session history are untouched.

Most valuable checks:

- Runtime selection precedence: PATH, fallback candidate, pinned managed, then
  the highest supported older managed version. A below-minimum or unparseable
  directory is never probed.
- The pre-download sweep removes obsolete versions and leaves supported ones;
  the post-install sweep keeps a supported superseded version while
  `runtimeInUse.isInUse`, on both the fresh-install and already-installed paths.
- Both sweeps still run before the terminal event, so a consumer that
  unsubscribes on `ProvisionReady` cannot skip cleanup.
- `needsManagedRuntimeUpgrade` is true only with a superseded directory, no
  explicit binary, a supported platform, and — for OpenCode — not in attach mode.
- OMP specifically: its manifest parses `omp/<semver>` from `--version` output
  and bare `<semver>` from directory names.

## Expected result

No user-visible change yet: nothing calls `needsManagedRuntimeUpgrade` until
Step 3. What does change today is that a harness whose managed runtime is older
than the pinned target but still at or above the minimum now resolves and
reports ready instead of runtime-missing, and its provision notice names the
version actually in use. No database or persisted-data effect. Internally, the
plugin-interface install contract and `RuntimeManifest` gain the parameters the
startup upgrade needs.

## Verification

- `dart analyze` clean across the whole `bridge/` workspace.
- 1716 tests green across `sesori_plugin_interface`, `sesori_plugin_runtime`,
  `sesori_plugin_codex`, `sesori_plugin_copilot`, `sesori_plugin_cursor`,
  `sesori_plugin_omp`, `sesori_plugin_opencode`, `sesori_plugin_pi`; plus
  `sesori_plugin_deepseek` (84) and `bridge/app` runtime and lifecycle suites
  (222).
- `architecture-implementation-review` accepted the change, explicitly endorsing
  both deviations and the `managedBinaryPath` and `RuntimeInUseSignal` shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Managed runtime selection now falls back to the newest installed version still at or above the minimum when the pinned version isn't on disk, so raising the pinned target no longer reports a harness as runtime-missing. Installs are also now safe while a live generation executes from an older supported version, via a two-stage sweep guided by a new in-use signal.

**Changes**
- Selection probes the pinned managed version first, then remaining installed versions newest-first; `ManagedRuntimeVersionPolicy` is deleted.
- The installer sweeps below-minimum versions before the download and the rest after the pinned version is verified, keeping any supported version a live generation may be running from.
- New `RuntimeInUseSignal` in `sesori_plugin_interface` mirrors `StartAbortSignal`; `BridgePluginDescriptor.installRuntime` gains it and `needsManagedRuntimeUpgrade` defaults to false.
- All seven managed descriptors update in lockstep; the provision notice names the selected version instead of `bundledVersion`.

**Deviations from the plan**
- The upgrade gate is the `install` capability, not each descriptor's private helper; OpenCode drops `install` in attach mode.
- New `RuntimeManifest.parseInstalledVersion` parses directory names separately from `--version` output, so OMP's `omp/` prefix stops hiding its superseded versions.

No wire, database, or persisted-state change; PATH installs, explicit binaries, credentials, and session history are untouched. Nothing calls `needsManagedRuntimeUpgrade` until Step 3.

<sup>Written for commit 2cc88e6e565b18478a0e251646bc7f8c16542779. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

