### PR TITLE
🌱 [managed-runtime-auto-upgrade] docs: reconcile runtime upgrade regression coverage [step 4/5]

### DIFF
--- a/.plan/active/managed-runtime-auto-upgrade/PLAN.md
+++ b/.plan/active/managed-runtime-auto-upgrade/PLAN.md
@@ -217,9 +217,15 @@ provider configuration, session history, or a running session's executable.
   the upgrade at info level and admit an install with
   `InstallCompletion.reinspectOnly`.
 - A private two-value enum `InstallCompletion { enableAndStart, reinspectOnly }`
-  replaces a boolean. `_executeInstall` takes it; on `ProvisionReady` it calls
-  `_enable` for `enableAndStart` (manual Install, unchanged) and
-  `_inspectForCommand` for `reinspectOnly`. Progress, failure, interruption,
+  replaces a boolean. It lives on `_ActivePluginCommand` and `_executeInstall`
+  reads it at the terminal event, not at admission: an explicit Install that
+  joins a running startup upgrade promotes it back to `enableAndStart`, so the
+  user's intent to start the harness survives the join. On `ProvisionReady` the
+  executor calls `_enable` for `enableAndStart` (manual Install, unchanged) and
+  `_inspectForCommand` for `reinspectOnly`. The reinspect-only branch re-reads
+  the completion after that inspection and starts the harness when a promotion
+  arrived during it, because the joiner owns the same slot until this command's
+  `finally` releases it. Both windows were found by review, not by the plan. Progress, failure, interruption,
   slot release, and management-snapshot publication are unchanged; a failed
   upgrade leaves the previous setup (ready on the older supported runtime, or
   runtime-missing with the descriptor's hint) in place.
@@ -303,6 +309,14 @@ implementation appears to need any of these, stop and ask.
 - `docs/regression/plugin-runtime-installation.md` Known Limitations currently
   states managed runtime refresh is not covered; Step 4 replaces it.
 - No obsolete transport shapes, flags, or database artifacts were found.
+
+Step 4 audit against the delivered implementation: `ManagedRuntimeVersionPolicy`
+and `ManagedRuntimeCleaner.sweep`'s `keepVersion` have no remaining references
+outside this plan document. The provision notice names the selected version. The
+three "needs a newer X" hints are still correct — they describe a below-minimum
+runtime, which is exactly the window before its obsolete directory is swept. No
+further cleanup was discovered; `managedBinaryPath`'s new `version` parameter and
+`parseInstalledVersion` both have live consumers.
 
 ## Delivery Plan
 

--- a/.plan/active/managed-runtime-auto-upgrade/TRACKER.md
+++ b/.plan/active/managed-runtime-auto-upgrade/TRACKER.md
@@ -3,9 +3,9 @@
 | Step | PR title | Status | PR | Notes |
 |---|---|---|---|---|
 | 1/5 | 🌱 [managed-runtime-auto-upgrade] docs: plan automatic managed runtime upgrades [step 1/5] | Merged | #1312 | |
-| 2/5 | 🚧 [managed-runtime-auto-upgrade] runtime: select supported managed versions and sweep by ownership [step 2/5] | This PR | — | Two plan deviations, both recorded in `PLAN.md`: the upgrade gate is the `install` capability (OpenCode drops it in attach mode), and `RuntimeManifest.parseInstalledVersion` splits directory-name parsing from `--version` token parsing so OMP's `omp/` prefix stops hiding its superseded versions. |
-| 3/5 | ⚙️ [managed-runtime-auto-upgrade] bridge: upgrade superseded managed runtimes on startup [step 3/5] | Planned | — | |
-| 4/5 | 🌱 [managed-runtime-auto-upgrade] docs: reconcile runtime upgrade regression coverage [step 4/5] | Planned | — | |
+| 2/5 | 🚧 [managed-runtime-auto-upgrade] runtime: select supported managed versions and sweep by ownership [step 2/5] | Merged | #1316 | Two plan deviations, both recorded in `PLAN.md`: the upgrade gate is the `install` capability (OpenCode drops it in attach mode), and `RuntimeManifest.parseInstalledVersion` splits directory-name parsing from `--version` token parsing so OMP's `omp/` prefix stops hiding its superseded versions. Two review findings on the in-use signal and the ownership-aware sweep were declined as disproportionate; both replies are on the PR. |
+| 3/5 | ⚙️ [managed-runtime-auto-upgrade] bridge: upgrade superseded managed runtimes on startup [step 3/5] | Merged | #1319 | Review found a real gap the plan did not anticipate: an explicit Install joining a running startup upgrade inherited `reinspectOnly` and never started the harness. `InstallCompletion` now lives on the active command and is read both at the terminal event and again after the post-upgrade inspection, so a join is honoured at every arrival time. |
+| 4/5 | 🌱 [managed-runtime-auto-upgrade] docs: reconcile runtime upgrade regression coverage [step 4/5] | This PR | — | |
 | 5/5 | 🌿 [managed-runtime-auto-upgrade] verify: run runtime upgrade coverage and retire the plan [step 5/5] | Planned | — | |
 
 Record regression-document deltas here as implementation steps merge; Step 4

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -16,6 +16,24 @@ Columns are the plugins registered in `bridge/app/lib/src/runtime/plugin_registr
 | ⬜ | Not implemented: the harness and the seam Sesori drives can provide it, Sesori does not yet. |
 | 🚫 | Not supported: the harness or the protocol seam Sesori drives cannot provide it. The footnote names the verified version. |
 
+## Managed runtime
+
+| Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Sesori-managed runtime installed on request | 🚫 | ✅ | ✅ | ✅ | ✅ | 🚫 | ✅ | ✅ | ✅ | 🚫 |
+| Superseded managed runtime upgraded automatically on bridge start | 🚫 | ✅ | ✅ | ✅ | ✅ | 🚫 | ✅ | ✅ | ✅ | 🚫 |
+
+Claude, Hermes, and Grok have no Sesori-managed runtime at all: they resolve a
+user-installed CLI from PATH or an explicit binary option, so there is nothing
+for Sesori to install or upgrade. The upgrade follows the install capability
+exactly — a harness configured with an explicit binary override, running on a
+platform with no pinned asset, or attached to an externally managed server
+(`--opencode-no-auto-start`) advertises neither.
+
+The upgrade only replaces a runtime Sesori already manages. A machine with no
+managed version directory keeps the explicit Install action; it never downloads
+a runtime the user has not asked for.
+
 ## Option pickers
 
 | Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |

--- a/docs/regression/plugin-runtime-installation.md
+++ b/docs/regression/plugin-runtime-installation.md
@@ -2,8 +2,9 @@
 
 ## Capability
 
-Installing a harness's pinned, bridge-managed runtime on request, from the app or the
-management API, when it reports its runtime as missing or too old.
+Installing a harness's pinned, bridge-managed runtime — on request from the app or the
+management API when it reports its runtime as missing or too old, and automatically on
+bridge start when Sesori already manages an older version.
 
 ## Required Behavior
 
@@ -36,22 +37,45 @@ management API, when it reports its runtime as missing or too old.
   command output stay in the log.
 - A duplicate request joins the running install, another command for the same harness
   conflicts, and a shutdown mid-install ends it as interrupted so a retry redoes it.
+- A bridge start upgrades every eligible harness that still has a Sesori-managed version
+  directory other than the pinned target, and only those: a machine with no managed
+  runtime keeps the explicit Install action and never downloads one unasked. The trigger
+  runs after single-live-bridge ownership is settled and returns without waiting, so
+  startup is never delayed by a download. Each upgrade occupies the harness's command
+  slot exactly like a manual install, so an overlapping request joins it and another
+  command conflicts. An explicit Install that joins a running upgrade carries the user's
+  intent with it: the joined install enables and starts the harness on success, even
+  though the upgrade alone would not have.
+- A managed version at or above the harness's minimum stays selectable and startable
+  while the target downloads; below the minimum it is never selected. Unlike a manual
+  install, a startup upgrade re-inspects but never starts a harness, so a blocked harness
+  becomes ready and selectable without a bridge restart and a running one keeps its
+  current generation until it stops.
+- Cleanup follows what is still usable. A below-minimum version directory is removed
+  before the download begins, because it can never be selected either way. A superseded
+  but still supported one survives until the pinned version is installed and verified,
+  and is kept when the harness has a live generation; a later install reclaims it.
+- A failed upgrade changes nothing: an older supported runtime stays selected and ready,
+  and a harness whose only managed runtime was below the minimum stays runtime-missing
+  with its install hint. Failure detail stays in the bridge log.
 
 ## Regression Levels
 
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Not included. Installation is a deliberate network-bound action, not a heartbeat. |
-| L2 Routine | Capability declaration is honest for every registered harness on the release-target bridge host: those with a pinned asset and no override advertise install, the rest do not. Automated manifest coverage includes Codex's and Copilot's exact six platform/architecture mappings and digests, plus preservation of nested package entries and sibling resources. Headless bridge; every supporting production harness. |
-| L3 Release | One complete install on the release-target bridge host from missing runtime through verification and extraction to enabled, re-inspected, and selectable, with progress shown on the release-target client platform. Client end to end; every harness advertising install. |
-| L4 Extended | Checksum mismatch or interrupted download failing safely, shutdown mid-install, duplicate join, competing-command rejection, authentication-required outcome, too-old runtime, and an alternate bridge host. Live plugin for bridge outcome, client end to end for card state. |
+| L2 Routine | Capability declaration is honest for every registered harness on the release-target bridge host: those with a pinned asset and no override advertise install and automatic upgrade, the rest do neither. A start with no managed version directory triggers no upgrade. Automated manifest coverage includes Codex's and Copilot's exact six platform/architecture mappings and digests, plus preservation of nested package entries and sibling resources. Headless bridge; every supporting production harness. |
+| L3 Release | One complete install on the release-target bridge host from missing runtime through verification and extraction to enabled, re-inspected, and selectable, with progress shown on the release-target client platform. Plus a start with a raised target over an older supported managed version: the harness stays selectable throughout, startup does not block, and the new version is used by the next generation; and over a below-minimum version: the harness is blocked briefly, then becomes selectable without a bridge restart or an Install press. Client end to end; every harness advertising install. |
+| L4 Extended | Checksum mismatch or interrupted download failing safely, shutdown mid-install, duplicate join, competing-command rejection, authentication-required outcome, too-old runtime, and an alternate bridge host. An Install pressed while a startup upgrade downloads, which joins it and still leaves the harness enabled and started. A forced upgrade failure over each of an older supported and a below-minimum version, leaving the documented fallback state. A session running on the older supported runtime during an upgrade continuing uninterrupted, with its version directory surviving until the generation stops and the next start resolving the pinned version. Live plugin for bridge outcome, client end to end for card state. |
 | L5 Full | Install on every supported platform and architecture where the harness publishes an asset, a superseded managed version swept after success, and pinned digests matching the upstream release assets. Copilot's complete matrix is its six official arm64/x64 macOS, Linux, and Windows archives. Packaged or external, since real upstream artifacts are part of the claim. |
 
 ## Exploration Guidance
 
-Vary the starting state: no runtime, a too-old managed runtime, a too-old runtime on the
-path, and a previously disabled harness. Vary the trigger between the app and the
-management API, whether another harness is busy, and the interruption point during
+Vary the starting state: no runtime, a superseded but still supported managed runtime, a
+below-minimum managed runtime, the pinned version already installed, a too-old runtime on
+the path, and a previously disabled harness. Vary the trigger between the app, the
+management API, and a bridge start; whether the harness is running, idle, or blocked when
+an upgrade completes; whether another harness is busy; and the interruption point during
 download, verification, or placement. Use a disposable data directory.
 
 ## Failure Signals
@@ -64,6 +88,19 @@ download, verification, or placement. Use a disposable data directory.
 - A completed install leaving the harness disabled, not re-inspected, or unselectable
   while reporting success, a Codex install missing `codex-code-mode-host` or package
   resources, or raw paths and command output reaching the client.
+- Bridge startup blocking on an upgrade download, an upgrade running for a harness with no
+  managed runtime directory or an explicit binary override, or a startup upgrade starting
+  a harness the user had not enabled.
+- An Install pressed while an upgrade is downloading reporting success but leaving the
+  harness stopped.
+- A superseded but still supported runtime removed before its replacement is verified, or
+  removed while a generation is running from it; a below-minimum directory still present
+  once a download has begun.
+- A harness dropping out of the selectable set while its upgrade downloads, or a
+  below-minimum harness staying blocked after a successful upgrade until the bridge is
+  restarted.
+- A failed upgrade downgrading a harness that was ready on an older supported runtime, or
+  its failure detail reaching the client instead of the log.
 
 ## Known Limitations
 
@@ -72,8 +109,20 @@ download, verification, or placement. Use a disposable data directory.
 - Backend authentication is out of scope; an install may end needing a machine-local
   login, and it never supersedes a configured binary path. Copilot authentication remains
   an out-of-band `copilot login`, supported token environment, or BYOK configuration.
-- Pinned digests are release-engineering state, checked upstream externally; refresh of
-  an installed managed runtime is not covered here.
+- Pinned digests are release-engineering state, checked upstream externally.
+- The upgrade replaces only a runtime Sesori already manages; a harness that has never
+  been installed through Sesori still needs the explicit Install action. A user who runs
+  a PATH install and also has a stale managed directory downloads one target they do not
+  run, once per target bump.
+- There is no hot swap: a generation started on the older supported runtime keeps it until
+  it stops. A harness that is running when its upgrade completes keeps that version
+  directory until a later install reclaims it.
+- A below-minimum upgrade whose download fails does not retry on the next start, because
+  its obsolete directory was already removed; the harness stays runtime-missing until the
+  user presses Install.
+- The trigger is bridge start only. There is no periodic or relay-driven update check, and
+  a headless startup upgrade shows no console progress — the log records start, outcome,
+  and failure detail.
 
 ## Sources
 
@@ -81,6 +130,8 @@ download, verification, or placement. Use a disposable data directory.
   `bridge/sesori_plugin_runtime/lib/src/provisioning/`, OpenCode, Codex, Cursor, Pi, and OMP manifests
 - `bridge/app/lib/src/services/plugin_lifecycle_service.dart`,
   `bridge/app/lib/src/runtime/plugin_registry.dart`,
+  `bridge/app/lib/src/runtime/plugin_runtime.dart`,
+  `bridge/app/lib/src/runtime/bridge_runtime_runner.dart`,
   `bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_runtime_manifest.dart`,
   `bridge/sesori_plugin_copilot/lib/src/runtime/copilot_runtime_manifest.dart`
 - `client/module_core/.../plugin_management_service.dart`,

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -15,6 +15,10 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Runtime resolution before start may resolve a suitable existing or managed binary but
   never downloads or mutates files, and failure there is non-fatal. The persisted disable
   list is the only durable eligibility policy, with setup deciding blocked versus routable.
+- Managed selection prefers the pinned target and otherwise takes the newest installed
+  managed version still at or above the harness's minimum, so raising the target leaves
+  the previous install usable rather than reporting the runtime as missing. A managed
+  version below the minimum is never selected.
 - Hermes is a direct-CLI harness with no managed install. Setup distinguishes a missing or
   pre-ACP binary, a Hermes Agent release below `0.20.0`, and missing model/provider
   configuration; startup revalidates the effective PATH or explicit `--hermes-bin` executable
@@ -23,7 +27,8 @@ idle suspension, the management snapshot, and lifecycle commands.
   Hermes entries give local setup guidance rather than offering bridge-managed login.
 - DeepSeek is an ACP harness with six-platform managed package archives. Its
   descriptor honors an explicit `--deepseek-bin` path before a compatible PATH
-  release (`>=0.1.3`) and the exact managed `0.1.3` release. An outdated explicit
+  release (`>=0.1.3`) and then a managed release at or above that minimum,
+  preferring the pinned `0.1.3` target. An outdated explicit
   binary is rejected; an old or malformed PATH candidate falls through to managed
   selection. It performs bounded parseable-version and
   side-effect-free `check --state-dir` probes, advertises install only on a
@@ -43,7 +48,8 @@ idle suspension, the management snapshot, and lifecycle commands.
 - GitHub Copilot is a standard ACP v1 harness launched as
   `copilot --no-auto-update --acp`. Setup keeps an explicit `--copilot-bin`
   authoritative, otherwise prefers a compatible PATH release (`>=1.0.78`) over
-  the exact managed release. Version output must retain Copilot branding, and
+  a managed release at or above that minimum, preferring the pinned target.
+  Version output must retain Copilot branding, and
   startup uses only the runtime selected during provisioning. Authentication is
   local and out of band; setup never reads credentials or runs `copilot login`.
   An unexpected owned-process exit degrades only Copilot, and demand reconnects


### PR DESCRIPTION
## Complexity

🌱 trivial — documentation only. No production code, no tests, no generated
files.

## What

Step 4/5 of `.plan/active/managed-runtime-auto-upgrade`: reconciles the
regression documents and the harness capability matrix with the behaviour
delivered by #1316 and #1319, and records the cleanup audit against the
implementation.

`docs/regression/plugin-runtime-installation.md`

- Capability now covers the automatic startup trigger, not just install on request.
- New required behaviour for the trigger and its eligibility, selection of a
  supported older managed version, obsolete-first cleanup, the ownership-aware
  sweep, re-inspection without a start, the joined-install promotion, and the
  failure fallbacks.
- L2 through L4 coverage extended; L3 gains the raised-target and below-minimum
  start cases, L4 the forced upgrade failures, the mid-upgrade Install join, and
  the running-session ownership check.
- Exploration guidance and failure signals widened to the new states.
- The "refresh of an installed managed runtime is not covered here" limitation is
  replaced by the four real accepted limits: no automatic first install, no hot
  swap, no retry after a below-minimum failure, and bridge start as the only
  trigger.

`docs/regression/plugin-setup-and-lifecycle.md`

- Managed selection documented as the newest installed version at or above the
  minimum, preferring the pinned target.
- DeepSeek's and Copilot's "the exact managed release" wording corrected to the
  minimum/target pair, which is no longer how selection behaves.

`docs/HARNESS_CAPABILITIES.md`

- New Managed runtime section: install on request and automatic upgrade are
  implemented for OpenCode, Codex, Copilot, Cursor, Pi, OMP, and DeepSeek, and
  not supported for Claude, Hermes, and Grok, which have no Sesori-managed
  runtime at all.

`PLAN.md` / `TRACKER.md` record the merged steps, the two review findings on the
join path, and the cleanup audit.

## Why

`AGENTS.md` requires the regression documents and the capability matrix to track
supported behaviour, and requires a capability that lands for some harnesses but
not others to be a visible, deliberate state. The runtime installation document
also carried a limitation that the delivered feature has now lifted.

## Risk and test focus

No risk: documentation only. No user-visible change, no database or persisted-data
effect, no production code touched.

The useful check is that the documents match the merged implementation — in
particular that no regression document still claims managed selection accepts
only the exact pinned release, and that the capability matrix columns match the
plugins registered in `plugin_registry.dart`.

## Expected result

No user-visible behaviour change. No database change. Internally, the regression
suite and capability matrix describe the shipped auto-upgrade behaviour, and the
stale refresh-not-covered limitation is gone.

## Verification

Per repository instructions, documentation changes need only their own relevant
validation; no Dart or Flutter suites were run. Verified by inspection against
the merged implementation: the capability matrix columns match
`plugin_registry.dart`, and a repository-wide search finds no remaining
"exact managed release" claim in the regression documents and no reference to
`ManagedRuntimeVersionPolicy` or `ManagedRuntimeCleaner.sweep`'s former
`keepVersion` parameter outside the plan document's own history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles the regression documents and harness capability matrix with the merged managed-runtime auto-upgrade behavior, replacing the stale install-only coverage.

- Records the automatic startup trigger, obsolete-first cleanup, ownership-aware sweep, and failure fallbacks in `plugin-runtime-installation.md`.
- Corrects DeepSeek's and Copilot's "exact managed release" wording to the minimum/target selection pair in `plugin-setup-and-lifecycle.md`.
- Adds a Managed runtime section to `HARNESS_CAPABILITIES.md` listing which harnesses support install and automatic upgrade.
- Records the cleanup audit and review findings in `PLAN.md` and `TRACKER.md`.

Documentation only; no production code, tests, or generated files touched.

<sup>Written for commit 6d5190230d7780229e3e234ccc1db77506a0254a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

