### PR TITLE
🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -309,3 +309,27 @@ asked to start working the plan; steps execute in order from step 2.
   file-local `_AuthResponseParsingException(innerError:)` whose presentation
   names only the cause type, replacing the string-only wrapping. OAuth polling
   and token refresh are untouched.
+
+## Step 18 execution — 2026-09-05
+
+- Two bridge fixture clusters consolidated, both test-only and deletion-heavy
+  (129 added, 1,152 removed): `active_session_tracker_test.dart` now builds its
+  75 `Project` and 15 `Session` values through the package's existing
+  `openCodeProject`/`openCodeSession` fixtures instead of repeating the full
+  literals, keeping every id, worktree, sandbox, parent and title the cases
+  assert on; `git_remote_api_test.dart` drops its duplicate `FakeProcessRunner`
+  and `Invocation` for the shared `helpers/fake_process_runner.dart`
+  `RecordingProcessRunner`, and folds its thirteen identical `GitCliApi(...)
+  .hasGitHubRemote(...)` constructions into one file-local `_hasGitHubRemote`
+  builder.
+- Retained deliberately: the `Session`/`GlobalSession` literals in
+  `opencode_repository_test.dart` and `opencode_service_test.dart` (needs a
+  nullable-title fixture and a new global-session fixture), the
+  `CreateSessionRequest` literals in the session creation and handler suites,
+  the `createTestDatabase` + `singlePluginSessionRepository` harness in
+  `session_repository_test.dart`, the repeated insert blocks in
+  `session_unseen_service_test.dart` and the `get_session_diffs` handler suites,
+  and the remaining duplicated `ProcessRunner`, `_FakeSessionRepository` and
+  `_FakeBridgePlugin` fakes. Each is a real cluster, but folding them here would
+  have doubled this PR past its size budget without making the two clusters
+  above any clearer.

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -25,7 +25,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Merged | [#1326](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1326) |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Merged | [#1328](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1328) |
 | 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Merged | [#1329](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1329) |
-| 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | In review | PENDING |
+| 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | In review | [#1330](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1330) |
 | 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | Proposed | — |
 | 20/25 | 🌿 [periodic-cleanup] tooling: remove verified unused dependencies and symbols [step 20/25] | Proposed | — |
 | 21/25 | 🌱 [periodic-cleanup] docs: simplify repository documentation [step 21/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -24,8 +24,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 14/25 | 🌿 [periodic-cleanup] bridge: fold repeated worktree and Codex algorithms [step 14/25] | Merged | [#1324](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1324) |
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Merged | [#1326](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1326) |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Merged | [#1328](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1328) |
-| 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | In review | [#1329](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1329) |
-| 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | Proposed | — |
+| 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Merged | [#1329](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1329) |
+| 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | In review | PENDING |
 | 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | Proposed | — |
 | 20/25 | 🌿 [periodic-cleanup] tooling: remove verified unused dependencies and symbols [step 20/25] | Proposed | — |
 | 21/25 | 🌱 [periodic-cleanup] docs: simplify repository documentation [step 21/25] | Proposed | — |

--- a/bridge/app/test/bridge/api/git_remote_api_test.dart
+++ b/bridge/app/test/bridge/api/git_remote_api_test.dart
@@ -6,313 +6,139 @@ import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/foundation/streaming_process_runner.dart";
 import "package:test/test.dart";
 
+import "../../helpers/fake_process_runner.dart";
+
 void main() {
   group("hasGitHubRemote", () {
     test("returns true for GitHub HTTPS URL", () async {
-      final mockRunner = FakeProcessRunner.result(
-        exitCode: 0,
-        stdout: "https://github.com/org/repo.git",
-      );
+      final mockRunner = RecordingProcessRunner(exitCode: 0, stdout: "https://github.com/org/repo.git");
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isTrue);
     });
 
     test("returns true for GitHub SSH URL", () async {
-      final mockRunner = FakeProcessRunner.result(
-        exitCode: 0,
-        stdout: "git@github.com:org/repo.git",
-      );
+      final mockRunner = RecordingProcessRunner(exitCode: 0, stdout: "git@github.com:org/repo.git");
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isTrue);
     });
 
     test("returns true for github.com with uppercase", () async {
-      final mockRunner = FakeProcessRunner.result(
-        exitCode: 0,
-        stdout: "https://GitHub.COM/org/repo.git",
-      );
+      final mockRunner = RecordingProcessRunner(exitCode: 0, stdout: "https://GitHub.COM/org/repo.git");
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isTrue);
     });
 
     test("returns false for GitLab URL", () async {
-      final mockRunner = FakeProcessRunner.result(
-        exitCode: 0,
-        stdout: "https://gitlab.com/org/repo.git",
-      );
+      final mockRunner = RecordingProcessRunner(exitCode: 0, stdout: "https://gitlab.com/org/repo.git");
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isFalse);
     });
 
     test("returns false for local path", () async {
-      final mockRunner = FakeProcessRunner.result(
-        exitCode: 0,
-        stdout: "/path/to/local/repo",
-      );
+      final mockRunner = RecordingProcessRunner(exitCode: 0, stdout: "/path/to/local/repo");
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isFalse);
     });
 
     test("returns false for empty output", () async {
-      final mockRunner = FakeProcessRunner.result(
-        exitCode: 0,
-        stdout: "",
-      );
+      final mockRunner = RecordingProcessRunner(exitCode: 0, stdout: "");
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isFalse);
     });
 
     test("returns false for whitespace-only output", () async {
-      final mockRunner = FakeProcessRunner.result(
+      final mockRunner = RecordingProcessRunner(
         exitCode: 0,
         stdout: "   \n  \t  ",
       );
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isFalse);
     });
 
     test("returns false on non-zero exit code", () async {
-      final mockRunner = FakeProcessRunner.result(
-        exitCode: 1,
-        stdout: "https://github.com/org/repo.git",
-      );
+      final mockRunner = RecordingProcessRunner(exitCode: 1, stdout: "https://github.com/org/repo.git");
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isFalse);
     });
 
     test("returns false on timeout", () async {
-      final mockRunner = FakeProcessRunner((
-        String executable,
-        List<String> arguments, {
-        Map<String, String>? environment,
-        String? workingDirectory,
-        Duration timeout = const Duration(seconds: 15),
-      }) async {
-        throw TimeoutException("timed out", timeout);
-      });
+      final mockRunner = RecordingProcessRunner(
+        responder: (_, _, {environment, workingDirectory, timeout = const Duration(seconds: 15)}) {
+          throw TimeoutException("timed out", timeout);
+        },
+      );
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isFalse);
     });
 
     test("passes correct working directory to process runner", () async {
-      final mockRunner = FakeProcessRunner.result(
-        exitCode: 0,
-        stdout: "https://github.com/org/repo.git",
-      );
+      final mockRunner = RecordingProcessRunner(exitCode: 0, stdout: "https://github.com/org/repo.git");
 
-      await GitCliApi(
-        streamingProcessRunner: const StreamingProcessRunner(),
-        processRunner: mockRunner,
-        gitPathExists: ({required String gitPath}) => true,
-      ).hasGitHubRemote(
-        projectPath: "/my/project/path",
-      );
+      await _hasGitHubRemote(runner: mockRunner, projectPath: "/my/project/path");
 
       expect(mockRunner.invocations.single.workingDirectory, equals("/my/project/path"));
     });
 
     test("passes correct git command to process runner", () async {
-      final mockRunner = FakeProcessRunner.result(
-        exitCode: 0,
-        stdout: "https://github.com/org/repo.git",
-      );
+      final mockRunner = RecordingProcessRunner(exitCode: 0, stdout: "https://github.com/org/repo.git");
 
-      await GitCliApi(
-        streamingProcessRunner: const StreamingProcessRunner(),
-        processRunner: mockRunner,
-        gitPathExists: ({required String gitPath}) => true,
-      ).hasGitHubRemote(
-        projectPath: "/path/to/project",
-      );
+      await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(mockRunner.invocations.single.executable, equals("git"));
       expect(mockRunner.invocations.single.arguments, equals(["config", "--get", "remote.origin.url"]));
     });
 
     test("handles exception from process runner", () async {
-      final mockRunner = FakeProcessRunner((
-        String executable,
-        List<String> arguments, {
-        Map<String, String>? environment,
-        String? workingDirectory,
-        Duration timeout = const Duration(seconds: 15),
-      }) async {
-        return ProcessResult(0, 127, "", "command not found");
-      });
+      final mockRunner = RecordingProcessRunner(
+        responder: (_, _, {environment, workingDirectory, timeout = const Duration(seconds: 15)}) {
+          return ProcessResult(0, 127, "", "command not found");
+        },
+      );
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isFalse);
     });
 
     test("trims whitespace from output", () async {
-      final mockRunner = FakeProcessRunner.result(
+      final mockRunner = RecordingProcessRunner(
         exitCode: 0,
         stdout: "  \n  https://github.com/org/repo.git  \n  ",
       );
 
-      final result =
-          await GitCliApi(
-            streamingProcessRunner: const StreamingProcessRunner(),
-            processRunner: mockRunner,
-            gitPathExists: ({required String gitPath}) => true,
-          ).hasGitHubRemote(
-            projectPath: "/path/to/project",
-          );
+      final result = await _hasGitHubRemote(runner: mockRunner, projectPath: "/path/to/project");
 
       expect(result, isTrue);
     });
   });
 }
 
