### PR TITLE
⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -19,8 +19,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 9/25 | ⚙️ [periodic-cleanup] plugins: stop forwarding unused backend events [step 9/25] | Merged | [#1314](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1314) |
 | 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | Merged | [#1318](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1318) |
 | 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | Merged | [#1320](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1320) |
-| 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | In review | [#1322](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1322) |
-| 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | In progress (local) | — |
+| 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | Merged | [#1322](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1322) |
+| 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | In review | [#1323](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1323) |
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Proposed | — |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Proposed | — |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -20,7 +20,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | Merged | [#1318](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1318) |
 | 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | Merged | [#1320](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1320) |
 | 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | In review | [#1322](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1322) |
-| 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Proposed | — |
+| 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | In progress (local) | — |
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Proposed | — |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Proposed | — |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Proposed | — |
@@ -243,3 +243,16 @@ asked to start working the plan; steps execute in order from step 2.
   operation-local HTTP client and finally-close, executor limits and Windows
   shell policy, probe timeout, validator and asset resolver (OMP's dynamic
   Linux resolution included). Existing runtime and descriptor suites pass.
+
+## Step 13 execution — 2026-09-05
+
+- `ManagedRuntimeComposition.createProvisioner` builds the selection service and
+  inventory from a descriptor's manifest, version validator and fallback
+  candidates; all seven managed descriptors use it and keep their probes,
+  explicit-bin short-circuits, fallback ordering and version policy.
+- `ManagedRuntimeColdStartService` (immutable budget and log tag) owns the
+  bounded initialize wait, connected/degraded report and post-budget failure
+  sink for Codex and OpenCode with one invocation-local `budgetExceeded`.
+  Descriptors keep API creation, OpenCode's condition for waiting at all, and
+  the unconditional abort-rollback check. Unit tests cover completion, failure
+  and budget exhaustion with a late failure; descriptor suites pass unchanged.

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -423,23 +423,21 @@ class const CodexPluginDescriptor({
     }
 
     const manifest = CodexRuntimeManifest();
-    yield* ManagedRuntimeProvisionService(
-      manifest: manifest,
-      selectionService: ManagedRuntimeSelectionService(
-        manifest: manifest,
-        versionValidator: RuntimeVersionValidator(
-          commandExecutor: HostProcessCommandExecutor(
-            processes: host.processes,
-            runInShell: io.Platform.isWindows,
-            maxCapturedOutputCharactersPerStream: null,
-          ),
+    yield* const ManagedRuntimeComposition()
+        .createProvisioner(
           manifest: manifest,
-          probeTimeout: _versionProbeTimeout,
-        ),
-        inventory: const ManagedRuntimeInventory(manifest: manifest),
-      ),
-      fallbackExecutableCandidates: _desktopCandidates(environment: host.environment),
-    ).provision(host: host, explicitExecutablePath: null);
+          versionValidator: RuntimeVersionValidator(
+            commandExecutor: HostProcessCommandExecutor(
+              processes: host.processes,
+              runInShell: io.Platform.isWindows,
+              maxCapturedOutputCharactersPerStream: null,
+            ),
+            manifest: manifest,
+            probeTimeout: _versionProbeTimeout,
+          ),
+          fallbackExecutableCandidates: _desktopCandidates(environment: host.environment),
+        )
+        .provision(host: host, explicitExecutablePath: null);
   }
 
   @override
@@ -654,38 +652,10 @@ class const CodexPluginDescriptor({
     // readiness probe but stalls the handshake must not hang start() under the
     // bridge's cross-instance startup mutex. Past the budget the cold-start
     // keeps running in the background and the plugin starts degraded.
-    final coldStart = api.initialize();
-    var budgetExceeded = false;
-    // The sink keeps a post-budget failure from surfacing as an unhandled async
-    // error once the await below has moved on; the awaited path observes (and
-    // logs) every pre-budget failure itself.
-    unawaited(
-      coldStart.catchError((Object error, StackTrace stackTrace) {
-        if (budgetExceeded) {
-          Log.w("[codex] cold-start failed after the start budget: $error");
-        }
-      }),
-    );
-    try {
-      await coldStart.timeout(
-        _coldStartBudget,
-        onTimeout: () {
-          budgetExceeded = true;
-          Log.w(
-            "[codex] cold-start did not finish within ${_coldStartBudget.inSeconds}s — "
-            "starting degraded while it keeps running in the background",
-          );
-        },
-      );
-      if (budgetExceeded) {
-        reporter.markDegradedNow();
-      } else {
-        reporter.markConnected();
-      }
-    } on Object catch (error) {
-      Log.w("[codex] cold-start did not complete cleanly: $error");
-      reporter.markDegradedNow();
-    }
+    await ManagedRuntimeColdStartService(
+      budget: _coldStartBudget,
+      logTag: "codex",
+    ).run(coldStart: api.initialize(), reporter: reporter);
 
     // The cold-start is a phase boundary: an abort observed here must roll back
     // everything acquired so far (api transport, monitor, the owned child)

--- a/bridge/sesori_plugin_copilot/lib/src/runtime/copilot_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_copilot/lib/src/runtime/copilot_plugin_descriptor.dart
@@ -110,18 +110,16 @@ final class const CopilotPluginDescriptor({
   @override
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
     const manifest = CopilotRuntimeManifest();
-    yield* ManagedRuntimeProvisionService(
-      manifest: manifest,
-      selectionService: ManagedRuntimeSelectionService(
-        manifest: manifest,
-        versionValidator: _versionValidator(processes: host.processes),
-        inventory: const ManagedRuntimeInventory(manifest: manifest),
-      ),
-      fallbackExecutableCandidates: const [],
-    ).provision(
-      host: host,
-      explicitExecutablePath: _explicitBin(config: host.config),
-    );
+    yield* const ManagedRuntimeComposition()
+        .createProvisioner(
+          manifest: manifest,
+          versionValidator: _versionValidator(processes: host.processes),
+          fallbackExecutableCandidates: const [],
+        )
+        .provision(
+          host: host,
+          explicitExecutablePath: _explicitBin(config: host.config),
+        );
   }
 
   @override

--- a/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart
@@ -167,15 +167,11 @@ class const CursorPluginDescriptor({
 
   ManagedRuntimeProvisionService _buildDefaultProvisionService({required PluginHost host}) {
     const manifest = CursorRuntimeManifest();
-    return ManagedRuntimeProvisionService(
+    return const ManagedRuntimeComposition().createProvisioner(
       manifest: manifest,
-      selectionService: ManagedRuntimeSelectionService(
-        manifest: manifest,
-        versionValidator: _versionValidatorFor(
-          processes: host.processes,
-          maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
-        ),
-        inventory: const ManagedRuntimeInventory(manifest: manifest),
+      versionValidator: _versionValidatorFor(
+        processes: host.processes,
+        maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
       ),
       // Cursor has no desktop-app-bundled CLI to fall back to.
       fallbackExecutableCandidates: const [],

--- a/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_plugin_descriptor.dart
@@ -92,18 +92,16 @@ class const DeepSeekPluginDescriptor() extends BridgePluginDescriptor {
   @override
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
     const manifest = DeepSeekRuntimeManifest();
-    yield* ManagedRuntimeProvisionService(
-      manifest: manifest,
-      selectionService: ManagedRuntimeSelectionService(
-        manifest: manifest,
-        versionValidator: _versionValidator(processes: host.processes),
-        inventory: const ManagedRuntimeInventory(manifest: manifest),
-      ),
-      fallbackExecutableCandidates: const [],
-    ).provision(
-      host: host,
-      explicitExecutablePath: _explicitBin(config: host.config),
-    );
+    yield* const ManagedRuntimeComposition()
+        .createProvisioner(
+          manifest: manifest,
+          versionValidator: _versionValidator(processes: host.processes),
+          fallbackExecutableCandidates: const [],
+        )
+        .provision(
+          host: host,
+          explicitExecutablePath: _explicitBin(config: host.config),
+        );
   }
 
   @override

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
@@ -127,15 +127,13 @@ final class const OmpPluginDescriptor({
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
     if (_explicitBin(host.config) != null) return;
     const manifest = OmpRuntimeManifest();
-    yield* ManagedRuntimeProvisionService(
-      manifest: manifest,
-      selectionService: ManagedRuntimeSelectionService(
-        manifest: manifest,
-        versionValidator: _versionValidator(processes: host.processes),
-        inventory: const ManagedRuntimeInventory(manifest: manifest),
-      ),
-      fallbackExecutableCandidates: const [],
-    ).provision(host: host, explicitExecutablePath: null);
+    yield* const ManagedRuntimeComposition()
+        .createProvisioner(
+          manifest: manifest,
+          versionValidator: _versionValidator(processes: host.processes),
+          fallbackExecutableCandidates: const [],
+        )
+        .provision(host: host, explicitExecutablePath: null);
   }
 
   @override

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -426,16 +426,12 @@ class const OpenCodePluginDescriptor({
       runInShell: io.Platform.isWindows,
       maxCapturedOutputCharactersPerStream: null,
     );
-    return ManagedRuntimeProvisionService(
+    return const ManagedRuntimeComposition().createProvisioner(
       manifest: manifest,
-      selectionService: ManagedRuntimeSelectionService(
+      versionValidator: RuntimeVersionValidator(
+        commandExecutor: commandExecutor,
         manifest: manifest,
-        versionValidator: RuntimeVersionValidator(
-          commandExecutor: commandExecutor,
-          manifest: manifest,
-          probeTimeout: _versionProbeTimeout,
-        ),
-        inventory: const ManagedRuntimeInventory(manifest: manifest),
+        probeTimeout: _versionProbeTimeout,
       ),
       // OpenCode has no desktop app bundling a CLI.
       fallbackExecutableCandidates: const [],
@@ -681,38 +677,10 @@ class const OpenCodePluginDescriptor({
       // health probe but stalls a REST call must not hang start() under the
       // bridge's cross-instance startup mutex. Past the budget the cold-start
       // keeps running in the background and the plugin starts degraded.
-      final coldStart = api.initialize();
-      var budgetExceeded = false;
-      // The sink keeps a post-budget failure from surfacing as an unhandled
-      // async error once the await below has moved on; the awaited path
-      // observes (and logs) every pre-budget failure itself.
-      unawaited(
-        coldStart.catchError((Object error, StackTrace stackTrace) {
-          if (budgetExceeded) {
-            Log.w("[opencode] cold-start failed after the start budget: $error");
-          }
-        }),
-      );
-      try {
-        await coldStart.timeout(
-          _coldStartBudget,
-          onTimeout: () {
-            budgetExceeded = true;
-            Log.w(
-              "[opencode] cold-start did not finish within ${_coldStartBudget.inSeconds}s — "
-              "starting degraded while it keeps running in the background",
-            );
-          },
-        );
-        if (budgetExceeded) {
-          reporter.markDegradedNow();
-        } else {
-          reporter.markConnected();
-        }
-      } on Object catch (error) {
-        Log.w("[opencode] cold-start did not complete cleanly: $error");
-        reporter.markDegradedNow();
-      }
+      await ManagedRuntimeColdStartService(
+        budget: _coldStartBudget,
+        logTag: "opencode",
+      ).run(coldStart: api.initialize(), reporter: reporter);
     }
 
     // The cold-start is a phase boundary like any other: an abort observed here

--- a/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
@@ -144,15 +144,13 @@ final class const PiPluginDescriptor({
   Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
     if (_explicitBin(host.config) != null) return;
     const manifest = PiRuntimeManifest();
-    yield* ManagedRuntimeProvisionService(
-      manifest: manifest,
-      selectionService: ManagedRuntimeSelectionService(
-        manifest: manifest,
-        versionValidator: _versionValidator(processes: host.processes),
-        inventory: const ManagedRuntimeInventory(manifest: manifest),
-      ),
-      fallbackExecutableCandidates: const [],
-    ).provision(host: host, explicitExecutablePath: null);
+    yield* const ManagedRuntimeComposition()
+        .createProvisioner(
+          manifest: manifest,
+          versionValidator: _versionValidator(processes: host.processes),
+          fallbackExecutableCandidates: const [],
+        )
+        .provision(host: host, explicitExecutablePath: null);
   }
 
   @override

--- a/bridge/sesori_plugin_runtime/lib/sesori_plugin_runtime.dart
+++ b/bridge/sesori_plugin_runtime/lib/sesori_plugin_runtime.dart
@@ -4,6 +4,7 @@ export "src/dynamic_port_candidates.dart";
 export "src/host_json_runtime_ownership_repository.dart";
 export "src/managed_process_service.dart";
 export "src/managed_runtime_bridge_plugin.dart";
+export "src/managed_runtime_cold_start_service.dart";
 export "src/managed_runtime_monitor.dart";
 export "src/managed_runtime_spec.dart";
 export "src/managed_runtime_status_reporter.dart";

--- a/bridge/sesori_plugin_runtime/lib/src/composition/managed_runtime_composition.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/composition/managed_runtime_composition.dart
@@ -2,6 +2,9 @@ import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
 
 import "../provisioning/managed_runtime_cleaner.dart";
 import "../provisioning/managed_runtime_install_service.dart";
+import "../provisioning/managed_runtime_inventory.dart";
+import "../provisioning/managed_runtime_provision_service.dart";
+import "../provisioning/managed_runtime_selection_service.dart";
 import "../provisioning/runtime_install_service.dart";
 import "../provisioning/runtime_manifest.dart";
 import "../provisioning/runtime_version_validator.dart";
@@ -35,6 +38,25 @@ class const ManagedRuntimeComposition() {
       ),
       cleaner: ManagedRuntimeCleaner(runtimeId: manifest.runtimeId),
       assetResolver: assetResolver,
+    );
+  }
+
+  /// The selection graph behind [ManagedRuntimeProvisionService]: PATH and
+  /// [fallbackExecutableCandidates] probed through [versionValidator], then the
+  /// managed inventory for [manifest].
+  ManagedRuntimeProvisionService createProvisioner({
+    required RuntimeManifest manifest,
+    required RuntimeVersionValidator versionValidator,
+    required List<String> fallbackExecutableCandidates,
+  }) {
+    return ManagedRuntimeProvisionService(
+      manifest: manifest,
+      selectionService: ManagedRuntimeSelectionService(
+        manifest: manifest,
+        versionValidator: versionValidator,
+        inventory: ManagedRuntimeInventory(manifest: manifest),
+      ),
+      fallbackExecutableCandidates: fallbackExecutableCandidates,
     );
   }
 }

--- a/bridge/sesori_plugin_runtime/lib/src/managed_runtime_cold_start_service.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/managed_runtime_cold_start_service.dart
@@ -1,0 +1,56 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "managed_runtime_status_reporter.dart";
+
+/// Bounded wait for a managed runtime's cold start (its first handshake).
+///
+/// A backend that passed its readiness probe but stalls the handshake must not
+/// hang `start()` under the bridge's cross-instance startup mutex. The wait is
+/// bounded by [budget]: within it, success reports connected and failure
+/// reports degraded; past it, the plugin starts degraded while the cold start
+/// keeps running in the background and a late failure is logged instead of
+/// surfacing as an unhandled error. The descriptor still owns creating the API,
+/// deciding whether to cold-start at all, and the abort check afterwards.
+class const ManagedRuntimeColdStartService({
+  required final Duration budget,
+  required final String logTag,
+}) {
+  Future<void> run({
+    required Future<void> coldStart,
+    required ManagedRuntimeStatusReporter reporter,
+  }) async {
+    var budgetExceeded = false;
+    // The sink keeps a post-budget failure from surfacing as an unhandled async
+    // error once the await below has moved on; the awaited path observes (and
+    // logs) every pre-budget failure itself.
+    unawaited(
+      coldStart.catchError((Object error, StackTrace stackTrace) {
+        if (budgetExceeded) {
+          Log.w("[$logTag] cold-start failed after the start budget", error, stackTrace);
+        }
+      }),
+    );
+    try {
+      await coldStart.timeout(
+        budget,
+        onTimeout: () {
+          budgetExceeded = true;
+          Log.w(
+            "[$logTag] cold-start did not finish within ${budget.inSeconds}s — "
+            "starting degraded while it keeps running in the background",
+          );
+        },
+      );
+      if (budgetExceeded) {
+        reporter.markDegradedNow();
+      } else {
+        reporter.markConnected();
+      }
+    } on Object catch (error, stackTrace) {
+      Log.w("[$logTag] cold-start did not complete cleanly", error, stackTrace);
+      reporter.markDegradedNow();
+    }
+  }
+}

--- a/bridge/sesori_plugin_runtime/test/managed_runtime_cold_start_service_test.dart
+++ b/bridge/sesori_plugin_runtime/test/managed_runtime_cold_start_service_test.dart
@@ -1,0 +1,54 @@
+import "dart:async";
+
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
+import "package:test/test.dart";
+
+void main() {
+  late PluginStatusController status;
+  late ManagedRuntimeStatusReporter reporter;
+
+  setUp(() {
+    status = PluginStatusController(initial: const PluginStarting());
+    reporter = ManagedRuntimeStatusReporter(
+      status: status,
+      clock: _FixedClock(),
+      degradedDebounce: const Duration(seconds: 5),
+    );
+  });
+
+  const service = ManagedRuntimeColdStartService(budget: Duration(milliseconds: 50), logTag: "test");
+
+  test("a cold start completing within the budget reports connected", () async {
+    await service.run(coldStart: Future<void>.value(), reporter: reporter);
+
+    expect(status.current, isA<PluginReady>());
+  });
+
+  test("a cold start failing within the budget reports degraded without throwing", () async {
+    await service.run(coldStart: Future<void>.error(StateError("handshake refused")), reporter: reporter);
+
+    expect(status.current, isA<PluginDegraded>());
+  });
+
+  test("a cold start exceeding the budget reports degraded and absorbs its late failure", () async {
+    final coldStart = Completer<void>();
+
+    await service.run(coldStart: coldStart.future, reporter: reporter);
+    expect(status.current, isA<PluginDegraded>());
+
+    // The background cold start failing later must not surface as an
+    // unhandled error; the sink logs it instead.
+    coldStart.completeError(StateError("late failure"));
+    await pumpEventQueue();
+    expect(status.current, isA<PluginDegraded>());
+  });
+}
+
+class _FixedClock() implements ServerClock {
+  @override
+  DateTime now() => DateTime.utc(2026, 9, 5);
+
+  @override
+  Future<void> delay({required Duration duration}) => Completer<void>().future;
+}


### PR DESCRIPTION
## Complexity

⚙️ moderate — one more composition method used by seven descriptors, plus a small lifecycle helper replacing two duplicated bounded waits in Codex and OpenCode.

## What

- `ManagedRuntimeComposition.createProvisioner` builds `ManagedRuntimeSelectionService` and the managed inventory from a descriptor's manifest, version validator, and fallback executable candidates, returning `ManagedRuntimeProvisionService` through its unchanged constructor. Codex, OpenCode, Copilot, Cursor, Pi, OMP, and DeepSeek call it. Each keeps its own version probe and output limits, explicit-bin short-circuit, fallback ordering, and exact-managed-version policy; no default executor is introduced.
- New `ManagedRuntimeColdStartService` in the runtime package: immutable budget and log tag; `run` receives the already-started initialize future and the status reporter and owns only the budgeted wait, the connected or degraded report, and the post-budget failure sink, with one invocation-local `budgetExceeded`. Codex and OpenCode call it in place of their duplicated blocks. Descriptors keep API creation, OpenCode's condition for waiting at all, and the unconditional abort-rollback check after the wait, including OpenCode's skipped-wait path. Timeout durations and recovery behavior are unchanged.
- Unit tests cover a cold start completing within budget, failing within budget, and exceeding the budget with a late failure absorbed by the sink. Runtime and all seven descriptor suites pass unchanged.

## Why

Step 13/25 of `.plan/active/periodic-cleanup`. The same selection graph and the same bounded wait existed as copies, so a policy fix in one place could miss another. Both now have one owner while each plugin's real differences stay visible in its descriptor.

## Risk and test focus

Medium lifecycle risk, bridge only. Impacted: runtime provisioning precedence for every managed plugin (explicit override, PATH, fallback candidates, managed install) and Codex and OpenCode start under a slow or failing handshake. Most valuable checks: headless inspection and provisioning for all seven plugins on macOS arm64; a Codex or OpenCode start where the handshake stalls past the budget shows degraded and later recovers; an abort during cold start rolls back the owned runtime, including OpenCode's failed-attach path.

No wire, runtime pin, installation format, authentication, capability, or database change.

## Expected result

- User-visible: none.
- Database/persisted data: none.
- Internal: one provisioning composition point and one cold-start owner; seven descriptors shrink to their real inputs.

## Verification

- `dart analyze` for the runtime package and all seven plugin packages: no issues.
- `dart test` for the runtime package (including the new suite) and the descriptor or runtime suites of all seven plugins: all pass after rebasing onto merged main.
- Architecture implementation review (sub-agent, single commit): approved, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shares runtime provisioning and bounded cold-start waiting so the same selection graph and handshake budget no longer exist as copies across plugins. No user-visible behavior changes; timeout durations and recovery behavior stay the same.

- Adds `ManagedRuntimeComposition.createProvisioner`, used by Codex, OpenCode, Copilot, Cursor, Pi, OMP, and DeepSeek; each keeps its own version probe, output limits, explicit-bin short-circuit, fallback ordering, and version policy.
- Adds `ManagedRuntimeColdStartService`, replacing the duplicated budgeted wait in Codex and OpenCode; descriptors keep API creation, the decision to wait at all, and the abort rollback check.
- Adds unit tests covering completion within budget, failure within budget, and budget exhaustion with a late failure absorbed by the sink.
- No wire, runtime pin, installation format, authentication, or database changes.

<sup>Written for commit bb93c27adcddd1633551679248715dc089b019ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

