### PR TITLE
🌿 bridge: fail a download that cannot open its destination instead of killing the bridge

### DIFF
--- a/bridge/sesori_bridge_foundation/lib/src/binary_download_client.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/binary_download_client.dart
@@ -14,27 +14,31 @@ const Duration _kDownloadInactivityTimeout = Duration(seconds: 30);
 ///   request timeout, or a dropped connection mid-body). Stay quiet and retry.
 /// - [failed]: a genuine failure (a non-retryable status such as 404, or an
 ///   unexpected local error) that will not fix itself on the next attempt.
-enum DownloadFailureKind() { network, failed }
+enum DownloadFailureKind() {
+  network,
+  failed,
+}
 
 /// Raised by [BinaryDownloadClient.download] (as a stream error) when a download
 /// cannot complete. Carries a neutral [kind] so each consumer maps it to its own
 /// result type at its boundary rather than the client knowing about them.
 class const DownloadException({
-    required final DownloadFailureKind kind,
-    required final String message,
-    final int? statusCode,
-  }) implements Exception {
+  required final DownloadFailureKind kind,
+  required final String message,
+  final int? statusCode,
+}) implements Exception {
   @override
   String toString() => "DownloadException(${kind.name}, status: $statusCode): $message";
 }
 
 /// A byte-progress update emitted while a download streams to disk.
 class const DownloadProgress({
-    required final int receivedBytes,
-    /// Total expected bytes from `Content-Length`, or `null` when the server did
+  required final int receivedBytes,
+
+  /// Total expected bytes from `Content-Length`, or `null` when the server did
   /// not advertise a length (progress is then indeterminate).
   required final int? totalBytes,
-  }) {
+}) {
   /// Fraction in `[0, 1]`, or `null` when the total size is unknown.
   double? get fraction {
     final int? total = totalBytes;
@@ -52,11 +56,10 @@ class const DownloadProgress({
 /// per body chunk, completes when the file is fully written, and raises a
 /// [DownloadException] (carrying a neutral [DownloadFailureKind]) on failure.
 class BinaryDownloadClient({
-    required final http.Client _httpClient,
-    final Duration _requestTimeout = _kDownloadRequestTimeout,
-    final Duration _streamInactivityTimeout = _kDownloadInactivityTimeout,
-  }) {
-
+  required final http.Client _httpClient,
+  final Duration _requestTimeout = _kDownloadRequestTimeout,
+  final Duration _streamInactivityTimeout = _kDownloadInactivityTimeout,
+}) {
   Stream<DownloadProgress> download({
     required String url,
     required String destinationPath,
@@ -70,15 +73,24 @@ class BinaryDownloadClient({
     try {
       response = await _httpClient.send(request).timeout(_requestTimeout);
     } on TimeoutException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection timed out: ${error.toString()}");
+      throw DownloadException(
+        kind: DownloadFailureKind.network,
+        message: "Download connection timed out: ${error.toString()}",
+      );
     } on SocketException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection failed: ${error.toString()}");
+      throw DownloadException(
+        kind: DownloadFailureKind.network,
+        message: "Download connection failed: ${error.toString()}",
+      );
     } on HttpException catch (error) {
       throw DownloadException(kind: DownloadFailureKind.network, message: "Download HTTP error: ${error.toString()}");
     } on http.ClientException catch (error) {
       throw DownloadException(kind: DownloadFailureKind.network, message: "Download client error: ${error.toString()}");
     } on Object catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.failed, message: "Download failed to start: ${error.toString()}");
+      throw DownloadException(
+        kind: DownloadFailureKind.failed,
+        message: "Download failed to start: ${error.toString()}",
+      );
     }
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -92,55 +104,79 @@ class BinaryDownloadClient({
     final int? totalBytes = response.contentLength;
     // Opening the destination is part of the contract too: a filesystem error
     // here is a failed download, not a raw FileSystemException.
-    final IOSink sink;
+    //
+    // Opened eagerly as a RandomAccessFile rather than through openWrite():
+    // an IOSink defers the real open until its first write, so a permission,
+    // path, or read-only-volume error escaped this try as an unhandled
+    // asynchronous error inside the sink and took the isolate down instead of
+    // failing the download.
+    final RandomAccessFile file;
     try {
-      sink = File(destinationPath).openWrite();
+      file = File(destinationPath).openSync(mode: FileMode.write);
     } on Object catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.failed, message: "Could not open download destination: ${error.toString()}");
+      throw DownloadException(
+        kind: DownloadFailureKind.failed,
+        message: "Could not open download destination: ${error.toString()}",
+      );
     }
 
     var receivedBytes = 0;
     var bodyCompleted = false;
     try {
       await for (final List<int> chunk in response.stream.timeout(_streamInactivityTimeout)) {
-        sink.add(chunk);
+        // Awaited per chunk so a write failure (disk full, quota, revoked
+        // permission) is raised into this try instead of into the file's own
+        // asynchronous machinery.
+        await file.writeFrom(chunk);
         receivedBytes += chunk.length;
         yield DownloadProgress(receivedBytes: receivedBytes, totalBytes: totalBytes);
       }
       bodyCompleted = true;
     } on TimeoutException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download stream stalled: ${error.toString()}");
+      throw DownloadException(
+        kind: DownloadFailureKind.network,
+        message: "Download stream stalled: ${error.toString()}",
+      );
     } on SocketException catch (error) {
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection failed: ${error.toString()}");
+      throw DownloadException(
+        kind: DownloadFailureKind.network,
+        message: "Download connection failed: ${error.toString()}",
+      );
     } on HttpException catch (error) {
       throw DownloadException(kind: DownloadFailureKind.network, message: "Download HTTP error: ${error.toString()}");
     } on http.ClientException catch (error) {
       // A connection reset/drop while reading the body (after a 2xx) is the same
       // transient outage class as a pre-response failure — keep it retryable.
-      throw DownloadException(kind: DownloadFailureKind.network, message: "Download connection dropped: ${error.toString()}");
+      throw DownloadException(
+        kind: DownloadFailureKind.network,
+        message: "Download connection dropped: ${error.toString()}",
+      );
     } on Object catch (error) {
       throw DownloadException(kind: DownloadFailureKind.failed, message: "Download failed: ${error.toString()}");
     } finally {
       // The finally also runs when the consumer cancels the subscription
-      // mid-stream, so the sink is always closed — no leaked handle or locked
+      // mid-stream, so the file is always closed — no leaked handle or locked
       // partial file on an abort/retry.
       if (bodyCompleted) {
-        // Success: a close failure means the on-disk file may be truncated
-        // (buffered writes lost to a disk-full/quota error), so it must fail the
-        // download rather than be silently swallowed. There is no in-flight
-        // exception here, so throwing from finally surfaces it as the result.
+        // Success: a close failure means the on-disk file may be incomplete, so
+        // it must fail the download rather than be silently swallowed. There is
+        // no in-flight exception here, so throwing from finally surfaces it as
+        // the result.
         try {
-          await sink.close();
+          await file.close();
         } on Object catch (error) {
-          throw DownloadException(kind: DownloadFailureKind.failed, message: "Could not finalize download: ${error.toString()}");
+          throw DownloadException(
+            kind: DownloadFailureKind.failed,
+            message: "Could not finalize download: ${error.toString()}",
+          );
         }
       } else {
         // Error or cancellation: close quietly so a teardown failure never masks
         // the in-flight error (and cancellation produces no error to mask).
         try {
-          await sink.close();
+          await file.close();
         } on Object catch (error, stackTrace) {
-          Log.w("BinaryDownloadClient: sink close failed during teardown", error, stackTrace);
+          Log.w("BinaryDownloadClient: destination close failed during teardown", error, stackTrace);
         }
       }
     }

--- a/bridge/sesori_bridge_foundation/lib/src/binary_download_client.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/binary_download_client.dart
@@ -94,6 +94,7 @@ class BinaryDownloadClient({
     }
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
+      await _releaseUnreadBody(response);
       throw DownloadException(
         kind: _isRetryableHttpStatus(response.statusCode) ? DownloadFailureKind.network : DownloadFailureKind.failed,
         message: "Download request to $url failed with status ${response.statusCode}",
@@ -114,6 +115,7 @@ class BinaryDownloadClient({
     try {
       file = File(destinationPath).openSync(mode: FileMode.write);
     } on Object catch (error) {
+      await _releaseUnreadBody(response);
       throw DownloadException(
         kind: DownloadFailureKind.failed,
         message: "Could not open download destination: ${error.toString()}",
@@ -179,6 +181,20 @@ class BinaryDownloadClient({
           Log.w("BinaryDownloadClient: destination close failed during teardown", error, stackTrace);
         }
       }
+    }
+  }
+
+  /// Releases the connection behind a response whose body will not be read.
+  ///
+  /// The client can outlive a single download — the bridge shares one across the
+  /// relay, the GitHub releases API, and the updater until shutdown — so an
+  /// unconsumed body would hold a pooled connection for the process lifetime.
+  /// Cancelling rather than draining avoids pulling down a body being discarded.
+  Future<void> _releaseUnreadBody(http.StreamedResponse response) async {
+    try {
+      await response.stream.listen(null).cancel();
+    } on Object catch (error, stackTrace) {
+      Log.w("BinaryDownloadClient: could not release an unread response body", error, stackTrace);
     }
   }
 

--- a/bridge/sesori_bridge_foundation/test/binary_download_client_test.dart
+++ b/bridge/sesori_bridge_foundation/test/binary_download_client_test.dart
@@ -102,6 +102,32 @@ void main() {
     );
   }, skip: Platform.isWindows ? "POSIX permission bits do not gate writes on Windows" : null);
 
+  test("a body that will not be read is released rather than left holding its connection", () async {
+    final tempDir = await Directory.systemTemp.createTemp("binary-download-client");
+    addTearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    var cancelled = false;
+    final controller = StreamController<List<int>>(onCancel: () => cancelled = true);
+    controller.add(const [1, 2, 3]);
+    final client = MockClient.streaming((_, _) async => http.StreamedResponse(controller.stream, 404));
+
+    await expectLater(
+      BinaryDownloadClient(httpClient: client)
+          .download(
+            url: "https://example.test/asset.tar.gz",
+            destinationPath: p.join(tempDir.path, "asset.tar.gz"),
+          )
+          .toList(),
+      throwsA(isA<DownloadException>()),
+    );
+
+    // The client outlives one download at some call sites, so an unread body
+    // must not keep its connection alive.
+    expect(cancelled, isTrue);
+  });
+
   test("a connection-phase failure is wrapped as a network DownloadException", () async {
     final client = _SendErrorClient(const SocketException("connection refused"));
     await expectLater(

--- a/bridge/sesori_bridge_foundation/test/binary_download_client_test.dart
+++ b/bridge/sesori_bridge_foundation/test/binary_download_client_test.dart
@@ -61,6 +61,47 @@ void main() {
     expect(progress.last.fraction, equals(1.0));
   });
 
+  test("an unwritable destination fails the download instead of crashing the isolate", () async {
+    final tempDir = await Directory.systemTemp.createTemp("binary-download-client");
+    addTearDown(() async {
+      if (tempDir.existsSync()) {
+        final destination = File(p.join(tempDir.path, "asset.tar.gz"));
+        if (destination.existsSync()) Process.runSync("chmod", ["600", destination.path]);
+        await tempDir.delete(recursive: true);
+      }
+    });
+    final destination = p.join(tempDir.path, "asset.tar.gz");
+    // Read-only, matching a managed runtime directory the bridge cannot write.
+    File(destination).writeAsStringSync("");
+    Process.runSync("chmod", ["400", destination]);
+
+    // Several chunks with real gaps between them: a single-chunk body would
+    // surface the failure from the awaited close() and hide the defect. An
+    // IOSink defers its open to the first write, so with more writes in flight
+    // the open error escaped as an unhandled asynchronous error and terminated
+    // the bridge process instead of failing this download.
+    Stream<List<int>> body() async* {
+      for (var chunk = 0; chunk < 5; chunk++) {
+        yield List<int>.filled(1024, 7);
+        await Future<void>.delayed(Duration.zero);
+      }
+    }
+
+    final client = MockClient.streaming(
+      (_, _) async => http.StreamedResponse(body(), 200, contentLength: 5 * 1024),
+    );
+    final download = BinaryDownloadClient(httpClient: client)
+        .download(url: "https://example.test/asset.tar.gz", destinationPath: destination)
+        .toList();
+
+    await expectLater(
+      download,
+      throwsA(
+        isA<DownloadException>().having((error) => error.kind, "kind", DownloadFailureKind.failed),
+      ),
+    );
+  }, skip: Platform.isWindows ? "POSIX permission bits do not gate writes on Windows" : null);
+
   test("a connection-phase failure is wrapped as a network DownloadException", () async {
     final client = _SendErrorClient(const SocketException("connection refused"));
     await expectLater(


### PR DESCRIPTION
## Complexity

🌿 straightforward — one function in `BinaryDownloadClient`, no contract change.
The classification, progress reporting, timeouts, and teardown semantics are all
unchanged; only the file handle behind them is.

## What

`BinaryDownloadClient.download` opened its destination with
`File.openWrite()`. That returns an `IOSink` which defers the real `open(2)`
until its first write, so the `try` wrapping it caught nothing — despite the
comment right above it saying "a filesystem error here is a failed download, not
a raw FileSystemException".

The destination is now opened eagerly with
`File(...).openSync(mode: FileMode.write)` and each chunk write is awaited, so
open and write failures alike land in the handlers that already exist and
surface as the documented `DownloadException`.

## Why

The deferred open meant the error arrived inside the sink's own asynchronous
machinery with nothing attached to it, so it escaped as an **unhandled
asynchronous error and terminated the bridge process**:

```
Unhandled exception:
PathAccessException: Cannot open file, path = '.../.sesori-runtime-download'
  (OS Error: Permission denied, errno = 13)
#1 _File.open.<anonymous closure> (dart:io/file_impl.dart:438:7)
#2 _FileStreamConsumer.addStream.<anonymous closure> (dart:io/file_impl.dart:223:15)
```

Any unwritable managed runtime directory — wrong permissions, a read-only
volume, a full disk mid-write — took the whole bridge down rather than failing
one install.

This is a pre-existing defect (the code has looked like this since #1086), but
its blast radius just grew: #1319 made managed runtime installs run
automatically at bridge startup, so what previously required a user to press
Install can now happen unattended on every start.

## Risk and test focus

Low risk, contained to one function. No user-visible change on the success path,
no wire, database, or persisted-data effect.

The behavioural difference worth reviewing is that chunk writes are now awaited
rather than buffered through an `IOSink`. That applies per-chunk backpressure
and bounds memory during a large download; the stream inactivity timeout still
governs the network side, and a local file write is negligible against it.

Most valuable checks: a download to an unwritable destination fails rather than
crashing; a normal download still writes the exact bytes and reports progress
and totals; a mid-body connection drop is still classified retryable; cancelling
mid-stream still closes the handle.

## Expected result

A managed runtime install that cannot write its download now reports
`ProvisionFailed` and leaves the harness on whatever runtime it already had,
which is what the install contract always promised. The bridge stays up. No
database or persisted-data effect.

## Verification

- New regression test `an unwritable destination fails the download instead of
  crashing the isolate`. It uses a multi-chunk streamed body on purpose: with a
  single chunk the error surfaces from the awaited `close()` and the defect is
  hidden, so a single-chunk test would pass against the broken code.
- Confirmed the test reproduces the original failure exactly — reverting to
  `openWrite()` + `sink.add()` fails it with the same
  `PathAccessException ... _FileStreamConsumer.addStream` seen in production.
- `sesori_bridge_foundation` 83 tests pass, `sesori_plugin_runtime` 186 pass,
  `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `BinaryDownloadClient` so a download that can't open its destination fails with `DownloadException` instead of terminating the bridge process, and releases unread response bodies so a shared client doesn't hold pooled connections for the process lifetime. The destination was opened lazily via `File.openWrite()`, so permission, path, and read-only-volume errors escaped as unhandled asynchronous errors that crashed the bridge; it is now opened eagerly as a `RandomAccessFile` with each chunk write awaited, so filesystem failures land in the existing handlers as a failed download. Any response whose body is discarded (non-2xx status, unwritable destination) now cancels the body rather than leaving the connection held.

Managed runtime installs now run automatically at bridge startup, so an unwritable runtime directory previously killed the bridge on every start. Such an install now reports `ProvisionFailed` and leaves the harness on its current runtime.

**Notes**
- Chunk writes are now awaited per chunk instead of buffered through an `IOSink`, applying per-chunk backpressure and bounding memory during large downloads.
- Added a regression test using a multi-chunk body; a single-chunk body would surface the error from `close()` and pass against the broken code.

<sup>Written for commit 4c0d277e3b8bf4de5c5ad77a4fd0b99d013d5b96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