-class const Invocation({
-  required final String executable,
-  required final List<String> arguments,
-  required final String? workingDirectory,
-});
-
-class FakeProcessRunner(
-  final Future<ProcessResult> Function(
-    String executable,
-    List<String> arguments, {
-    Map<String, String>? environment,
-    String? workingDirectory,
-    Duration timeout,
-  })
-  _runImpl,
-) implements ProcessRunner {
-  @override
-  Future<int> startDetached({
-    required String executable,
-    required List<String> arguments,
-    Map<String, String>? environment,
-  }) async {
-    throw UnimplementedError();
-  }
-
-  final List<Invocation> invocations = <Invocation>[];
-
-  factory result({required int exitCode, required String stdout}) {
-    return FakeProcessRunner((
-      String executable,
-      List<String> arguments, {
-      Map<String, String>? environment,
-      String? workingDirectory,
-      Duration timeout = const Duration(seconds: 15),
-    }) async {
-      return ProcessResult(0, exitCode, stdout, "");
-    });
-  }
-
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    Map<String, String>? environment,
-    String? workingDirectory,
-    Duration timeout = const Duration(seconds: 15),
-  }) async {
-    invocations.add(
-      Invocation(
-        executable: executable,
-        arguments: List<String>.from(arguments),
-        workingDirectory: workingDirectory,
-      ),
-    );
-    return await _runImpl(
-      executable,
-      arguments,
-      environment: environment,
-      workingDirectory: workingDirectory,
-      timeout: timeout,
-    );
-  }
+/// Runs the remote check through a real [GitCliApi] backed by [runner].
+///
+/// Every case in this suite exercises the same wiring; only the process
+/// responses and the project path differ.
+Future<bool> _hasGitHubRemote({required ProcessRunner runner, required String projectPath}) {
+  return GitCliApi(
+    streamingProcessRunner: const StreamingProcessRunner(),
+    processRunner: runner,
+    gitPathExists: ({required String gitPath}) => true,
+  ).hasGitHubRemote(projectPath: projectPath);
 }

