### PR TITLE
⚙️ [claude-inline-subtasks] deepseek: replay child tiles with stable identities [step 5/5]

### DIFF
--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -610,7 +610,7 @@ packaging-only change.
 | 2/5 | Verbatim protocol-v2 fixtures and integrity | [PR #1301](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1301) merged at `cde00fdf90` |
 | 3/5 | Typed protocol boundary and conformance | [PR #1304](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1304) merged at `747fbd3eb9` |
 | 4/5 | Live lifecycle, correlation, catalogs, runtime 0.1.3 | [PR #1306](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1306) merged at `400dcbe01a` |
-| 5/5 | Replay callback, history, remaining consumer docs | Implemented on `claude-inline-subtasks-deepseek-replay`; architecture review pending |
+| 5/5 | Replay callback, history, remaining consumer docs | Implemented on `claude-inline-subtasks-deepseek-replay`; architecture approved |
 
 Slice 1 verification: ACP analyze + 310 tests, unchanged DeepSeek analyze +
 42 tests, and Grok analyze + 83 tests passed. The replay callback and its
@@ -691,3 +691,8 @@ Final feature E2E and scoped-stop consumption are still pending.
 
 User priority (2026-09-05): complete remaining DeepSeek follow-ups, then Codex.
 Automatic managed-runtime upgrades are owned by another session, not this series.
+Architecture implementation review approved with no findings. Implementation
+head `fa4f7aaa8fa80eaf68df6b27f904d7672c1cb2fb` is **+541/-30 = 571 lines**, below
+the planned 800–1,100 range without omitting required callers or replay coverage.
+Reproduce with `git diff --numstat 8bdc2345e301e8bf7da906299df622bb9d650e19 fa4f7aaa8fa80eaf68df6b27f904d7672c1cb2fb`;
+this review bookkeeping is additional.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -695,4 +695,5 @@ Architecture implementation review approved with no findings. Implementation
 head `fa4f7aaa8fa80eaf68df6b27f904d7672c1cb2fb` is **+541/-30 = 571 lines**, below
 the planned 800–1,100 range without omitting required callers or replay coverage.
 Reproduce with `git diff --numstat 8bdc2345e301e8bf7da906299df622bb9d650e19 fa4f7aaa8fa80eaf68df6b27f904d7672c1cb2fb`;
-this review bookkeeping is additional.
+PR-opening head `f6c319e5c` adds five review-bookkeeping lines: **+546/-30 = 576**.
+These are fixed historical measurements, not totals for subsequent revisions.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -609,8 +609,8 @@ packaging-only change.
 | 1/5 | Shared ACP live prerequisites | [PR #1298](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1298) merged at `59464ca14a` |
 | 2/5 | Verbatim protocol-v2 fixtures and integrity | [PR #1301](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1301) merged at `cde00fdf90` |
 | 3/5 | Typed protocol boundary and conformance | [PR #1304](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1304) merged at `747fbd3eb9` |
-| 4/5 | Live lifecycle, correlation, catalogs, runtime 0.1.3 | [PR #1306](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1306) includes verified published assets |
-| 5/5 | Replay callback, history, remaining consumer docs | Pending slice 4 merge |
+| 4/5 | Live lifecycle, correlation, catalogs, runtime 0.1.3 | [PR #1306](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1306) merged at `400dcbe01a` |
+| 5/5 | Replay callback, history, remaining consumer docs | Implemented on `claude-inline-subtasks-deepseek-replay`; architecture review pending |
 
 Slice 1 verification: ACP analyze + 310 tests, unchanged DeepSeek analyze +
 42 tests, and Grok analyze + 83 tests passed. The replay callback and its
@@ -675,3 +675,19 @@ Reproduce against its immutable merge base (later review bookkeeping is addition
 git diff --numstat 747fbd3eb9f20f07d0478dc8469dba7140103400 97adc68c8ba19d27085f4cc04b7129afa2d5668a |
   awk '{ a += $1; d += $2 } END { print a, d, a + d }'
 ```
+
+Slice 5 verification: ACP analysis and 312 tests, DeepSeek analysis and 88 tests,
+and unchanged Grok analysis and 83 tests pass. The required synchronous replay
+replacement callback lands with all callers; null preserves generic ACP tools.
+History uses chronological typed metadata without reading/mutating live child
+or delegation trackers. Run alignment preserves part order and direct-parent
+child identities; later ordinary runs receive unique message/part IDs, and empty
+source envelopes remain intact. Unlike the archive, terminal mapping stays
+non-nullable and running replay state is explicit at its call site. Tests cover
+multiple interleaved child tiles, reverse pagination, live/replay convergence,
+unbound startup failures, ordinary tool fallback, and replay-state isolation.
+Both protocol fixture versions and runtime 0.1.3 pins/checksums remain unchanged.
+Final feature E2E and scoped-stop consumption are still pending.
+
+User priority (2026-09-05): complete remaining DeepSeek follow-ups, then Codex.
+Automatic managed-runtime upgrades are owned by another session, not this series.

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1867,6 +1867,7 @@ abstract class AcpPlugin({
       // Reclassify a halt notice (e.g. Cursor's account/plan gate) the same way
       // the live stream does, so reloaded history renders it identically.
       haltClassifier: eventMapper.classifyHaltNotice,
+      toolPartReplacement: null,
     );
     List<PluginMessageWithParts> buildReplay() => collector.buildWithAssistantSelection(
       modelId: eventMapper.modelForSession(sessionId: sessionId),

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -7,6 +7,10 @@ import "repositories/trackers/acp_tool_content_tracker.dart";
 
 typedef AcpReplayUserMessageIdOverride = String? Function({required String acpMessageId});
 typedef AcpReplayMessageTimeResolver = PluginMessageTime? Function({required Map<String, dynamic> params});
+typedef AcpReplayToolPartReplacement = PluginMessagePart? Function({
+  required String toolCallId,
+  required PluginMessagePartTool toolPart,
+});
 typedef _AcpReplayAssistantSelection = ({String? modelId, String? providerId, String? variant});
 
 /// Accumulates the `session/update` notifications replayed by `session/load`
@@ -31,6 +35,11 @@ class AcpReplayCollector({
   /// notice as an error message exactly as it appeared live. Null on backends
   /// with no halt notices.
   required final AcpHaltNotice? Function({required String text})? haltClassifier,
+
+  /// Replaces one materialized standard tool part with a harness-specific part.
+  /// Null retains the generic ACP projection. This synchronous projection is
+  /// replay-local; it must not read or mutate live lifecycle state.
+  required final AcpReplayToolPartReplacement? toolPartReplacement,
 }) {
   static const AcpContentMapper _contentMapper = AcpContentMapper();
 
@@ -404,7 +413,7 @@ class AcpReplayCollector({
     required _ToolDraft tool,
   }) {
     final content = tool.contentTracker.snapshot;
-    return PluginMessagePart.tool(
+    final toolPart = PluginMessagePartTool(
       id: "${draft.id}-tool-$toolId",
       sessionID: sessionId,
       messageID: draft.id,
@@ -417,6 +426,7 @@ class AcpReplayCollector({
         attachments: content.attachments,
       ),
     );
+    return toolPartReplacement?.call(toolCallId: toolId, toolPart: toolPart) ?? toolPart;
   }
 
   void _retainTime({required _Draft draft, required PluginMessageTime? time}) {

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -89,6 +89,7 @@ void main() {
           messageIdOverride: null,
           messageTimeResolver: null,
           haltClassifier: null,
+          toolPartReplacement: null,
         );
         final liveEvents = <BridgeSseEvent>[];
 
@@ -134,6 +135,7 @@ void main() {
                   messageIdOverride: null,
                   messageTimeResolver: null,
                   haltClassifier: null,
+                  toolPartReplacement: null,
                 )
                 ..consume(
                   upd({
@@ -177,6 +179,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -236,6 +239,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: null,
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "tool_call",
@@ -272,6 +276,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -310,6 +315,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -354,6 +360,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -387,6 +394,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: null,
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "tool_call",
@@ -411,6 +419,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: null,
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -443,6 +452,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -482,6 +492,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -507,6 +518,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -532,6 +544,7 @@ void main() {
         messageIdOverride: null,
         messageTimeResolver: null,
         haltClassifier: null,
+        toolPartReplacement: null,
       );
 
       expect(
@@ -549,6 +562,7 @@ void main() {
         messageIdOverride: null,
         messageTimeResolver: null,
         haltClassifier: null,
+        toolPartReplacement: null,
       );
       final output = _captureWarnings(() {
         for (var index = 0; index < 2; index++) {
@@ -576,6 +590,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -687,6 +702,7 @@ void main() {
                 messageIdOverride: null,
                 messageTimeResolver: null,
                 haltClassifier: null,
+                toolPartReplacement: null,
               )
               ..consume(
                 upd({
@@ -740,6 +756,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -780,6 +797,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -810,6 +828,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -840,6 +859,7 @@ void main() {
               messageIdOverride: null,
               messageTimeResolver: null,
               haltClassifier: null,
+              toolPartReplacement: null,
             )
             ..consume(
               upd({
@@ -885,6 +905,7 @@ void main() {
             messageTimeResolver: null,
             haltClassifier: ({required text}) =>
                 text.trim() == "Check your settings to continue" ? const AcpHaltNotice(errorName: "cursor_gate") : null,
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -913,6 +934,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -933,6 +955,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -966,6 +989,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: ({required text}) => const AcpHaltNotice(errorName: "cursor_gate"),
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -990,6 +1014,7 @@ void main() {
             messageIdOverride: null,
             messageTimeResolver: null,
             haltClassifier: null,
+            toolPartReplacement: null,
           )..consume(
             upd({
               "sessionUpdate": "agent_message_chunk",
@@ -999,6 +1024,48 @@ void main() {
       final message = collector.build().single;
       expect(message.info, isA<PluginMessageAssistant>());
       expect(message.parts, isNotEmpty);
+    });
+
+    test("a replay-local callback can replace one generic tool part", () {
+      final collector =
+          AcpReplayCollector(
+            sessionId: "s1",
+            agentId: "ACP",
+            initialUserMessageId: null,
+            messageIdOverride: null,
+            messageTimeResolver: null,
+            haltClassifier: null,
+            toolPartReplacement: ({required toolCallId, required toolPart}) {
+              expect(toolCallId, "call-1");
+              return PluginMessagePart.subtask(
+                id: toolPart.id,
+                sessionID: toolPart.sessionID,
+                messageID: toolPart.messageID,
+                prompt: "Synthetic prompt",
+                description: "Synthetic child",
+                agent: "synthetic",
+                taskState: const PluginToolState(
+                  status: PluginToolStatus.running,
+                  title: null,
+                  output: null,
+                  error: null,
+                  attachments: [],
+                ),
+                childSessionID: "child-1",
+              );
+            },
+          )..consume(
+            upd({
+              "sessionUpdate": "tool_call",
+              "toolCallId": "call-1",
+              "title": "delegate",
+              "status": "in_progress",
+            }),
+          );
+
+      final part = collector.build().single.parts.single as PluginMessagePartSubtask;
+      expect(part.id, "s1-h0-assistant-tool-call-1");
+      expect(part.childSessionID, "child-1");
     });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_tool_content_integration_test.dart
@@ -617,6 +617,7 @@ AcpReplayCollector _collector() => AcpReplayCollector(
   messageIdOverride: null,
   messageTimeResolver: null,
   haltClassifier: null,
+  toolPartReplacement: null,
 );
 
 PluginToolState _replayState({required AcpReplayCollector collector}) => collector.build().single.parts.single.state;

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_history_repository.dart
@@ -5,12 +5,14 @@ import "../api/deepseek_acp_api.dart";
 import "../api/models/deepseek_protocol_dto.dart";
 import "../deepseek_event_mapper.dart";
 import "../deepseek_message_time_parser.dart";
+import "mappers/deepseek_subagent_mapper.dart";
 
 class DeepSeekHistoryRepository({
   required final DeepSeekAcpApi api,
   required final DeepSeekEventMapper eventMapper,
   required final String pluginId,
   required final DeepSeekMessageTimeParser messageTimeParser,
+  required final DeepSeekSubagentMapper subagentMapper,
 }) {
   static const int _maxPages = 100;
   static const int _pageSize = 100;
@@ -19,6 +21,7 @@ class DeepSeekHistoryRepository({
     required AcpStdioClient client,
     required String sessionId,
   }) async {
+    final subagentsByToolCallId = <String, DeepSeekSubagentReplayDto>{};
     final collector = AcpReplayCollector(
       sessionId: sessionId,
       agentId: pluginId,
@@ -26,6 +29,10 @@ class DeepSeekHistoryRepository({
       messageIdOverride: ({required acpMessageId}) => acpMessageId,
       messageTimeResolver: ({required params}) => messageTimeParser.parse(params),
       haltClassifier: eventMapper.classifyHaltNotice,
+      toolPartReplacement: ({required toolCallId, required toolPart}) {
+        final replay = subagentsByToolCallId[toolCallId];
+        return replay == null ? null : subagentMapper.mapReplay(toolPart: toolPart, replay: replay);
+      },
     );
     int? cursor;
     final pages = <List<DeepSeekSessionUpdateEnvelopeDto>>[];
@@ -43,13 +50,20 @@ class DeepSeekHistoryRepository({
           case DeepSeekTerminalHistoryResponseDto():
             for (final updates in pages.reversed) {
               for (final envelope in updates) {
+                final toolCallId = envelope.update["toolCallId"];
+                final subagent = envelope.metadata?.deepSeek?.subagent;
+                if (toolCallId is String && toolCallId.isNotEmpty && subagent != null) {
+                  subagentsByToolCallId[toolCallId] = subagent;
+                }
                 collector.consume(envelope.toJson());
               }
             }
-            return collector.buildWithAssistantSelection(
-              modelId: eventMapper.modelForSession(sessionId: sessionId),
-              providerId: eventMapper.providerForSession(sessionId: sessionId),
-              variant: null,
+            return subagentMapper.alignReplayChildIdentities(
+              messages: collector.buildWithAssistantSelection(
+                modelId: eventMapper.modelForSession(sessionId: sessionId),
+                providerId: eventMapper.providerForSession(sessionId: sessionId),
+                variant: null,
+              ),
             );
           case DeepSeekPaginatedHistoryResponseDto(:final nextBeforeSeq):
             if (cursor != null && nextBeforeSeq >= cursor) {

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/mappers/deepseek_subagent_mapper.dart
@@ -47,6 +47,71 @@ class const DeepSeekSubagentMapper({required final String agentId}) {
     };
   }
 
+  PluginMessagePartSubtask mapReplay({
+    required PluginMessagePartTool toolPart,
+    required DeepSeekSubagentReplayDto replay,
+  }) {
+    final childSessionId = replay.childSessionId;
+    final messageId = childSessionId == null ? toolPart.messageID : "${toolPart.sessionID}-subagent-$childSessionId";
+    return PluginMessagePartSubtask(
+      id: childSessionId == null ? toolPart.id : "$messageId-subtask",
+      sessionID: toolPart.sessionID,
+      messageID: messageId,
+      prompt: replay.prompt,
+      description: replay.label,
+      agent: agentId,
+      taskState: switch (replay.ended) {
+        null => const PluginToolState(
+          status: PluginToolStatus.running,
+          title: null,
+          output: null,
+          error: null,
+          attachments: [],
+        ),
+        final ended => mapState(stopReason: ended.stopReason, summary: ended.summary),
+      },
+      childSessionID: childSessionId,
+    );
+  }
+
+  /// Splits contiguous part runs without changing their order. Child-linked
+  /// identities match live tiles; the first ordinary run keeps its source ID,
+  /// and later ordinary runs get deterministic message and part IDs for storage.
+  List<PluginMessageWithParts> alignReplayChildIdentities({required List<PluginMessageWithParts> messages}) {
+    final aligned = <PluginMessageWithParts>[];
+    for (final message in messages) {
+      if (message.parts.isEmpty) {
+        aligned.add(message);
+        continue;
+      }
+      var runStart = 0;
+      var parentRunOrdinal = 0;
+      for (var end = 1; end <= message.parts.length; end++) {
+        final first = message.parts[runStart];
+        if (end < message.parts.length &&
+            message.parts[end].messageID == first.messageID &&
+            message.parts[end].sessionID == first.sessionID) {
+          continue;
+        }
+        final isParentRun = first.messageID == message.info.id && first.sessionID == message.info.sessionID;
+        if (isParentRun) parentRunOrdinal++;
+        final suffix = isParentRun && parentRunOrdinal > 1 ? "-deepseek-replay-run-$parentRunOrdinal" : null;
+        final messageId = suffix == null ? first.messageID : "${first.messageID}$suffix";
+        aligned.add(
+          PluginMessageWithParts(
+            info: message.info.copyWith(id: messageId, sessionID: first.sessionID),
+            parts: [
+              for (final part in message.parts.sublist(runStart, end))
+                suffix == null ? part : part.copyWith(id: "${part.id}$suffix", messageID: messageId),
+            ],
+          ),
+        );
+        runStart = end;
+      }
+    }
+    return aligned;
+  }
+
   String? _bounded({required String? value}) =>
       value == null || value.isEmpty ? null : String.fromCharCodes(value.runes.take(maxToolOutputLength));
 

--- a/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
@@ -277,6 +277,7 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
         eventMapper: mapper,
         pluginId: DeepSeekIdentity.id,
         messageTimeParser: messageTimeParser,
+        subagentMapper: subagentMapper,
       ),
       deepSeekSessionService: DeepSeekSessionService(
         repository: const DeepSeekSessionRepository(api: api),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_approval_registry_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_approval_registry_test.dart
@@ -68,6 +68,7 @@ void main() {
         eventMapper: mapper,
         pluginId: DeepSeekIdentity.id,
         messageTimeParser: const DeepSeekMessageTimeParser(),
+        subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
       ),
       deepSeekSessionService: DeepSeekSessionService(
         repository: const DeepSeekSessionRepository(api: api),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_history_repository_test.dart
@@ -18,8 +18,11 @@ void main() {
         ],
       ),
     ]);
-    final repository = _repository(api);
-    final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
+    final repository = _repository(api: api, childSessions: AcpChildSessionTracker());
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "s1",
+    );
 
     expect(api.cursors, [null, 10]);
     expect(messages.map((message) => message.info.id), [
@@ -36,10 +39,11 @@ void main() {
 
   test("history rejects a non-progressing cursor with preserved cause", () async {
     final repository = _repository(
-      _HistoryApi([
+      api: _HistoryApi([
         const DeepSeekPaginatedHistoryResponseDto(updates: [], nextBeforeSeq: 10),
         const DeepSeekPaginatedHistoryResponseDto(updates: [], nextBeforeSeq: 10),
       ]),
+      childSessions: AcpChildSessionTracker(),
     );
 
     await expectLater(
@@ -51,23 +55,309 @@ void main() {
       ),
     );
   });
+
+  test("history preserves an empty user envelope when there are no parts to align", () async {
+    final tracker = AcpChildSessionTracker();
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(updates: [_update("s1", "user_message_chunk", "user-empty", "")]),
+      ]),
+      childSessions: tracker,
+    );
+
+    final message = (await repository.getMessages(client: _unusedClient(), sessionId: "s1")).single;
+    expect(message.info.id, "user-empty");
+    expect(message.parts, isEmpty);
+    await tracker.dispose();
+  });
+
+  test("history replaces a running delegation tool with one child-linked subtask", () async {
+    final tracker = AcpChildSessionTracker();
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-1",
+              sessionUpdate: "tool_call",
+              ended: null,
+            ),
+          ],
+        ),
+      ]),
+      childSessions: tracker,
+    );
+
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "s1",
+    );
+    final tile = messages.single.parts.single as PluginMessagePartSubtask;
+    expect(tile.id, "s1-subagent-child-1-subtask");
+    expect(tile.sessionID, "s1");
+    expect(tile.messageID, "s1-subagent-child-1");
+    expect(messages.single.info.id, tile.messageID);
+    expect(tile.prompt, "Inspect the synthetic module");
+    expect(tile.description, "Research child");
+    expect(tile.childSessionID, "child-1");
+    expect(tile.taskState?.status, PluginToolStatus.running);
+    expect(tracker.childStatuses, isEmpty, reason: "history replay is isolated from live lifecycle state");
+    await tracker.dispose();
+  });
+
+  test("history preserves ordered unique ordinary runs around multiple child tiles", () async {
+    final tracker = AcpChildSessionTracker();
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [
+            _update("s1", "agent_message_chunk", "assistant", "before"),
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-1",
+              sessionUpdate: "tool_call",
+              ended: null,
+            ),
+            _update("s1", "agent_message_chunk", "assistant", "middle"),
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-2",
+              sessionUpdate: "tool_call",
+              ended: null,
+            ),
+            _update("s1", "agent_message_chunk", "assistant", "after"),
+          ],
+        ),
+      ]),
+      childSessions: tracker,
+    );
+
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "s1",
+    );
+
+    expect(messages, hasLength(5));
+    expect(messages.map((message) => message.info.id), [
+      "s1-massistant-assistant",
+      "s1-subagent-child-1",
+      "s1-massistant-assistant-deepseek-replay-run-2",
+      "s1-subagent-child-2",
+      "s1-massistant-assistant-deepseek-replay-run-3",
+    ]);
+    expect(messages.map((message) => message.info.id).toSet(), hasLength(5));
+    expect(messages.expand((message) => message.parts).map((part) => part.id).toSet(), hasLength(5));
+    for (final message in messages) {
+      for (final part in message.parts) {
+        expect(part.messageID, message.info.id);
+        expect(part.sessionID, message.info.sessionID);
+      }
+    }
+    expect((messages[0].parts.single as PluginMessagePartText).text, "before");
+    expect(messages[1].parts.single, isA<PluginMessagePartSubtask>());
+    expect((messages[2].parts.single as PluginMessagePartText).text, "middle");
+    expect(messages[3].parts.single, isA<PluginMessagePartSubtask>());
+    expect((messages[4].parts.single as PluginMessagePartText).text, "after");
+    await tracker.dispose();
+  });
+
+  test("a running replay and later live end address the same child tile", () async {
+    final tracker = AcpChildSessionTracker();
+    final liveStart = tracker.spawn(
+      sessionId: "s1",
+      spawn: const AcpChildSpawn(
+        childSessionId: "child-1",
+        description: "Research child",
+        agent: DeepSeekIdentity.id,
+        prompt: "Inspect the synthetic module",
+        isBackground: true,
+      ),
+      directory: "/project",
+    )!;
+    final liveTile = liveStart.events.whereType<BridgeSseMessagePartUpdated>().single.part;
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-1",
+              sessionUpdate: "tool_call",
+              ended: null,
+            ),
+          ],
+        ),
+      ]),
+      childSessions: tracker,
+    );
+
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "s1",
+    );
+    final replayTile = messages.single.parts.single;
+    final liveEnd = tracker.finish(
+      childSessionId: "child-1",
+      status: PluginToolStatus.completed,
+      output: "Done",
+      error: null,
+    );
+    final endedTile = liveEnd.whereType<BridgeSseMessagePartUpdated>().single.part;
+
+    expect(replayTile.id, liveTile.id);
+    expect(replayTile.messageID, liveTile.messageID);
+    expect(endedTile.id, replayTile.id);
+    expect(endedTile.messageID, replayTile.messageID);
+    await tracker.dispose();
+  });
+
+  test("nested replay stays in its direct parent's history when live tracking is empty", () async {
+    final tracker = AcpChildSessionTracker();
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [
+            _subagentUpdate(
+              sessionId: "child",
+              childSessionId: "grandchild",
+              sessionUpdate: "tool_call",
+              ended: null,
+            ),
+          ],
+        ),
+      ]),
+      childSessions: tracker,
+    );
+
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "child",
+    );
+    final tile = messages.single.parts.single as PluginMessagePartSubtask;
+    expect(messages.single.info.id, "child-subagent-grandchild");
+    expect(messages.single.info.sessionID, "child");
+    expect(tile.id, "child-subagent-grandchild-subtask");
+    expect(tile.sessionID, "child");
+    await tracker.dispose();
+  });
+
+  test("unbound failed delegation and ordinary tools retain their source identities", () async {
+    final tracker = AcpChildSessionTracker();
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: null,
+              sessionUpdate: "tool_call_update",
+              ended: const DeepSeekSubagentReplayEndedDto(
+                stopReason: DeepSeekSubagentStopReason.error,
+                summary: "Startup failed",
+              ),
+            ),
+            const DeepSeekSessionUpdateEnvelopeDto(
+              sessionId: "s1",
+              metadata: null,
+              update: {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "ordinary",
+                "title": "read_file",
+                "status": "completed",
+              },
+            ),
+          ],
+        ),
+      ]),
+      childSessions: tracker,
+    );
+
+    final messages = await repository.getMessages(client: _unusedClient(), sessionId: "s1");
+    expect(messages.map((message) => message.info.id), ["s1-h0-assistant", "s1-h1-assistant"]);
+    final tile = messages.first.parts.single as PluginMessagePartSubtask;
+    expect(tile.id, "s1-h0-assistant-tool-call-failed");
+    expect(tile.childSessionID, isNull);
+    expect(tile.taskState?.status, PluginToolStatus.error);
+    expect(tile.taskState?.error, "Startup failed");
+    final ordinary = messages.last.parts.single as PluginMessagePartTool;
+    expect(ordinary.id, "s1-h1-assistant-tool-ordinary");
+    expect(ordinary.state.status, PluginToolStatus.completed);
+    for (final message in messages) {
+      expect(message.parts.map((part) => part.messageID), everyElement(message.info.id));
+    }
+    expect(tracker.childStatuses, isEmpty);
+    await tracker.dispose();
+  });
+
+  test("latest replay metadata across reverse-paginated history settles the same tile", () async {
+    final tracker = AcpChildSessionTracker();
+    final repository = _repository(
+      api: _HistoryApi([
+        DeepSeekPaginatedHistoryResponseDto(
+          nextBeforeSeq: 10,
+          updates: [
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-1",
+              sessionUpdate: "tool_call_update",
+              ended: const DeepSeekSubagentReplayEndedDto(
+                stopReason: DeepSeekSubagentStopReason.completed,
+                summary: "Done",
+              ),
+            ),
+          ],
+        ),
+        DeepSeekTerminalHistoryResponseDto(
+          updates: [
+            _subagentUpdate(
+              sessionId: "s1",
+              childSessionId: "child-1",
+              sessionUpdate: "tool_call",
+              ended: null,
+            ),
+          ],
+        ),
+      ]),
+      childSessions: tracker,
+    );
+
+    final messages = await repository.getMessages(
+      client: _unusedClient(),
+      sessionId: "s1",
+    );
+    expect(messages.single.parts, hasLength(1));
+    final tile = messages.single.parts.single as PluginMessagePartSubtask;
+    expect(tile.id, "s1-subagent-child-1-subtask");
+    expect(tile.taskState?.status, PluginToolStatus.completed);
+    expect(tile.taskState?.output, "Done");
+    expect(tracker.childStatuses, isEmpty);
+    await tracker.dispose();
+  });
 }
 
-DeepSeekHistoryRepository _repository(DeepSeekAcpApi api) => DeepSeekHistoryRepository(
-  api: api,
-  messageTimeParser: const DeepSeekMessageTimeParser(),
-  eventMapper: DeepSeekEventMapper(
-    messageTimeParser: const DeepSeekMessageTimeParser(),
-    subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
-    delegationTracker: DeepSeekDelegationTracker(),
-    launchDirectory: "/project",
-    pluginId: DeepSeekIdentity.id,
-    configurationTracker: AcpSessionConfigurationTracker(),
-    childSessions: AcpChildSessionTracker(),
+DeepSeekHistoryRepository _repository({
+  required DeepSeekAcpApi api,
+  required AcpChildSessionTracker childSessions,
+}) {
+  const subagentMapper = DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id);
+  return DeepSeekHistoryRepository(
     api: api,
-  ),
-  pluginId: DeepSeekIdentity.id,
-);
+    messageTimeParser: const DeepSeekMessageTimeParser(),
+    subagentMapper: subagentMapper,
+    eventMapper: DeepSeekEventMapper(
+      messageTimeParser: const DeepSeekMessageTimeParser(),
+      subagentMapper: subagentMapper,
+      launchDirectory: "/project",
+      pluginId: DeepSeekIdentity.id,
+      configurationTracker: AcpSessionConfigurationTracker(),
+      childSessions: childSessions,
+      api: api,
+      delegationTracker: DeepSeekDelegationTracker(),
+    ),
+    pluginId: DeepSeekIdentity.id,
+  );
+}
 
 AcpStdioClient _unusedClient() => AcpStdioClient(
   launchSpec: const AcpLaunchSpec(command: "unused", args: [], cwd: "/", environment: {}),
@@ -84,6 +374,33 @@ DeepSeekSessionUpdateEnvelopeDto _update(String sessionId, String kind, String m
         "content": {"type": "text", "text": text},
       },
     );
+
+DeepSeekSessionUpdateEnvelopeDto _subagentUpdate({
+  required String sessionId,
+  required String? childSessionId,
+  required String sessionUpdate,
+  required DeepSeekSubagentReplayEndedDto? ended,
+}) => DeepSeekSessionUpdateEnvelopeDto(
+  metadata: DeepSeekEnvelopeMetadataDto.fromJson({
+    DeepSeekAcpApi.initializeMetadataKey: DeepSeekEnvelopeDeepSeekMetadataDto(
+      messageCreatedAt: 1,
+      subagent: DeepSeekSubagentReplayDto(
+        prompt: "Inspect the synthetic module",
+        label: "Research child",
+        mode: DeepSeekSubagentMode.background,
+        childSessionId: childSessionId,
+        ended: ended,
+      ),
+    ).toJson(),
+  }),
+  sessionId: sessionId,
+  update: {
+    "sessionUpdate": sessionUpdate,
+    "toolCallId": "call-${childSessionId ?? 'failed'}",
+    "title": "subagent",
+    "status": ended == null ? "in_progress" : "completed",
+  },
+);
 
 class _HistoryApi(final List<DeepSeekHistoryResponseDto> responses) extends DeepSeekAcpApi {
   this : super(pluginId: DeepSeekIdentity.id);

--- a/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_message_times_test.dart
@@ -95,6 +95,7 @@ void main() {
       messageIdOverride: ({required acpMessageId}) => acpMessageId,
       messageTimeResolver: ({required params}) => parser.parse(params),
       haltClassifier: null,
+      toolPartReplacement: null,
     );
     collector.consume(
       notification({
@@ -144,6 +145,7 @@ void main() {
       messageIdOverride: null,
       messageTimeResolver: ({required params}) => parser.parse(params),
       haltClassifier: classifier,
+      toolPartReplacement: null,
     );
     final halted = collector(({required text}) => const AcpHaltNotice(errorName: "halt"));
     halted.consume(

--- a/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
@@ -136,6 +136,7 @@ DeepSeekPlugin _buildPlugin(FakeAcpProcess fake) {
       eventMapper: mapper,
       pluginId: DeepSeekIdentity.id,
       messageTimeParser: const DeepSeekMessageTimeParser(),
+      subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
     ),
     deepSeekSessionService: DeepSeekSessionService(
       repository: const DeepSeekSessionRepository(api: api),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_session_metadata_test.dart
@@ -35,6 +35,7 @@ void main() {
         eventMapper: mapper,
         pluginId: DeepSeekIdentity.id,
         messageTimeParser: const DeepSeekMessageTimeParser(),
+        subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
       ),
       deepSeekSessionService: DeepSeekSessionService(
         repository: const DeepSeekSessionRepository(api: api),

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -96,9 +96,10 @@ turn.
 
 ⁹ DeepSeek's published adapter 0.1.3 over dsh 0.1.1-rc.2 is the managed target
 and minimum accepted runtime. The consumer requires extension protocol v2 and
-implements live correlated tiles and child transcripts/catalogs. Replay tile
-projection and scoped stop remain unimplemented consumer follow-ups, although
-the adapter supplies their contracts. Foreground children die with the parent;
+implements live/replayed correlated tiles and child transcripts/catalogs.
+Replay retains direct-parent tile identities and ordered ordinary-content runs
+without changing live child state. Scoped stop remains an unimplemented consumer
+follow-up, although the adapter supplies its contract. Foreground children die with the parent;
 background children survive, making main-agent-only stop supportable when all
 running children are background. Final feature E2E coverage remains pending.
 

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -99,9 +99,10 @@ and minimum accepted runtime. The consumer requires extension protocol v2 and
 implements live/replayed correlated tiles and child transcripts/catalogs.
 Replay retains direct-parent tile identities and ordered ordinary-content runs
 without changing live child state. Scoped stop remains an unimplemented consumer
-follow-up, although the adapter supplies its contract. Foreground children die with the parent;
-background children survive, making main-agent-only stop supportable when all
-running children are background. Final feature E2E coverage remains pending.
+follow-up, although the adapter supplies its contract. Foreground children die
+with the parent; background children survive, making main-agent-only stop
+supportable when all running children are background. Final feature E2E coverage
+remains pending.
 
 ¹⁰ Grok Build (1.0.5, probed 2026-09-03) sends `subagent_spawned`/`subagent_progress`/
 `subagent_finished` with parent and child session ids as

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -28,6 +28,13 @@ reconnect or restart.
   decoded once into typed fields and validated at the API boundary; malformed
   timestamps or sub-agent metadata fail the read rather than reaching replay.
   Unrecognized additive metadata remains intact when envelopes are serialized.
+  Replay replaces a delegation's generic tool part using its enclosing tool-call
+  ID and the latest typed metadata in chronological page order, without reading
+  or mutating live child/delegation trackers. Child-linked tiles use the same
+  direct-parent message/part IDs as live updates. Ordinary parts before, between,
+  and after tiles preserve their order: the first ordinary run retains its IDs,
+  and later runs get deterministic unique IDs with parts referencing their owning
+  envelope, so database import cannot collapse separated runs.
 - GitHub Copilot history uses standard ACP `session/load` on a dedicated
   short-lived connection. Replayed updates backfill the bridge transcript, while
   reopening a prior session after plugin, process, or bridge restart loads it
@@ -147,7 +154,7 @@ reconnect or restart.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, one representative plugin: a previously synced session's transcript is served with every backend stopped. |
-| L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Codex also trims only verified sub-agent copied prefixes while preserving root and ordinary-fork history; Claude also covers one stable live/replay identity for a CLI-authored API failure and suppression of its duplicate terminal result, while Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, early tool-call metadata with the pre-0.84.3 fallback, duplicate terminal suppression, cumulative tool updates, and live/replay final parity. |
+| L2 Routine | Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Codex also trims only verified sub-agent copied prefixes while preserving root and ordinary-fork history; Claude also covers one stable live/replay identity for a CLI-authored API failure and suppression of its duplicate terminal result, while Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, early tool-call metadata with the pre-0.84.3 fallback, duplicate terminal suppression, cumulative tool updates, and live/replay final parity. Automated DeepSeek coverage checks direct-parent live/replay tile identity, multiple ordered storage-safe content runs, latest metadata across pages, unbound startup errors, and live-state isolation. |
 | L3 Release | Client end to end on the release-target client platform, every supporting production plugin: open a long session, page back, continue a live turn, reopen cold, and confirm live and replayed content converge including tool parts and image parts where declared. Grok additionally retains its exact loaded model/effort attribution across first load, cold reopen, plugin restart, and bridge restart. |
 | L4 Extended | Relay integration plus owning client automated coverage, every supporting production plugin: session advanced through the backend's own CLI, plugin restart and event-stream-gap invalidation, bridge restart, client reconnect inside and outside the replay window without refresh losing concurrently finalized content, two clients on one session, a slow request beside unrelated traffic. Copilot and Grok additionally replace their ACP process, reload the same session, and converge standard replay with the bridge transcript without duplicate live delivery. |
 | L5 Full | Automated and headless bridge for unreadable or partial store artifacts, interrupted backfill, and startup reconciliation; packaged or external for pagination's released-client shape; live plugin for very large transcripts. Every supporting production plugin. |
@@ -165,6 +172,11 @@ sessions and content types, since tool and image parts converge by their own
 rules where supported.
 
 ## Failure Signals
+
+- DeepSeek replay duplicates a generic delegation card and child tile, attributes
+  a nested tile to the root instead of its direct parent, changes live child
+  activity, loses latest terminal metadata across pages, or collapses/reorders
+  ordinary-content runs when imported by message/part identity.
 
 - Opening synced history starts a stopped backend, or content visible live
   disappears after a refresh or reopen.

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -50,13 +50,14 @@ signal that a tool changed files.
   identity, bounded presenter output, terminal result/error state, and diff
   content. Presenter failure degrades to a generic bounded tool card instead of
   dropping the call or result. With adapter 0.1.3 and protocol v2, correlated
-  sub-agent starts
-  replace exact `subagent`/`subagent_fork` cards with one child-linked tile;
+  sub-agent starts replace exact `subagent`/`subagent_fork` cards with one child-linked tile;
   identifiable updates arriving before their call are deferred too. Start/end
   events retain the direct parent's transcript and keep root activity busy.
   Launch prompts remain authoritative without child prompt echoes; malformed
   ends finalize known children as error. Startup failures retain one generic
-  terminal card. Initialization requires protocol v2; replay projection is pending.
+  terminal card. Replay projects typed delegation metadata into the same tile
+  identity and terminal policy, or an unlinked tile when no child was created;
+  unrelated tools retain the generic ACP projection. Initialization requires v2.
 - Cursor's fire-and-forget tool extensions preserve their top-level tool-call
   correlation before falling back to the active turn, including while another
   session is in flight.


### PR DESCRIPTION
## Complexity

⚙️ Moderate — adds one shared synchronous replay projection seam and backend-local deterministic history identities, with every constructor caller updated together.

## What

- Add required `AcpReplayCollector.toolPartReplacement`; null callbacks/results retain ordinary ACP tools.
- Index typed DeepSeek subagent metadata in chronological page order using the enclosing tool-call ID, then replace delegation tools with subtask tiles.
- Match live/direct-parent child message and part IDs without reading or mutating live lifecycle trackers.
- Preserve original part order across child tiles and ordinary content. First ordinary run keeps its source identity; subsequent runs receive deterministic unique message/part suffixes with matching owning envelope IDs.
- Update replay regression/capability docs and the plan tracker.

**Size: +550/-32 = 582 changed lines**, including tests/docs. Step 5/5 replacing #1293; follows merged #1298, #1301, #1304, and #1306.

## Why

Opening/reloading DeepSeek history should reconstruct the same child tiles without duplicate generic tool cards, root misattribution, lost terminal metadata, or database import collapsing separated ordinary-content runs.

The archived implementation is not frozen: this slice retains the current non-null terminal mapper, uses explicit running replay state, avoids subtype casts, and simplifies alignment to a single boundary scan.

## Risk and test focus

- Moderate transcript-projection risk: cross-page terminal metadata, direct-parent identities, interleaved ordinary/child runs, and null replacement behavior for other ACP consumers.
- No schema migration, runtime version change, scoped interrupt consumption, or automatic-upgrade implementation.
- Both authoritative fixture versions and runtime 0.1.3 pins/checksums remain unchanged.

## Expected result

DeepSeek replay reconstructs child-linked or honestly unlinked subtask tiles with correct lifecycle/prompt, while unrelated tools remain generic. Direct-parent live/replay identities converge and content order survives identity-based storage import. No database schema impact.

## Verification

- ACP analysis clean; 312 package tests passed (43 focused replay/content tests also passed).
- DeepSeek analysis clean; 88 tests passed.
- Unchanged Grok analysis clean; 83 tests passed.
- Architecture implementation review: approved, no findings.
- Formatting and `git diff --check`: passed.
- Regression coverage includes multiple interleaved tiles, reverse pagination, startup failures, live/replay identity convergence, generic fallback, empty envelopes, and live-state isolation.

Final feature E2E and DeepSeek scoped-stop consumption remain pending. Finish remaining DeepSeek follow-ups before Codex; automatic managed-runtime upgrades belong to another session.
