### PR TITLE
⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -19,7 +19,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Merged | [#1314](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1314) |
 | 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | Merged | [#1318](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1318) |
 | 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | In review | [#1320](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1320) |
-| 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | Proposed | — |
+| 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | In progress (local, awaiting step 11 merge) | — |
 | 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Proposed | — |
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Proposed | — |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Proposed | — |
@@ -231,3 +231,15 @@ asked to start working the plan; steps execute in order from step 2.
   tests cover newest-success confirmation, fallback after a failed visible
   rename, newer-confirmation precedence and a null original; both cubit rename
   suites pass unchanged.
+
+## Step 12 execution — 2026-09-05
+
+- Stateless `ManagedRuntimeComposition.createInstaller` in
+  `sesori_plugin_runtime/lib/src/composition/` builds the checksum, extractor,
+  installer and cleaner graph from a descriptor's manifest, executor, download
+  client, version validator and asset resolver, returning
+  `ManagedRuntimeInstallService` through its unchanged constructor. Codex,
+  OpenCode, Copilot, Cursor, Pi, OMP and DeepSeek call it; each keeps its
+  operation-local HTTP client and finally-close, executor limits and Windows
+  shell policy, probe timeout, validator and asset resolver (OMP's dynamic
+  Linux resolution included). Existing runtime and descriptor suites pass.

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -18,8 +18,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 8/25 | ⚙️ [periodic-cleanup] bridge: narrow session and activity projections [step 8/25] | Merged | [#1313](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1313) |
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Merged | [#1314](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1314) |
 | 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | Merged | [#1318](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1318) |
-| 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | In review | [#1320](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1320) |
-| 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | In progress (local, awaiting step 11 merge) | — |
+| 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | Merged | [#1320](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1320) |
+| 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | In review | [#1322](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1322) |
 | 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Proposed | — |
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Proposed | — |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Proposed | — |

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -289,21 +289,15 @@ class const CodexPluginDescriptor({
     );
     final httpClient = http.Client();
     try {
-      final installService = ManagedRuntimeInstallService(
+      final installService = const ManagedRuntimeComposition().createInstaller(
         manifest: manifest,
+        commandExecutor: commandExecutor,
+        downloadClient: BinaryDownloadClient(httpClient: httpClient),
         versionValidator: RuntimeVersionValidator(
           commandExecutor: commandExecutor,
           manifest: manifest,
           probeTimeout: _versionProbeTimeout,
         ),
-        installService: RuntimeInstallService(
-          downloadClient: BinaryDownloadClient(httpClient: httpClient),
-          checksumValidator: ChecksumValidator(),
-          archiveExtractor: ArchiveExtractor(commandExecutor: commandExecutor),
-          commandExecutor: commandExecutor,
-          runtimeId: manifest.runtimeId,
-        ),
-        cleaner: ManagedRuntimeCleaner(runtimeId: manifest.runtimeId),
         assetResolver: ({required target}) async => manifest.assetFor(target: target),
       );
       yield* installService.install(

--- a/bridge/sesori_plugin_copilot/lib/src/runtime/copilot_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_copilot/lib/src/runtime/copilot_plugin_descriptor.dart
@@ -141,21 +141,15 @@ final class const CopilotPluginDescriptor({
     );
     final httpClient = http.Client();
     try {
-      final service = ManagedRuntimeInstallService(
+      final service = const ManagedRuntimeComposition().createInstaller(
         manifest: manifest,
+        commandExecutor: commandExecutor,
+        downloadClient: BinaryDownloadClient(httpClient: httpClient),
         versionValidator: RuntimeVersionValidator(
           commandExecutor: commandExecutor,
           manifest: manifest,
           probeTimeout: _versionProbeTimeout,
         ),
-        installService: RuntimeInstallService(
-          downloadClient: BinaryDownloadClient(httpClient: httpClient),
-          checksumValidator: ChecksumValidator(),
-          archiveExtractor: ArchiveExtractor(commandExecutor: commandExecutor),
-          commandExecutor: commandExecutor,
-          runtimeId: manifest.runtimeId,
-        ),
-        cleaner: ManagedRuntimeCleaner(runtimeId: manifest.runtimeId),
         assetResolver: ({required target}) async => manifest.assetFor(target: target),
       );
       yield* service.install(

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -3,14 +3,7 @@ import "dart:io" as io;
 import "package:acp_plugin/acp_plugin.dart";
 import "package:http/http.dart" as http;
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart"
-    show
-        ArchiveExtractor,
-        BinaryDownloadClient,
-        ChecksumValidator,
-        CommandResult,
-        HostProcessCommandExecutor,
-        PlatformTarget,
-        stripAnsi;
+    show BinaryDownloadClient, CommandResult, HostProcessCommandExecutor, PlatformTarget, stripAnsi;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 import "package:sesori_shared/sesori_shared.dart" show Harness;
@@ -214,20 +207,14 @@ class const CursorPluginDescriptor({
     );
     final httpClient = http.Client();
     try {
-      final installService = ManagedRuntimeInstallService(
+      final installService = const ManagedRuntimeComposition().createInstaller(
         manifest: manifest,
+        commandExecutor: commandExecutor,
+        downloadClient: BinaryDownloadClient(httpClient: httpClient),
         versionValidator: _versionValidatorFor(
           processes: processes,
           maxCapturedOutputCharactersPerStream: null,
         ),
-        installService: RuntimeInstallService(
-          downloadClient: BinaryDownloadClient(httpClient: httpClient),
-          checksumValidator: ChecksumValidator(),
-          archiveExtractor: ArchiveExtractor(commandExecutor: commandExecutor),
-          commandExecutor: commandExecutor,
-          runtimeId: manifest.runtimeId,
-        ),
-        cleaner: ManagedRuntimeCleaner(runtimeId: manifest.runtimeId),
         assetResolver: ({required target}) async => manifest.assetFor(target: target),
       );
       yield* installService.install(

--- a/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
@@ -119,17 +119,11 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
     final commandExecutor = _executor(processes);
     final httpClient = http.Client();
     try {
-      final service = ManagedRuntimeInstallService(
+      final service = const ManagedRuntimeComposition().createInstaller(
         manifest: manifest,
+        commandExecutor: commandExecutor,
+        downloadClient: BinaryDownloadClient(httpClient: httpClient),
         versionValidator: _versionValidator(processes: processes),
-        installService: RuntimeInstallService(
-          downloadClient: BinaryDownloadClient(httpClient: httpClient),
-          checksumValidator: ChecksumValidator(),
-          archiveExtractor: ArchiveExtractor(commandExecutor: commandExecutor),
-          commandExecutor: commandExecutor,
-          runtimeId: manifest.runtimeId,
-        ),
-        cleaner: ManagedRuntimeCleaner(runtimeId: manifest.runtimeId),
         assetResolver: ({required target}) async => manifest.assetFor(target: target),
       );
       yield* service.install(

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
@@ -159,17 +159,11 @@ final class const OmpPluginDescriptor({
     );
     final httpClient = http.Client();
     try {
-      final service = ManagedRuntimeInstallService(
+      final service = const ManagedRuntimeComposition().createInstaller(
         manifest: manifest,
+        commandExecutor: commandExecutor,
+        downloadClient: BinaryDownloadClient(httpClient: httpClient),
         versionValidator: _versionValidator(processes: processes),
-        installService: RuntimeInstallService(
-          downloadClient: BinaryDownloadClient(httpClient: httpClient),
-          checksumValidator: ChecksumValidator(),
-          archiveExtractor: ArchiveExtractor(commandExecutor: commandExecutor),
-          commandExecutor: commandExecutor,
-          runtimeId: manifest.runtimeId,
-        ),
-        cleaner: ManagedRuntimeCleaner(runtimeId: manifest.runtimeId),
         assetResolver: runtimeAssetService.resolve,
       );
       yield* service.install(

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -293,21 +293,15 @@ class const OpenCodePluginDescriptor({
     );
     final httpClient = http.Client();
     try {
-      final installService = ManagedRuntimeInstallService(
+      final installService = const ManagedRuntimeComposition().createInstaller(
         manifest: manifest,
+        commandExecutor: commandExecutor,
+        downloadClient: BinaryDownloadClient(httpClient: httpClient),
         versionValidator: RuntimeVersionValidator(
           commandExecutor: commandExecutor,
           manifest: manifest,
           probeTimeout: _versionProbeTimeout,
         ),
-        installService: RuntimeInstallService(
-          downloadClient: BinaryDownloadClient(httpClient: httpClient),
-          checksumValidator: ChecksumValidator(),
-          archiveExtractor: ArchiveExtractor(commandExecutor: commandExecutor),
-          commandExecutor: commandExecutor,
-          runtimeId: manifest.runtimeId,
-        ),
-        cleaner: ManagedRuntimeCleaner(runtimeId: manifest.runtimeId),
         assetResolver: ({required target}) async => manifest.assetFor(target: target),
       );
       yield* installService.install(

--- a/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
@@ -172,17 +172,11 @@ final class const PiPluginDescriptor({
     );
     final httpClient = http.Client();
     try {
-      final service = ManagedRuntimeInstallService(
+      final service = const ManagedRuntimeComposition().createInstaller(
         manifest: manifest,
+        commandExecutor: commandExecutor,
+        downloadClient: BinaryDownloadClient(httpClient: httpClient),
         versionValidator: _versionValidator(processes: processes),
-        installService: RuntimeInstallService(
-          downloadClient: BinaryDownloadClient(httpClient: httpClient),
-          checksumValidator: ChecksumValidator(),
-          archiveExtractor: ArchiveExtractor(commandExecutor: commandExecutor),
-          commandExecutor: commandExecutor,
-          runtimeId: manifest.runtimeId,
-        ),
-        cleaner: ManagedRuntimeCleaner(runtimeId: manifest.runtimeId),
         assetResolver: ({required target}) async => manifest.assetFor(target: target),
       );
       yield* service.install(

--- a/bridge/sesori_plugin_runtime/lib/sesori_plugin_runtime.dart
+++ b/bridge/sesori_plugin_runtime/lib/sesori_plugin_runtime.dart
@@ -1,3 +1,4 @@
+export "src/composition/managed_runtime_composition.dart";
 export "src/draining_spawned_process.dart";
 export "src/dynamic_port_candidates.dart";
 export "src/host_json_runtime_ownership_repository.dart";

--- a/bridge/sesori_plugin_runtime/lib/src/composition/managed_runtime_composition.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/composition/managed_runtime_composition.dart
@@ -1,0 +1,40 @@
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+
+import "../provisioning/managed_runtime_cleaner.dart";
+import "../provisioning/managed_runtime_install_service.dart";
+import "../provisioning/runtime_install_service.dart";
+import "../provisioning/runtime_manifest.dart";
+import "../provisioning/runtime_version_validator.dart";
+
+/// Assembles the managed-runtime object graphs every managed plugin shares.
+///
+/// Stateless: it constructs a graph from the collaborators a descriptor already
+/// owns and returns the service through its ordinary constructor. It never
+/// forwards install calls and owns no resource, so descriptors keep their
+/// operation-local HTTP client lifetime, executor limits, probe timeouts and
+/// per-plugin asset resolution.
+class const ManagedRuntimeComposition() {
+  /// The checksum, extractor, installer and cleaner graph behind
+  /// [ManagedRuntimeInstallService], keyed to [manifest]'s runtime id.
+  ManagedRuntimeInstallService createInstaller({
+    required RuntimeManifest manifest,
+    required CommandExecutor commandExecutor,
+    required BinaryDownloadClient downloadClient,
+    required RuntimeVersionValidator versionValidator,
+    required RuntimeAssetResolver assetResolver,
+  }) {
+    return ManagedRuntimeInstallService(
+      manifest: manifest,
+      versionValidator: versionValidator,
+      installService: RuntimeInstallService(
+        downloadClient: downloadClient,
+        checksumValidator: ChecksumValidator(),
+        archiveExtractor: ArchiveExtractor(commandExecutor: commandExecutor),
+        commandExecutor: commandExecutor,
+        runtimeId: manifest.runtimeId,
+      ),
+      cleaner: ManagedRuntimeCleaner(runtimeId: manifest.runtimeId),
+      assetResolver: assetResolver,
+    );
+  }
+}


### PR DESCRIPTION
## Complexity

⚙️ moderate — one stateless composition class replaces the same hand-assembled installer graph in seven plugin descriptors; no behavior or contract change.

## What

- Adds `ManagedRuntimeComposition` under `sesori_plugin_runtime/lib/src/composition/`. Its `createInstaller` takes the manifest, command executor, download client, version validator, and asset resolver a descriptor already owns, builds the checksum, extractor, installer, and cleaner graph, and returns `ManagedRuntimeInstallService` through its unchanged constructor. The class holds no state, forwards no calls, and owns no resource.
- Codex, OpenCode, Copilot, Cursor, Pi, OMP, and DeepSeek descriptors call it in place of their identical graph construction. Each keeps its operation-local HTTP client and `finally` close, executor output limits and Windows shell policy, version-probe timeout, validator, and per-plugin asset resolver, including OMP's dynamic Linux resolution.
- The Cursor descriptor drops two now-unused names from its `show` list.

## Why

Step 12/25 of `.plan/active/periodic-cleanup`. Seven copies of one composition drift independently and hide which inputs actually vary per plugin. With the shared graph, the per-plugin differences are the only thing left in each descriptor.

## Risk and test focus

Medium installation risk, bridge only. Impacted: managed runtime installation and re-inspection for every managed plugin. Most valuable checks: on macOS arm64 with an isolated runtime root, install one managed runtime from scratch, cancel one install mid-download and confirm cleanup, and re-inspect an installed runtime; existing fixture tests cover platform-specific executor and resolver inputs.

No runtime pin, installation format, authentication, capability, lifecycle, database, or wire change.

## Expected result

- User-visible: none.
- Database/persisted data: none.
- Internal: one composition point for the installer graph; seven descriptors shrink to their real differences.

## Verification

- `dart analyze` for the whole `bridge/` workspace: no issues.
- `dart test` for the runtime provisioning suite and the descriptor or runtime suites of all seven plugins: all pass after rebasing onto merged main.
- Architecture implementation review (sub-agent, single commit): approved, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hand-assembled managed runtime installer graph in the Codex, OpenCode, Copilot, Cursor, Pi, OMP, and DeepSeek descriptors with a shared stateless `ManagedRuntimeComposition`. No behavior or contract changes: each descriptor keeps its executor, validator, HTTP client lifetime, and asset resolution, so only real differences remain.

- `ManagedRuntimeComposition.createInstaller` builds the checksum, extractor, installer, and cleaner graph from a descriptor's manifest, executor, download client, version validator, and asset resolver.
- The Cursor descriptor drops two now-unused imports.
- Updates the step 12 tracker entry.

Because this touches every managed plugin's install path, verify one fresh install, one mid-download cancel, and one re-inspect on a real runtime.

<sup>Written for commit 6c8f6f0acd83aff57395adc5684d7fbfbc364789. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

