### PR TITLE
🌱 tooling: bump version to 1.8.4

### DIFF
--- a/bridge/app/lib/src/version.dart
+++ b/bridge/app/lib/src/version.dart
@@ -1,1 +1,1 @@
-const String appVersion = '1.8.3';
+const String appVersion = '1.8.4';

--- a/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-arm64",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS ARM64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.3",
+    "releaseTag": "v1.8.4",
     "releaseArtifact": "sesori-bridge-macos-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-darwin-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-darwin-x64",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on macOS x64",
   "os": [
     "darwin"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.3",
+    "releaseTag": "v1.8.4",
     "releaseArtifact": "sesori-bridge-macos-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-arm64",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux ARM64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.3",
+    "releaseTag": "v1.8.4",
     "releaseArtifact": "sesori-bridge-linux-arm64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-linux-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-linux-x64",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Linux x64",
   "os": [
     "linux"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.3",
+    "releaseTag": "v1.8.4",
     "releaseArtifact": "sesori-bridge-linux-x64.tar.gz",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-arm64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-arm64",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows ARM64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.3",
+    "releaseTag": "v1.8.4",
     "releaseArtifact": "sesori-bridge-windows-arm64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge-win32-x64/package.json
+++ b/bridge/app/npm/sesori-bridge-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sesori/bridge-win32-x64",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Bootstrap payload for the managed Sesori Bridge runtime on Windows x64",
   "os": [
     "win32"
@@ -14,7 +14,7 @@
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.3",
+    "releaseTag": "v1.8.4",
     "releaseArtifact": "sesori-bridge-windows-x64.zip",
     "runtimeBundlePath": "lib/runtime"
   },

--- a/bridge/app/npm/sesori-bridge/package.json
+++ b/bridge/app/npm/sesori-bridge/package.json
@@ -1,22 +1,22 @@
 {
   "name": "@sesori/bridge",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Bootstrap launcher for the managed Sesori Bridge runtime",
   "bin": {
     "sesori-bridge": "bin/bridge.js"
   },
   "optionalDependencies": {
-    "@sesori/bridge-darwin-arm64": "1.8.3",
-    "@sesori/bridge-darwin-x64": "1.8.3",
-    "@sesori/bridge-linux-x64": "1.8.3",
-    "@sesori/bridge-linux-arm64": "1.8.3",
-    "@sesori/bridge-win32-x64": "1.8.3",
-    "@sesori/bridge-win32-arm64": "1.8.3"
+    "@sesori/bridge-darwin-arm64": "1.8.4",
+    "@sesori/bridge-darwin-x64": "1.8.4",
+    "@sesori/bridge-linux-x64": "1.8.4",
+    "@sesori/bridge-linux-arm64": "1.8.4",
+    "@sesori/bridge-win32-x64": "1.8.4",
+    "@sesori/bridge-win32-arm64": "1.8.4"
   },
   "sesoriBridge": {
     "bootstrapOnly": true,
     "managedRuntimeOwner": false,
-    "releaseTag": "v1.8.3",
+    "releaseTag": "v1.8.4",
     "runtimeBundleSource": "github-release-assets"
   },
   "license": "SEE LICENSE IN LICENSE",

--- a/bridge/app/pubspec.yaml
+++ b/bridge/app/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sesori_bridge
 description: Dart implementation of the Sesori Bridge CLI for WebSocket communication.
-version: 1.8.3
+version: 1.8.4
 publish_to: none
 resolution: workspace
 

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -17,7 +17,7 @@ resolution: workspace
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.8.3+1
+version: 1.8.4+1
 environment:
   sdk: ^3.13.2
 


### PR DESCRIPTION
## Complexity

🌱 Trivial. Ran the repo's existing `tool/sync_versions.dart --version=1.8.4`; no hand edits.

## What

Bumps the product version from 1.8.3 to 1.8.4 across the bridge and client:

- `bridge/app/pubspec.yaml`, `bridge/app/lib/src/version.dart`
- `client/app/pubspec.yaml` (1.8.3+1 -> 1.8.4+1)
- All seven `bridge/app/npm/*/package.json` manifests (`version`, optional dependency pins, `releaseTag`)

## Why

Routine release version bump.

## Risk and test focus

No user-visible behavior change and no database impact. Version strings only. Existing `COMPATIBILITY YYYY-MM-DD (v1.8.3)` markers are intentionally left untouched — they record the version at which the compatibility was introduced, not the current version.

## Expected result

`grep -rn "1\.8\.3"` finds no remaining version references outside those historical compatibility markers and `.plan` documents. Bridge reports `1.8.4`; client builds as `1.8.4+1`.

## Verification

- `dart run tool/sync_versions.dart --version=1.8.4` reported both syncs and rewrote all 10 files.
- Grep confirmed no stray `1.8.3` version strings remain.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the product version from 1.8.3 to 1.8.4.

- Updates the version in the bridge and client apps plus all seven `@sesori/bridge*` npm packages.
- Leaves `COMPATIBILITY YYYY-MM-DD (v1.8.3)` markers untouched; they record when compatibility was introduced, not the current version.
- No user-visible behavior change or migration needed.

<sup>Written for commit c9da250b15f5a6e10f4d3857526803def7f0ae98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

