### PR TITLE
🌿 bridge: stop repeating the gh identity warning on hosts without gh login

### DIFF
--- a/bridge/app/lib/src/services/pr_sync_service.dart
+++ b/bridge/app/lib/src/services/pr_sync_service.dart
@@ -54,6 +54,9 @@ class PrSyncService({
   /// reusing a successful result for [_githubCliCacheTtl]. Each call is a
   /// network round trip, and an explicit refresh otherwise pays for several in
   /// series. Failures are never cached so a fixed login is picked up at once.
+  ///
+  /// Returns null when gh is missing or unauthenticated, without running the
+  /// identity query.
   Future<VerifiedGithubLogin?> verifyGithubIdentity() async {
     final inFlight = _identityVerification;
     if (inFlight != null) return await inFlight;
@@ -76,28 +79,41 @@ class PrSyncService({
 
   Future<VerifiedGithubLogin?> _verifyGithubIdentity() async {
     try {
+      // A missing gh install or missing login is already reported once by
+      // GhCliApi with the exact command to run. Checking capability first stops
+      // every request from running `gh api user` only to fail the same way.
+      if (!await _hasGithubCliCapability()) return null;
+
       final identity = await _prSource.getAuthenticatedIdentity();
       if (identity == null) {
-        _reportIdentityVerificationFailure();
+        _reportIdentityVerificationFailure(error: null, stackTrace: null);
         return null;
       }
       _identityVerificationFailureReported = false;
       _verifiedIdentityCache = (login: identity, checkedAt: _clock.now());
       return identity;
     } on Object catch (error, stackTrace) {
-      _reportIdentityVerificationFailure();
+      _reportIdentityVerificationFailure(error: error, stackTrace: stackTrace);
+      return null;
+    }
+  }
+
+  /// Reports one warning per failing streak. Failures are never cached, so a gh
+  /// account that stays unverifiable would otherwise repeat the same message and
+  /// stack trace for every request until it is fixed.
+  void _reportIdentityVerificationFailure({
+    required Object? error,
+    required StackTrace? stackTrace,
+  }) {
+    if (_identityVerificationFailureReported) return;
+    _identityVerificationFailureReported = true;
+    if (error != null) {
       Log.w(
         "[PrSyncService] Failed to verify the active GitHub identity; PR refresh is skipped",
         error,
         stackTrace,
       );
-      return null;
     }
-  }
-
-  void _reportIdentityVerificationFailure() {
-    if (_identityVerificationFailureReported) return;
-    _identityVerificationFailureReported = true;
     Console.warning(
       "GitHub CLI (gh) could not verify the active github.com account. "
       "GitHub pull request and CI status metadata cannot be refreshed until verification succeeds. "
@@ -285,9 +301,6 @@ class PrSyncService({
     }
 
     try {
-      if (!await _hasGithubCliCapability()) {
-        return _finishCycle(outcomes: outcomes);
-      }
       final verifiedGithubLogin = await verifyGithubIdentity();
       if (verifiedGithubLogin == null) {
         return _finishCycle(outcomes: outcomes);

--- a/bridge/app/test/bridge/services/pr_sync_service_test.dart
+++ b/bridge/app/test/bridge/services/pr_sync_service_test.dart
@@ -587,6 +587,29 @@ void main() {
       expect(source.identityCallCount, 4);
     });
 
+    test("skips the identity query when gh is unavailable or unauthenticated", () async {
+      final source = _FakePrSource()..isAvailableResult = false;
+      final service = _service(
+        source: source,
+        pullRequests: _FakePullRequestRepository(),
+        sessionsByProject: const {},
+      );
+      addTearDown(service.dispose);
+
+      expect(await service.verifyGithubIdentity(), isNull);
+      expect(source.identityCallCount, 0);
+
+      source
+        ..isAvailableResult = true
+        ..isAuthenticatedResult = false;
+      expect(await service.verifyGithubIdentity(), isNull);
+      expect(source.identityCallCount, 0);
+
+      source.isAuthenticatedResult = true;
+      expect(await service.verifyGithubIdentity(), _verifiedGithubLogin);
+      expect(source.identityCallCount, 1);
+    });
+
     test("isolates replacement exceptions and continues later projects", () async {
       final source = _FakePrSource(
         targetsByDirectory: {

--- a/docs/regression/pull-request-monitoring.md
+++ b/docs/regression/pull-request-monitoring.md
@@ -30,7 +30,9 @@ change. Bridge-owned, plugin-agnostic, backed by the user's local gh CLI.
   the next refresh, while an unknown, failed, or switched login returns session
   and branch without PR metadata instead of another account's cache. Fetched PR
   data is fenced by the viewer login in the same response. No token is stored
-  and no GitHub login reaches clients. Routine
+  and no GitHub login reaches clients. A host with gh missing or not logged in
+  never runs the identity query, and each failing streak warns once with the
+  command to run rather than once per request. Routine
   logs carry no branch, repo slug, PR title, URL, or path; recovered failures retain
   the original error, stack, and diagnostically useful local context.
 - Presence is connection-scoped and unioned across devices; one timer serves the
@@ -70,6 +72,8 @@ alternate whether list or detail holds the claim.
 - Refresh cycles overlap, run with no viewer, stop after an interval change, make a
   newly viewed project wait a full interval, leak branch names, repo slugs, PR
   titles, URLs, or paths into routine logs, or discard useful failure diagnostics.
+- A bridge without gh installed or logged in repeats an identity warning or stack
+  trace for every sessions request instead of one per failing streak.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Complexity

Straightforward. One early return, one moved log call, one deleted redundant check.

## What

`PrSyncService.verifyGithubIdentity()` now returns null when gh is missing or
unauthenticated, without running `gh api user`, and reports a failed
verification once per failing streak instead of once per request.

`_runRefreshCycle` drops its own capability check, which the shared identity
verification now performs.

## Why

`GET /sessions` calls `verifyGithubIdentity()` on every request, and that path
never consulted the gh capability check that the refresh cycle used. Identity
failures are deliberately not cached, so a bridge on a host without `gh auth
login` spawned `gh api user`, failed, and logged a full warning plus stack trace
for every sessions poll:

```
[PrSyncService] Failed to verify the active GitHub identity; PR refresh is skipped
ProcessException: To get started with GitHub CLI, please run:  gh auth login
```

`GhCliApi` already emits one deduplicated, actionable warning for a missing
install or missing login, so the generic per-request message added noise without
adding information.

## Risk and test focus

No user-visible change and no database impact: PR-free responses on an
unauthenticated host behave exactly as before. Failed logins are still never
cached, so a fresh `gh auth login` is picked up on the next refresh — now via the
capability cache, which also only caches successes.

Focus on hosts where gh is installed and `gh auth status` passes but `gh api
user` fails (expired token, no network): the first failure still logs the error
and stack, and the streak resets on the next success.

## Expected result

A bridge without gh, or with gh not logged in, logs one console warning naming
the command to run and then stays quiet, instead of one warning and stack trace
per sessions request.

## Verification

- `dart test test/bridge/services/pr_sync_service_test.dart test/bridge/routing/get_sessions_handler_test.dart` — 60 passing, including a new test that the identity query is skipped while gh is unavailable or unauthenticated.
- `dart analyze` on the touched files — clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `verifyGithubIdentity()` from running `gh api user` when gh is missing or unauthenticated, and now reports identity verification failure only once per failing streak instead of once per request. This removes the repeated warning and stack trace on hosts without a gh login. The shared identity verification now checks gh capability first, so the refresh cycle no longer needs its own check. Failed logins are still never cached, so a fresh `gh auth login` is picked up on the next refresh.

<sup>Written for commit a1bb756526b6dcf4bffd01ec8725984d57a62134. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

