### PR TITLE
🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25]

### DIFF
--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -25,8 +25,8 @@ asked to start working the plan; steps execute in order from step 2.
 | 15/25 | 🌿 [periodic-cleanup] bridge: preserve caught errors and stacks in logs [step 15/25] | Merged | [#1326](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1326) |
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Merged | [#1328](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1328) |
 | 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Merged | [#1329](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1329) |
-| 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | In review | [#1330](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1330) |
-| 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | Proposed | — |
+| 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | Merged | [#1330](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1330) |
+| 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | In review | PENDING |
 | 20/25 | 🌿 [periodic-cleanup] tooling: remove verified unused dependencies and symbols [step 20/25] | Proposed | — |
 | 21/25 | 🌱 [periodic-cleanup] docs: simplify repository documentation [step 21/25] | Proposed | — |
 | 22/25 | 🌱 [periodic-cleanup] docs: simplify client regression guides [step 22/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -26,7 +26,7 @@ asked to start working the plan; steps execute in order from step 2.
 | 16/25 | ⚙️ [periodic-cleanup] client: share shell cubit composition [step 16/25] | Merged | [#1328](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1328) |
 | 17/25 | ⚙️ [periodic-cleanup] auth: share response and interactive login completion [step 17/25] | Merged | [#1329](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1329) |
 | 18/25 | 🌿 [periodic-cleanup] tests: consolidate substantial bridge fixtures [step 18/25] | Merged | [#1330](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1330) |
-| 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | In review | PENDING |
+| 19/25 | 🌿 [periodic-cleanup] tests: consolidate substantial client fixtures [step 19/25] | In review | [#1331](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1331) |
 | 20/25 | 🌿 [periodic-cleanup] tooling: remove verified unused dependencies and symbols [step 20/25] | Proposed | — |
 | 21/25 | 🌱 [periodic-cleanup] docs: simplify repository documentation [step 21/25] | Proposed | — |
 | 22/25 | 🌱 [periodic-cleanup] docs: simplify client regression guides [step 22/25] | Proposed | — |

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -333,3 +333,22 @@ asked to start working the plan; steps execute in order from step 2.
   `_FakeBridgePlugin` fakes. Each is a real cluster, but folding them here would
   have doubled this PR past its size budget without making the two clusters
   above any clearer.
+
+## Step 19 execution — 2026-09-05
+
+- Two client session-detail suites gain a group-local `buildCubit` builder and
+  drop their repeated 14-line `SessionDetailCubit(...)` constructions (116 added,
+  1,014 removed): `session_detail_cubit_test.dart` folds 47 copies, whose only
+  differences were the session/project viewing services and the lifecycle source,
+  and `session_detail_stale_test.dart` folds 21 copies differing only in the
+  lifecycle source and the refresh cooldown. The stale builder defaults
+  `eventRefreshMinInterval` to the production five seconds, so the twelve cases
+  that omitted it keep their exact behavior, and the nine coalescing cases still
+  name the short test cooldown.
+- Retained deliberately: the single case in `session_detail_cubit_test.dart` that
+  passes `notificationCanceller: null` keeps its explicit construction, because
+  that null is the behavior under test rather than shared setup. The auth,
+  new-session and project-tile suites named in the plan were left alone; their
+  repeated setup is smaller and already goes through existing stub helpers, so
+  folding it here would have pushed this PR past its size budget without making
+  those suites clearer.

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -312,10 +312,9 @@ asked to start working the plan; steps execute in order from step 2.
 
 ## Step 18 execution — 2026-09-05
 
-- Two bridge fixture clusters consolidated, both test-only and deletion-heavy
-  (129 added and 1,152 removed across the two test files, excluding the tracker
-  note in the same commit): `active_session_tracker_test.dart` now builds its
-  75 `Project` and 15 `Session` values through the package's existing
+- Two bridge fixture clusters consolidated, both test-only and deletion-heavy:
+  `active_session_tracker_test.dart` now builds its 75 `Project` and 15
+  `Session` values through the package's existing
   `openCodeProject`/`openCodeSession` fixtures instead of repeating the full
   literals, keeping every id, worktree, sandbox, parent and title the cases
   assert on; `git_remote_api_test.dart` drops its duplicate `FakeProcessRunner`
@@ -323,6 +322,12 @@ asked to start working the plan; steps execute in order from step 2.
   `RecordingProcessRunner`, and folds its thirteen identical `GitCliApi(...)
   .hasGitHubRemote(...)` constructions into one file-local `_hasGitHubRemote`
   builder.
+- Line split, measured at the squashed commit `7a396d1fc8` on `main`
+  (`git diff --numstat 7a396d1fc8~1..7a396d1fc8 -- \
+  bridge/sesori_plugin_opencode/test/active_session_tracker_test.dart \
+  bridge/app/test/bridge/api/git_remote_api_test.dart`): 81+/930- and 48+/222-,
+  so 129+/1,152- across the two suites, excluding the tracker note in the same
+  commit.
 - Retained deliberately: the `Session`/`GlobalSession` literals in
   `opencode_repository_test.dart` and `opencode_service_test.dart` (needs a
   nullable-title fixture and a new global-session fixture), the
@@ -338,14 +343,21 @@ asked to start working the plan; steps execute in order from step 2.
 ## Step 19 execution — 2026-09-05
 
 - Two client session-detail suites gain a group-local `buildCubit` builder and
-  drop their repeated 14-line `SessionDetailCubit(...)` constructions (116 added
-  and 1,014 removed across the two test files, excluding this tracker note): `session_detail_cubit_test.dart` folds 47 copies, whose only
-  differences were the session/project viewing services and the lifecycle source,
-  and `session_detail_stale_test.dart` folds 21 copies differing only in the
+  drop their repeated 14-line `SessionDetailCubit(...)` constructions.
+  `session_detail_cubit_test.dart` folds 47 copies, whose only differences were
+  the session/project viewing services and the lifecycle source, and
+  `session_detail_stale_test.dart` folds 21 copies differing only in the
   lifecycle source and the refresh cooldown. The stale builder defaults
   `eventRefreshMinInterval` to the production five seconds, so the twelve cases
   that omitted it keep their exact behavior, and the nine coalescing cases still
   name the short test cooldown.
+- Line split, measured at PR head `e6cb5b1132` against merge base `7a396d1fc8`
+  (`git diff --numstat 7a396d1fc8..e6cb5b1132 -- \
+  client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart \
+  client/module_core/test/cubits/session_detail/session_detail_stale_test.dart`):
+  71+/690- and 45+/324-, so 116+/1,014- across the two suites. The path filter
+  makes the figure self-exclusive: it counts neither this tracker note nor the
+  later fix commits on the branch.
 - Retained deliberately: the single case in `session_detail_cubit_test.dart` that
   passes `notificationCanceller: null` keeps its explicit construction, because
   that null is the behavior under test rather than shared setup. The auth,

--- a/.plan/active/periodic-cleanup/TRACKER.md
+++ b/.plan/active/periodic-cleanup/TRACKER.md
@@ -313,7 +313,8 @@ asked to start working the plan; steps execute in order from step 2.
 ## Step 18 execution — 2026-09-05
 
 - Two bridge fixture clusters consolidated, both test-only and deletion-heavy
-  (129 added, 1,152 removed): `active_session_tracker_test.dart` now builds its
+  (129 added and 1,152 removed across the two test files, excluding the tracker
+  note in the same commit): `active_session_tracker_test.dart` now builds its
   75 `Project` and 15 `Session` values through the package's existing
   `openCodeProject`/`openCodeSession` fixtures instead of repeating the full
   literals, keeping every id, worktree, sandbox, parent and title the cases
@@ -337,8 +338,8 @@ asked to start working the plan; steps execute in order from step 2.
 ## Step 19 execution — 2026-09-05
 
 - Two client session-detail suites gain a group-local `buildCubit` builder and
-  drop their repeated 14-line `SessionDetailCubit(...)` constructions (116 added,
-  1,014 removed): `session_detail_cubit_test.dart` folds 47 copies, whose only
+  drop their repeated 14-line `SessionDetailCubit(...)` constructions (116 added
+  and 1,014 removed across the two test files, excluding this tracker note): `session_detail_cubit_test.dart` folds 47 copies, whose only
   differences were the session/project viewing services and the lifecycle source,
   and `session_detail_stale_test.dart` folds 21 copies differing only in the
   lifecycle source and the refresh cooldown. The stale builder defaults

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
@@ -21,6 +21,7 @@ import "package:sesori_dart_core/src/repositories/project_repository.dart";
 import "package:sesori_dart_core/src/repositories/session_repository.dart";
 import "package:sesori_dart_core/src/services/project_viewing_service.dart";
 import "package:sesori_dart_core/src/services/session_detail_load_service.dart";
+import "package:sesori_dart_core/src/services/session_viewing_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -123,6 +124,30 @@ void main() {
       );
     });
 
+    /// Builds the cubit under test with the collaborators every case shares.
+    ///
+    /// Only the viewing services and the lifecycle source differ between cases,
+    /// so each test names just the seam it exercises.
+    SessionDetailCubit buildCubit({
+      SessionViewingService? sessionViewingService,
+      ProjectViewingService? projectViewingService,
+      LifecycleSource? lifecycleSource,
+    }) => SessionDetailCubit(
+      mockConnectionService,
+      loadService: loadService,
+      promptDispatcher: promptDispatcher,
+      permissionRepository: mockPermissionRepository,
+      sessionViewingService: sessionViewingService ?? stubbedSessionViewingService(),
+      projectViewingService: projectViewingService ?? stubbedProjectViewingService(),
+      lifecycleSource: lifecycleSource ?? MockLifecycleSource(),
+      composerDraftRepository: inMemoryComposerDraftRepository(),
+      productAnalyticsService: mockProductAnalyticsService,
+      sessionId: sessionId,
+      projectId: "project-1",
+      notificationCanceller: mockNotificationCanceller,
+      failureReporter: mockFailureReporter,
+    );
+
     tearDown(() async {
       await sessionEvents.close();
       await globalEvents.close();
@@ -131,21 +156,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "initial load success emits SessionDetailLoaded",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       expect: () => [
         isA<SessionDetailLoaded>(),
       ],
@@ -181,21 +192,7 @@ void main() {
 
     test("does not declare a covered route when its initial load completes", () async {
       final sessionViewingService = stubbedSessionViewingService();
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: sessionViewingService,
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      );
+      final cubit = buildCubit(sessionViewingService: sessionViewingService);
       cubit.setRouteVisible(isVisible: false);
 
       await _awaitLoaded(cubit);
@@ -217,21 +214,7 @@ void main() {
           ),
         ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       expect: () => [
         isA<SessionDetailFailed>(),
@@ -240,21 +223,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "reload re-fetches all initial data",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         await cubit.reload();
@@ -295,21 +264,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "sendMessage when connected delegates to service with trimmed text",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         await cubit.sendMessage(
@@ -362,21 +317,7 @@ void main() {
           sessionId: sessionId,
           session: testSession(id: sessionId, pluginId: "codex"),
         );
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -422,21 +363,7 @@ void main() {
           sessionId: sessionId,
           session: testSession(id: sessionId, pluginId: "opencode"),
         );
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -470,21 +397,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "sendMessage refuses a command carrying attachments instead of dropping them",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         await cubit.sendMessage(
@@ -518,21 +431,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "sendMessage with command when connected delegates to service",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         await cubit.sendMessage(
@@ -573,21 +472,7 @@ void main() {
     );
 
     test("voice completion reports a content-free outcome", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
 
       cubit.reportVoiceTranscriptionCompleted();
@@ -602,21 +487,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "sendMessage sends immediately when session is busy but connected",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
 
@@ -692,21 +563,7 @@ void main() {
             ),
           ),
         );
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -756,21 +613,7 @@ void main() {
             ),
           ),
         );
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -793,21 +636,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "selectModel updates selected provider and model",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         cubit.selectModel(providerID: "openai", modelID: "gpt-4.1");
@@ -855,21 +684,7 @@ void main() {
             ),
           ),
         );
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -891,21 +706,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "abort delegates to service.abortSession",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         await cubit.abort(subAgents: SessionAbortSubAgentPolicy.stop);
@@ -930,21 +731,7 @@ void main() {
           (_) async => ApiResponse.success(PendingQuestionResponse(data: [testPendingQuestion()])),
         );
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -983,21 +770,7 @@ void main() {
           (_) async => ApiResponse.success(PendingQuestionResponse(data: [testPendingQuestion()])),
         );
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -1017,21 +790,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "clearNotifications dismisses all notifications for the session",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         cubit.clearNotifications();
@@ -1070,21 +829,7 @@ void main() {
 
     test("reassertViewingSession restores a loaded parent after child navigation", () async {
       final sessionViewingService = stubbedSessionViewingService();
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: sessionViewingService,
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      );
+      final cubit = buildCubit(sessionViewingService: sessionViewingService);
       addTearDown(cubit.close);
       await _awaitLoaded(cubit);
       clearInteractions(sessionViewingService);
@@ -1113,21 +858,7 @@ void main() {
           ),
         );
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -1150,21 +881,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "SSE session.status updates session status",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         sessionEvents.add(
@@ -1186,21 +903,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "SSE question.asked adds pending question",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         sessionEvents.add(testSseQuestionAsked());
@@ -1220,21 +923,7 @@ void main() {
           (_) async => ApiResponse.success(PendingQuestionResponse(data: [testPendingQuestion()])),
         );
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -1254,21 +943,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "SSE session.updated updates title",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         sessionEvents.add(
@@ -1302,21 +977,7 @@ void main() {
           () => mockSessionService.getChildren(sessionId: sessionId),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [oldChild, midChild, newChild])));
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       expect: () => [
         isA<SessionDetailLoaded>().having(
@@ -1336,21 +997,7 @@ void main() {
           () => mockSessionService.getChildren(sessionId: sessionId),
         ).thenAnswer((_) async => ApiResponse.success(SessionListResponse(items: [existingChild])));
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -1393,21 +1040,7 @@ void main() {
           (_) async => ApiResponse.success(SessionListResponse(items: [newChild, oldChild])),
         );
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -1501,21 +1134,7 @@ void main() {
         );
       });
 
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
       await _awaitLoaded(cubit);
 
@@ -1562,21 +1181,7 @@ void main() {
           (_) async => ApiResponse.success(SessionListResponse(items: [newChild, oldChild])),
         );
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -1608,21 +1213,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "close disposes event subscriptions",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         await cubit.close();
@@ -1639,21 +1230,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "sendMessage queues when connection is lost",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         when(() => mockConnectionService.currentStatus).thenReturn(
@@ -1695,21 +1272,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "sendMessage queues when reconnecting",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
         when(() => mockConnectionService.currentStatus).thenReturn(
@@ -1765,21 +1328,7 @@ void main() {
           ),
         ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -1832,21 +1381,7 @@ void main() {
             const SessionStatusResponse(statuses: {sessionId: SessionStatus.busy()}),
           ),
         );
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -1912,21 +1447,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "connection restored drains queued messages",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
 
@@ -1997,21 +1518,7 @@ void main() {
     );
 
     test("whitespace-only command is queued and drained as a normal prompt", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
       await _awaitLoaded(cubit);
 
@@ -2098,21 +1605,7 @@ void main() {
         );
       });
 
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
       await _awaitLoaded(cubit);
 
@@ -2197,21 +1690,7 @@ void main() {
         return ApiResponse<void>.success(null);
       });
 
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
       await _awaitLoaded(cubit);
 
@@ -2302,21 +1781,7 @@ void main() {
         return ApiResponse<void>.success(null);
       });
 
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
       await _awaitLoaded(cubit);
 
@@ -2356,21 +1821,7 @@ void main() {
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "multiple queued messages drain sequentially on reconnection",
-      build: () => SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: MockLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: mockProductAnalyticsService,
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: mockFailureReporter,
-      ),
+      build: buildCubit,
       act: (cubit) async {
         await _awaitLoaded(cubit);
 
@@ -2458,21 +1909,7 @@ void main() {
           ),
         ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
 
-        return SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        return buildCubit();
       },
       act: (cubit) async {
         await _awaitLoaded(cubit);
@@ -2555,21 +1992,7 @@ void main() {
         when(
           () => projectViewingService.beginDetailClaim(projectId: "project-1"),
         ).thenReturn(projectClaim);
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: viewingService,
-          projectViewingService: projectViewingService,
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        final cubit = buildCubit(sessionViewingService: viewingService, projectViewingService: projectViewingService);
         await _awaitLoaded(cubit);
 
         verify(() => viewingService.setViewingSession(sessionId)).called(1);
@@ -2602,21 +2025,7 @@ void main() {
         when(
           () => projectViewingService.beginDetailClaim(projectId: "project-1"),
         ).thenReturn(projectClaim);
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: viewingService,
-          projectViewingService: projectViewingService,
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        final cubit = buildCubit(sessionViewingService: viewingService, projectViewingService: projectViewingService);
         addTearDown(cubit.close);
         await awaitState(
           cubit: cubit,
@@ -2638,21 +2047,7 @@ void main() {
             config: ServerConnectionConfig(relayHost: "fake.example.com", authToken: null),
           ),
         );
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: viewingService,
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: MockLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        final cubit = buildCubit(sessionViewingService: viewingService);
         addTearDown(cubit.close);
         await Future<void>.delayed(Duration.zero);
         clearInteractions(viewingService);
@@ -2695,21 +2090,7 @@ void main() {
             health: HealthResponse(healthy: true, version: "1", filesystemAccessDegraded: false),
           ),
         );
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: viewingService,
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: lifecycle,
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: mockProductAnalyticsService,
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: mockFailureReporter,
-        );
+        final cubit = buildCubit(sessionViewingService: viewingService, lifecycleSource: lifecycle);
         addTearDown(cubit.close);
         await _awaitLoaded(cubit);
         clearInteractions(viewingService);

--- a/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_stale_test.dart
@@ -106,6 +106,30 @@ void main() {
       _stubLoadApis(mockSessionService, sessionId: sessionId);
     });
 
+    /// Builds the cubit under test with the collaborators every case shares.
+    ///
+    /// [eventRefreshMinInterval] defaults to the production cooldown; cases that
+    /// exercise coalescing pass the short test cooldown instead.
+    SessionDetailCubit buildCubit({
+      LifecycleSource? lifecycleSource,
+      Duration eventRefreshMinInterval = const Duration(seconds: 5),
+    }) => SessionDetailCubit(
+      mockConnectionService,
+      loadService: loadService,
+      promptDispatcher: promptDispatcher,
+      permissionRepository: mockPermissionRepository,
+      sessionViewingService: stubbedSessionViewingService(),
+      projectViewingService: stubbedProjectViewingService(),
+      lifecycleSource: lifecycleSource ?? FakeLifecycleSource(),
+      composerDraftRepository: inMemoryComposerDraftRepository(),
+      productAnalyticsService: stubbedProductAnalyticsService(),
+      sessionId: sessionId,
+      projectId: "project-1",
+      notificationCanceller: mockNotificationCanceller,
+      failureReporter: MockFailureReporter(),
+      eventRefreshMinInterval: eventRefreshMinInterval,
+    );
+
     tearDown(() async {
       await sessionEvents.close();
       await globalEvents.close();
@@ -115,21 +139,7 @@ void main() {
     test(
       "deferred refresh: stale while disconnected waits for ConnectionConnected before refreshing",
       () async {
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: FakeLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: stubbedProductAnalyticsService(),
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: MockFailureReporter(),
-        );
+        final cubit = buildCubit();
         addTearDown(cubit.close);
 
         await _awaitLoaded(cubit);
@@ -199,21 +209,7 @@ void main() {
     );
 
     test("deferred refresh: stale when connected triggers immediate refresh", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await _awaitLoaded(cubit);
@@ -275,21 +271,7 @@ void main() {
     });
 
     test("selectAgent preserves the model when the agent has no model preference", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await _awaitLoaded(cubit);
@@ -302,21 +284,7 @@ void main() {
     });
 
     test("silent refresh preserves selectedAgent and selectedAgentModel", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await _awaitLoaded(cubit);
@@ -395,21 +363,7 @@ void main() {
         ),
       ).thenAnswer((_) async => ApiResponse<void>.success(null));
 
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await _awaitLoaded(cubit);
@@ -479,21 +433,7 @@ void main() {
         ),
       ).thenAnswer((_) async => ApiResponse<void>.success(null));
 
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await _awaitLoaded(cubit);
@@ -524,21 +464,7 @@ void main() {
     });
 
     test("delta race: streaming deltas arriving during refresh are preserved", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await _awaitLoaded(cubit);
@@ -612,21 +538,7 @@ void main() {
     });
 
     test("option failure retains the prior snapshot while waiting for retry", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await _awaitLoaded(cubit);
@@ -672,21 +584,7 @@ void main() {
         ),
       ).thenAnswer((_) => messagesCompleter.future);
 
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      );
+      final cubit = buildCubit();
 
       mockConnectionService.emitDataMayBeStale();
       await pumpEventQueue();
@@ -737,21 +635,7 @@ void main() {
         ),
       ).thenAnswer((_) async => ApiResponse.error(ApiError.generic()));
 
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await _awaitFailed(cubit);
@@ -776,21 +660,7 @@ void main() {
         setLogLevel(LogLevel.debug);
         addTearDown(() => setLogLevel(previousLogLevel));
         final cubit = runZoned(
-          () => SessionDetailCubit(
-            mockConnectionService,
-            loadService: loadService,
-            promptDispatcher: promptDispatcher,
-            permissionRepository: mockPermissionRepository,
-            sessionViewingService: stubbedSessionViewingService(),
-            projectViewingService: stubbedProjectViewingService(),
-            lifecycleSource: FakeLifecycleSource(),
-            composerDraftRepository: inMemoryComposerDraftRepository(),
-            productAnalyticsService: stubbedProductAnalyticsService(),
-            sessionId: sessionId,
-            projectId: "project-1",
-            notificationCanceller: mockNotificationCanceller,
-            failureReporter: MockFailureReporter(),
-          ),
+          buildCubit,
           zoneSpecification: ZoneSpecification(
             print: (self, parent, zone, line) => logs.add(line),
           ),
@@ -843,22 +713,7 @@ void main() {
 
     test("a failed leading stale refresh retries until a snapshot succeeds", () {
       fakeAsync((FakeAsync async) {
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: FakeLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: stubbedProductAnalyticsService(),
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: MockFailureReporter(),
-          eventRefreshMinInterval: _cooldown,
-        );
+        final cubit = buildCubit(eventRefreshMinInterval: _cooldown);
 
         _settleLoaded(async: async, cubit: cubit);
         reset(mockSessionService);
@@ -910,22 +765,7 @@ void main() {
 
     test("an option load failure preserves catalogs and retries until options load", () {
       fakeAsync((FakeAsync async) {
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: FakeLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: stubbedProductAnalyticsService(),
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: MockFailureReporter(),
-          eventRefreshMinInterval: _cooldown,
-        );
+        final cubit = buildCubit(eventRefreshMinInterval: _cooldown);
 
         _settleLoaded(async: async, cubit: cubit);
         final before = cubit.state as SessionDetailLoaded;
@@ -967,22 +807,7 @@ void main() {
       late final SessionDetailCubit cubit;
       late final StreamSubscription<SessionDetailState> sub;
       fakeAsync((FakeAsync async) {
-        cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: FakeLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: stubbedProductAnalyticsService(),
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: MockFailureReporter(),
-          eventRefreshMinInterval: _cooldown,
-        );
+        cubit = buildCubit(eventRefreshMinInterval: _cooldown);
 
         _settleLoaded(async: async, cubit: cubit);
         reset(mockSessionService);
@@ -1043,21 +868,7 @@ void main() {
     });
 
     test("concurrent stale signals are coalesced (single API call)", () async {
-      final cubit = SessionDetailCubit(
-        mockConnectionService,
-        loadService: loadService,
-        promptDispatcher: promptDispatcher,
-        permissionRepository: mockPermissionRepository,
-        sessionViewingService: stubbedSessionViewingService(),
-        projectViewingService: stubbedProjectViewingService(),
-        lifecycleSource: FakeLifecycleSource(),
-        composerDraftRepository: inMemoryComposerDraftRepository(),
-        productAnalyticsService: stubbedProductAnalyticsService(),
-        sessionId: sessionId,
-        projectId: "project-1",
-        notificationCanceller: mockNotificationCanceller,
-        failureReporter: MockFailureReporter(),
-      );
+      final cubit = buildCubit();
       addTearDown(cubit.close);
 
       await _awaitLoaded(cubit);
@@ -1148,22 +959,7 @@ void main() {
 
     test("staleness bursts inside the cooldown collapse into one immediate and one trailing refresh", () {
       fakeAsync((FakeAsync async) {
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: FakeLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: stubbedProductAnalyticsService(),
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: MockFailureReporter(),
-          eventRefreshMinInterval: _cooldown,
-        );
+        final cubit = buildCubit(eventRefreshMinInterval: _cooldown);
 
         _settleLoaded(async: async, cubit: cubit);
         reset(mockSessionService);
@@ -1218,22 +1014,7 @@ void main() {
 
     test("a queued signal survives a refresh that outlives the cooldown window", () {
       fakeAsync((FakeAsync async) {
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: FakeLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: stubbedProductAnalyticsService(),
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: MockFailureReporter(),
-          eventRefreshMinInterval: _cooldown,
-        );
+        final cubit = buildCubit(eventRefreshMinInterval: _cooldown);
 
         _settleLoaded(async: async, cubit: cubit);
         reset(mockSessionService);
@@ -1315,22 +1096,7 @@ void main() {
 
     test("the trailing refresh runs as soon as a slow refresh completes, not a window later", () {
       fakeAsync((FakeAsync async) {
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: FakeLifecycleSource(),
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: stubbedProductAnalyticsService(),
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: MockFailureReporter(),
-          eventRefreshMinInterval: _cooldown,
-        );
+        final cubit = buildCubit(eventRefreshMinInterval: _cooldown);
 
         _settleLoaded(async: async, cubit: cubit);
         reset(mockSessionService);
@@ -1409,22 +1175,7 @@ void main() {
     test("the queue is held while hidden and consumed by the resume refresh", () {
       fakeAsync((FakeAsync async) {
         final lifecycle = FakeLifecycleSource();
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: lifecycle,
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: stubbedProductAnalyticsService(),
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: MockFailureReporter(),
-          eventRefreshMinInterval: _cooldown,
-        );
+        final cubit = buildCubit(lifecycleSource: lifecycle, eventRefreshMinInterval: _cooldown);
 
         _settleLoaded(async: async, cubit: cubit);
         reset(mockSessionService);
@@ -1489,22 +1240,7 @@ void main() {
     test("a failed resume refresh preserves hidden staleness until a snapshot succeeds", () {
       fakeAsync((FakeAsync async) {
         final lifecycle = FakeLifecycleSource();
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: lifecycle,
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: stubbedProductAnalyticsService(),
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: MockFailureReporter(),
-          eventRefreshMinInterval: _cooldown,
-        );
+        final cubit = buildCubit(lifecycleSource: lifecycle, eventRefreshMinInterval: _cooldown);
 
         _settleLoaded(async: async, cubit: cubit);
         reset(mockSessionService);
@@ -1562,22 +1298,7 @@ void main() {
     test("a signal queued behind an in-flight refresh survives a pause/resume cycle", () {
       fakeAsync((FakeAsync async) {
         final lifecycle = FakeLifecycleSource();
-        final cubit = SessionDetailCubit(
-          mockConnectionService,
-          loadService: loadService,
-          promptDispatcher: promptDispatcher,
-          permissionRepository: mockPermissionRepository,
-          sessionViewingService: stubbedSessionViewingService(),
-          projectViewingService: stubbedProjectViewingService(),
-          lifecycleSource: lifecycle,
-          composerDraftRepository: inMemoryComposerDraftRepository(),
-          productAnalyticsService: stubbedProductAnalyticsService(),
-          sessionId: sessionId,
-          projectId: "project-1",
-          notificationCanceller: mockNotificationCanceller,
-          failureReporter: MockFailureReporter(),
-          eventRefreshMinInterval: _cooldown,
-        );
+        final cubit = buildCubit(lifecycleSource: lifecycle, eventRefreshMinInterval: _cooldown);
 
         _settleLoaded(async: async, cubit: cubit);
         reset(mockSessionService);


### PR DESCRIPTION
## Complexity

🌿 Straightforward. Test-only, and overwhelmingly deletion: 116 lines added
against 1,014 removed across the two test files.

## What

Both large session-detail suites gain a group-local `buildCubit` builder and drop
their repeated 14-line `SessionDetailCubit(...)` constructions:

- `session_detail_cubit_test.dart`: 47 copies folded. Their only differences were
  the session viewing service, the project viewing service and the lifecycle
  source, so the builder takes exactly those three as optional overrides.
- `session_detail_stale_test.dart`: 21 copies folded. These differed only in the
  lifecycle source and the refresh cooldown. The builder defaults
  `eventRefreshMinInterval` to the production five seconds, so the twelve cases
  that omitted it keep their exact behavior, and the nine coalescing cases still
  name the short test cooldown at their call site.

Sites that need no override now read `build: buildCubit` or `buildCubit()`.

## Why

Step 19 of the periodic-cleanup series consolidates substantial repeated client
test setup. Every case in these two suites repeated the same thirteen
collaborators, so the one or two arguments a case actually exercised were buried
in identical wiring, and any constructor change meant editing 68 copies.

## Risk and test focus

Test-only: no production code, product behavior, wire contract or database
change. The risk is a builder default quietly changing what a case asserts, so
review focus is the two defaults that carry behavior — `eventRefreshMinInterval`
matching the production five seconds, and the `??` fallbacks resolving to the
same stubs the copies used.

## Expected result

Both suites assert exactly what they asserted before, with each case naming only
the seam it exercises.

## Verification

- `dart analyze test/cubits/session_detail` in `client/module_core`: no issues.
- `dart test test/cubits/session_detail`: all 195 tests pass.

## Retained deliberately

Recorded in the tracker: the single case passing `notificationCanceller: null`
keeps its explicit construction, because that null is the behavior under test
rather than shared setup. The auth, new-session and project-tile suites named in
the plan were left alone — their repeated setup is smaller and already goes
through existing stub helpers, so folding it here would have pushed this PR past
its size budget without making those suites clearer.

This branch also clarifies that the recorded fixture line totals in the tracker
count the test files only, excluding the tracker note in the same commit, which a
review comment on #1330 asked for.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates repeated `SessionDetailCubit` construction in the two session-detail test suites into a group-local `buildCubit` builder, removing ~1,000 duplicate lines without changing what the tests assert.

**Notes**

- `session_detail_cubit_test.dart` folds 47 copies; only the viewing services and lifecycle source differ, so those are the builder’s overrides.
- `session_detail_stale_test.dart` folds 21 copies; lifecycle source and refresh cooldown are overridable, with the cooldown defaulting to production’s five seconds so the twelve cases that omitted it keep their exact behavior.
- The single case explicitly passing `notificationCanceller: null` keeps its inline construction because that null is the behavior under test, not shared setup.

<sup>Written for commit c6f7ba660ede19868b8602b3ba8b3e1ac6eb28a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