--- a/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
+++ b/bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart
@@ -226,16 +226,7 @@ void main() {
       test("coldStart seeds aliases from the backend's sandboxes", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>["/moved/repo"],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo", sandboxes: <String>["/moved/repo"]),
           ],
         );
 
@@ -253,16 +244,7 @@ void main() {
         // worktree.
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>["/moved/repo"],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo", sandboxes: <String>["/moved/repo"]),
           ],
           sessions: [_session("s1", "/moved/repo")],
           statuses: {"s1": const SessionStatusBusy()},
@@ -284,16 +266,7 @@ void main() {
       test("coldStart replaces previously-seeded aliases", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
         tracker.registerWorktreeAlias(directory: "/stale/location", worktree: "/repo");
@@ -523,16 +496,7 @@ void main() {
     test("session directory exactly matches worktree", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/projects/foo",
-          ),
+          openCodeProject(id: "p1", worktree: "/projects/foo"),
         ],
       );
 
@@ -546,16 +510,7 @@ void main() {
     test("session directory as subdirectory resolves to project", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/projects/foo",
-          ),
+          openCodeProject(id: "p1", worktree: "/projects/foo"),
         ],
       );
 
@@ -569,16 +524,7 @@ void main() {
     test("session directory with no matching worktree is ignored", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/projects/foo",
-          ),
+          openCodeProject(id: "p1", worktree: "/projects/foo"),
         ],
       );
 
