### PR TITLE
🌿 pi: report a logged-out install as authentication required

### DIFF
--- a/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
@@ -7,6 +7,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 
 import "../api/pi_process_factory.dart";
+import "../api/pi_rpc_client.dart";
 import "../pi_identity.dart";
 import "../pi_plugin_impl.dart";
 import "pi_bridge_plugin.dart";
@@ -209,7 +210,14 @@ final class const PiPluginDescriptor({
           stateDirectory: stateDirectory,
           abortSignal: StartAbortSignal.never,
         );
-    if (selection is ManagedRuntimeSelected) return const PluginSetupReady();
+    if (selection case ManagedRuntimeSelected(:final binaryPath, :final version)) {
+      return await _inspectAuthentication(
+        binaryPath: binaryPath,
+        processes: processes,
+        environment: environment,
+        runtimeVersion: version.raw,
+      );
+    }
     final notSelected = selection as ManagedRuntimeNotSelected;
     if (explicitBin != null) {
       return switch (notSelected.primaryRejection) {
@@ -234,6 +242,42 @@ final class const PiPluginDescriptor({
       actionHint: _supportsManagedInstall(config: config)
           ? "Install Pi from Sesori, or install it locally and retry setup detection."
           : "Install Pi locally, then retry setup detection.",
+    );
+  }
+
+  /// Asks Pi which models it can actually use.
+  ///
+  /// Pi accepts credentials from its auth file, from inline provider entries in
+  /// its models file, and from the environment, so only Pi itself can answer
+  /// whether any provider is usable. Listing models neither starts a backend
+  /// nor initiates authentication, and an empty listing carries the same
+  /// diagnostic the session path already recognizes.
+  Future<PluginSetupStatus> _inspectAuthentication({
+    required String binaryPath,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String runtimeVersion,
+  }) async {
+    final CommandResult result;
+    try {
+      result = await HostProcessCommandExecutor(
+        processes: processes,
+        runInShell: io.Platform.isWindows,
+        maxCapturedOutputCharactersPerStream: 64 * 1024,
+      ).run(binaryPath, const ["--list-models"], environment: environment, timeout: _versionProbeTimeout);
+    } on Object {
+      return PluginSetupUnknown.versioned(
+        actionHint: "Pi could not list its available models. Verify the local CLI and retry.",
+        runtimeVersion: runtimeVersion,
+      );
+    }
+    final listedNoModels =
+        result.stdout.contains(PiRpcClient.noModelsDiagnosticPrefix) ||
+        result.stderr.contains(PiRpcClient.noModelsDiagnosticPrefix);
+    if (!listedNoModels) return PluginSetupReady.versioned(runtimeVersion: runtimeVersion);
+    return PluginSetupAuthenticationRequired.versioned(
+      actionHint: "Run `pi` on this machine and use /login to add a provider, then retry setup detection.",
+      runtimeVersion: runtimeVersion,
     );
   }
 

--- a/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_pi/lib/src/runtime/pi_plugin_descriptor.dart
@@ -258,6 +258,11 @@ final class const PiPluginDescriptor({
     required Map<String, String> environment,
     required String runtimeVersion,
   }) async {
+    PluginSetupStatus undetermined() => PluginSetupUnknown.versioned(
+      actionHint: "Pi could not list its available models. Verify the local CLI and retry.",
+      runtimeVersion: runtimeVersion,
+    );
+
     final CommandResult result;
     try {
       result = await HostProcessCommandExecutor(
@@ -265,20 +270,27 @@ final class const PiPluginDescriptor({
         runInShell: io.Platform.isWindows,
         maxCapturedOutputCharactersPerStream: 64 * 1024,
       ).run(binaryPath, const ["--list-models"], environment: environment, timeout: _versionProbeTimeout);
-    } on Object {
-      return PluginSetupUnknown.versioned(
-        actionHint: "Pi could not list its available models. Verify the local CLI and retry.",
-        runtimeVersion: runtimeVersion,
-      );
+    } on Object catch (error, stackTrace) {
+      Log.w("[${PiPluginIdentity.id}] model listing probe failed for '$binaryPath --list-models'", error, stackTrace);
+      return undetermined();
     }
+    // The diagnostic stays authoritative ahead of the exit code, so a release
+    // that reports having no models through a failing exit is still read as
+    // logged out rather than as a broken probe.
     final listedNoModels =
         result.stdout.contains(PiRpcClient.noModelsDiagnosticPrefix) ||
         result.stderr.contains(PiRpcClient.noModelsDiagnosticPrefix);
-    if (!listedNoModels) return PluginSetupReady.versioned(runtimeVersion: runtimeVersion);
-    return PluginSetupAuthenticationRequired.versioned(
-      actionHint: "Run `pi` on this machine and use /login to add a provider, then retry setup detection.",
-      runtimeVersion: runtimeVersion,
-    );
+    if (listedNoModels) {
+      return PluginSetupAuthenticationRequired.versioned(
+        actionHint: "Run `pi` on this machine and use /login to add a provider, then retry setup detection.",
+        runtimeVersion: runtimeVersion,
+      );
+    }
+    if (result.exitCode != 0) {
+      Log.d("[${PiPluginIdentity.id}] model listing probe '$binaryPath --list-models' exited ${result.exitCode}");
+      return undetermined();
+    }
+    return PluginSetupReady.versioned(runtimeVersion: runtimeVersion);
   }
 
   bool _isUnknownRejection(ManagedRuntimeRejection rejection) {

--- a/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
@@ -142,6 +142,38 @@ void main() {
       );
     });
 
+    test("inspectSetup cannot determine setup when the model listing exits non-zero", () async {
+      final result = await PiPluginDescriptor.production().inspectSetup(
+        config: const PluginConfig(values: {PiPluginDescriptor.binOption: "pi"}),
+        processes: _Processes(
+          outputs: const [
+            _Output(stdout: "pi 0.84.2\n", exitCode: 0),
+            _Output(stdout: "unreadable catalog\n", exitCode: 2),
+          ],
+        ),
+        environment: const {},
+        stateDirectory: "/state",
+      );
+
+      expect(result, isA<PluginSetupUnknown>());
+    });
+
+    test("inspectSetup trusts the no-models diagnostic over a non-zero listing exit", () async {
+      final result = await PiPluginDescriptor.production().inspectSetup(
+        config: const PluginConfig(values: {PiPluginDescriptor.binOption: "pi"}),
+        processes: _Processes(
+          outputs: const [
+            _Output(stdout: "pi 0.84.2\n", exitCode: 0),
+            _Output(stdout: "${PiRpcClient.noModelsDiagnosticPrefix}\n", exitCode: 1),
+          ],
+        ),
+        environment: const {},
+        stateDirectory: "/state",
+      );
+
+      expect(result, isA<PluginSetupAuthenticationRequired>());
+    });
+
     test("inspectSetup cannot determine setup when the model listing fails to run", () async {
       final result = await PiPluginDescriptor.production().inspectSetup(
         config: const PluginConfig(values: {PiPluginDescriptor.binOption: "pi"}),

--- a/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart
@@ -101,8 +101,13 @@ void main() {
       expect(processes.executables, ["pi", contains("/state/pi/0.84.4/pi")]);
     });
 
-    test("inspectSetup checks only version and preserves the environment", () async {
-      final processes = _Processes(outputs: const [_Output(stdout: "pi 0.84.2\n", exitCode: 0)]);
+    test("inspectSetup reports a usable model listing as ready and preserves the environment", () async {
+      final processes = _Processes(
+        outputs: const [
+          _Output(stdout: "pi 0.84.2\n", exitCode: 0),
+          _Output(stdout: "provider      model\nopenai-codex  gpt-5.4\n", exitCode: 0),
+        ],
+      );
       final result = await PiPluginDescriptor.production().inspectSetup(
         config: const PluginConfig(values: {PiPluginDescriptor.binOption: "pi"}),
         processes: processes,
@@ -110,11 +115,45 @@ void main() {
         stateDirectory: "/state",
       );
 
-      expect(result, const PluginSetupReady());
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "0.84.2"));
       expect(processes.arguments, [
         const ["--version"],
+        const ["--list-models"],
       ]);
-      expect(processes.environments.single, const {"PI_CODING_AGENT_DIR": "/profile"});
+      expect(processes.environments, everyElement(const {"PI_CODING_AGENT_DIR": "/profile"}));
+    });
+
+    test("inspectSetup reports an empty model listing as authentication required", () async {
+      final result = await PiPluginDescriptor.production().inspectSetup(
+        config: const PluginConfig(values: {PiPluginDescriptor.binOption: "pi"}),
+        processes: _Processes(
+          outputs: const [
+            _Output(stdout: "pi 0.84.2\n", exitCode: 0),
+            _Output(stdout: "${PiRpcClient.noModelsDiagnosticPrefix}\n  docs/providers.md\n", exitCode: 0),
+          ],
+        ),
+        environment: const {},
+        stateDirectory: "/state",
+      );
+
+      expect(
+        result,
+        isA<PluginSetupAuthenticationRequired>().having((s) => s.runtimeVersion, "runtimeVersion", "0.84.2"),
+      );
+    });
+
+    test("inspectSetup cannot determine setup when the model listing fails to run", () async {
+      final result = await PiPluginDescriptor.production().inspectSetup(
+        config: const PluginConfig(values: {PiPluginDescriptor.binOption: "pi"}),
+        processes: _Processes(
+          outputs: const [_Output(stdout: "pi 0.84.2\n", exitCode: 0)],
+          spawnErrorAfter: 1,
+        ),
+        environment: const {},
+        stateDirectory: "/state",
+      );
+
+      expect(result, isA<PluginSetupUnknown>());
     });
 
     test("explicit binary is authoritative and classifies setup failures", () async {
@@ -379,6 +418,7 @@ class const _Output({required final String stdout, required final int exitCode})
 class _Processes({
   final List<_Output> outputs = const [],
   final Object? spawnError,
+  final int? spawnErrorAfter,
 }) implements HostProcessService {
   final List<String> executables = [];
   final List<List<String>> arguments = [];
@@ -398,6 +438,7 @@ class _Processes({
     this.arguments.add(arguments);
     environments.add(environment);
     if (spawnError case final error?) throw error;
+    if (_index == spawnErrorAfter) throw ProcessException(executable, arguments, "spawn failed");
     return _ProbeProcess(output: outputs[_index++]);
   }
 

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -45,6 +45,29 @@ release first, which is the best signal its catalog offers. Other plugins
 still declare variants default-first (the client falls back to the first
 listed variant when no default is declared) and models in plugin-defined order.
 
+## Setup detection
+
+| Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Logged-out backend reported as `authenticationRequired` | ✅ | ⬜¹² | ✅ | ⬜¹³ | ✅ | ✅ | ✅¹¹ | ⬜¹⁴ | ⬜¹⁵ | ⬜¹⁶ |
+
+`inspectSetup` owns this state. Where a plugin does not probe credentials it
+returns `PluginSetupReady` as soon as it resolves a runtime, so a harness that
+is installed but logged into nothing is shown as ready and fails at session
+start instead. Sesori-managed installs make this visible: installing the
+runtime never authenticates it.
+
+A probe belongs here only when it answers "can this harness serve a turn right
+now" without starting a backend or initiating authentication. Counting stored
+credentials is not equivalent: a harness with bundled free models or an
+environment-supplied key is usable with an empty credential store, and blocking
+those installs is worse than the stale ready state this capability replaces.
+
+The marks above cover setup inspection only. A plugin that raises
+`PluginAuthenticationRequiredException` while running still moves the slot to
+`authenticationRequired` and blocks further starts; the ⬜ plugins do not do
+that either.
+
 ## Command limitations
 
 Pi 0.84.4 advertises its bundled `/llama` command over RPC, but the handler
@@ -128,3 +151,39 @@ remains pending.
 under the child id, and exposes `_x.ai/subagent/cancel` per child. A root
 `session/cancel` cancels background children too, so main-agent-only is not
 supported.
+
+¹¹ Pi (0.84.4, probed 2026-09-05) reports it from `pi --list-models`, which
+prints one row per usable model and otherwise prints the
+"No models available. Use /login…" text that
+`PiRpcClient.noModelsDiagnosticPrefix` already matches on the session path, so
+an empty listing is the logged-out signal. Listing resolves every credential
+source Pi accepts — `~/.pi/agent/auth.json`, inline provider keys in
+`~/.pi/agent/models.json`, and environment API keys — which reading the auth
+file alone would not: a user carrying only an environment key or a local
+provider has no `auth.json` entry and a working install. `pi auth check` is
+unusable here because it requires an explicit `--provider` or `--model` and Pi
+exposes no global variant. Verified against a fresh Sesori-managed 0.84.2
+install with no credentials.
+
+¹² OpenCode (1.18.25, probed 2026-09-05) exposes credential counts through
+`opencode auth list`, but that count does not answer this question: `opencode
+models` lists the bundled free `opencode/…` models identically with five
+credentials and with zero, so an empty credential store does not mean the
+harness is unusable. Reporting authentication required from the count alone
+would block installs that still work.
+
+¹³ Copilot has not been probed for a non-interactive credential check.
+
+¹⁴ Oh My Pi (18.1.10, probed 2026-09-05) can report this and does not yet.
+`omp models --json` returns `{"models":[]}` with no credentials and a populated
+list otherwise, which is the same signal Pi exposes in a structured form.
+
+¹⁵ DeepSeek already probes readiness in `inspectSetup` but maps a negative
+result to `PluginSetupUnknown`, so a logged-out install is reported as
+undetermined rather than as authentication required.
+
+¹⁶ Grok Build (1.0.5, probed 2026-09-05) can report this and does not yet.
+`grok models` prints `You are logged in with <account>.` or
+`You are not authenticated.` ahead of a model list that is identical either
+way, so the authentication line is the only signal; the listing itself is not
+one.

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -170,7 +170,10 @@ install with no credentials.
 models` lists the bundled free `opencode/…` models identically with five
 credentials and with zero, so an empty credential store does not mean the
 harness is unusable. Reporting authentication required from the count alone
-would block installs that still work.
+would block installs that still work. This stays ⬜ rather than 🚫 because only
+those two surfaces were probed and neither is equivalent; whether the bundled
+free models actually serve a turn without credentials is unverified, so no
+claim is made that the seam cannot answer the question.
 
 ¹³ Copilot has not been probed for a non-interactive credential check.
 

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -72,6 +72,13 @@ idle suspension, the management snapshot, and lifecycle commands.
   skills, and prompt templates are trusted without prompts); OMP launches `omp acp`
   without an approval-mode override, leaving approval behavior to OMP. Provider login
   for both happens locally, never from the phone.
+- Pi setup inspection follows its version probe with a bounded `--list-models`
+  run in the same environment. A listing that reports no available models is
+  authentication-required carrying the resolved version, any other listing is
+  ready, and a listing that cannot be run is unknown rather than ready. The
+  probe never starts a backend, opens an RPC session, or invokes login, so a
+  managed install with no provider credentials stops being reported as ready
+  and stops offering start.
 - Backend `tui.toast.show` SSE events render through the backend-neutral toast
   surface, presented with the design-system popup alert on the root navigator's
   overlay. Session-attributed events appear only while that session's detail or


### PR DESCRIPTION
## Complexity

Straightforward. One added probe in `PiPluginDescriptor.inspectSetup`, reusing an existing diagnostic constant and the existing `authenticationRequired` seam. No new types, no contract or DI changes.

## What

Pi setup inspection returned `PluginSetupReady` as soon as it resolved a runtime, so a Sesori-managed install with no provider credentials was reported as ready and offered start.

Inspection now follows its version probe with a bounded `pi --list-models` run in the same environment:

- listing reports no available models → `PluginSetupAuthenticationRequired` with the resolved version
- any other listing → `PluginSetupReady` with the resolved version (previously unversioned)
- listing cannot be run → `PluginSetupUnknown`

Also records the capability across every harness in `docs/HARNESS_CAPABILITIES.md` under a new **Setup detection** section, since this gap is not Pi-specific.

## Why

Installing a runtime never authenticates it, so "installed" and "ready" are different states, and Pi conflated them. Pi already detects the logged-out condition — but only at session start, as `PiSessionAuthenticationException` — so the harness advertised ready and then failed every turn.

`--list-models` was chosen over reading `~/.pi/agent/auth.json` because Pi accepts credentials from three places: that auth file, inline provider keys in `~/.pi/agent/models.json`, and environment API keys. Only the first appears in the auth file, so a file check reports "not logged in" for working installs — including any local provider configured through `models.json`. Listing asks Pi itself and covers all three.

`pi auth check` cannot be used: it requires an explicit `--provider` or `--model` and Pi exposes no global variant.

## Risk and test focus

No user-visible impact for an authenticated Pi install beyond the setup card now showing the runtime version. No database impact. No wire contract change — `PluginSetupState.authenticationRequired` already exists and is already handled by client and bridge.

The behavior change is deliberate: a Pi install with no credentials moves from ready to authentication-required, and `startAllowed` becomes false for it. That is the point of the change, but it is the line to review.

Failure mode to watch: a false `authenticationRequired` would block a working install. Guarded by only treating the explicit no-models diagnostic as logged out — anything unrecognized stays ready, matching today's behavior — and by a probe failure mapping to `unknown`, which does not block start.

Probe cost is one short-lived process spawn, measured at ~1.0s, bounded by the existing version-probe timeout. It starts no backend, opens no RPC session, and initiates no authentication, so it stays inside the `inspectSetup` contract.

## Expected result

A freshly installed Pi with no provider credentials reports authentication required with an action hint pointing at local `/login`, instead of reporting ready and failing at session start. An authenticated Pi is unaffected.

## Verification

- `dart test bridge/sesori_plugin_pi/test/pi_plugin_descriptor_test.dart` — 14/14 pass, including three new cases covering the ready, authentication-required, and unknown branches.
- `dart analyze` on both changed files — no issues.
- Probed against pi 0.84.4 locally and the reporter's fresh Sesori-managed 0.84.2 install on a clean host, which printed the no-models diagnostic while Sesori reported it as ready.

## Follow-up not in this PR

The matrix records what the survey found for the other harnesses:

- **Oh My Pi** and **Grok Build** can report this and do not yet — `omp models --json` returns `{"models":[]}` unauthenticated, and `grok models` prints an explicit authentication line. Both verified 2026-09-05.
- **OpenCode** exposes a credential count, but it does not answer the question: `opencode models` lists the bundled free models identically with five credentials and with zero, so an empty store does not mean the install is unusable.
- **DeepSeek** already probes readiness but maps a negative result to `unknown` rather than `authenticationRequired`.
- **Copilot** has not been probed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pi setup inspection now probes `pi --list-models` after the version check, so a logged-out Pi reports authentication-required instead of ready. A listing that can't run maps to unknown, and the resolved version now appears on the setup card.

- `--list-models` covers all three credential sources (auth file, models.json, environment keys); reading the auth file alone would miss working installs.
- Only the explicit no-models diagnostic maps to authentication-required; anything unrecognized stays ready, and a probe failure is unknown, so a working install can't be blocked.

<sup>Written for commit 9f1de10fe51f666a573b29ac48e9245f663f360a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

