### PR TITLE
⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -23,8 +23,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 13/25 | ⚙️ [periodic-cleanup] runtime: share provisioning and bounded cold-start waiting [step 13/25] | Merged | [#1323](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1323) |
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Merged | [#1324](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1324) |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Merged | [#1326](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1326) |
-| 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | In review | [#1328](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1328) |
-| 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | In progress (local, awaiting step 16 merge) | — |
+| 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Merged | [#1328](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1328) |
+| 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | In review | PENDING |
 | 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | Proposed | — |
 | 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | Proposed | — |
 | 20/25 | 🌿 [periodic-cleanup] tooling: remove verified unused dependencies and symbols [step 20/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -24,7 +24,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Merged | [#1324](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1324) |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Merged | [#1326](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1326) |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Merged | [#1328](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1328) |
-| 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | In review | PENDING |
+| 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | In review | [#1329](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1329) |
 | 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | Proposed | — |
 | 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | Proposed | — |
 | 20/25 | 🌿 [periodic-cleanup] tooling: remove verified unused dependencies and symbols [step 20/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -24,7 +24,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Merged | [#1324](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1324) |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Merged | [#1326](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1326) |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | In review | [#1328](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1328) |
-| 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Proposed | — |
+| 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | In progress (local, awaiting step 16 merge) | — |
 | 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | Proposed | — |
 | 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | Proposed | — |
 | 20/25 | 🌿 [periodic-cleanup] tooling: remove verified unused dependencies and symbols [step 20/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -294,3 +294,18 @@ asked to start working the plan; steps execute in order from step 2.
   `BlocProvider(create:)`; route ids, disposal and surface presentation stay in
   the shells, and the session-activity analytics owners remain separate. No
   GetIt import in cubits, no singleton, static locator or wrapper widget.
+
+## Step 17 execution — 2026-09-05
+
+- `HttpApiClient._toApiResponse` is the single response-to-`ApiResponse` branch
+  for ordinary and multipart requests: non-2xx keeps status and raw body, an
+  empty 2xx body reaches `fromJson(null)`, and a decode/parse failure logs the
+  typed `_JsonResponseParsingException` under the per-operation label before
+  returning `ApiError.jsonParsing`. `AuthManager._completeInteractiveLogin`
+  takes the captured generation and parsed `AuthLoginResponse`, runs the
+  existing `_persistAuthenticatedResult` call (OAuth state cleared, no OAuth
+  ownership) and returns `AuthLoginResult`; email keeps its own request, 401
+  message and validation, Apple its own request. The shared parse now throws the
+  file-local `_AuthResponseParsingException(innerError:)` whose presentation
+  names only the cause type, replacing the string-only wrapping. OAuth polling
+  and token refresh are untouched.

--- a/client/module_auth/lib/src/auth_manager.dart
+++ b/client/module_auth/lib/src/auth_manager.dart
@@ -696,27 +696,7 @@ class AuthManager(
     }
     _ensureSuccess(response, context: "Email/password login failed");
 
-    final decodedBody = jsonDecodeMap(response.body);
-    final AuthLoginResponse authResponse;
-    try {
-      authResponse = AuthLoginResponse.fromJson(decodedBody);
-    } on Object catch (e) {
-      throw Exception("Failed to parse auth response: ${e.toString()}");
-    }
-
-    final bool persisted = await _persistAuthenticatedResult(
-      generation: generation,
-      accessToken: authResponse.accessToken,
-      refreshToken: authResponse.refreshToken,
-      user: authResponse.user,
-      clearOAuthState: true,
-      requireOAuthOwnership: false,
-      oauthSessionToken: null,
-    );
-    if (!persisted) {
-      throw const _AuthFlowSuperseded();
-    }
-    return AuthLoginResult(user: authResponse.user, accountStatus: authResponse.accountStatus);
+    return await _completeInteractiveLogin(generation: generation, authResponse: _parseLoginResponse(response));
   }
 
   @override
@@ -730,14 +710,24 @@ class AuthManager(
 
     _ensureSuccess(response, context: "Apple Sign-In failed");
 
-    final decodedBody = jsonDecodeMap(response.body);
-    final AuthLoginResponse authResponse;
-    try {
-      authResponse = AuthLoginResponse.fromJson(decodedBody);
-    } on Object catch (e) {
-      throw Exception("Failed to parse auth response: ${e.toString()}");
-    }
+    return await _completeInteractiveLogin(generation: generation, authResponse: _parseLoginResponse(response));
+  }
 
+  AuthLoginResponse _parseLoginResponse(http.Response response) {
+    try {
+      return AuthLoginResponse.fromJson(jsonDecodeMap(response.body));
+    } on Object catch (error, stackTrace) {
+      Error.throwWithStackTrace(_AuthResponseParsingException(innerError: error), stackTrace);
+    }
+  }
+
+  /// Persists a successful email or Apple login for [generation] and reports
+  /// the account status; a login superseded by logout or a newer login throws
+  /// and leaves no tokens behind.
+  Future<AuthLoginResult> _completeInteractiveLogin({
+    required int generation,
+    required AuthLoginResponse authResponse,
+  }) async {
     final bool persisted = await _persistAuthenticatedResult(
       generation: generation,
       accessToken: authResponse.accessToken,
@@ -966,6 +956,15 @@ class AuthManager(
       throw StateError("$context (HTTP ${response.statusCode})");
     }
   }
+}
+
+/// A login response the server accepted but the client could not parse.
+///
+/// The body may carry tokens, so only the cause's type is presented; the
+/// typed cause itself stays available to the logging caller.
+final class const _AuthResponseParsingException({required final Object innerError}) implements Exception {
+  @override
+  String toString() => "Failed to parse auth response (innerError: ${innerError.runtimeType.toString()})";
 }
 
 final class const _AuthFlowSuperseded() implements Exception {

--- a/client/module_auth/lib/src/client/http_api_client.dart
+++ b/client/module_auth/lib/src/client/http_api_client.dart
@@ -172,37 +172,7 @@ class HttpApiClient(final http.Client _client) implements SafeApiClient {
       final Future<http.StreamedResponse> sendFuture = _client.send(request);
       final streamedResponse = timeout != null ? await sendFuture.timeout(timeout) : await sendFuture;
       final response = await http.Response.fromStream(streamedResponse);
-
-      if (response.statusCode >= 200 && response.statusCode < 300) {
-        if (response.body.isEmpty) {
-          // ignore: no_slop_linter/prefer_specific_type, json parsing
-          return ApiResponse.success(fromJson(null));
-        }
-        try {
-          // ignore: no_slop_linter/prefer_specific_type, json decoding
-          final json = jsonDecode(response.body);
-          return ApiResponse.success(fromJson(json));
-        } on Object catch (error, stackTrace) {
-          developer.log(
-            "Failed to parse multipart response JSON",
-            name: "sesori_auth",
-            error: _JsonResponseParsingException(
-              message: "Invalid multipart response JSON",
-              innerError: error,
-            ),
-            stackTrace: stackTrace,
-            level: 1000,
-          );
-          return ApiResponse.error(ApiError.jsonParsing(response.body));
-        }
-      } else {
-        return ApiResponse.error(
-          ApiError.nonSuccessCode(
-            errorCode: response.statusCode,
-            rawErrorString: response.body,
-          ),
-        );
-      }
+      return _toApiResponse(response: response, fromJson: fromJson, operation: "multipart response");
     } on http.ClientException catch (e) {
       return ApiResponse.error(ApiError.dartHttpClient(e));
     }
@@ -251,39 +221,51 @@ class HttpApiClient(final http.Client _client) implements SafeApiClient {
         case HttpMethod.delete:
           response = await _client.delete(url, headers: allHeaders);
       }
-
-      if (response.statusCode >= 200 && response.statusCode < 300) {
-        if (response.body.isEmpty) {
-          // ignore: no_slop_linter/prefer_specific_type, json parsing
-          return ApiResponse.success(fromJson(null));
-        }
-        try {
-          // ignore: no_slop_linter/prefer_specific_type, json decoding
-          final json = jsonDecode(response.body);
-          return ApiResponse.success(fromJson(json));
-        } on Object catch (error, stackTrace) {
-          developer.log(
-            "Failed to parse response JSON",
-            name: "sesori_auth",
-            error: _JsonResponseParsingException(
-              message: "Invalid response JSON",
-              innerError: error,
-            ),
-            stackTrace: stackTrace,
-            level: 1000,
-          );
-          return ApiResponse.error(ApiError.jsonParsing(response.body));
-        }
-      } else {
-        return ApiResponse.error(
-          ApiError.nonSuccessCode(
-            errorCode: response.statusCode,
-            rawErrorString: response.body,
-          ),
-        );
-      }
+      return _toApiResponse(response: response, fromJson: fromJson, operation: "response");
     } on http.ClientException catch (e) {
       return ApiResponse.error(ApiError.dartHttpClient(e));
+    }
+  }
+
+  /// Turns a completed HTTP exchange into an [ApiResponse].
+  ///
+  /// An empty 2xx body is handed to [fromJson] as `null`; a body that fails to
+  /// decode or parse becomes [ApiError.jsonParsing] with the typed cause logged
+  /// under [operation]. Non-2xx responses keep their status and raw body.
+  ApiResponse<T> _toApiResponse<T>({
+    required http.Response response,
+    // ignore: no_slop_linter/prefer_specific_type, json parsing callback
+    required T Function(dynamic json) fromJson,
+    required String operation,
+  }) {
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      return ApiResponse.error(
+        ApiError.nonSuccessCode(
+          errorCode: response.statusCode,
+          rawErrorString: response.body,
+        ),
+      );
+    }
+    if (response.body.isEmpty) {
+      // ignore: no_slop_linter/prefer_specific_type, json parsing
+      return ApiResponse.success(fromJson(null));
+    }
+    try {
+      // ignore: no_slop_linter/prefer_specific_type, json decoding
+      final json = jsonDecode(response.body);
+      return ApiResponse.success(fromJson(json));
+    } on Object catch (error, stackTrace) {
+      developer.log(
+        "Failed to parse $operation JSON",
+        name: "sesori_auth",
+        error: _JsonResponseParsingException(
+          message: "Invalid $operation JSON",
+          innerError: error,
+        ),
+        stackTrace: stackTrace,
+        level: 1000,
+      );
+      return ApiResponse.error(ApiError.jsonParsing(response.body));
     }
   }
 }

--- a/client/module_auth/test/auth_manager_test.dart
+++ b/client/module_auth/test/auth_manager_test.dart
@@ -1717,6 +1717,30 @@ void main() {
       expect(savedEmailUser.providerUsername, "testuser");
     });
 
+    test("rejects a malformed success body without persisting tokens", () async {
+      when(
+        () => mockHttpClient.post(
+          Uri.parse("$authBaseUrl/auth/email"),
+          headers: any(named: "headers"),
+          body: any(named: "body"),
+        ),
+      ).thenAnswer((_) async => http.Response('{"accessToken": "only-a-token"', 200));
+
+      await expectLater(
+        () => authManager.loginWithEmail(email: "test@example.com", password: "correct-password"),
+        throwsA(
+          isA<Exception>().having((e) => e.toString(), "toString", startsWith("Failed to parse auth response")),
+        ),
+      );
+      verifyNever(
+        () => mockTokenStorage.saveTokens(
+          accessToken: any(named: "accessToken"),
+          refreshToken: any(named: "refreshToken"),
+        ),
+      );
+      expect(authManager.currentState, const AuthState.initial());
+    });
+
     test("throws on 401 invalid credentials", () async {
       when(
         () => mockHttpClient.post(

--- a/docs/regression/account-and-onboarding.md
+++ b/docs/regression/account-and-onboarding.md
@@ -61,7 +61,8 @@ the prompt and a reused one when testing suppression.
 - Splash doing network work, or routing a valid session to sign-in.
 - A recoverable interruption surfacing as terminal, or a real failure as silent.
 - Tokens surviving logout, an in-flight login/refresh/restore re-saving tokens or
-  emitting authenticated after logout, a rejected refresh leaving credentials
+  emitting authenticated after logout, a malformed or non-2xx login response
+  persisting tokens, a rejected refresh leaving credentials
   restorable after relaunch, a transport failure clearing a usable session, or
   macOS OAuth completion failing with a missing Keychain entitlement (`-34018`).
 - A delayed persisted registered-bridge read restoring the previous account's


### PR DESCRIPTION
## Complexity

⚙️ Moderate. Two local folds inside the auth HTTP client and `AuthManager`, in
security-sensitive code whose generation fencing and persistence ordering must
survive unchanged.

## What

- `HttpApiClient._toApiResponse` becomes the single HTTP-response-to-`ApiResponse`
  branch for both ordinary and multipart requests. Non-2xx keeps its status code
  and raw body, an empty 2xx body still reaches `fromJson(null)`, and a decode or
  parse failure still logs the typed `_JsonResponseParsingException` — now under a
  per-operation label — before returning `ApiError.jsonParsing`.
- `AuthManager._completeInteractiveLogin` takes the captured generation and the
  parsed `AuthLoginResponse`, performs the existing `_persistAuthenticatedResult`
  call (OAuth state cleared, no OAuth ownership requirement) and returns
  `AuthLoginResult`. Email and Apple keep their own requests; email keeps its 401
  message and input validation.
- The shared `_parseLoginResponse` throws a file-local
  `_AuthResponseParsingException(innerError:)` instead of wrapping the cause in a
  string. Its presentation names only the cause's runtime type, because the body
  may carry tokens.

OAuth polling, token refresh and OAuth ownership are untouched.

## Why

Step 17 of the periodic-cleanup series. Both response branches and both
interactive login tails were duplicated line for line, so a change to empty-body
handling, parse-failure reporting or persistence ordering had to be made twice to
stay correct. The typed inner cause also replaces string-only wrapping, matching
the repository's error-translation rule.

## Risk and test focus

High sensitivity, small surface. Focus on: superseded-login fencing still throwing
and leaving no tokens; secure persistence ordering unchanged; OAuth state clearing
and returned account status unchanged; email's 401 path; non-2xx and malformed
bodies on both the ordinary and multipart client paths.

No authentication endpoint, credential format, trust posture, public API, wire
contract or database change. No user-visible change beyond identical failures now
carrying a typed cause in local logs.

## Expected result

Email and Apple sign-in behave exactly as before, including their failure and
supersession behavior. Voice's multipart upload path is unchanged.

## Verification

- `dart analyze` in `client/module_auth`: no issues.
- `dart test` in `client/module_auth`: 109 tests pass, including the new
  "rejects a malformed success body without persisting tokens" case.
- `dart test test/capabilities/voice/voice_api_test.dart` in `client/module_core`
  (multipart consumer): 8 tests pass.
- `docs/regression/account-and-onboarding.md` gains the matching failure signal.
- Architecture implementation review (required by the plan because a production
  exception type is introduced): approved, no findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates auth response handling and interactive login completion so email and Apple logins share code paths. Behavior is unchanged for users; the only difference is that parse failures now carry a typed cause in local logs.

- Both ordinary and multipart HTTP responses now go through one `_toApiResponse` branch; empty 2xx bodies still reach `fromJson(null)`, and non-2xx keeps its status and raw body.
- Email and Apple logins share `_completeInteractiveLogin`, which persists credentials with OAuth state cleared and no OAuth ownership requirement.
- Auth parse failures now throw a file-local `_AuthResponseParsingException` whose presentation names only the cause's runtime type, because the body may contain tokens.
- OAuth polling, token refresh, and OAuth ownership are untouched.

<sup>Written for commit 5b2c1d8fa6e5b2b3f948ce306df0dfa4443f278e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