@@ -592,16 +538,7 @@ void main() {
     test("empty directory is handled gracefully", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/projects/foo",
-          ),
+          openCodeProject(id: "p1", worktree: "/projects/foo"),
         ],
       );
 
@@ -615,26 +552,8 @@ void main() {
     test("longest matching worktree is selected", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/projects/foo",
-          ),
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p2",
-            worktree: "/projects/foo/packages/bar",
-          ),
+          openCodeProject(id: "p1", worktree: "/projects/foo"),
+          openCodeProject(id: "p2", worktree: "/projects/foo/packages/bar"),
         ],
       );
 
@@ -656,16 +575,7 @@ void main() {
     test("windows-style path prefixes resolve to project", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: r"C:\repo\foo",
-          ),
+          openCodeProject(id: "p1", worktree: r"C:\repo\foo"),
         ],
       );
 
@@ -679,16 +589,7 @@ void main() {
     test("busy increments and idle decrements active count", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
       );
 
@@ -706,16 +607,7 @@ void main() {
     test("retry session status counts as active", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
       );
 
@@ -740,16 +632,7 @@ void main() {
     test("multiple busy sessions in same project are all counted", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
       );
 
@@ -767,16 +650,7 @@ void main() {
       () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -802,16 +676,7 @@ void main() {
       () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -825,16 +690,7 @@ void main() {
     test("reset clears all state", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
       );
 
@@ -851,26 +707,8 @@ void main() {
     test("buildSummary includes only projects with active sessions", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo-a",
-          ),
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p2",
-            worktree: "/repo-b",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo-a"),
+          openCodeProject(id: "p2", worktree: "/repo-b"),
         ],
       );
 
@@ -886,16 +724,7 @@ void main() {
     test("handleEvent change detection and idempotency", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
       );
 
@@ -920,70 +749,12 @@ void main() {
     test("coldStart populates state from API", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/foo",
-          ),
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p2",
-            worktree: "/bar",
-          ),
+          openCodeProject(id: "p1", worktree: "/foo"),
+          openCodeProject(id: "p2", worktree: "/bar"),
         ],
         sessions: [
-          const Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: null,
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "s1",
-            projectID: "p1",
-            directory: "/foo",
-          ),
-          const Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: null,
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "s2",
-            projectID: "p2",
-            directory: "/bar",
-          ),
+          openCodeSession(id: "s1", directory: "/foo"),
+          openCodeSession(id: "s2", directory: "/bar", projectID: "p2"),
         ],
         statuses: {"s1": const SessionStatusBusy(), "s2": const SessionStatusIdle()},
       );
@@ -994,39 +765,10 @@ void main() {
     test("coldStart buildSummary reflects busy sessions", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
         sessions: [
-          const Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: null,
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "s1",
-            projectID: "p1",
-            directory: "/repo",
-          ),
+          openCodeSession(id: "s1", directory: "/repo"),
         ],
         statuses: {"s1": const SessionStatusBusy()},
       );
@@ -1042,60 +784,11 @@ void main() {
     test("coldStart groups child sessions under parents", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
         sessions: [
-          const Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: null,
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "s1",
-            projectID: "p1",
-            directory: "/repo",
-          ),
-          const Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: "s1",
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "c1",
-            projectID: "p1",
-            directory: "/repo",
-          ),
+          openCodeSession(id: "s1", directory: "/repo"),
+          openCodeSession(id: "c1", directory: "/repo", parentID: "s1"),
         ],
         statuses: {"c1": const SessionStatusBusy()},
       );
@@ -1111,16 +804,7 @@ void main() {
     test("buildSummary includes activeSessions for busy sessions", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/projects/foo",
-          ),
+          openCodeProject(id: "p1", worktree: "/projects/foo"),
         ],
       );
 
