### PR TITLE
🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -21,8 +21,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 11/25 | ⚙️ [periodic-cleanup] client: share optimistic rename bookkeeping [step 11/25] | Merged | [#1320](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1320) |
 | 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | Merged | [#1322](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1322) |
 | 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Merged | [#1323](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1323) |
-| 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | In review | [#1324](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1324) |
-| 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | In progress (local, awaiting step 14 merge) | — |
+| 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Merged | [#1324](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1324) |
+| 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | In review | [#1326](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1326) |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Proposed | — |
 | 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Proposed | — |
 | 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -22,7 +22,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | Merged | [#1322](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1322) |
 | 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Merged | [#1323](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1323) |
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | In review | [#1324](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1324) |
-| 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Proposed | — |
+| 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | In progress (local, awaiting step 14 merge) | — |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Proposed | — |
 | 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Proposed | — |
 | 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | Proposed | — |
@@ -270,3 +270,16 @@ asked to start working the plan; steps execute in order from step 2.
 - Rollout tool mapper: one `_JsLexicalState` owns the string/comment cursor
   advance used by both scanners; quoted escapes and line/block comments are
   handled identically. Owning suites pass unchanged; no new tests were needed.
+
+## Step 15 execution — 2026-09-05
+
+- Recount after steps 7/13/14: 72 log lines interpolate an error or stack.
+  Changed 36 recovered-failure sites across the orchestrator, debug server,
+  SSE manager/mapper, runtime runner, device detection, host process service,
+  worktree repository, push, diagnostics, git CLI, Codex client/descriptor and
+  OpenCode service/tracker/SSE/descriptor to pass the typed error and stack
+  through the logger's arguments, capturing the stack where the catch lacked it.
+- Left as-is: `Log.d`/`Log.v` sites (the logger takes no error there and they
+  are expected, ignored failures), deliberately redacted Claude/Codex frame
+  logs, terminal `Log.e("$error")` exits the GUI reads, and exception messages
+  built from a cause (out of this step's scope). No new logging category.

--- a/bridge/app/lib/src/api/git_cli_api.dart
+++ b/bridge/app/lib/src/api/git_cli_api.dart
@@ -528,7 +528,7 @@ class GitCliApi({
       final output = result.stdout.toString().trim();
       return output.isNotEmpty && output.toLowerCase().contains("github.com");
     } on Object catch (e) {
-      Log.w("[GitCli] failed to detect remote: $e");
+      Log.w("[GitCli] failed to detect remote", e);
       return false;
     }
   }
@@ -557,7 +557,7 @@ class GitCliApi({
         try {
           worktreeDir.deleteSync(recursive: true);
         } on FileSystemException catch (e) {
-          Log.w("[GitCli] failed to delete worktree directory $worktreePath: $e");
+          Log.w("[GitCli] failed to delete worktree directory $worktreePath", e);
         }
       }
 
@@ -569,7 +569,7 @@ class GitCliApi({
             parentDir.deleteSync();
           }
         } on FileSystemException catch (e) {
-          Log.w("[GitCli] failed to delete empty .worktrees directory ${parentDir.path}: $e");
+          Log.w("[GitCli] failed to delete empty .worktrees directory ${parentDir.path}", e);
         }
       }
     }

--- a/bridge/app/lib/src/debug_server.dart
+++ b/bridge/app/lib/src/debug_server.dart
@@ -216,7 +216,7 @@ class DebugServer({
           .listen(
             (_) {},
             onError: (Object e, StackTrace st) {
-              Log.w("debug SSE stream error: $e");
+              Log.w("debug SSE stream error", e, st);
               unawaited(
                 _failureReporter.recordFailure(
                   error: e,

--- a/bridge/app/lib/src/foundation/device_type_detector.dart
+++ b/bridge/app/lib/src/foundation/device_type_detector.dart
@@ -63,7 +63,7 @@ class DeviceTypeDetector({
       final model = (result.stdout as String).trim().toLowerCase();
       return model.contains("macbook");
     } on Object catch (error) {
-      Log.w("[device-type] failed to detect macOS laptop: $error");
+      Log.w("[device-type] failed to detect macOS laptop", error);
       return false;
     }
   }
@@ -87,7 +87,7 @@ class DeviceTypeDetector({
       final count = int.tryParse((result.stdout as String).trim()) ?? 0;
       return count > 0;
     } on Object catch (error) {
-      Log.w("[device-type] failed to detect Windows laptop: $error");
+      Log.w("[device-type] failed to detect Windows laptop", error);
       return false;
     }
   }
@@ -103,7 +103,7 @@ class DeviceTypeDetector({
         (e) => e.path.split("/").last.startsWith("BAT"),
       );
     } on Object catch (error) {
-      Log.w("[device-type] failed to detect Linux laptop: $error");
+      Log.w("[device-type] failed to detect Linux laptop", error);
       return false;
     }
   }

--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -970,7 +970,7 @@ class OrchestratorSession._({
         unawaited(_processPluginEventInOrder(source));
       },
       onError: (Object e, StackTrace st) {
-        Log.w("plugin event stream error: $e");
+        Log.w("plugin event stream error", e, st);
         unawaited(
           _failureReporter.recordFailure(
             error: e,
@@ -1637,7 +1637,7 @@ class OrchestratorSession._({
         );
       }
     } catch (e, st) {
-      Log.e("[sse] error processing event $eventType: $e\n$st");
+      Log.e("[sse] error processing event $eventType", e, st);
       unawaited(
         _failureReporter
             .recordFailure(
@@ -1861,7 +1861,7 @@ class OrchestratorSession._({
         projects: await _sessionRepository.getProjectActivitySummaries(),
       );
     } catch (e, st) {
-      Log.e("[sse] error building projects summary: $e\n$st");
+      Log.e("[sse] error building projects summary", e, st);
       unawaited(
         _failureReporter
             .recordFailure(
@@ -1978,14 +1978,14 @@ class OrchestratorSession._({
       try {
         cachedToken = _accessTokenProvider.accessToken;
       } on Object {
-        Log.w("Token refresh failed and no cached token is available; deferring reconnect: $e");
+        Log.w("Token refresh failed and no cached token is available; deferring reconnect", e);
         return false;
       }
       if (cachedToken.isEmpty) {
-        Log.w("Token refresh failed and the cached token is empty; deferring reconnect: $e");
+        Log.w("Token refresh failed and the cached token is empty; deferring reconnect", e);
         return false;
       }
-      Log.w("Token refresh failed; reconnecting with the cached token: $e");
+      Log.w("Token refresh failed; reconnecting with the cached token", e);
       return true;
     }
   }
@@ -2136,8 +2136,8 @@ class OrchestratorSession._({
           try {
             encrypted = await _keyExchangeManager.handleKeyExchange(message: relayMessage);
             Log.d("key exchange OK, sending ready to connID=$connID");
-          } catch (e) {
-            Log.e("failed key exchange for connId $connID: $e");
+          } catch (e, st) {
+            Log.e("failed key exchange for connId $connID", e, st);
             break processMessage;
           }
 

--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -1969,7 +1969,7 @@ class OrchestratorSession._({
     } on ControlTokenUnavailableException catch (e) {
       Log.w("No access token available for reconnect: $e");
       return false;
-    } catch (e) {
+    } catch (e, st) {
       // The refresh failed for some other reason. Only reconnect if a usable
       // cached token actually exists — reading it throws when the cache is empty
       // or sign-out-invalidated, in which case there is nothing safe to reconnect
@@ -1978,14 +1978,14 @@ class OrchestratorSession._({
       try {
         cachedToken = _accessTokenProvider.accessToken;
       } on Object {
-        Log.w("Token refresh failed and no cached token is available; deferring reconnect", e);
+        Log.w("Token refresh failed and no cached token is available; deferring reconnect", e, st);
         return false;
       }
       if (cachedToken.isEmpty) {
-        Log.w("Token refresh failed and the cached token is empty; deferring reconnect", e);
+        Log.w("Token refresh failed and the cached token is empty; deferring reconnect", e, st);
         return false;
       }
-      Log.w("Token refresh failed; reconnecting with the cached token", e);
+      Log.w("Token refresh failed; reconnecting with the cached token", e, st);
       return true;
     }
   }

--- a/bridge/app/lib/src/persistence/bridge_diagnostics.dart
+++ b/bridge/app/lib/src/persistence/bridge_diagnostics.dart
@@ -16,7 +16,7 @@ class BridgeDiagnostics({required final bool _isSupervised}) {
       final (hasFileSystemAccess, hasGitAvailable) = await (checkFilesystemAccess(), checkGitAvailable()).wait;
       return hasFileSystemAccess && hasGitAvailable;
     } on Object catch (error, stackTrace) {
-      Log.w("Unexpected error during diagnostics: $error\n$stackTrace");
+      Log.w("Unexpected error during diagnostics", error, stackTrace);
       return false;
     }
   }

--- a/bridge/app/lib/src/push/maintenance_push_listener.dart
+++ b/bridge/app/lib/src/push/maintenance_push_listener.dart
@@ -71,7 +71,7 @@ class MaintenancePushListener({
     try {
       action();
     } catch (error, stackTrace) {
-      Log.w("[push] maintenance step '$label' failed: $error\n$stackTrace");
+      Log.w("[push] maintenance step '$label' failed", error, stackTrace);
     }
   }
 }

--- a/bridge/app/lib/src/push/push_dispatcher.dart
+++ b/bridge/app/lib/src/push/push_dispatcher.dart
@@ -104,9 +104,9 @@ class PushDispatcher({
     unawaited(
       _client.sendNotification(payload).catchError((Object e) {
         if (e is TokenRefreshException || (e is PushSendException && e.statusCode == 401)) {
-          Log.e("[push] auth failure, credentials may need re-authentication: $e");
+          Log.e("[push] auth failure, credentials may need re-authentication", e);
         } else {
-          Log.w("[push] send error: $e");
+          Log.w("[push] send error", e);
         }
       }),
     );

--- a/bridge/app/lib/src/repositories/worktree_repository.dart
+++ b/bridge/app/lib/src/repositories/worktree_repository.dart
@@ -15,13 +15,12 @@ import "models/worktree_types.dart";
 const _worktreeDir = ".worktrees";
 
 class WorktreeRepository({
-    required final ProjectsDao _projectsDao,
-    required final SessionDao _sessionDao,
-    required final FilesystemApi _filesystemApi,
-    required final GitCliApi _gitApi,
-    required final PluginRuntime _runtime,
-  }) {
-
+  required final ProjectsDao _projectsDao,
+  required final SessionDao _sessionDao,
+  required final FilesystemApi _filesystemApi,
+  required final GitCliApi _gitApi,
+  required final PluginRuntime _runtime,
+}) {
   Future<({String path, String branchName, String baseBranch, String baseCommit})?> getParentWorktree({
     required String parentSessionId,
   }) async {
@@ -196,7 +195,7 @@ class WorktreeRepository({
         startPoint: startPointResult.ref,
       );
     } on Object catch (error) {
-      Log.w("[WorktreeRepository] failed to resolve base branch/commit for $projectPath: $error");
+      Log.w("[WorktreeRepository] failed to resolve base branch/commit for $projectPath", error);
       return null;
     }
   }
@@ -300,4 +299,6 @@ class WorktreeRepository({
   }
 }
 
-enum _WorktreeOperation() { deleteWorkspace }
+enum _WorktreeOperation() {
+  deleteWorkspace,
+}

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -475,8 +475,8 @@ class const BridgeRuntimeRunner._() {
       if (updatesEnabledForThisInstall) {
         try {
           await updateLifecycle.reconcile();
-        } on Object catch (error) {
-          Log.w("Update reconciliation failed (non-fatal): $error");
+        } on Object catch (error, stackTrace) {
+          Log.w("Update reconciliation failed (non-fatal)", error, stackTrace);
         }
       }
 
@@ -683,8 +683,8 @@ class const BridgeRuntimeRunner._() {
         if (updatesEnabledForThisInstall) {
           try {
             await updateLifecycle.reconcile();
-          } on Object catch (error) {
-            Log.w("Update reconciliation after predecessor exit failed (non-fatal): $error");
+          } on Object catch (error, stackTrace) {
+            Log.w("Update reconciliation after predecessor exit failed (non-fatal)", error, stackTrace);
           }
         }
       }
@@ -1276,7 +1276,7 @@ class const BridgeRuntimeRunner._() {
         // method doc), so surface the failure instead of degrading.
         rethrow;
       }
-      Log.w("Failed to inspect own process (pid ${io.pid}); using fallback identity: $error");
+      Log.w("Failed to inspect own process (pid ${io.pid}); using fallback identity", error);
     }
     return _fallbackCurrentBridgeIdentity(
       currentUser: currentUser,

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -1270,13 +1270,13 @@ class const BridgeRuntimeRunner._() {
         return inspected;
       }
       Log.w("Could not find own process (pid ${io.pid}) in the process table; using fallback identity");
-    } on Object catch (error) {
+    } on Object catch (error, stackTrace) {
       if (!isWindows) {
         // A marker-less fallback would corrupt the startup lock on POSIX (see
         // method doc), so surface the failure instead of degrading.
         rethrow;
       }
-      Log.w("Failed to inspect own process (pid ${io.pid}); using fallback identity", error);
+      Log.w("Failed to inspect own process (pid ${io.pid}); using fallback identity", error, stackTrace);
     }
     return _fallbackCurrentBridgeIdentity(
       currentUser: currentUser,

--- a/bridge/app/lib/src/server/host/bridge_host_process_service.dart
+++ b/bridge/app/lib/src/server/host/bridge_host_process_service.dart
@@ -80,7 +80,7 @@ class BridgeHostProcessService({
       // caller stop it, so nothing thrown by the process-table read — Errors
       // included — may fail the spawn. Fall back to the partial spawn-time
       // identity.
-      Log.w("Post-spawn identity inspection failed for pid ${spawnIdentity.pid}\n$error");
+      Log.w("Post-spawn identity inspection failed for pid ${spawnIdentity.pid}", error);
       return spawnIdentity;
     }
 

--- a/bridge/app/lib/src/server/host/bridge_host_process_service.dart
+++ b/bridge/app/lib/src/server/host/bridge_host_process_service.dart
@@ -75,12 +75,12 @@ class BridgeHostProcessService({
     final ProcessIdentity? inspectedIdentity;
     try {
       inspectedIdentity = await _processRepository.inspectProcess(pid: spawnIdentity.pid);
-    } on Object catch (error) {
+    } on Object catch (error, stackTrace) {
       // The child is already running and only the returned handle lets the
       // caller stop it, so nothing thrown by the process-table read — Errors
       // included — may fail the spawn. Fall back to the partial spawn-time
       // identity.
-      Log.w("Post-spawn identity inspection failed for pid ${spawnIdentity.pid}", error);
+      Log.w("Post-spawn identity inspection failed for pid ${spawnIdentity.pid}", error, stackTrace);
       return spawnIdentity;
     }
 

--- a/bridge/app/lib/src/sse/bridge_event_mapper.dart
+++ b/bridge/app/lib/src/sse/bridge_event_mapper.dart
@@ -161,7 +161,7 @@ class BridgeEventMapper({
           ),
       };
     } catch (e, st) {
-      Log.e("[sse-mapper] error mapping event ${event.runtimeType}: $e\n$st");
+      Log.e("[sse-mapper] error mapping event ${event.runtimeType}", e, st);
       unawaited(
         _failureReporter
             .recordFailure(

--- a/bridge/app/lib/src/sse/sse_manager.dart
+++ b/bridge/app/lib/src/sse/sse_manager.dart
@@ -190,7 +190,7 @@ class SSEManager({
         Log.v("[sse] retaining event ${event.runtimeType} for connID=$connID after relay turnover");
         return;
       }
-      Log.w("[sse] failed to send event ${event.runtimeType} to connID=$connID: $error");
+      Log.w("[sse] failed to send event ${event.runtimeType} to connID=$connID", error);
       unawaited(
         _failureReporter
             .recordFailure(

--- a/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_protocol.dart
@@ -37,7 +37,7 @@ abstract final class AcpMethods() {
 /// An auth method advertised by the agent in the `initialize` result.
 enum AcpAuthMethodType() {
   terminal,
-  other;
+  other,
 }
 
 class const AcpAuthMethod({

--- a/bridge/sesori_plugin_codex/lib/src/codex_app_server_client.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_app_server_client.dart
@@ -330,7 +330,7 @@ class CodexAppServerClient({
     } catch (error, stack) {
       // The error (e.g. a FormatException from jsonDecode) can embed a snippet
       // of the offending frame, so redact it too.
-      Log.w("[codex][ws] failed to parse frame: ${_redactForLog("$error")}\n$stack");
+      Log.w("[codex][ws] failed to parse frame: ${_redactForLog("$error")}", null, stack);
     }
   }
 

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart
@@ -663,8 +663,8 @@ class const CodexPluginDescriptor({
     if (host.startAborted.isAborted) {
       try {
         await plugin.shutdown(budget: null);
-      } on Object catch (error) {
-        Log.e("[codex] rollback after aborted start failed: $error");
+      } on Object catch (error, stackTrace) {
+        Log.e("[codex] rollback after aborted start failed", error, stackTrace);
       }
       throw const PluginStartAbortedException();
     }

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -85,9 +85,9 @@ class ActiveSessionTracker(final OpenCodeRepository _repository) {
       sessionQueryDirectories.map((directory) async {
         try {
           return await _repository.listSessions(directory: directory, roots: false);
-        } catch (e) {
+        } catch (e, st) {
           _workStateBaselineTrusted = false;
-          Log.w("coldStart: failed to list sessions for ${directory ?? "<cwd>"}", e);
+          Log.w("coldStart: failed to list sessions for ${directory ?? "<cwd>"}", e, st);
           return <Session>[];
         }
       }),
@@ -120,9 +120,9 @@ class ActiveSessionTracker(final OpenCodeRepository _repository) {
           allStatuses[entry.key] = entry.value;
           if (worktree != null) _sessionWorktrees[entry.key] = worktree;
         }
-      } catch (e) {
+      } catch (e, st) {
         _workStateBaselineTrusted = false;
-        Log.w("coldStart: failed to fetch session statuses for ${directory ?? "<cwd>"}", e);
+        Log.w("coldStart: failed to fetch session statuses for ${directory ?? "<cwd>"}", e, st);
       }
     });
     await Future.wait(statusFutures);

--- a/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/active_session_tracker.dart
@@ -87,7 +87,7 @@ class ActiveSessionTracker(final OpenCodeRepository _repository) {
           return await _repository.listSessions(directory: directory, roots: false);
         } catch (e) {
           _workStateBaselineTrusted = false;
-          Log.w("coldStart: failed to list sessions for ${directory ?? "<cwd>"}: $e");
+          Log.w("coldStart: failed to list sessions for ${directory ?? "<cwd>"}", e);
           return <Session>[];
         }
       }),
@@ -122,7 +122,7 @@ class ActiveSessionTracker(final OpenCodeRepository _repository) {
         }
       } catch (e) {
         _workStateBaselineTrusted = false;
-        Log.w("coldStart: failed to fetch session statuses for ${directory ?? "<cwd>"}: $e");
+        Log.w("coldStart: failed to fetch session statuses for ${directory ?? "<cwd>"}", e);
       }
     });
     await Future.wait(statusFutures);

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -873,7 +873,7 @@ class OpenCodePlugin._({
           return;
       }
     } catch (e, st) {
-      Log.e("[opencode] SSE event processing error: $e\n$st");
+      Log.e("[opencode] SSE event processing error", e, st);
     }
   }
 

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -293,8 +293,8 @@ class OpenCodeService(
         "for session $sessionId via getSession: ${session.directory}",
       );
       return session.directory;
-    } catch (e) {
-      Log.w("_resolveSessionDirectory: failed to resolve directory for session $sessionId", e);
+    } catch (e, st) {
+      Log.w("_resolveSessionDirectory: failed to resolve directory for session $sessionId", e, st);
       return null;
     }
   }

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -294,7 +294,7 @@ class OpenCodeService(
       );
       return session.directory;
     } catch (e) {
-      Log.w("_resolveSessionDirectory: failed to resolve directory for session $sessionId: $e");
+      Log.w("_resolveSessionDirectory: failed to resolve directory for session $sessionId", e);
       return null;
     }
   }
@@ -313,7 +313,7 @@ class OpenCodeService(
       if (!_isLikelyDecodeOrSchemaDriftError(error)) {
         rethrow;
       }
-      Log.w("Failed to decode messages for session $sessionId: $error\n$stackTrace");
+      Log.w("Failed to decode messages for session $sessionId", error, stackTrace);
       throw PluginApiException("GET /session/$sessionId/message", 502);
     }
   }
@@ -726,7 +726,7 @@ class OpenCodeService(
       await _hydratePendingInput();
       Log.v("[coldStart] hydratePendingInput finished in ${hydrateSw.elapsedMilliseconds}ms");
     } catch (e, st) {
-      Log.w("coldStart: failed to hydrate pending input: $e\n$st");
+      Log.w("coldStart: failed to hydrate pending input", e, st);
     }
   }
 
@@ -828,7 +828,7 @@ class OpenCodeService(
     required Object error,
     required StackTrace stackTrace,
   }) async {
-    Log.w("createSession: prompt send failed for session ${session.id}: $error\n$stackTrace");
+    Log.w("createSession: prompt send failed for session ${session.id}", error, stackTrace);
     try {
       await repository.deleteSession(
         sessionId: session.id,

--- a/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/runtime/open_code_plugin_descriptor.dart
@@ -664,7 +664,7 @@ class const OpenCodePluginDescriptor({
       reporter.markDegradedNow();
       unawaited(
         api.initialize().catchError((Object error, StackTrace stackTrace) {
-          Log.w("[opencode] background cold-start did not complete cleanly: $error");
+          Log.w("[opencode] background cold-start did not complete cleanly", error, stackTrace);
         }),
       );
     } else {
@@ -690,8 +690,8 @@ class const OpenCodePluginDescriptor({
     if (host.startAborted.isAborted) {
       try {
         await plugin.shutdown(budget: null);
-      } on Object catch (error) {
-        Log.e("[opencode] rollback after aborted start failed: $error");
+      } on Object catch (error, stackTrace) {
+        Log.e("[opencode] rollback after aborted start failed", error, stackTrace);
       }
       throw const PluginStartAbortedException();
     }

--- a/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/sse/sse_connection.dart
@@ -89,7 +89,7 @@ class SseConnection({
         await _readStream(response, generation);
       } catch (e, st) {
         if (!_active || _generation != generation) return;
-        Log.e("[sse-conn] stream loop error: $e\n$st");
+        Log.e("[sse-conn] stream loop error", e, st);
       } finally {
         client.close();
         if (_currentClient == client) _currentClient = null;
@@ -134,7 +134,7 @@ class SseConnection({
             try {
               _onEvent(dataLines.join("\n"));
             } catch (e, st) {
-              Log.e("[sse-conn] onEvent callback error: $e\n$st");
+              Log.e("[sse-conn] onEvent callback error", e, st);
             }
             dataLines.clear();
           }
@@ -153,7 +153,7 @@ class SseConnection({
       try {
         _onEvent(dataLines.join("\n"));
       } catch (e, st) {
-        Log.e("[sse-conn] onEvent callback error: $e\n$st");
+        Log.e("[sse-conn] onEvent callback error", e, st);
       }
       dataLines.clear();
     }


### PR DESCRIPTION
## Complexity

🌿 straightforward — mechanical logging-argument changes at 36 catch sites, no control-flow change.

## What

- At 36 recovered-failure log sites across the orchestrator, debug server, SSE manager and mapper, runtime runner, device detection, host process service, worktree repository, push, diagnostics, git CLI, the Codex client and descriptor, and the OpenCode service, tracker, SSE connection, and descriptor, the caught error and stack are now passed through the logger's own error and stack arguments instead of being interpolated into the message. Where the catch clause did not bind a stack trace it now does.
- Left unchanged on purpose: debug and verbose sites (that logger level accepts no error argument, and those are expected, ignored failures), the Claude and Codex frame logs that deliberately redact the error text, the terminal `Log.e("$error")` exits the desktop GUI reads, and exception messages built from a cause, which are outside this step.

## Why

Step 15/25 of `.plan/active/periodic-cleanup`. Interpolating an error into the message flattens it to text and drops the stack in most sites, which is exactly what a bridge log needs to keep for a user who chooses to inspect and share it. The recount after steps 7, 13, and 14 found 72 candidate lines; the 36 changed here are the recovered failures.

## Risk and test focus

Low operational risk, bridge only. Impacted: the content of warning and error log lines at those sites. Most valuable checks: trigger one recovered failure per area (an SSE send failure, a push send error, a git worktree cleanup failure) and confirm the log line carries the error type and stack rather than a flattened string.

No user-visible, database, or wire change.

## Expected result

- User-visible: none.
- Database/persisted data: none.
- Internal: log lines at those sites carry typed error and stack context; no new logging category, wrapper, or retry.

## Verification

- `dart analyze` for every touched file in `bridge/app` and for the ACP, Codex, and OpenCode packages: no issues (the whole-workspace analyzer currently crashes, so touched scopes were analyzed directly).
- `dart test` for the app push, SSE, worktree, and debug server suites; OpenCode service, tracker, runtime, and plugin suites; Codex client and runtime suites; ACP projects and turn suites: all pass after rebasing onto merged main.
- Architecture review: not run, per the plan's exemption for logging changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves caught errors and their stacks in bridge logs by passing them through the logger's own error and stack arguments at 36 recovered-failure sites, adding stack bindings where catches previously bound only the error. Interpolating flattened errors to text and dropped stacks at most sites; typed errors and stacks now survive for users who inspect or share logs. Log content changes only, with no user-visible, database, or wire change.

**What changed**
- Updated catch sites across the orchestrator, debug server, SSE manager and mapper, runtime runner, device detection, host process service, worktree repository, push, diagnostics, git CLI, Codex, and OpenCode.
- The Codex frame-log site keeps its redacted message but now passes the stack through.
- Left unchanged: debug/verbose sites, terminal `Log.e("$error")` lines, and exception messages built from a cause.

<sup>Written for commit 12c1838bbe16b5374c3b6c92a92b446706b7eb6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

