### PR TITLE
🌿 bridge: delete sessions whose backend is uninstalled

### DIFF
--- a/bridge/app/lib/src/repositories/session_repository.dart
+++ b/bridge/app/lib/src/repositories/session_repository.dart
@@ -588,11 +588,13 @@ class SessionRepository({
     // uninstalled or unstartable plugin would otherwise leave the user with a
     // row they can never remove. The tombstone below keeps a surviving backend
     // session from being re-imported.
+    var backendDeleteAttempted = false;
     try {
       await _useBoundSessionPlugin(
         binding: binding,
         operation: SessionOperation.deleteSession,
         body: (plugin) async {
+          backendDeleteAttempted = true;
           try {
             await plugin.deleteSession(binding.backendSessionId);
           } on PluginOperationException catch (error) {
@@ -601,7 +603,9 @@ class SessionRepository({
         },
       );
     } on PluginOperationException catch (error, stackTrace) {
-      if (!error.isUnavailable) rethrow;
+      // A backend that answered keeps its existing retry semantics; only never
+      // reaching it clears the way for a local-only delete.
+      if (backendDeleteAttempted || !error.isUnavailable) rethrow;
       Log.w(
         "Backend ${binding.pluginId} was unreachable while deleting session $sessionId; "
         "removing the bridge record anyway",

--- a/bridge/app/lib/src/repositories/session_repository.dart
+++ b/bridge/app/lib/src/repositories/session_repository.dart
@@ -584,17 +584,31 @@ class SessionRepository({
       rows: [binding],
       verifiedGithubLogin: null,
     )).single;
-    await _useBoundSessionPlugin(
-      binding: binding,
-      operation: SessionOperation.deleteSession,
-      body: (plugin) async {
-        try {
-          await plugin.deleteSession(binding.backendSessionId);
-        } on PluginOperationException catch (error) {
-          if (!error.isNotFound) rethrow;
-        }
-      },
-    );
+    // An unreachable backend must not strand the session in the catalog: an
+    // uninstalled or unstartable plugin would otherwise leave the user with a
+    // row they can never remove. The tombstone below keeps a surviving backend
+    // session from being re-imported.
+    try {
+      await _useBoundSessionPlugin(
+        binding: binding,
+        operation: SessionOperation.deleteSession,
+        body: (plugin) async {
+          try {
+            await plugin.deleteSession(binding.backendSessionId);
+          } on PluginOperationException catch (error) {
+            if (!error.isNotFound) rethrow;
+          }
+        },
+      );
+    } on PluginOperationException catch (error, stackTrace) {
+      if (!error.isUnavailable) rethrow;
+      Log.w(
+        "Backend ${binding.pluginId} was unreachable while deleting session $sessionId; "
+        "removing the bridge record anyway",
+        error,
+        stackTrace,
+      );
+    }
     await _sessionDao.transaction(() async {
       final deletedAt = DateTime.now().millisecondsSinceEpoch;
       for (final binding in subtree) {
@@ -1394,6 +1408,15 @@ class SessionRepository({
         return stored;
       }),
     );
+  }
+
+  /// Session identity for bridge-owned work that does not need the backend, so
+  /// it stays available when the plugin cannot start.
+  Future<StoredSession> requireStoredSession({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async {
+    return (await _requireBinding(sessionId: sessionId, operation: operation)).toStoredSession();
   }
 
   Future<StoredSession> requireRoutableStoredSession({

--- a/bridge/app/lib/src/services/session_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/session_lifecycle_service.dart
@@ -44,12 +44,16 @@ class SessionLifecycleService({
 
   /// Runs cleanup inside a session-family operation already reserved by the
   /// archive or deletion workflow.
+  ///
+  /// Worktree removal is git-only, so this path deliberately skips the
+  /// routability requirement: deleting a session must still work when its
+  /// backend is uninstalled or cannot start.
   Future<CleanupResult> cleanupAlreadyReserved({
     required String sessionId,
     required bool deleteWorktree,
     required bool force,
   }) async {
-    final storedSession = await _sessionRepository.requireRoutableStoredSession(
+    final storedSession = await _sessionRepository.requireStoredSession(
       sessionId: sessionId,
       operation: SessionOperation.cleanupSession,
     );

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -423,6 +423,32 @@ void main() {
       expect(operationLog, equals(["checkSafety", "removeWorktree", "pluginDelete"]));
     });
 
+    test("backend that answers 503 keeps the session for retry", () async {
+      await _insertSession(
+        db: db,
+        sessionId: "s10-unavailable",
+        projectId: "/repo",
+        worktreePath: null,
+        branchName: null,
+      );
+      plugin.throwOnDeleteSessionError = PluginApiException("/session/s10-unavailable", 503);
+
+      await expectLater(
+        () => handler.handle(
+          makeRequest("DELETE", "/session/delete"),
+          body: const DeleteSessionRequest(
+            sessionId: "s10-unavailable",
+            deleteWorktree: false,
+            deleteBranch: false,
+            force: false,
+          ),
+        ),
+        throwsA(isA<PluginApiException>()),
+      );
+
+      expect(await db.sessionDao.getSession(sessionId: "s10-unavailable"), isNotNull);
+    });
+
     test("11) plugin delete 404: tolerated, DB row still removed", () async {
       await _insertSession(
         db: db,

--- a/bridge/app/test/bridge/routing/delete_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/delete_session_handler_test.dart
@@ -357,14 +357,14 @@ void main() {
       expect(operationLog, equals(["pluginDelete"]));
     });
 
-    test("stored plugin mismatch returns 503 before plugin I/O or cleanup", () async {
+    test("unreachable backend still deletes the session and its worktree", () async {
       await _insertSession(
         db: db,
         sessionId: "s9",
         projectId: "/repo",
         worktreePath: "/repo/.worktrees/session-009",
         branchName: "session-009",
-        pluginId: "stopped-plugin",
+        pluginId: "uninstalled-plugin",
       );
 
       final response = await handler.routeForTest(
@@ -382,12 +382,15 @@ void main() {
         ),
       );
 
-      expect(response.status, 503);
+      expect(response.status, 200);
       expect(plugin.lastDeleteSessionId, isNull);
-      expect(worktreeService.checkCallCount, equals(0));
-      expect(worktreeService.removeCallCount, equals(0));
-      expect(await db.sessionDao.getSession(sessionId: "s9"), isNotNull);
-      expect(operationLog, isEmpty);
+      expect(worktreeService.removeCallCount, equals(1));
+      expect(await db.sessionDao.getSession(sessionId: "s9"), isNull);
+      expect(
+        await db.sessionDao.getTombstonedSessionIds(pluginId: "uninstalled-plugin"),
+        contains("s9"),
+      );
+      expect(operationLog, equals(["checkSafety", "removeWorktree"]));
     });
 
     test("10) plugin delete non-404 failure: cleanup already ran and DB row remains", () async {

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -530,6 +530,17 @@ class _NoopSessionRepository() implements SessionRepository {
   }) async => null;
 
   @override
+  Future<StoredSession> requireStoredSession({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async {
+    throw PluginOperationException.notFound(
+      operation.name,
+      message: "session $sessionId was not found",
+    );
+  }
+
+  @override
   Future<StoredSession> requireRoutableStoredSession({
     required String sessionId,
     required SessionOperation operation,
@@ -987,7 +998,7 @@ class FakeSessionRepository({
   }) async => null;
 
   @override
-  Future<StoredSession> requireRoutableStoredSession({
+  Future<StoredSession> requireStoredSession({
     required String sessionId,
     required SessionOperation operation,
   }) async {
@@ -998,6 +1009,15 @@ class FakeSessionRepository({
         message: "session $sessionId was not found",
       );
     }
+    return stored;
+  }
+
+  @override
+  Future<StoredSession> requireRoutableStoredSession({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async {
+    final stored = await requireStoredSession(sessionId: sessionId, operation: operation);
     await ensurePluginRoutable(pluginId: stored.pluginId, operation: operation);
     return stored;
   }

--- a/bridge/app/test/bridge/services/session_family_mutation_test.dart
+++ b/bridge/app/test/bridge/services/session_family_mutation_test.dart
@@ -417,7 +417,7 @@ class _FamilyRepository() implements SessionRepository {
   }
 
   @override
-  Future<StoredSession> requireRoutableStoredSession({
+  Future<StoredSession> requireStoredSession({
     required String sessionId,
     required SessionOperation operation,
   }) async {
@@ -425,6 +425,12 @@ class _FamilyRepository() implements SessionRepository {
     if (record == null) throw _notFound(sessionId: sessionId, operation: operation);
     return record.stored;
   }
+
+  @override
+  Future<StoredSession> requireRoutableStoredSession({
+    required String sessionId,
+    required SessionOperation operation,
+  }) => requireStoredSession(sessionId: sessionId, operation: operation);
 
   @override
   Future<List<String>> getSessionSubtreeIds({required String sessionId}) async => [

--- a/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
+++ b/bridge/app/test/bridge/services/session_lifecycle_service_test.dart
@@ -467,7 +467,7 @@ class _FakeSessionRepository() implements SessionRepository {
   Future<StoredSession?> getStoredSession({required String sessionId}) async => storedSession;
 
   @override
-  Future<StoredSession> requireRoutableStoredSession({
+  Future<StoredSession> requireStoredSession({
     required String sessionId,
     required SessionOperation operation,
   }) async {
@@ -478,6 +478,15 @@ class _FakeSessionRepository() implements SessionRepository {
         message: "session $sessionId was not found",
       );
     }
+    return session;
+  }
+
+  @override
+  Future<StoredSession> requireRoutableStoredSession({
+    required String sessionId,
+    required SessionOperation operation,
+  }) async {
+    final session = await requireStoredSession(sessionId: sessionId, operation: operation);
     await ensurePluginRoutable(pluginId: session.pluginId, operation: operation);
     return session;
   }

--- a/bridge/sesori_plugin_interface/lib/src/plugin_operation_exception.dart
+++ b/bridge/sesori_plugin_interface/lib/src/plugin_operation_exception.dart
@@ -32,6 +32,10 @@ class PluginOperationException implements Exception {
   /// `true` when this failure means the target entity does not exist.
   bool get isNotFound => statusCode == 404;
 
+  /// `true` when the backend could not be reached at all, so retrying the same
+  /// call cannot succeed until the plugin becomes routable again.
+  bool get isUnavailable => statusCode == 503;
+
   @override
   String toString() {
     final status = statusCode == null ? "" : " with status $statusCode";

--- a/docs/regression/session-archiving-and-deletion.md
+++ b/docs/regression/session-archiving-and-deletion.md
@@ -22,6 +22,11 @@ entirely along with its transcript and, optionally, its worktree.
   reconciliation. Worktree cleanup happens only when requested; unsafe cleanup
   (unstaged changes or a shared worktree) is refused with its issues and proceeds
   only on a forced retry. Session retirement never deletes a Git branch.
+- Deletion never depends on a reachable backend. A session whose plugin is
+  uninstalled, disabled, or unstartable still deletes: worktree cleanup is Git
+  only, the unreachable backend delete is logged and skipped, and the plugin
+  tombstone keeps a surviving backend session from being re-imported. A backend
+  that is reachable but fails the delete still preserves the session for retry.
 - Per-session prompt defaults are live composer cache, not audit data. Archiving
   clears them from the session row and omits them from the archive snapshot;
   deletion removes them with the row. The separate last-successful New Session


### PR DESCRIPTION
## Complexity

Straightforward. Two small guard changes on the delete path plus a shared
`isUnavailable` accessor; the rest is fake/test alignment.

## What

Sessions whose backend plugin cannot start can now be deleted.

- `cleanupAlreadyReserved` resolves the stored session through a new
  `SessionRepository.requireStoredSession` instead of the routable variant.
  Worktree cleanup is git-only, so it never needed a live backend.
- `SessionRepository.deleteSession` tolerates an unreachable plugin (any
  `PluginOperationException` with status 503), logs it, and removes the bridge
  record anyway. A reachable backend that fails the delete still preserves the
  row for retry, unchanged.
- Adds `PluginOperationException.isUnavailable` next to `isNotFound`.

## Why

Uninstalling a backend CLI on a host gates its plugin off (`startAllowed` goes
false once setup detection stops finding it). Deletion then hit the runtime
twice — once resolving the session for cleanup, once propagating the delete —
and both answered 503, so the session could never be removed from the catalog.
Reported from a VPS bridge after uninstalling opencode.

## Risk and test focus

User-visible: a delete that previously failed with 503 now succeeds. The
session's backend record may survive on disk when the backend is unreachable;
the existing plugin tombstone keeps it from being re-imported.

No database or wire-contract impact.

Focus review on the delete path's failure classification: only runtime/backend
unreachability (503) is swallowed, and a genuine backend delete failure still
aborts before the row is removed.

## Expected result

Deleting a session belonging to an uninstalled, disabled, or unstartable plugin
removes the row, its worktree when requested, and its history, and writes a
tombstone. A warning naming the plugin and session is logged locally.

## Verification

- `dart test` on `delete_session_handler_test.dart`,
  `session_lifecycle_service_test.dart`, `session_family_mutation_test.dart`,
  `session_mutation_dispatcher_test.dart`, `session_repository_test.dart`,
  `deleted_session_storage_cleanup_service_test.dart`,
  `plugin_operation_exception_test.dart` — all pass.
- `dart analyze` clean on `bridge/app` and `bridge/sesori_plugin_interface`.
- The delete-handler test that asserted the old 503 now asserts the delete
  completes, with the worktree removed and a tombstone written.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sessions whose backend is uninstalled or unreachable can now be deleted; previously deletion failed with 503 and left the session stuck in the catalog.

- Worktree cleanup now uses the stored session without requiring a routable plugin; git-only cleanup never needed it.
- Deleting through the repository now tolerates a 503 from the backend, logs it, and removes the bridge record anyway.
- The existing tombstone keeps any surviving backend session from being re-imported.
- A reachable backend that fails the delete still preserves the row for retry.
- Adds `PluginOperationException.isUnavailable` next to `isNotFound`.

<sup>Written for commit b6952c17ef8b8c0305afa8964174985628f74954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