@@ -1139,16 +823,7 @@ void main() {
     test("buildSummary excludes idle sessions from activeSessions", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/projects/foo",
-          ),
+          openCodeProject(id: "p1", worktree: "/projects/foo"),
         ],
       );
 
@@ -1167,26 +842,8 @@ void main() {
     test("buildSummary groups session IDs by worktree correctly", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/projects/foo",
-          ),
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p2",
-            worktree: "/projects/bar",
-          ),
+          openCodeProject(id: "p1", worktree: "/projects/foo"),
+          openCodeProject(id: "p2", worktree: "/projects/bar"),
         ],
       );
 
@@ -1209,44 +866,15 @@ void main() {
     test("child sessions are grouped under their parent", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
       );
 
       tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
       tracker.handleEvent(_sessionBusy("s1"), null);
       tracker.handleEvent(
-        const SseEventData.sessionCreated(
-          info: Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: "s1",
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "c1",
-            projectID: "project",
-            directory: "/repo",
-          ),
+        SseEventData.sessionCreated(
+          info: openCodeSession(id: "c1", directory: "/repo", projectID: "project", parentID: "s1"),
         ),
         null,
       );
@@ -1264,43 +892,14 @@ void main() {
     test("idle root with busy children appears in summary", () async {
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
       );
 
       tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
       tracker.handleEvent(
-        const SseEventData.sessionCreated(
-          info: Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: "s1",
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "c1",
-            projectID: "project",
-            directory: "/repo",
-          ),
+        SseEventData.sessionCreated(
+          info: openCodeSession(id: "c1", directory: "/repo", projectID: "project", parentID: "s1"),
         ),
         null,
       );
@@ -1323,42 +922,13 @@ void main() {
       // the child becoming its own (phantom) root.
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
       );
 
       tracker.handleEvent(
-        const SseEventData.sessionCreated(
-          info: Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: "root",
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "c1",
-            projectID: "project",
-            directory: "/repo",
-          ),
+        SseEventData.sessionCreated(
+          info: openCodeSession(id: "c1", directory: "/repo", projectID: "project", parentID: "root"),
         ),
         null,
       );
@@ -1379,60 +949,11 @@ void main() {
       // After switching to listSessions(), child metadata is available.
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
         sessions: [
-          const Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: null,
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "s1",
-            projectID: "p1",
-            directory: "/repo",
-          ),
-          const Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: "s1",
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "c1",
-            projectID: "p1",
-            directory: "/repo",
-          ),
+          openCodeSession(id: "s1", directory: "/repo"),
+          openCodeSession(id: "c1", directory: "/repo", parentID: "s1"),
         ],
         statuses: {"c1": const SessionStatusBusy()},
       );
@@ -1453,71 +974,22 @@ void main() {
       // attributed to its immediate parent rather than walked up to the root.
       final tracker = await _coldStartedTracker(
         projects: [
-          const Project(
-            time: ProjectTime(created: 0, updated: 0, initialized: null),
-            sandboxes: <String>[],
-            vcs: null,
-            name: null,
-            icon: null,
-            commands: null,
-            id: "p1",
-            worktree: "/repo",
-          ),
+          openCodeProject(id: "p1", worktree: "/repo"),
         ],
       );
 
       tracker.handleEvent(_sessionCreated("s1", "/repo"), null);
       tracker.handleEvent(_sessionBusy("s1"), null);
       tracker.handleEvent(
-        const SseEventData.sessionCreated(
-          info: Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: "s1",
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "c1",
-            projectID: "project",
-            directory: "/repo",
-          ),
+        SseEventData.sessionCreated(
+          info: openCodeSession(id: "c1", directory: "/repo", projectID: "project", parentID: "s1"),
         ),
         null,
       );
       tracker.handleEvent(_sessionBusy("c1"), null);
       tracker.handleEvent(
-        const SseEventData.sessionCreated(
-          info: Session(
-            slug: "slug",
-            title: "title",
-            version: "v",
-            workspaceID: null,
-            path: null,
-            summary: null,
-            cost: null,
-            tokens: null,
-            share: null,
-            agent: null,
-            model: null,
-            metadata: null,
-            permission: null,
-            revert: null,
-            parentID: "c1",
-            time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-            id: "g1",
-            projectID: "project",
-            directory: "/repo",
-          ),
+        SseEventData.sessionCreated(
+          info: openCodeSession(id: "g1", directory: "/repo", projectID: "project", parentID: "c1"),
         ),
         null,
       );
@@ -1538,16 +1010,7 @@ void main() {
       test("busy child with unknown parent is a phantom root until resolved", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              id: "p1",
-              worktree: "/repo",
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1589,16 +1052,7 @@ void main() {
         // status event, so the busy child produces no row yet.
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              id: "p1",
-              worktree: "/repo",
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1627,16 +1081,7 @@ void main() {
         // root row and registerSession must report the change.
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              id: "p1",
-              worktree: "/repo",
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1662,16 +1107,7 @@ void main() {
         // re-registration must not trigger a redundant re-emit.
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              id: "p1",
-              worktree: "/repo",
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1688,16 +1124,7 @@ void main() {
       test("registerSession returns false when the session is not active", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              id: "p1",
-              worktree: "/repo",
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1714,16 +1141,7 @@ void main() {
       test("registerSession returns false when the parent is unchanged", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              id: "p1",
-              worktree: "/repo",
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1745,16 +1163,7 @@ void main() {
       test("question asked sets awaitingInput true, replied clears it", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1775,16 +1184,7 @@ void main() {
       test("question rejected clears awaitingInput", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1802,16 +1202,7 @@ void main() {
       test("permission asked sets awaitingInput, replied clears it via requestID mapping", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1830,16 +1221,7 @@ void main() {
       test("multiple pending questions require all resolved to clear", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1864,16 +1246,7 @@ void main() {
       test("session deleted cleans up pending input state", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1892,16 +1265,7 @@ void main() {
       test("session idle removes activity without clearing pending input", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1924,16 +1288,7 @@ void main() {
       test("question asked on active session triggers change detection", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -1949,16 +1304,7 @@ void main() {
       test("populatePendingQuestions populates from cold start data", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
           sessions: [_session("s1", "/repo")],
           statuses: {"s1": const SessionStatusBusy()},
@@ -1978,16 +1324,7 @@ void main() {
       test("permission replied for unknown requestID is a no-op", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -2004,16 +1341,7 @@ void main() {
       test("clearPendingQuestion by sessionId and id clears awaitingInput and fires change", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -2033,16 +1361,7 @@ void main() {
       test("clearPendingQuestion scans by id when sessionId is absent", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -2062,16 +1381,7 @@ void main() {
       test("clearPendingQuestion reports found but no summary change when other pending questions remain", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -2092,16 +1402,7 @@ void main() {
       test("getSessionIdForQuestion returns owning session id", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -2115,16 +1416,7 @@ void main() {
       test("clearPendingPermission clears awaitingInput and fires change", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -2143,16 +1435,7 @@ void main() {
       test("clearPendingPermission reports found but no summary change when other pending input remains", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -2172,16 +1455,7 @@ void main() {
       test("child session pending question bubbles up to root awaitingInput", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -2204,16 +1478,7 @@ void main() {
       test("child session pending permission bubbles up to root awaitingInput", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
         );
 
@@ -2238,40 +1503,11 @@ void main() {
       test("populatePendingPermissions hydrates from cold start data", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo"),
           ],
           statuses: {"s1": const SessionStatusBusy()},
           sessions: [
-            const Session(
-              slug: "slug",
-              title: "title",
-              version: "v",
-              workspaceID: null,
-              path: null,
-              summary: null,
-              cost: null,
-              tokens: null,
-              share: null,
-              agent: null,
-              model: null,
-              metadata: null,
-              permission: null,
-              revert: null,
-              parentID: null,
-              time: SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-              id: "s1",
-              projectID: "p1",
-              directory: "/repo",
-            ),
+            openCodeSession(id: "s1", directory: "/repo"),
           ],
         );
 
@@ -2299,26 +1535,8 @@ void main() {
       test("populates statuses and worktrees correctly", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo-a",
-            ),
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p2",
-              worktree: "/repo-b",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo-a"),
+            openCodeProject(id: "p2", worktree: "/repo-b"),
           ],
           sessions: [
             _session("session-a", "/repo-a"),
@@ -2347,26 +1565,8 @@ void main() {
       test("per-directory error does not break other directories", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/repo-a",
-            ),
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p2",
-              worktree: "/repo-b",
-            ),
+            openCodeProject(id: "p1", worktree: "/repo-a"),
+            openCodeProject(id: "p2", worktree: "/repo-b"),
           ],
           sessions: [
             _session("session-b", "/repo-b"),
@@ -2405,16 +1605,7 @@ void main() {
       test("replaces old worktrees", () async {
         final tracker = await _coldStartedTracker(
           projects: [
-            const Project(
-              time: ProjectTime(created: 0, updated: 0, initialized: null),
-              sandboxes: <String>[],
-              vcs: null,
-              name: null,
-              icon: null,
-              commands: null,
-              id: "p1",
-              worktree: "/old-repo",
-            ),
+            openCodeProject(id: "p1", worktree: "/old-repo"),
           ],
         );
 
@@ -2507,53 +1698,13 @@ void main() {
 
 SseEventData _sessionCreated(String id, String directory) {
   return SseEventData.sessionCreated(
-    info: Session(
-      slug: "slug",
-      title: "title",
-      version: "v",
-      workspaceID: null,
-      path: null,
-      summary: null,
-      cost: null,
-      tokens: null,
-      share: null,
-      agent: null,
-      model: null,
-      metadata: null,
-      permission: null,
-      revert: null,
-      parentID: null,
-      time: const SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-      id: id,
-      projectID: "project",
-      directory: directory,
-    ),
+    info: openCodeSession(id: id, directory: directory, projectID: "project"),
   );
 }
 
 SseEventData _childSessionCreated(String id, String parentId, String directory) {
   return SseEventData.sessionCreated(
-    info: Session(
-      slug: "slug",
-      title: "title",
-      version: "v",
-      workspaceID: null,
-      path: null,
-      summary: null,
-      cost: null,
-      tokens: null,
-      share: null,
-      agent: null,
-      model: null,
-      metadata: null,
-      permission: null,
-      revert: null,
-      parentID: parentId,
-      time: const SessionTime(created: 0, updated: 0, compacting: null, archived: null),
-      id: id,
-      projectID: "project",
-      directory: directory,
-    ),
+    info: openCodeSession(id: id, directory: directory, projectID: "project", parentID: parentId),
   );
 }
 


### PR DESCRIPTION
## Complexity

🌿 Straightforward. Test-only, and overwhelmingly deletion: 153 lines added
against 1,152 removed.

## What

Two bridge fixture clusters from the step-18 inventory:

- `bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart` builds its
  75 `Project` and 15 `Session` values through the package's existing
  `openCodeProject` / `openCodeSession` fixtures instead of repeating the full
  10- and 21-line literals. Every id, worktree, sandbox, parent and title the
  cases assert on is preserved; only the identical filler fields disappear. A few
  `SseEventData` wrappers lose `const`, because a fixture call is not a constant
  expression.
- `bridge/app/test/bridge/api/git_remote_api_test.dart` drops its file-local
  `FakeProcessRunner` and `Invocation` duplicates for the shared
  `helpers/fake_process_runner.dart` `RecordingProcessRunner`, and folds thirteen
  identical `GitCliApi(...).hasGitHubRemote(...)` constructions into one
  file-local `_hasGitHubRemote` builder.

## Why

Step 18 of the periodic-cleanup series consolidates substantial repeated bridge
test setup. In the tracker suite the fixture functions already existed and were
imported, but were used 8 times against 75 hand-written copies, so the actual
inputs of each case were buried in identical filler. The Git remote suite carried
its own copy of a process-runner fake the shared helper already provides.

## Risk and test focus

Test-only: no production code, product behavior, wire contract or database
change. The risk is a fixture silently changing a value a case depends on, so
review focus is that the folded call arguments still carry the ids, worktrees,
sandboxes, parent ids and titles the assertions read, and that
`RecordingProcessRunner` records the same invocations the Git remote assertions
inspect.

## Expected result

Both suites assert exactly what they asserted before, with each case's distinct
inputs visible on one line.

## Verification

- `dart analyze` and `dart test` in `bridge/sesori_plugin_opencode`: no issues,
  431 tests pass.
- `dart analyze` and `dart test` on `bridge/app/test/bridge/api`: no issues,
  50 tests pass (13 of them the rewritten Git remote suite).

## Retained deliberately

Recorded in the tracker: the `Session` / `GlobalSession` literals in
`opencode_repository_test.dart` and `opencode_service_test.dart` (these need a
nullable-title fixture and a new global-session fixture), the
`CreateSessionRequest` literals, the `createTestDatabase` +
`singlePluginSessionRepository` harness, the repeated insert blocks in
`session_unseen_service_test.dart` and the `get_session_diffs` handler suites,
and the remaining duplicated `ProcessRunner`, `_FakeSessionRepository` and
`_FakeBridgePlugin` fakes. Each is a real cluster, but folding them here would
have pushed this PR well past its size budget without making these two clusters
any clearer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates two bridge test fixture clusters so the values each case depends on are visible on one line instead of buried in repeated literals, without changing what the tests assert.

- `active_session_tracker_test.dart` builds its `Project` and `Session` values through the package's existing `openCodeProject`/`openCodeSession` fixtures.
- `git_remote_api_test.dart` replaces its file-local `FakeProcessRunner` and `Invocation` with the shared `RecordingProcessRunner` and folds the repeated `GitCliApi(...).hasGitHubRemote(...)` calls into one `_hasGitHubRemote` builder.
- A few `SseEventData` wrappers lose `const` because a fixture call is not a constant expression.

**Review focus**
- Confirm folded call arguments carry the ids, worktrees, sandboxes, parent ids, and titles the assertions read.
- Confirm `RecordingProcessRunner` records the same invocations the Git remote assertions inspect.

<sup>Written for commit c4a0a0e146154f42dc02b9510b55a7a37558a302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

