### PR TITLE
⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -22,8 +22,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 12/25 | ⚙️ [periodic-cleanup] runtime: share managed installer composition [step 12/25] | Merged | [#1322](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1322) |
 | 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Merged | [#1323](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1323) |
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Merged | [#1324](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1324) |
-| 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | In review | [#1326](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1326) |
-| 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | In progress (local, awaiting step 15 merge) | — |
+| 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Merged | [#1326](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1326) |
+| 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | In review | [#1328](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1328) |
 | 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Proposed | — |
 | 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | Proposed | — |
 | 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -23,7 +23,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Merged | [#1323](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1323) |
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Merged | [#1324](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1324) |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | In review | [#1326](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1326) |
-| 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Proposed | — |
+| 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | In progress (local, awaiting step 15 merge) | — |
 | 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Proposed | — |
 | 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | Proposed | — |
 | 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | Proposed | — |
@@ -283,3 +283,14 @@ asked to start working the plan; steps execute in order from step 2.
   are expected, ignored failures), deliberately redacted Claude/Codex frame
   logs, terminal `Log.e("$error")` exits the GUI reads, and exception messages
   built from a cause (out of this step's scope). No new logging category.
+
+## Step 16 execution — 2026-09-05
+
+- `client/module_core/lib/src/di/cubit_composition.dart` exports four named
+  functions (`createSessionDetailCubit`, `createProjectListCubit`,
+  `createSessionListCubit`, `createNewSessionCubit`) taking a required `GetIt`
+  locator plus runtime ids and returning a fresh cubit with the collaborators
+  both shells resolved. All eight shell sites call them inside their existing
+  `BlocProvider(create:)`; route ids, disposal and surface presentation stay in
+  the shells, and the session-activity analytics owners remain separate. No
+  GetIt import in cubits, no singleton, static locator or wrapper widget.

--- a/client/app/lib/features/new_session/new_session_screen.dart
+++ b/client/app/lib/features/new_session/new_session_screen.dart
@@ -16,17 +16,7 @@ class const NewSessionScreen({
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => NewSessionCubit(
-        connectionService: getIt<ConnectionService>(),
-        sessionRepository: getIt<SessionRepository>(),
-        newSessionPluginService: getIt<NewSessionPluginService>(),
-        newSessionOptionsService: getIt<NewSessionOptionsService>(),
-        projectRepository: getIt<ProjectRepository>(),
-        selectionTracker: getIt<NewSessionSelectionTracker>(),
-        composerDraftRepository: getIt<ComposerDraftRepository>(),
-        productAnalyticsService: getIt<ProductAnalyticsService>(),
-        projectId: projectId,
-      ),
+      create: (_) => createNewSessionCubit(locator: getIt, projectId: projectId),
       child: NewSessionView(
         projectId: projectId,
         onBack: context.pop,

--- a/client/app/lib/features/project_list/project_list_screen.dart
+++ b/client/app/lib/features/project_list/project_list_screen.dart
@@ -30,21 +30,7 @@ class const ProjectListScreen({super.key}) extends StatelessWidget {
     return MultiBlocProvider(
       providers: [
         BlocProvider(
-          create: (_) => ProjectListCubit(
-            getIt<ProjectRepository>(),
-            getIt<ConnectionService>(),
-            getIt<SseEventTracker>(),
-            getIt<RouteSource>(),
-            projectListService: getIt<ProjectListService>(),
-            sessionUnseenTracker: getIt<SessionUnseenTracker>(),
-            registeredBridgesService: getIt<RegisteredBridgesService>(),
-            productAnalyticsService: getIt<ProductAnalyticsService>(),
-            loadedStateAnalyticsReporter: LoadedStateAnalyticsReporter.projectInventory(
-              productAnalyticsService: getIt<ProductAnalyticsService>(),
-            ),
-            failureReporter: getIt<FailureReporter>(),
-            catalogRescanService: getIt<CatalogRescanService>(),
-          ),
+          create: (_) => createProjectListCubit(locator: getIt),
         ),
         BlocProvider(
           create: (_) => BridgeIdentityCubit(

--- a/client/app/lib/features/session_detail/session_detail_screen.dart
+++ b/client/app/lib/features/session_detail/session_detail_screen.dart
@@ -6,7 +6,6 @@ import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_app_ui/sesori_app_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
-import "package:sesori_shared/sesori_shared.dart";
 
 import "../../core/di/injection.dart";
 import "../../core/external_link.dart";
@@ -27,21 +26,7 @@ class const SessionDetailScreen({
     return MultiBlocProvider(
       providers: [
         BlocProvider(
-          create: (_) => SessionDetailCubit(
-            getIt<ConnectionService>(),
-            loadService: getIt<SessionDetailLoadService>(),
-            promptDispatcher: getIt<SessionRepository>(),
-            permissionRepository: getIt<PermissionRepository>(),
-            sessionViewingService: getIt<SessionViewingService>(),
-            projectViewingService: getIt<ProjectViewingService>(),
-            lifecycleSource: getIt<LifecycleSource>(),
-            composerDraftRepository: getIt<ComposerDraftRepository>(),
-            productAnalyticsService: getIt<ProductAnalyticsService>(),
-            sessionId: sessionId,
-            projectId: projectId,
-            notificationCanceller: getIt<NotificationCanceller>(),
-            failureReporter: getIt<FailureReporter>(),
-          ),
+          create: (_) => createSessionDetailCubit(locator: getIt, sessionId: sessionId, projectId: projectId),
         ),
       ],
       child: _SessionActivityAnalyticsOwner(

--- a/client/app/lib/features/session_list/session_list_cubit_provider.dart
+++ b/client/app/lib/features/session_list/session_list_cubit_provider.dart
@@ -1,7 +1,6 @@
 import "package:flutter/widgets.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
-import "package:sesori_shared/sesori_shared.dart";
 
 import "../../core/di/injection.dart";
 
@@ -13,19 +12,7 @@ class const SessionListCubitProvider({
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => SessionListCubit(
-        sessionRepository: getIt<SessionRepository>(),
-        sessionListService: getIt<SessionListService>(),
-        projectRepository: getIt<ProjectRepository>(),
-        connectionService: getIt<ConnectionService>(),
-        sseEventTracker: getIt<SseEventTracker>(),
-        sessionUnseenTracker: getIt<SessionUnseenTracker>(),
-        projectViewingService: getIt<ProjectViewingService>(),
-        routeSource: getIt<RouteSource>(),
-        projectId: projectId,
-        failureReporter: getIt<FailureReporter>(),
-        catalogRescanService: getIt<CatalogRescanService>(),
-      ),
+      create: (_) => createSessionListCubit(locator: getIt, projectId: projectId),
       child: child,
     );
   }

--- a/client/desktop/lib/features/new_session/desktop_new_session_screen.dart
+++ b/client/desktop/lib/features/new_session/desktop_new_session_screen.dart
@@ -18,17 +18,7 @@ class const DesktopNewSessionScreen({
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => NewSessionCubit(
-        connectionService: getIt<ConnectionService>(),
-        sessionRepository: getIt<SessionRepository>(),
-        newSessionPluginService: getIt<NewSessionPluginService>(),
-        newSessionOptionsService: getIt<NewSessionOptionsService>(),
-        projectRepository: getIt<ProjectRepository>(),
-        selectionTracker: getIt<NewSessionSelectionTracker>(),
-        composerDraftRepository: getIt<ComposerDraftRepository>(),
-        productAnalyticsService: getIt<ProductAnalyticsService>(),
-        projectId: projectId,
-      ),
+      create: (_) => createNewSessionCubit(locator: getIt, projectId: projectId),
       child: DesktopNewSessionView(
         projectId: projectId,
         projectName: projectName,

--- a/client/desktop/lib/features/projects/desktop_project_list_screen.dart
+++ b/client/desktop/lib/features/projects/desktop_project_list_screen.dart
@@ -29,21 +29,7 @@ class const DesktopProjectListScreen({
     return MultiBlocProvider(
       providers: [
         BlocProvider(
-          create: (_) => ProjectListCubit(
-            getIt<ProjectRepository>(),
-            getIt<ConnectionService>(),
-            getIt<SseEventTracker>(),
-            getIt<RouteSource>(),
-            projectListService: getIt<ProjectListService>(),
-            sessionUnseenTracker: getIt<SessionUnseenTracker>(),
-            registeredBridgesService: getIt<RegisteredBridgesService>(),
-            productAnalyticsService: getIt<ProductAnalyticsService>(),
-            loadedStateAnalyticsReporter: LoadedStateAnalyticsReporter.projectInventory(
-              productAnalyticsService: getIt<ProductAnalyticsService>(),
-            ),
-            failureReporter: getIt<FailureReporter>(),
-            catalogRescanService: getIt<CatalogRescanService>(),
-          ),
+          create: (_) => createProjectListCubit(locator: getIt),
         ),
         BlocProvider(
           create: (_) => BridgeIdentityCubit(

--- a/client/desktop/lib/features/sessions/desktop_session_detail_screen.dart
+++ b/client/desktop/lib/features/sessions/desktop_session_detail_screen.dart
@@ -5,7 +5,6 @@ import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_app_ui/sesori_app_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
-import "package:sesori_shared/sesori_shared.dart";
 
 import "../../core/di/injection.dart";
 import "../../core/external_link.dart";
@@ -25,21 +24,7 @@ class const DesktopSessionDetailScreen({
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => SessionDetailCubit(
-        getIt<ConnectionService>(),
-        loadService: getIt<SessionDetailLoadService>(),
-        promptDispatcher: getIt<SessionRepository>(),
-        permissionRepository: getIt<PermissionRepository>(),
-        sessionViewingService: getIt<SessionViewingService>(),
-        projectViewingService: getIt<ProjectViewingService>(),
-        lifecycleSource: getIt<LifecycleSource>(),
-        composerDraftRepository: getIt<ComposerDraftRepository>(),
-        productAnalyticsService: getIt<ProductAnalyticsService>(),
-        sessionId: sessionId,
-        projectId: projectId,
-        notificationCanceller: getIt<NotificationCanceller>(),
-        failureReporter: getIt<FailureReporter>(),
-      ),
+      create: (_) => createSessionDetailCubit(locator: getIt, sessionId: sessionId, projectId: projectId),
       child: DesktopComposerPresentationScope(
         child: _SessionActivityAnalyticsOwner(
           child: DesktopSessionDetailView(

--- a/client/desktop/lib/features/sessions/desktop_session_list_screen.dart
+++ b/client/desktop/lib/features/sessions/desktop_session_list_screen.dart
@@ -2,7 +2,6 @@ import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_app_ui/sesori_app_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
-import "package:sesori_shared/sesori_shared.dart";
 
 import "../../core/di/injection.dart";
 
@@ -15,19 +14,7 @@ class const DesktopSessionListCubitProvider({
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => SessionListCubit(
-        sessionRepository: getIt<SessionRepository>(),
-        sessionListService: getIt<SessionListService>(),
-        projectRepository: getIt<ProjectRepository>(),
-        connectionService: getIt<ConnectionService>(),
-        sseEventTracker: getIt<SseEventTracker>(),
-        sessionUnseenTracker: getIt<SessionUnseenTracker>(),
-        projectViewingService: getIt<ProjectViewingService>(),
-        routeSource: getIt<RouteSource>(),
-        projectId: projectId,
-        failureReporter: getIt<FailureReporter>(),
-        catalogRescanService: getIt<CatalogRescanService>(),
-      ),
+      create: (_) => createSessionListCubit(locator: getIt, projectId: projectId),
       child: child,
     );
   }

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -104,6 +104,7 @@ export "src/cubits/sse_toast/sse_toast_cubit.dart";
 export "src/cubits/sse_toast/sse_toast_state.dart";
 export "src/cubits/voice_input/voice_input_cubit.dart";
 export "src/cubits/voice_input/voice_input_state.dart";
+export "src/di/cubit_composition.dart";
 export "src/di/injection.dart";
 export "src/errors/remote_failure_reason.dart";
 export "src/foundation/io/file_attachment_thumbnail_storage.dart";

--- a/client/module_core/lib/src/di/cubit_composition.dart
+++ b/client/module_core/lib/src/di/cubit_composition.dart
@@ -1,0 +1,106 @@
+import "package:get_it/get_it.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+import "../capabilities/server_connection/connection_service.dart";
+import "../cubits/new_session/new_session_cubit.dart";
+import "../cubits/project_list/project_list_cubit.dart";
+import "../cubits/session_detail/session_detail_cubit.dart";
+import "../cubits/session_list/session_list_cubit.dart";
+import "../platform/lifecycle_source.dart";
+import "../platform/notification_canceller.dart";
+import "../platform/route_source.dart";
+import "../repositories/composer_draft_repository.dart";
+import "../repositories/permission_repository.dart";
+import "../repositories/project_repository.dart";
+import "../repositories/session_repository.dart";
+import "../services/catalog_rescan_service.dart";
+import "../services/loaded_state_analytics_reporter.dart";
+import "../services/new_session_options_service.dart";
+import "../services/new_session_plugin_service.dart";
+import "../services/new_session_selection_tracker.dart";
+import "../services/product_analytics_service.dart";
+import "../services/project_list_service.dart";
+import "../services/project_viewing_service.dart";
+import "../services/registered_bridges_service.dart";
+import "../services/session_detail_load_service.dart";
+import "../services/session_list_service.dart";
+import "../services/session_unseen_tracker.dart";
+import "../services/session_viewing_service.dart";
+import "../services/sse_event_tracker.dart";
+
+/// Shared cubit composition for the phone and desktop shells.
+///
+/// Each function returns a fresh cubit wired to the same collaborators every
+/// shell resolves from its locator. Shells keep `BlocProvider(create:)`, route
+/// ids, ownership and disposal, and surface-specific presentation; only the
+/// collaborator list lives here, so the two shells cannot drift apart.
+
+SessionDetailCubit createSessionDetailCubit({
+  required GetIt locator,
+  required String sessionId,
+  required String projectId,
+}) {
+  return SessionDetailCubit(
+    locator<ConnectionService>(),
+    loadService: locator<SessionDetailLoadService>(),
+    promptDispatcher: locator<SessionRepository>(),
+    permissionRepository: locator<PermissionRepository>(),
+    sessionViewingService: locator<SessionViewingService>(),
+    projectViewingService: locator<ProjectViewingService>(),
+    lifecycleSource: locator<LifecycleSource>(),
+    composerDraftRepository: locator<ComposerDraftRepository>(),
+    productAnalyticsService: locator<ProductAnalyticsService>(),
+    sessionId: sessionId,
+    projectId: projectId,
+    notificationCanceller: locator<NotificationCanceller>(),
+    failureReporter: locator<FailureReporter>(),
+  );
+}
+
+ProjectListCubit createProjectListCubit({required GetIt locator}) {
+  return ProjectListCubit(
+    locator<ProjectRepository>(),
+    locator<ConnectionService>(),
+    locator<SseEventTracker>(),
+    locator<RouteSource>(),
+    projectListService: locator<ProjectListService>(),
+    sessionUnseenTracker: locator<SessionUnseenTracker>(),
+    registeredBridgesService: locator<RegisteredBridgesService>(),
+    productAnalyticsService: locator<ProductAnalyticsService>(),
+    loadedStateAnalyticsReporter: LoadedStateAnalyticsReporter.projectInventory(
+      productAnalyticsService: locator<ProductAnalyticsService>(),
+    ),
+    failureReporter: locator<FailureReporter>(),
+    catalogRescanService: locator<CatalogRescanService>(),
+  );
+}
+
+SessionListCubit createSessionListCubit({required GetIt locator, required String projectId}) {
+  return SessionListCubit(
+    sessionRepository: locator<SessionRepository>(),
+    sessionListService: locator<SessionListService>(),
+    projectRepository: locator<ProjectRepository>(),
+    connectionService: locator<ConnectionService>(),
+    sseEventTracker: locator<SseEventTracker>(),
+    sessionUnseenTracker: locator<SessionUnseenTracker>(),
+    projectViewingService: locator<ProjectViewingService>(),
+    routeSource: locator<RouteSource>(),
+    projectId: projectId,
+    failureReporter: locator<FailureReporter>(),
+    catalogRescanService: locator<CatalogRescanService>(),
+  );
+}
+
+NewSessionCubit createNewSessionCubit({required GetIt locator, required String projectId}) {
+  return NewSessionCubit(
+    connectionService: locator<ConnectionService>(),
+    sessionRepository: locator<SessionRepository>(),
+    newSessionPluginService: locator<NewSessionPluginService>(),
+    newSessionOptionsService: locator<NewSessionOptionsService>(),
+    projectRepository: locator<ProjectRepository>(),
+    selectionTracker: locator<NewSessionSelectionTracker>(),
+    composerDraftRepository: locator<ComposerDraftRepository>(),
+    productAnalyticsService: locator<ProductAnalyticsService>(),
+    projectId: projectId,
+  );
+}


### PR DESCRIPTION
## Complexity
⚙️ Moderate. Four composition functions plus eight shell call-site replacements; no behavior change intended.

## What
- Adds `client/module_core/lib/src/di/cubit_composition.dart` with `createSessionDetailCubit`, `createProjectListCubit`, `createSessionListCubit` and `createNewSessionCubit`. Each takes the required `GetIt` locator plus runtime ids and returns a fresh cubit wired to the collaborators both shells resolved inline.
- Exports the file from the `sesori_dart_core` barrel.
- The phone and desktop shells call these functions inside their existing `BlocProvider(create:)` for project list, session list, new session and session detail.

## Why
Step 16/25 of `.plan/active/periodic-cleanup`: the two shells carried byte-identical collaborator lists for the same four cubits, so a new dependency had to be added twice and could silently drift. The collaborator list now lives once at the DI boundary while ownership stays with the shell.

## Risk and test focus
- Cubit lifetime is unchanged: `BlocProvider` still creates and disposes; no cubit imports GetIt, no singleton or static locator, no wrapper widget.
- Route ids, per-surface presentation and the separate session-activity analytics owners remain in the shells.
- No user-visible, wire or database impact.
- Focus: each screen still resolves the same collaborators (the diff is a mechanical move), and the project inventory `LoadedStateAnalyticsReporter` is still constructed per cubit.

## Expected result
Both shells behave exactly as before. Adding a collaborator to one of these cubits now requires a single edit.

## Verification
- `dart analyze` on `client/module_core`: clean.
- `flutter analyze` on `client/app` and `client/desktop`: no issues.
- App shell screen suites (new session, session detail routing/title hydration, project list): 133 passed. Desktop new-session/projects/sessions suites: 5 passed.
- Architecture implementation review (scoped to this commit): approved, no findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the session detail, project list, session list, and new-session cubit wiring that the phone and desktop shells previously duplicated byte-for-byte, so a collaborator change no longer needs two edits that can silently drift.

**Refactors**
- Adds `createSessionDetailCubit`, `createProjectListCubit`, `createSessionListCubit`, and `createNewSessionCubit` to `client/module_core/lib/src/di/cubit_composition.dart`; each takes a `GetIt` locator plus runtime ids and returns a fresh cubit.
- The eight shell `BlocProvider(create:)` sites now call these functions; route ids, disposal, surface presentation, and the per-cubit `LoadedStateAnalyticsReporter` stay in the shells.
- No behavior change: cubits never import `GetIt`, no singleton or static locator, and the session-activity analytics owners remain separate per surface.

<sup>Written for commit 974cde45e65cd35cff694309cce2cbe03eb19646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

