### PR TITLE
🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -20,8 +20,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 10/25 | ⚙️ [periodic-cleanup] client: share native thumbnail storage [step 10/25] | Merged | [#1318](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1318) |
 | 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | Merged | [#1320](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1320) |
 | 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | Merged | [#1322](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1322) |
-| 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | In review | [#1323](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1323) |
-| 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | In progress (local, awaiting step 13 merge) | — |
+| 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Merged | [#1323](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1323) |
+| 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | In review | [#1324](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1324) |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Proposed | — |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Proposed | — |
 | 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -21,7 +21,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | Merged | [#1320](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1320) |
 | 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | Merged | [#1322](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1322) |
 | 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | In review | [#1323](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1323) |
-| 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Proposed | — |
+| 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | In progress (local, awaiting step 13 merge) | — |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Proposed | — |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Proposed | — |
 | 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Proposed | — |
@@ -256,3 +256,17 @@ asked to start working the plan; steps execute in order from step 2.
   Descriptors keep API creation, OpenCode's condition for waiting at all, and
   the unconditional abort-rollback check. Unit tests cover completion, failure
   and budget exhaustion with a late failure; descriptor suites pass unchanged.
+
+## Step 14 execution — 2026-09-05
+
+- `WorktreeService.create`: both candidate loops share one attempt helper that
+  returns taken / failed / created; the slug loop moves on after a failed
+  creation while the suffix loop still stops after one, and collision checks,
+  candidate order, bounds and fallback outcome are unchanged.
+- `CodexSessionService`: `_prepareTurn` resumes when needed and derives model,
+  mode and effort once; `startTurn` and `sendCommand` keep exactly one forced
+  resume retry on `CodexThreadNotFoundException`, recompute through it, and
+  retain their different arguments and result shapes.
+- Rollout tool mapper: one `_JsLexicalState` owns the string/comment cursor
+  advance used by both scanners; quoted escapes and line/block comments are
+  handled identically. Owning suites pass unchanged; no new tests were needed.

--- a/bridge/app/lib/src/services/worktree_service.dart
+++ b/bridge/app/lib/src/services/worktree_service.dart
@@ -216,71 +216,44 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
     final colorOffset = _random.nextInt(_workspaceColors.length);
     final animalOffset = _random.nextInt(_workspaceAnimals.length);
 
-    // Advancing both curated lists keeps every bounded candidate distinct.
+    Future<_WorktreeCandidateAttempt> attemptCandidate(String branchName) => _attemptWorktreeCandidate(
+      projectPath: projectPath,
+      branchName: branchName,
+      startPoint: startPoint,
+      baseBranch: baseBranch,
+      baseCommit: baseCommit,
+    );
+
+    // Advancing both curated lists keeps every bounded candidate distinct. A
+    // failed creation on an available slug moves on to the next slug.
     for (var attempt = 0; attempt < _maxWorktreeCreationAttempts; attempt++) {
-      final branchName = _workspaceSlug(
-        colorIndex: (colorOffset + attempt) % _workspaceColors.length,
-        animalIndex: (animalOffset + attempt) % _workspaceAnimals.length,
+      final attempted = await attemptCandidate(
+        _workspaceSlug(
+          colorIndex: (colorOffset + attempt) % _workspaceColors.length,
+          animalIndex: (animalOffset + attempt) % _workspaceAnimals.length,
+        ),
       );
-      final worktreePath = "$projectPath/$_worktreeDir/$branchName";
-
-      if (await _worktreeRepository.branchExists(
-        projectPath: projectPath,
-        branchName: branchName,
-      )) {
-        continue;
-      }
-      if (_worktreeRepository.worktreePathExists(worktreePath: worktreePath)) {
-        continue;
-      }
-
-      final created = await _worktreeRepository.createWorktree(
-        projectPath: projectPath,
-        worktreePath: worktreePath,
-        branchName: branchName,
-        startPoint: startPoint,
-      );
-
-      if (created) {
-        return WorktreeSuccess(
-          path: worktreePath,
-          branchName: branchName,
-          baseBranch: baseBranch,
-          baseCommit: baseCommit,
-        );
-      }
+      if (attempted case _WorktreeCandidateCreated(:final success)) return success;
     }
 
     final lastSlug = _workspaceSlug(
       colorIndex: (colorOffset + _maxWorktreeCreationAttempts - 1) % _workspaceColors.length,
       animalIndex: (animalOffset + _maxWorktreeCreationAttempts - 1) % _workspaceAnimals.length,
     );
+    // Suffixed candidates skip taken names but stop after one failed creation
+    // on an available name: git itself refused, so another suffix will not help.
     final suffixOffset = _random.nextInt(_suffixSpace);
     for (var suffixAttempt = 0; suffixAttempt < _maxWorktreeCreationAttempts; suffixAttempt++) {
-      final branchName = "$lastSlug-${_hexSuffix((suffixOffset + suffixAttempt) % _suffixSpace)}";
-      final worktreePath = "$projectPath/$_worktreeDir/$branchName";
-      if (await _worktreeRepository.branchExists(
-        projectPath: projectPath,
-        branchName: branchName,
-      )) {
-        continue;
-      }
-      if (_worktreeRepository.worktreePathExists(worktreePath: worktreePath)) {
-        continue;
-      }
-      final created = await _worktreeRepository.createWorktree(
-        projectPath: projectPath,
-        worktreePath: worktreePath,
-        branchName: branchName,
-        startPoint: startPoint,
+      final attempted = await attemptCandidate(
+        "$lastSlug-${_hexSuffix((suffixOffset + suffixAttempt) % _suffixSpace)}",
       );
-      if (created) {
-        return WorktreeSuccess(
-          path: worktreePath,
-          branchName: branchName,
-          baseBranch: baseBranch,
-          baseCommit: baseCommit,
-        );
+      switch (attempted) {
+        case _WorktreeCandidateCreated(:final success):
+          return success;
+        case _WorktreeCandidateTaken():
+          continue;
+        case _WorktreeCandidateFailed():
+          break;
       }
       break;
     }
@@ -296,6 +269,36 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
 
   static String _workspaceSlug({required int colorIndex, required int animalIndex}) =>
       "${_workspaceColors[colorIndex]}-${_workspaceAnimals[animalIndex]}";
+
+  /// Creates the worktree for [branchName] unless the branch or path is taken.
+  Future<_WorktreeCandidateAttempt> _attemptWorktreeCandidate({
+    required String projectPath,
+    required String branchName,
+    required String startPoint,
+    required String baseBranch,
+    required String baseCommit,
+  }) async {
+    final worktreePath = "$projectPath/$_worktreeDir/$branchName";
+    if (await _worktreeRepository.branchExists(projectPath: projectPath, branchName: branchName) ||
+        _worktreeRepository.worktreePathExists(worktreePath: worktreePath)) {
+      return const _WorktreeCandidateTaken();
+    }
+    final created = await _worktreeRepository.createWorktree(
+      projectPath: projectPath,
+      worktreePath: worktreePath,
+      branchName: branchName,
+      startPoint: startPoint,
+    );
+    if (!created) return const _WorktreeCandidateFailed();
+    return _WorktreeCandidateCreated(
+      success: WorktreeSuccess(
+        path: worktreePath,
+        branchName: branchName,
+        baseBranch: baseBranch,
+        baseCommit: baseCommit,
+      ),
+    );
+  }
 
   Future<GeneratedBranchRenameResult> renameGeneratedBranch({
     required String worktreePath,
@@ -314,9 +317,9 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
       return GeneratedBranchRenameSkipped(reason: GeneratedBranchRenameSkipReason.initialBranchChanged);
     }
     if (await _worktreeRepository.hasUpstream(
-      worktreePath: worktreePath,
-      branchName: initialBranchName,
-    ) ||
+          worktreePath: worktreePath,
+          branchName: initialBranchName,
+        ) ||
         await _worktreeRepository.hasRemoteBranch(
           worktreePath: worktreePath,
           branchName: initialBranchName,
@@ -457,3 +460,14 @@ class WorktreeService({required final WorktreeRepository _worktreeRepository}) {
     );
   }
 }
+
+/// Outcome of one generated worktree candidate.
+sealed class const _WorktreeCandidateAttempt();
+
+/// The branch or path already exists; the candidate was never tried.
+final class const _WorktreeCandidateTaken() extends _WorktreeCandidateAttempt;
+
+/// The candidate was available but git refused to create the worktree.
+final class const _WorktreeCandidateFailed() extends _WorktreeCandidateAttempt;
+
+final class const _WorktreeCandidateCreated({required final WorktreeSuccess success}) extends _WorktreeCandidateAttempt;

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -696,46 +696,13 @@ final RegExp _codeModeCommandInvocationPrefixPattern = RegExp(
 
 bool _hasSingleCodeModeCommandInvocation(String source) {
   var invocationCount = 0;
-  int? quote;
-  var escaped = false;
-  var inLineComment = false;
-  var inBlockComment = false;
+  final lexical = _JsLexicalState();
   for (var index = 0; index < source.length; index++) {
     final current = source.codeUnitAt(index);
     final next = index + 1 < source.length ? source.codeUnitAt(index + 1) : null;
-    if (inLineComment) {
-      if (current == 0x0A || current == 0x0D) inLineComment = false;
-      continue;
-    }
-    if (inBlockComment) {
-      if (current == 0x2A && next == 0x2F) {
-        inBlockComment = false;
-        index++;
-      }
-      continue;
-    }
-    if (quote != null) {
-      if (escaped) {
-        escaped = false;
-      } else if (current == 0x5C) {
-        escaped = true;
-      } else if (current == quote) {
-        quote = null;
-      }
-      continue;
-    }
-    if (current == 0x2F && next == 0x2F) {
-      inLineComment = true;
-      index++;
-      continue;
-    }
-    if (current == 0x2F && next == 0x2A) {
-      inBlockComment = true;
-      index++;
-      continue;
-    }
-    if (current == 0x22 || current == 0x27 || current == 0x60) {
-      quote = current;
+    final skipped = lexical.skipNonCode(current: current, next: next);
+    if (skipped != null) {
+      index += skipped;
       continue;
     }
     final invocation = _codeModeCommandInvocationPrefixPattern.matchAsPrefix(
@@ -825,46 +792,13 @@ int? _matchingInvocationEnd({
   }
 
   var depth = 0;
-  int? quote;
-  var escaped = false;
-  var inLineComment = false;
-  var inBlockComment = false;
+  final lexical = _JsLexicalState();
   for (var index = openParenthesisIndex; index < source.length; index++) {
     final current = source.codeUnitAt(index);
     final next = index + 1 < source.length ? source.codeUnitAt(index + 1) : null;
-    if (inLineComment) {
-      if (current == 0x0A || current == 0x0D) inLineComment = false;
-      continue;
-    }
-    if (inBlockComment) {
-      if (current == 0x2A && next == 0x2F) {
-        inBlockComment = false;
-        index++;
-      }
-      continue;
-    }
-    if (quote != null) {
-      if (escaped) {
-        escaped = false;
-      } else if (current == 0x5C) {
-        escaped = true;
-      } else if (current == quote) {
-        quote = null;
-      }
-      continue;
-    }
-    if (current == 0x2F && next == 0x2F) {
-      inLineComment = true;
-      index++;
-      continue;
-    }
-    if (current == 0x2F && next == 0x2A) {
-      inBlockComment = true;
-      index++;
-      continue;
-    }
-    if (current == 0x22 || current == 0x27 || current == 0x60) {
-      quote = current;
+    final skipped = lexical.skipNonCode(current: current, next: next);
+    if (skipped != null) {
+      index += skipped;
       continue;
     }
     if (index > openParenthesisIndex && _nestedToolInvocationPrefixPattern.matchAsPrefix(source, index) != null) {
@@ -878,4 +812,54 @@ int? _matchingInvocationEnd({
     }
   }
   return null;
+}
+
+/// Tracks whether a JavaScript scan is inside a string or comment so callers
+/// only inspect code. Shared by both rollout scanners so quoted escapes and
+/// line/block comments are recognised identically.
+final class _JsLexicalState() {
+  int? _quote;
+  var _escaped = false;
+  var _inLineComment = false;
+  var _inBlockComment = false;
+
+  /// Consumes [current] (with [next] as lookahead). Returns how many extra
+  /// code units the caller must skip (0 or 1) when the character is not code,
+  /// or null when [current] is code the caller should inspect.
+  int? skipNonCode({required int current, required int? next}) {
+    if (_inLineComment) {
+      if (current == 0x0A || current == 0x0D) _inLineComment = false;
+      return 0;
+    }
+    if (_inBlockComment) {
+      if (current == 0x2A && next == 0x2F) {
+        _inBlockComment = false;
+        return 1;
+      }
+      return 0;
+    }
+    if (_quote case final quote?) {
+      if (_escaped) {
+        _escaped = false;
+      } else if (current == 0x5C) {
+        _escaped = true;
+      } else if (current == quote) {
+        _quote = null;
+      }
+      return 0;
+    }
+    if (current == 0x2F && next == 0x2F) {
+      _inLineComment = true;
+      return 1;
+    }
+    if (current == 0x2F && next == 0x2A) {
+      _inBlockComment = true;
+      return 1;
+    }
+    if (current == 0x22 || current == 0x27 || current == 0x60) {
+      _quote = current;
+      return 0;
+    }
+    return null;
+  }
 }

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -511,63 +511,48 @@ class CodexSessionService({
     required String? effort,
     required CodexCollaborationMode? collaborationMode,
   }) async {
-    var resumed = await resumeThreadIfNeeded(threadId: threadId, force: false);
-    var turnModel = _resolveTurnModel(
+    Future<({CodexThreadRecord? resumedThread, String? resolvedModel, String? turnId, bool started})> start(
+      _PreparedTurn prepared,
+    ) async {
+      final turnId = await _connectedThreadRepository.startTurn(
+        threadId: threadId,
+        parts: parts,
+        clientUserMessageId: clientUserMessageId,
+        model: prepared.model,
+        effort: prepared.effort,
+        collaborationMode: prepared.mode,
+      );
+      if (turnId != null) {
+        _rememberThreadModel(threadId: threadId, model: prepared.model);
+      }
+      return (
+        resumedThread: prepared.resumedThread,
+        resolvedModel: prepared.model,
+        turnId: turnId,
+        started: turnId != null,
+      );
+    }
+
+    final prepared = await _prepareTurn(
       threadId: threadId,
-      requestedModel: model,
+      forceResume: false,
+      model: model,
+      effort: effort,
       collaborationMode: collaborationMode,
     );
-    var turnMode = _resolveCollaborationMode(
-      model: turnModel,
-      collaborationMode: collaborationMode,
-    );
-    var turnEffort = effort ?? turnMode?.defaultReasoningEffort;
     try {
-      final turnId = await _connectedThreadRepository.startTurn(
-        threadId: threadId,
-        parts: parts,
-        clientUserMessageId: clientUserMessageId,
-        model: turnModel,
-        effort: turnEffort,
-        collaborationMode: turnMode,
-      );
-      if (turnId != null) {
-        _rememberThreadModel(threadId: threadId, model: turnModel);
-      }
-      return (
-        resumedThread: resumed,
-        resolvedModel: turnModel,
-        turnId: turnId,
-        started: turnId != null,
-      );
+      return await start(prepared);
     } on CodexThreadNotFoundException {
-      resumed = await resumeThreadIfNeeded(threadId: threadId, force: true);
-      turnModel = _resolveTurnModel(
-        threadId: threadId,
-        requestedModel: model,
-        collaborationMode: collaborationMode,
-      );
-      turnMode = _resolveCollaborationMode(
-        model: turnModel,
-        collaborationMode: collaborationMode,
-      );
-      turnEffort = effort ?? turnMode?.defaultReasoningEffort;
-      final turnId = await _connectedThreadRepository.startTurn(
-        threadId: threadId,
-        parts: parts,
-        clientUserMessageId: clientUserMessageId,
-        model: turnModel,
-        effort: turnEffort,
-        collaborationMode: turnMode,
-      );
-      if (turnId != null) {
-        _rememberThreadModel(threadId: threadId, model: turnModel);
-      }
-      return (
-        resumedThread: resumed,
-        resolvedModel: turnModel,
-        turnId: turnId,
-        started: turnId != null,
+      // Exactly one forced-resume retry; the resume may change the thread's
+      // model, so everything derived from it is recomputed.
+      return await start(
+        await _prepareTurn(
+          threadId: threadId,
+          forceResume: true,
+          model: model,
+          effort: effort,
+          collaborationMode: collaborationMode,
+        ),
       );
     }
   }
@@ -581,57 +566,69 @@ class CodexSessionService({
     required String? effort,
     required CodexCollaborationMode? collaborationMode,
   }) async {
-    var resumed = await resumeThreadIfNeeded(threadId: threadId, force: false);
-    var turnModel = _resolveTurnModel(
+    Future<String?> dispatch(_PreparedTurn prepared) => _dispatchCommand(
+      threadId: threadId,
+      command: command,
+      arguments: arguments,
+      clientUserMessageId: clientUserMessageId,
+      model: prepared.model,
+      effort: prepared.effort,
+      collaborationMode: prepared.mode,
+    );
+
+    var prepared = await _prepareTurn(
+      threadId: threadId,
+      forceResume: false,
+      model: model,
+      effort: effort,
+      collaborationMode: collaborationMode,
+    );
+    String? turnId;
+    try {
+      turnId = await dispatch(prepared);
+    } on CodexThreadNotFoundException {
+      // Exactly one forced-resume retry; the resume may change the thread's
+      // model, so everything derived from it is recomputed.
+      prepared = await _prepareTurn(
+        threadId: threadId,
+        forceResume: true,
+        model: model,
+        effort: effort,
+        collaborationMode: collaborationMode,
+      );
+      turnId = await dispatch(prepared);
+    }
+    if (command != compactionCommandName) {
+      _rememberThreadModel(threadId: threadId, model: prepared.model);
+    }
+    return (
+      resumedThread: prepared.resumedThread,
+      resolvedModel: command == compactionCommandName ? null : prepared.model,
+      turnId: turnId,
+    );
+  }
+
+  /// Resumes the thread when needed and derives the model, collaboration mode
+  /// and effort a turn or command runs with.
+  Future<_PreparedTurn> _prepareTurn({
+    required String threadId,
+    required bool forceResume,
+    required String? model,
+    required String? effort,
+    required CodexCollaborationMode? collaborationMode,
+  }) async {
+    final resumedThread = await resumeThreadIfNeeded(threadId: threadId, force: forceResume);
+    final turnModel = _resolveTurnModel(
       threadId: threadId,
       requestedModel: model,
       collaborationMode: collaborationMode,
     );
-    var turnMode = _resolveCollaborationMode(
-      model: turnModel,
-      collaborationMode: collaborationMode,
-    );
-    var turnEffort = effort ?? turnMode?.defaultReasoningEffort;
-    String? turnId;
-    try {
-      turnId = await _dispatchCommand(
-        threadId: threadId,
-        command: command,
-        arguments: arguments,
-        clientUserMessageId: clientUserMessageId,
-        model: turnModel,
-        effort: turnEffort,
-        collaborationMode: turnMode,
-      );
-    } on CodexThreadNotFoundException {
-      resumed = await resumeThreadIfNeeded(threadId: threadId, force: true);
-      turnModel = _resolveTurnModel(
-        threadId: threadId,
-        requestedModel: model,
-        collaborationMode: collaborationMode,
-      );
-      turnMode = _resolveCollaborationMode(
-        model: turnModel,
-        collaborationMode: collaborationMode,
-      );
-      turnEffort = effort ?? turnMode?.defaultReasoningEffort;
-      turnId = await _dispatchCommand(
-        threadId: threadId,
-        command: command,
-        arguments: arguments,
-        clientUserMessageId: clientUserMessageId,
-        model: turnModel,
-        effort: turnEffort,
-        collaborationMode: turnMode,
-      );
-    }
-    if (command != compactionCommandName) {
-      _rememberThreadModel(threadId: threadId, model: turnModel);
-    }
+    final turnMode = _resolveCollaborationMode(model: turnModel, collaborationMode: collaborationMode);
     return (
-      resumedThread: resumed,
-      resolvedModel: command == compactionCommandName ? null : turnModel,
-      turnId: turnId,
+      resumedThread: resumedThread,
+      model: turnModel,
+      mode: turnMode,
+      effort: effort ?? turnMode?.defaultReasoningEffort,
     );
   }
 
@@ -946,3 +943,10 @@ class CodexSessionService({
     return repository;
   }
 }
+
+typedef _PreparedTurn = ({
+  CodexThreadRecord? resumedThread,
+  String? model,
+  CodexCollaborationMode? mode,
+  String? effort,
+});


### PR DESCRIPTION
## Complexity

🌿 straightforward — three local folds inside their existing owning classes, no new abstraction, behavior preserved by the owning suites.

## What

- `WorktreeService.create`: both candidate loops call one attempt helper that returns taken, failed, or created with the constructed `WorktreeSuccess`. The curated-slug loop still moves on after a failed creation, the suffix loop still stops after one failed creation on an available name, and collision checks, candidate order, attempt bounds, and the fallback outcome are unchanged.
- `CodexSessionService`: a `_prepareTurn` helper resumes the thread when needed and derives model, collaboration mode, and effort once. `startTurn` and `sendCommand` use it for the first attempt and for their exactly-one forced-resume retry on `CodexThreadNotFoundException`, recomputing everything derived from the resumed thread, while keeping their different arguments and result shapes.
- Codex rollout tool mapper: one `_JsLexicalState` owns the string and comment cursor advance shared by both scanners, so quoted escapes and line and block comments are recognised identically.

## Why

Step 14/25 of `.plan/active/periodic-cleanup`. Each pair of copies could drift on a policy detail (which loop stops when, what a resume recomputes, how a quote escape is handled). One owner per algorithm makes the remaining differences deliberate and visible.

## Risk and test focus

Moderate logic risk, bridge only. Impacted: dedicated worktree creation and generated-branch suffixing, Codex turn and command dispatch after a lost thread, and Codex rollout tool parsing. Most valuable checks: create a dedicated Codex session and confirm the worktree and branch appear; send a prompt after Codex forgets the thread and confirm exactly one resume; load a Codex history whose tool calls include quoted parentheses or comments.

No product behavior, wire, database, or persistent-state change.

## Expected result

- User-visible: none.
- Database/persisted data: none.
- Internal: three duplicated algorithms have one owner each. No retry service, callback abstraction, or shared parser package was introduced.

## Verification

- `dart analyze` for the worktree service file and the Codex plugin package: no issues (the full bridge workspace analyzer currently crashes; touched packages were analyzed directly).
- `dart test` for the worktree service suite and the full Codex plugin suite (427 tests before rebase; owning suites re-run after rebasing onto merged main): all pass.
- Architecture review: not run, per the plan's exemption for ordinary local method folds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folds three repeated worktree and Codex algorithms into single per-class helpers with no behavior change. No user-visible, wire, database, or persisted-state impact.

**Refactors**
- `WorktreeService.create` shares one attempt helper between its two candidate loops; the curated-slug loop still moves on after a failed creation while the suffix loop still stops after one.
- `CodexSessionService._prepareTurn` resumes when needed and derives model, collaboration mode, and effort once, while `startTurn` and `sendCommand` keep their distinct arguments and result shapes.
- The Codex rollout tool mapper shares one `_JsLexicalState` so quoted escapes and line and block comments are recognized identically.

<sup>Written for commit c10b89d390776e081ce724c2f90b5938187e8370. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

