### PR TITLE
⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -18,7 +18,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | Merged | [#1313](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1313) |
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Merged | [#1314](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1314) |
 | 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | In review | [#1318](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1318) |
-| 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | Proposed | — |
+| 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | In progress (local, awaiting step 10 merge) | — |
 | 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | Proposed | — |
 | 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Proposed | — |
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Proposed | — |
@@ -221,3 +221,13 @@ asked to start working the plan; steps execute in order from step 2.
   `client/module_core/test/foundation/io/` with a required-provider fake and no
   test-only constructor; the storage suite moved beside it. Shell DI tests
   assert only the adapter binding.
+
+## Step 11 execution — 2026-09-05
+
+- `client/module_core/lib/src/cubits/shared/optimistic_rename_tracker.dart`
+  owns the pending-token/visible/confirmed algorithm; `SessionListCubit` and
+  `ProjectListCubit` instantiate one per entity in place of their private
+  copies and keep entity maps, repository calls, refresh and projection. Unit
+  tests cover newest-success confirmation, fallback after a failed visible
+  rename, newer-confirmation precedence and a null original; both cubit rename
+  suites pass unchanged.

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -17,8 +17,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 7/25 | 🚧 [periodic-cleanup] plugins: keep message events typed [step 7/25] | Merged | [#1311](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1311) |
 | 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | Merged | [#1313](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1313) |
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Merged | [#1314](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1314) |
-| 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | In review | [#1318](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1318) |
-| 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | In progress (local, awaiting step 10 merge) | — |
+| 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | Merged | [#1318](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1318) |
+| 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | In review | [#1320](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1320) |
 | 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | Proposed | — |
 | 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Proposed | — |
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Proposed | — |

--- a/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/project_list/project_list_cubit.dart
@@ -24,6 +24,7 @@ import "../../services/project_list_service.dart";
 import "../../services/registered_bridges_service.dart";
 import "../../services/session_unseen_tracker.dart";
 import "../../services/sse_event_tracker.dart";
+import "../shared/optimistic_rename_tracker.dart";
 import "add_project_outcome.dart";
 import "project_list_state.dart";
 
@@ -39,57 +40,6 @@ enum _ProjectFetchOutcome() {
   applied,
   failed,
   superseded,
-}
-
-/// Tracks every in-flight rename so out-of-order completions preserve the
-/// newest confirmed name and the latest unresolved user intent.
-final class _ProjectRenameState({required String? confirmedName}) {
-  final Map<int, String> _pendingNames = {};
-  int _visibleToken = 0;
-  late String _visibleName;
-  int _confirmedToken = 0;
-  String? _confirmedName = confirmedName;
-
-  String get visibleName => _visibleName;
-  String? get confirmedName => _confirmedName;
-  bool get isSettled => _pendingNames.isEmpty;
-
-  void begin({required int token, required String name}) {
-    _pendingNames[token] = name;
-    _visibleToken = token;
-    _visibleName = name;
-  }
-
-  void complete({required int token, required String name, required bool succeeded}) {
-    _pendingNames.remove(token);
-    if (succeeded && token > _confirmedToken) {
-      _confirmedToken = token;
-      _confirmedName = name;
-    }
-    if (!succeeded && token == _visibleToken && _pendingNames.isNotEmpty) {
-      _selectLatestVisibleName();
-    }
-  }
-
-  void _selectLatestVisibleName() {
-    final firstPendingRename = _pendingNames.entries.first;
-    var latestPendingToken = firstPendingRename.key;
-    var latestPendingName = firstPendingRename.value;
-    for (final MapEntry(:key, :value) in _pendingNames.entries.skip(1)) {
-      if (key > latestPendingToken) {
-        latestPendingToken = key;
-        latestPendingName = value;
-      }
-    }
-    final confirmedName = _confirmedName;
-    if (_confirmedToken > latestPendingToken && confirmedName != null) {
-      _visibleToken = _confirmedToken;
-      _visibleName = confirmedName;
-      return;
-    }
-    _visibleToken = latestPendingToken;
-    _visibleName = latestPendingName;
-  }
 }
 
 class ProjectListCubit(
@@ -109,7 +59,7 @@ class ProjectListCubit(
 
   /// Keeps pre-rename list responses from repainting an old name while the
   /// mutation is still pending.
-  final Map<String, _ProjectRenameState> _renameStateByProjectId = {};
+  final Map<String, OptimisticRenameTracker> _renameStateByProjectId = {};
   int _nextRenameToken = 0;
 
   // ignore: no_slop_linter/prefer_required_named_parameters, public cubit constructor API
@@ -645,7 +595,7 @@ class ProjectListCubit(
   Iterable<ProjectSummary> _withOptimisticProjectNames({required Iterable<ProjectSummary> projects}) {
     return projects.map((project) {
       final renameState = _renameStateByProjectId[project.id];
-      return renameState == null ? project : project.copyWith(name: renameState.visibleName);
+      return renameState == null ? project : project.copyWith(name: renameState.visibleValue);
     });
   }
 
@@ -715,9 +665,9 @@ class ProjectListCubit(
     final token = ++_nextRenameToken;
     final renameState = _renameStateByProjectId.putIfAbsent(
       projectId,
-      () => _ProjectRenameState(confirmedName: currentState.projects[index].name),
+      () => OptimisticRenameTracker(confirmedValue: currentState.projects[index].name),
     );
-    renameState.begin(token: token, name: name);
+    renameState.begin(token: token, value: name);
     final projects = [...currentState.projects];
     projects[index] = projects[index].copyWith(name: name);
     _emitOrdered(
@@ -775,7 +725,7 @@ class ProjectListCubit(
   }) {
     final renameState = _renameStateByProjectId[projectId];
     if (renameState == null) return;
-    renameState.complete(token: token, name: name, succeeded: succeeded);
+    renameState.complete(token: token, value: name, succeeded: succeeded);
     if (!renameState.isSettled) {
       final currentState = state;
       if (!isClosed && currentState is ProjectListLoaded) {
@@ -794,7 +744,7 @@ class ProjectListCubit(
     final index = currentState.projects.indexWhere((project) => project.id == projectId);
     final projects = [...currentState.projects];
     if (index >= 0) {
-      projects[index] = projects[index].copyWith(name: renameState.confirmedName);
+      projects[index] = projects[index].copyWith(name: renameState.confirmedValue);
     }
     _emitOrdered(
       loaded: currentState,

--- a/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_list/session_list_cubit.dart
@@ -24,63 +24,13 @@ import "../../services/project_viewing_service.dart";
 import "../../services/session_list_service.dart";
 import "../../services/session_unseen_tracker.dart";
 import "../../services/sse_event_tracker.dart";
+import "../shared/optimistic_rename_tracker.dart";
 import "session_list_state.dart";
 
 enum _SessionFetchOutcome() {
   applied,
   failed,
   superseded,
-}
-
-/// Tracks every in-flight rename so out-of-order completions preserve the
-/// newest confirmed title and the latest unresolved user intent.
-final class _SessionRenameState({required String? confirmedTitle}) {
-  final Map<int, String> _pendingTitles = {};
-  int _visibleToken = 0;
-  late String _visibleTitle;
-  int _confirmedToken = 0;
-  String? _confirmedTitle = confirmedTitle;
-
-  String get visibleTitle => _visibleTitle;
-  String? get confirmedTitle => _confirmedTitle;
-  bool get isSettled => _pendingTitles.isEmpty;
-
-  void begin({required int token, required String title}) {
-    _pendingTitles[token] = title;
-    _visibleToken = token;
-    _visibleTitle = title;
-  }
-
-  void complete({required int token, required String title, required bool succeeded}) {
-    _pendingTitles.remove(token);
-    if (succeeded && token > _confirmedToken) {
-      _confirmedToken = token;
-      _confirmedTitle = title;
-    }
-    if (!succeeded && token == _visibleToken && _pendingTitles.isNotEmpty) {
-      _selectLatestVisibleTitle();
-    }
-  }
-
-  void _selectLatestVisibleTitle() {
-    final firstPendingRename = _pendingTitles.entries.first;
-    var latestPendingToken = firstPendingRename.key;
-    var latestPendingTitle = firstPendingRename.value;
-    for (final MapEntry(:key, :value) in _pendingTitles.entries.skip(1)) {
-      if (key > latestPendingToken) {
-        latestPendingToken = key;
-        latestPendingTitle = value;
-      }
-    }
-    final confirmedTitle = _confirmedTitle;
-    if (_confirmedToken > latestPendingToken && confirmedTitle != null) {
-      _visibleToken = _confirmedToken;
-      _visibleTitle = confirmedTitle;
-      return;
-    }
-    _visibleToken = latestPendingToken;
-    _visibleTitle = latestPendingTitle;
-  }
 }
 
 class SessionListCubit({
@@ -463,9 +413,9 @@ class SessionListCubit({
     final token = ++_nextRenameToken;
     final renameState = _renameStateBySessionId.putIfAbsent(
       sessionId,
-      () => _SessionRenameState(confirmedTitle: _allSessions[index].title),
+      () => OptimisticRenameTracker(confirmedValue: _allSessions[index].title),
     );
-    renameState.begin(token: token, title: title);
+    renameState.begin(token: token, value: title);
     _allSessions = _sessionListService.upsertSession(
       sessions: _allSessions,
       session: _allSessions[index].copyWith(title: title),
@@ -522,7 +472,7 @@ class SessionListCubit({
   }) {
     final renameState = _renameStateBySessionId[sessionId];
     if (renameState == null) return;
-    renameState.complete(token: token, title: title, succeeded: succeeded);
+    renameState.complete(token: token, value: title, succeeded: succeeded);
     if (!renameState.isSettled) {
       if (!isClosed && state is SessionListLoaded) _emitFiltered();
       return;
@@ -534,7 +484,7 @@ class SessionListCubit({
     if (index >= 0) {
       _allSessions = _sessionListService.upsertSession(
         sessions: _allSessions,
-        session: _allSessions[index].copyWith(title: renameState.confirmedTitle),
+        session: _allSessions[index].copyWith(title: renameState.confirmedValue),
       );
     }
     _emitFiltered();
@@ -603,7 +553,7 @@ class SessionListCubit({
 
   /// Keeps pre-rename list responses from repainting an old title while the
   /// mutation is still pending.
-  final Map<String, _SessionRenameState> _renameStateBySessionId = {};
+  final Map<String, OptimisticRenameTracker> _renameStateBySessionId = {};
   int _nextRenameToken = 0;
   bool _showArchived = false;
 
@@ -616,7 +566,7 @@ class SessionListCubit({
     final visible = _sessionListService.visibleSessions(
       sessions: _allSessions.map((session) {
         final renameState = _renameStateBySessionId[session.id];
-        return renameState == null ? session : session.copyWith(title: renameState.visibleTitle);
+        return renameState == null ? session : session.copyWith(title: renameState.visibleValue);
       }),
       showArchived: _showArchived,
       activityBySessionId: _sseEventTracker.currentSessionActivity[_projectId] ?? const {},

--- a/client/module_core/lib/src/cubits/shared/optimistic_rename_tracker.dart
+++ b/client/module_core/lib/src/cubits/shared/optimistic_rename_tracker.dart
@@ -1,0 +1,70 @@
+/// Per-entity bookkeeping for optimistic renames.
+///
+/// A rename sheet closes as soon as the user confirms, so several renames of
+/// the same entity can be in flight at once and complete out of order. The
+/// tracker keeps the newest confirmed value and the latest unresolved user
+/// intent so the visible value never regresses to an older request:
+///
+/// - the visible value is the most recently begun rename until it fails;
+/// - a success is confirmed only when it is newer than the current
+///   confirmation, so an older success cannot overwrite a newer one;
+/// - when the visible rename fails and others are still pending, the visible
+///   value falls back to the newest pending request, or to the confirmation if
+///   that is newer still.
+///
+/// Owning cubits instantiate one tracker per entity and keep entity maps,
+/// repository calls and state projection to themselves. [confirmedValue] is
+/// nullable because an entity may have no name before its first rename.
+final class OptimisticRenameTracker({required String? confirmedValue}) {
+  final Map<int, String> _pendingValues = {};
+  int _visibleToken = 0;
+  late String _visibleValue;
+  int _confirmedToken = 0;
+  String? _confirmedValue = confirmedValue;
+
+  /// The value the UI shows while renames are unresolved.
+  String get visibleValue => _visibleValue;
+
+  /// The newest value the bridge accepted, or the original when none has.
+  String? get confirmedValue => _confirmedValue;
+
+  /// True once no rename is outstanding; the owner then drops this tracker.
+  bool get isSettled => _pendingValues.isEmpty;
+
+  void begin({required int token, required String value}) {
+    _pendingValues[token] = value;
+    _visibleToken = token;
+    _visibleValue = value;
+  }
+
+  void complete({required int token, required String value, required bool succeeded}) {
+    _pendingValues.remove(token);
+    if (succeeded && token > _confirmedToken) {
+      _confirmedToken = token;
+      _confirmedValue = value;
+    }
+    if (!succeeded && token == _visibleToken && _pendingValues.isNotEmpty) {
+      _selectLatestVisibleValue();
+    }
+  }
+
+  void _selectLatestVisibleValue() {
+    final firstPending = _pendingValues.entries.first;
+    var latestPendingToken = firstPending.key;
+    var latestPendingValue = firstPending.value;
+    for (final MapEntry(:key, :value) in _pendingValues.entries.skip(1)) {
+      if (key > latestPendingToken) {
+        latestPendingToken = key;
+        latestPendingValue = value;
+      }
+    }
+    final confirmedValue = _confirmedValue;
+    if (_confirmedToken > latestPendingToken && confirmedValue != null) {
+      _visibleToken = _confirmedToken;
+      _visibleValue = confirmedValue;
+      return;
+    }
+    _visibleToken = latestPendingToken;
+    _visibleValue = latestPendingValue;
+  }
+}

--- a/client/module_core/test/cubits/shared/optimistic_rename_tracker_test.dart
+++ b/client/module_core/test/cubits/shared/optimistic_rename_tracker_test.dart
@@ -1,0 +1,57 @@
+import "package:sesori_dart_core/src/cubits/shared/optimistic_rename_tracker.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("OptimisticRenameTracker", () {
+    test("shows the latest request and confirms the newest success", () {
+      final tracker = OptimisticRenameTracker(confirmedValue: "original");
+
+      tracker.begin(token: 1, value: "first");
+      tracker.begin(token: 2, value: "second");
+      expect(tracker.visibleValue, "second");
+      expect(tracker.confirmedValue, "original");
+      expect(tracker.isSettled, isFalse);
+
+      tracker.complete(token: 2, value: "second", succeeded: true);
+      tracker.complete(token: 1, value: "first", succeeded: true);
+
+      expect(tracker.confirmedValue, "second", reason: "an older success must not overwrite a newer one");
+      expect(tracker.visibleValue, "second");
+      expect(tracker.isSettled, isTrue);
+    });
+
+    test("a failed visible rename falls back to the newest pending request", () {
+      final tracker = OptimisticRenameTracker(confirmedValue: "original");
+
+      tracker.begin(token: 1, value: "first");
+      tracker.begin(token: 2, value: "second");
+      tracker.complete(token: 2, value: "second", succeeded: false);
+
+      expect(tracker.visibleValue, "first");
+      expect(tracker.isSettled, isFalse);
+    });
+
+    test("a failed visible rename prefers a newer confirmation over an older pending request", () {
+      final tracker = OptimisticRenameTracker(confirmedValue: "original");
+
+      tracker.begin(token: 1, value: "first");
+      tracker.begin(token: 2, value: "second");
+      tracker.begin(token: 3, value: "third");
+      tracker.complete(token: 2, value: "second", succeeded: true);
+      tracker.complete(token: 3, value: "third", succeeded: false);
+
+      expect(tracker.visibleValue, "second");
+      expect(tracker.confirmedValue, "second");
+    });
+
+    test("a rejected rename of an entity without a name settles back to null", () {
+      final tracker = OptimisticRenameTracker(confirmedValue: null);
+
+      tracker.begin(token: 1, value: "first");
+      tracker.complete(token: 1, value: "first", succeeded: false);
+
+      expect(tracker.isSettled, isTrue);
+      expect(tracker.confirmedValue, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Complexity

⚙️ moderate — one shared collaborator replaces two identical private classes inside two cubits, with a new unit suite and both existing cubit rename suites as the safety net.

## What

- Adds `OptimisticRenameTracker` under `client/module_core/lib/src/cubits/shared/`. It owns the pending-token, visible-value, and confirmed-value algorithm: the visible value follows the latest request until that request fails, a success is confirmed only when newer than the current confirmation, and a failed visible rename falls back to the newest pending request or to a newer confirmation.
- `SessionListCubit` and `ProjectListCubit` delete their identical private rename-state classes and instantiate one tracker per entity. Token allocation, entity maps, repository calls, refresh, and state projection stay in the cubits. No DI singleton and no generic mutation framework.
- New unit tests cover newest-success confirmation with out-of-order completion, fallback after a failed visible rename, newer-confirmation precedence, and a null original that settles back to null.

## Why

Step 11/25 of `.plan/active/periodic-cleanup`. The rename sheet closes as soon as the user confirms, so overlapping renames are ordinary behavior, and the two cubits had grown byte-identical bookkeeping for it that could drift independently.

## Risk and test focus

Medium UI-state risk, client only. Impacted: optimistic session and project renames on phone and desktop, including overlapping renames and rejected renames. Most valuable checks: rename a session twice quickly and confirm the final title matches the last accepted rename; rename a project, force the bridge to reject it, and confirm the previous name returns; both shells build and analyze.

No database or wire-contract change.

## Expected result

- User-visible: none.
- Database/persisted data: none.
- Internal: one tracker class instead of two private copies.

## Verification

- `dart analyze` in `client/module_core`: no issues.
- `dart test` for the tracker suite and both cubit rename suites: 158 tests pass after rebasing onto merged main.
- Architecture implementation review (sub-agent, single commit): approved, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the duplicate optimistic rename bookkeeping in `SessionListCubit` and `ProjectListCubit` with one shared `OptimisticRenameTracker` class, so the two copies can't drift independently. No user-visible behavior change.

**Refactors**
- Adds `OptimisticRenameTracker` under `client/module_core/lib/src/cubits/shared/` owning the pending-token, visible-value, and confirmed-value algorithm.
- Deletes the identical private rename-state classes from both cubits, which now each instantiate one tracker per entity and keep their entity maps, repository calls, refresh, and state projection.
- Adds unit tests covering out-of-order completion, failed visible rename fallback, newer-confirmation precedence, and a null original.

No database or wire-contract change.

<sup>Written for commit 605b8ddee4df4478b4e93244312983ad857ec714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

