### PR TITLE
⚙️ [managed-runtime-auto-upgrade] bridge: upgrade superseded managed runtimes on startup [step 3/5]

### DIFF
--- a/bridge/app/lib/src/repositories/plugin_lifecycle_repository.dart
+++ b/bridge/app/lib/src/repositories/plugin_lifecycle_repository.dart
@@ -36,6 +36,9 @@ class PluginLifecycleRepository({required final PluginRuntime _runtime}) {
   Stream<RuntimeProvisionProgress> installRuntime({required String pluginId}) =>
       _runtime.installRuntime(pluginId: pluginId);
 
+  bool needsManagedRuntimeUpgrade({required String pluginId}) =>
+      _runtime.needsManagedRuntimeUpgrade(pluginId: pluginId);
+
   PluginRuntimeAuthenticationOperation authenticate({required String pluginId}) =>
       _runtime.authenticate(pluginId: pluginId);
 

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -709,6 +709,10 @@ class const BridgeRuntimeRunner._() {
         Log.i("Plugin start aborted as requested.");
         return 0;
       }
+      // After ownership is settled, so no other live bridge is using this
+      // machine's managed runtime directories when the obsolete sweep runs.
+      // Returns immediately; the downloads continue behind startup.
+      activePluginLifecycleService.upgradeManagedRuntimes();
       for (final pluginId in startupPolicy.eligiblePluginIds) {
         final diagnostics = activePluginRuntime.describe(pluginId: pluginId);
         if (diagnostics != null) Console.message("Target [$pluginId]: ${diagnostics.endpoint ?? pluginId}");

--- a/bridge/app/lib/src/runtime/plugin_runtime.dart
+++ b/bridge/app/lib/src/runtime/plugin_runtime.dart
@@ -255,6 +255,19 @@ class PluginRuntime({
     }
   }
 
+  /// Whether a bridge start should install this plugin's pinned managed runtime
+  /// in the background because Sesori already manages an older one.
+  ///
+  /// The descriptor owns the decision and answers from configuration and its
+  /// state directory alone — no probing, no process spawning, no network.
+  bool needsManagedRuntimeUpgrade({required String pluginId}) {
+    final slot = _requireSlot(pluginId);
+    return slot.registration.descriptor.needsManagedRuntimeUpgrade(
+      config: slot.registration.config,
+      stateDirectory: slot.registration.stateDirectory,
+    );
+  }
+
   PluginRuntimeAuthenticationOperation authenticate({required String pluginId}) {
     final slot = _requireSlot(pluginId);
     if (_shuttingDown) throw const PluginStartAbortedException();

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -287,9 +287,14 @@ class PluginLifecycleService({
       if (active.request == request) {
         // A joined install returns the accepted snapshot immediately; the
         // in-flight install keeps streaming progress and owns the slot.
-        return request is PluginLifecycleInstallRequest
-            ? Future<PluginManagementResponse>.value(_managementSnapshotAfterMutation)
-            : active.completer.future;
+        if (request is PluginLifecycleInstallRequest) {
+          // The in-flight install may be a startup upgrade, which deliberately
+          // does not start the harness. An explicit Install carries the user's
+          // intent to enable and start it, so it takes over the completion.
+          active.installCompletion = InstallCompletion.enableAndStart;
+          return Future<PluginManagementResponse>.value(_managementSnapshotAfterMutation);
+        }
+        return active.completer.future;
       }
       throw PluginManagementConflictException(
         PluginLifecycleConflict(
@@ -333,9 +338,9 @@ class PluginLifecycleService({
     required PluginLifecycleInstallRequest request,
     required InstallCompletion completion,
   }) {
-    final command = _ActivePluginCommand(request: request);
+    final command = _ActivePluginCommand(request: request, installCompletion: completion);
     _activePluginCommands[pluginId] = command;
-    unawaited(_executeInstall(pluginId: pluginId, command: command, completion: completion));
+    unawaited(_executeInstall(pluginId: pluginId, command: command));
   }
 
   /// Installs the pinned managed runtime for every eligible plugin that still
@@ -608,7 +613,6 @@ class PluginLifecycleService({
   Future<void> _executeInstall({
     required String pluginId,
     required _ActivePluginCommand command,
-    required InstallCompletion completion,
   }) async {
     try {
       RuntimeProvisionProgress? terminal;
@@ -647,7 +651,9 @@ class PluginLifecycleService({
       switch (terminal) {
         case ProvisionReady():
           _emitInstallProgress(pluginId: pluginId, phase: PluginInstallPhase.finalizing, percent: null, message: null);
-          switch (completion) {
+          // Read now, not at admission: an explicit Install may have joined a
+          // startup upgrade while it was downloading.
+          switch (command.installCompletion) {
             case InstallCompletion.enableAndStart:
               await _enable(pluginId: pluginId, command: command);
             case InstallCompletion.reinspectOnly:
@@ -1584,7 +1590,14 @@ enum InstallCompletion() {
   reinspectOnly,
 }
 
-class _ActivePluginCommand({required final PluginLifecycleCommandRequest request}) {
+class _ActivePluginCommand({
+  required final PluginLifecycleCommandRequest request,
+
+  /// Read only when [request] is an install, and read at the terminal event so
+  /// an explicit Install that joins a running startup upgrade can still promote
+  /// it. Defaults to the meaning every user-issued command carries.
+  var InstallCompletion installCompletion = InstallCompletion.enableAndStart,
+}) {
   final Completer<PluginManagementResponse> completer = Completer<PluginManagementResponse>();
 }
 

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -660,7 +660,16 @@ class PluginLifecycleService({
               // A startup upgrade nobody asked for must not spawn a process.
               // Re-inspection is what flips a runtime-missing harness to ready
               // and routable; a running harness keeps its current generation.
-              await _inspectForCommand(pluginId: pluginId, command: command);
+              final setup = await _inspectForCommand(pluginId: pluginId, command: command);
+              // An explicit Install can still join during that inspection — it
+              // owns the same slot until this command releases it — so honour a
+              // promotion that arrived too late for the branch above.
+              if (command.installCompletion == InstallCompletion.enableAndStart && setup is PluginSetupReady) {
+                _handleRuntimeCommandResult(
+                  pluginId: pluginId,
+                  result: await _lifecycleRepository.start(pluginId: pluginId),
+                );
+              }
           }
           // The binary is installed, but setup can still be blocked (most
           // often authentication). Report completed only when the harness

--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -309,18 +309,55 @@ class PluginLifecycleService({
       );
     }
 
-    final command = _ActivePluginCommand(request: request);
-    _activePluginCommands[pluginId] = command;
     if (request is PluginLifecycleInstallRequest) {
       // Accepted-immediately: a download can run for minutes, far beyond any
       // relay request budget. The HTTP response is the current snapshot;
       // progress streams via SSE and the terminal outcome invalidates the
       // management snapshot. The slot stays occupied until the install ends.
-      unawaited(_executeInstall(pluginId: pluginId, command: command));
+      _admitInstall(pluginId: pluginId, request: request, completion: InstallCompletion.enableAndStart);
       return Future<PluginManagementResponse>.value(_managementSnapshotAfterMutation);
     }
+    final command = _ActivePluginCommand(request: request);
+    _activePluginCommands[pluginId] = command;
     unawaited(_executeCommand(pluginId: pluginId, command: command));
     return command.completer.future;
+  }
+
+  /// Occupies [pluginId]'s command slot with an install and starts it.
+  ///
+  /// Shared by the explicit Install command and the startup upgrade so both
+  /// join, conflict, and release the slot identically. Returns as soon as the
+  /// install is admitted; the download runs on its own.
+  void _admitInstall({
+    required String pluginId,
+    required PluginLifecycleInstallRequest request,
+    required InstallCompletion completion,
+  }) {
+    final command = _ActivePluginCommand(request: request);
+    _activePluginCommands[pluginId] = command;
+    unawaited(_executeInstall(pluginId: pluginId, command: command, completion: completion));
+  }
+
+  /// Installs the pinned managed runtime for every eligible plugin that still
+  /// has an older Sesori-managed one on disk.
+  ///
+  /// Called once per bridge start, after single-live-bridge ownership is settled
+  /// so no other bridge is using this machine's managed runtime directories.
+  /// Returns immediately: startup never waits on a download, and a harness
+  /// already running an older supported version keeps serving until its next
+  /// generation. A plugin with a command already in flight is skipped; that
+  /// command owns the slot.
+  void upgradeManagedRuntimes() {
+    for (final pluginId in _requireEligiblePluginIds()) {
+      if (_activePluginCommands.containsKey(pluginId)) continue;
+      if (!_lifecycleRepository.needsManagedRuntimeUpgrade(pluginId: pluginId)) continue;
+      Log.i('Plugin "$pluginId" has a superseded managed runtime; installing the current one in the background.');
+      _admitInstall(
+        pluginId: pluginId,
+        request: const PluginLifecycleInstallRequest(),
+        completion: InstallCompletion.reinspectOnly,
+      );
+    }
   }
 
   Stream<PluginInstallProgressUpdate> get installProgress => _installProgressController.stream;
@@ -571,6 +608,7 @@ class PluginLifecycleService({
   Future<void> _executeInstall({
     required String pluginId,
     required _ActivePluginCommand command,
+    required InstallCompletion completion,
   }) async {
     try {
       RuntimeProvisionProgress? terminal;
@@ -609,7 +647,15 @@ class PluginLifecycleService({
       switch (terminal) {
         case ProvisionReady():
           _emitInstallProgress(pluginId: pluginId, phase: PluginInstallPhase.finalizing, percent: null, message: null);
-          await _enable(pluginId: pluginId, command: command);
+          switch (completion) {
+            case InstallCompletion.enableAndStart:
+              await _enable(pluginId: pluginId, command: command);
+            case InstallCompletion.reinspectOnly:
+              // A startup upgrade nobody asked for must not spawn a process.
+              // Re-inspection is what flips a runtime-missing harness to ready
+              // and routable; a running harness keeps its current generation.
+              await _inspectForCommand(pluginId: pluginId, command: command);
+          }
           // The binary is installed, but setup can still be blocked (most
           // often authentication). Report completed only when the harness
           // actually became usable; otherwise the phone would show success
@@ -1526,6 +1572,17 @@ class const PluginManagementCommandFailedException(final String message) impleme
 }
 
 class const PluginManagementMutationOutcomeUncertainException() implements Exception;
+
+/// What a finished install does with the plugin it just provisioned.
+enum InstallCompletion() {
+  /// An explicit Install: the user asked for this harness, so enable it,
+  /// re-inspect, and start it.
+  enableAndStart,
+
+  /// A startup upgrade: re-inspect so a harness blocked on an old runtime
+  /// becomes routable, but never spawn a process nobody asked for.
+  reinspectOnly,
+}
 
 class _ActivePluginCommand({required final PluginLifecycleCommandRequest request}) {
   final Completer<PluginManagementResponse> completer = Completer<PluginManagementResponse>();

--- a/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_runtime_test.dart
@@ -124,6 +124,30 @@ void main() {
     expect(inUseReadings, [false, true], reason: "the signal is read live, not captured at install start");
   });
 
+  test("needsManagedRuntimeUpgrade asks the descriptor with the slot's registration", () {
+    final queries = <({PluginConfig config, String stateDirectory})>[];
+    final runtime = _runtime(
+      factory: _FakeGenerationFactory(startGate: Future<void>.value()),
+      descriptor: _FakeDescriptor(
+        upgradeNeeded: ({required config, required stateDirectory}) {
+          queries.add((config: config, stateDirectory: stateDirectory));
+          return true;
+        },
+      ),
+    );
+    addTearDown(runtime.dispose);
+
+    expect(runtime.needsManagedRuntimeUpgrade(pluginId: "one"), isTrue);
+    expect(queries.single.stateDirectory, ".");
+  });
+
+  test("needsManagedRuntimeUpgrade declines for a descriptor without a managed runtime", () {
+    final runtime = _runtime(factory: _FakeGenerationFactory(startGate: Future<void>.value()));
+    addTearDown(runtime.dispose);
+
+    expect(runtime.needsManagedRuntimeUpgrade(pluginId: "one"), isFalse);
+  });
+
   test("installRuntime fails immediately while shutting down", () async {
     final runtime = _runtime(factory: _FakeGenerationFactory(startGate: Future<void>.value()));
     addTearDown(runtime.dispose);
@@ -1975,6 +1999,7 @@ class const _FakeDescriptor({
   final Future<PluginSetupStatus> Function()? inspect,
   final Stream<RuntimeProvisionProgress> Function(StartAbortSignal startAborted, RuntimeInUseSignal runtimeInUse)?
   install,
+  final bool Function({required PluginConfig config, required String stateDirectory})? upgradeNeeded,
 }) extends BridgePluginDescriptor {
   @override
   String get id => "one";
@@ -2022,6 +2047,15 @@ class const _FakeDescriptor({
       );
     }
     return handler(startAborted, runtimeInUse);
+  }
+
+  @override
+  bool needsManagedRuntimeUpgrade({required PluginConfig config, required String stateDirectory}) {
+    final handler = upgradeNeeded;
+    if (handler == null) {
+      return super.needsManagedRuntimeUpgrade(config: config, stateDirectory: stateDirectory);
+    }
+    return handler(config: config, stateDirectory: stateDirectory);
   }
 
   @override

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -2181,6 +2181,43 @@ void main() {
     );
   });
 
+  test("an explicit install joining during the post-upgrade inspection still starts the harness", () async {
+    final inspectionGate = Completer<void>();
+    final repository =
+        _CommandLifecycleRepository(
+            inspectionResult: const PluginSetupReady(),
+            inspectionGate: inspectionGate,
+            startFailureMessage: null,
+          )
+          ..installEvents = const [ProvisionReady(binaryPath: "/managed/one")]
+          ..needsUpgrade = true;
+    addTearDown(repository.dispose);
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupRuntimeMissing(actionHint: "This bridge needs a newer One.")},
+        );
+    addTearDown(service.dispose);
+    final progress = <PluginInstallProgressUpdate>[];
+    final progressSubscription = service.installProgress.listen(progress.add);
+    addTearDown(progressSubscription.cancel);
+
+    service.upgradeManagedRuntimes();
+    // The download is done and the upgrade is inside its re-inspection, past
+    // the point where it already chose reinspect-only.
+    await _waitUntil(() => repository.inspectCalls == 1);
+    await service.command(pluginId: "one", request: const PluginLifecycleCommandRequest.install());
+    inspectionGate.complete();
+    await installSettled(progress: progress);
+
+    expect(repository.installCalls, 1, reason: "the explicit install joined rather than starting a second one");
+    expect(repository.startCalls, 1, reason: "a promotion arriving during the inspection is still honoured");
+  });
+
   test("a startup upgrade alone still does not start the harness", () async {
     final installGate = Completer<void>();
     final repository =
@@ -3114,4 +3151,12 @@ Future<void> _waitFor(bool Function() predicate) async {
     await Future<void>.delayed(Duration.zero);
   }
   throw StateError("condition was not reached");
+}
+
+Future<void> _waitUntil(bool Function() predicate) async {
+  for (var attempt = 0; attempt < 200; attempt++) {
+    if (predicate()) return;
+    await Future<void>.delayed(Duration.zero);
+  }
+  throw StateError("condition did not become true");
 }

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -2176,9 +2176,42 @@ void main() {
     await installSettled(progress: progress);
     expect(
       repository.startCalls,
-      isZero,
-      reason: "the joined command adopts the upgrade's completion, which never starts",
+      1,
+      reason: "the explicit Install carries the user's intent to start, so it promotes the upgrade",
     );
+  });
+
+  test("a startup upgrade alone still does not start the harness", () async {
+    final installGate = Completer<void>();
+    final repository =
+        _CommandLifecycleRepository(
+            inspectionResult: const PluginSetupReady(),
+            inspectionGate: null,
+            startFailureMessage: null,
+          )
+          ..installEvents = const [ProvisionReady(binaryPath: "/managed/one")]
+          ..installGate = installGate
+          ..needsUpgrade = true;
+    addTearDown(repository.dispose);
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
+    addTearDown(service.dispose);
+    final progress = <PluginInstallProgressUpdate>[];
+    final progressSubscription = service.installProgress.listen(progress.add);
+    addTearDown(progressSubscription.cancel);
+
+    service.upgradeManagedRuntimes();
+    installGate.complete();
+    await installSettled(progress: progress);
+
+    expect(repository.startCalls, isZero);
   });
 
   test("install requires the install capability", () async {

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -1975,6 +1975,212 @@ void main() {
     expect(repository.startCalls, 1);
   });
 
+  test("startup upgrades only eligible plugins with a superseded managed runtime", () async {
+    final installGate = Completer<void>();
+    final repository =
+        _CommandLifecycleRepository(
+            inspectionResult: const PluginSetupReady(),
+            inspectionGate: null,
+            startFailureMessage: null,
+          )
+          ..installEvents = const [ProvisionReady(binaryPath: "/managed/one")]
+          ..installGate = installGate
+          ..needsUpgrade = true;
+    addTearDown(repository.dispose);
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
+    addTearDown(service.dispose);
+    final progress = <PluginInstallProgressUpdate>[];
+    final progressSubscription = service.installProgress.listen(progress.add);
+    addTearDown(progressSubscription.cancel);
+
+    // Returns synchronously: bridge startup must not wait on a download.
+    service.upgradeManagedRuntimes();
+    expect(repository.upgradeQueries, ["one"]);
+
+    await Future<void>.delayed(Duration.zero);
+    expect(repository.installCalls, 1);
+    expect(progress, isEmpty, reason: "the install is admitted but still gated on the download");
+
+    installGate.complete();
+    await installSettled(progress: progress);
+    expect(repository.startCalls, isZero, reason: "a startup upgrade never spawns a process");
+    expect(progress.last.phase, PluginInstallPhase.completed);
+  });
+
+  test("startup skips a plugin whose descriptor reports no superseded runtime", () {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupReady(),
+      inspectionGate: null,
+      startFailureMessage: null,
+    );
+    addTearDown(repository.dispose);
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
+    addTearDown(service.dispose);
+
+    service.upgradeManagedRuntimes();
+
+    expect(repository.upgradeQueries, ["one"]);
+    expect(repository.installCalls, isZero);
+  });
+
+  test("startup does not ask a disabled plugin whether it needs an upgrade", () {
+    final repository = _CommandLifecycleRepository(
+      inspectionResult: const PluginSetupReady(),
+      inspectionGate: null,
+      startFailureMessage: null,
+    )..needsUpgrade = true;
+    addTearDown(repository.dispose);
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {"one"},
+          setupById: const {"one": PluginSetupReady()},
+        );
+    addTearDown(service.dispose);
+
+    service.upgradeManagedRuntimes();
+
+    expect(repository.upgradeQueries, isEmpty);
+    expect(repository.installCalls, isZero);
+  });
+
+  test("a startup upgrade makes a blocked harness ready without starting it", () async {
+    final repository =
+        _CommandLifecycleRepository(
+            inspectionResult: const PluginSetupReady(),
+            inspectionGate: null,
+            startFailureMessage: null,
+          )
+          ..installEvents = const [ProvisionReady(binaryPath: "/managed/one")]
+          ..needsUpgrade = true;
+    addTearDown(repository.dispose);
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupRuntimeMissing(actionHint: "This bridge needs a newer One.")},
+        );
+    addTearDown(service.dispose);
+    final progress = <PluginInstallProgressUpdate>[];
+    final progressSubscription = service.installProgress.listen(progress.add);
+    addTearDown(progressSubscription.cancel);
+    final ready = <List<String>>[];
+    final readySubscription = service.readyPluginIds.listen(ready.add);
+    addTearDown(readySubscription.cancel);
+
+    service.upgradeManagedRuntimes();
+    await installSettled(progress: progress);
+
+    expect(repository.inspectCalls, 1);
+    expect(repository.startCalls, isZero);
+    expect(ready.last, ["one"]);
+  });
+
+  test("a failed startup upgrade leaves the previous setup in place", () async {
+    final repository =
+        _CommandLifecycleRepository(
+            inspectionResult: const PluginSetupReady(),
+            inspectionGate: null,
+            startFailureMessage: null,
+          )
+          ..installEvents = const [ProvisionFailed(message: "download died")]
+          ..needsUpgrade = true;
+    addTearDown(repository.dispose);
+    const priorSetup = PluginSetupReady.versioned(runtimeVersion: "1.0.0");
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": priorSetup},
+        );
+    addTearDown(service.dispose);
+    final progress = <PluginInstallProgressUpdate>[];
+    final progressSubscription = service.installProgress.listen(progress.add);
+    addTearDown(progressSubscription.cancel);
+
+    service.upgradeManagedRuntimes();
+    await installSettled(progress: progress);
+
+    expect(progress.single.phase, PluginInstallPhase.failed);
+    expect(repository.inspectCalls, isZero, reason: "a failed upgrade must not re-inspect");
+    expect(service.setupSnapshot.plugins.single.runtimeVersion, "1.0.0");
+  });
+
+  test("an explicit install joins a running startup upgrade and a refresh conflicts", () async {
+    final installGate = Completer<void>();
+    final repository =
+        _CommandLifecycleRepository(
+            inspectionResult: const PluginSetupReady(),
+            inspectionGate: null,
+            startFailureMessage: null,
+          )
+          ..installEvents = const [ProvisionReady(binaryPath: "/managed/one")]
+          ..installGate = installGate
+          ..needsUpgrade = true;
+    addTearDown(repository.dispose);
+    final service =
+        _commandService(
+          repository: repository,
+          settingsRepository: null,
+          managementCapabilities: installCapableManagementCapabilities,
+        )..initialize(
+          disabledPluginIds: const {},
+          setupById: const {"one": PluginSetupReady()},
+        );
+    addTearDown(service.dispose);
+    final progress = <PluginInstallProgressUpdate>[];
+    final progressSubscription = service.installProgress.listen(progress.add);
+    addTearDown(progressSubscription.cancel);
+
+    service.upgradeManagedRuntimes();
+    await service.command(pluginId: "one", request: const PluginLifecycleCommandRequest.install());
+
+    expect(repository.installCalls, 1, reason: "the explicit install joined the upgrade already in flight");
+    expect(
+      () => service.command(pluginId: "one", request: const PluginLifecycleCommandRequest.refresh()),
+      throwsA(
+        isA<PluginManagementConflictException>().having(
+          (error) => error.conflict.reasons,
+          "reasons",
+          [PluginLifecycleConflictReason.transitioning],
+        ),
+      ),
+    );
+
+    installGate.complete();
+    await installSettled(progress: progress);
+    expect(
+      repository.startCalls,
+      isZero,
+      reason: "the joined command adopts the upgrade's completion, which never starts",
+    );
+  });
+
   test("install requires the install capability", () async {
     final repository = _CommandLifecycleRepository(
       inspectionResult: const PluginSetupReady(),
@@ -2610,6 +2816,8 @@ class _CommandLifecycleRepository({
   int installCalls = 0;
   List<RuntimeProvisionProgress> installEvents = const [];
   Completer<void>? installGate;
+  bool needsUpgrade = false;
+  final List<String> upgradeQueries = [];
   final StreamController<PluginAuthenticationEvent> authenticationEvents =
       StreamController<PluginAuthenticationEvent>();
   int authenticationCalls = 0;
@@ -2649,6 +2857,12 @@ class _CommandLifecycleRepository({
     installCalls++;
     await installGate?.future;
     yield* Stream.fromIterable(installEvents);
+  }
+
+  @override
+  bool needsManagedRuntimeUpgrade({required String pluginId}) {
+    upgradeQueries.add(pluginId);
+    return needsUpgrade;
   }
 
   @override


### PR DESCRIPTION
## Complexity

⚙️ moderate — one new startup call and a completion mode threaded through the
existing install executor. It reuses the command slot, progress reporting, and
abort handling that a manual Install already goes through, so the surface is
small, but it touches lifecycle ordering.

## What

Step 3/5 of `.plan/active/managed-runtime-auto-upgrade`, covering Design §3.
Step 2 (#1316) made an older supported managed runtime selectable and the
installer safe to run alongside a live generation; this step pulls the trigger.

- `PluginRuntime.needsManagedRuntimeUpgrade(pluginId:)` asks the descriptor with
  the slot's config and state directory; `PluginLifecycleRepository` exposes it.
- The install admission sequence moved out of `command()` into a shared
  `_admitInstall` helper, so the explicit Install and the startup upgrade occupy,
  join, conflict on, and release the command slot through identical code.
- `PluginLifecycleService.upgradeManagedRuntimes()` admits one background install
  per eligible plugin whose descriptor reports a superseded managed runtime and
  that has no command already in flight. Synchronous and `void`: startup never
  waits on a download.
- `InstallCompletion { enableAndStart, reinspectOnly }` replaces what would
  otherwise be a boolean. A manual Install still enables, re-inspects, and starts.
  A startup upgrade only re-inspects — that is what flips a harness blocked on an
  old runtime to ready and routable, without spawning a process nobody asked for.
- `bridge_runtime_runner.dart` calls it immediately after
  `enforceBridgeOwnership()` and its abort check, before eager starts.

Progress, failure, interruption, slot release, and management-snapshot
publication are unchanged; a failed upgrade leaves the previous setup in place.

## Why

A bridge release that raises a harness's pinned managed runtime currently leaves
the user to press Install. With Step 2 in, an older supported version already
keeps the harness usable — this step makes the replacement arrive on its own, in
the background, without a restart.

## Risk and test focus

Moderate risk in bridge startup ordering and the shared install path. No wire,
database, persisted-state, or client change: progress reaches the harness card
through the existing `plugin.install.progress` SSE event and the terminal outcome
invalidates the management snapshot as it does today. PATH installs, explicit
`--<plugin>-bin` binaries, credentials, provider configuration, session history,
and a running session's executable are untouched.

Most valuable checks:

- Startup returns while an upgrade is still downloading, and the ordering after
  `enforceBridgeOwnership()` holds so no other live bridge owns the managed
  directories when the obsolete sweep runs.
- Only eligible plugins are asked; a disabled plugin is never queried at all.
- A startup upgrade never calls `start`, and a harness blocked on an old runtime
  becomes ready and routable after `ProvisionReady`.
- A failed upgrade preserves the prior setup and reported runtime version.
- An explicit Install arriving mid-upgrade joins it; another lifecycle command
  conflicts exactly as during a manual Install.

## Expected result

After a bridge update that raises a managed runtime target, a user who had the
previous managed version sees the harness stay usable while the new version
downloads, and the next generation uses the new one. A user whose managed
version fell below the minimum sees the harness blocked briefly, then ready,
without pressing Install or restarting the bridge. Console output shows no
progress for a headless startup upgrade; the log records the start, the outcome,
and any failure detail. No database or persisted-data effect.

## Verification

- `dart analyze` clean across the whole `bridge/` workspace.
- 2817 `bridge/app` tests pass, including six new lifecycle-service cases and two
  new `PluginRuntime` cases covering the behaviour above.
- Rebased onto `main` at `a3f222e92c` (Step 2) and re-verified there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bridge startup now installs a superseded managed runtime in the background, so users no longer need to press Install after a bridge update raises a harness's pinned runtime.

- Runs once after single-live-bridge ownership is settled, returns immediately, and never starts a process nobody asked for.
- Reuses the explicit install path, so progress, conflict, and slot-release behavior are unchanged; a manual Install arriving at any point mid-upgrade joins it and promotes the completion to enable and start.
- On success the upgrade only re-inspects, which flips a runtime-missing harness to ready without spawning a process; a failed upgrade leaves the previous setup in place.
- Disabled plugins are never queried, and a plugin with a command already in flight is skipped.

<sup>Written for commit ea96eab73e6b4cdfa1d4ec17b275bfaf994815cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1319?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

