### PR TITLE
🌿 [harness-auth-detection] omp, grok: report a logged-out install as authentication required

### DIFF
--- a/bridge/sesori_plugin_grok/lib/src/runtime/grok_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_grok/lib/src/runtime/grok_plugin_descriptor.dart
@@ -109,22 +109,66 @@ class const GrokPluginDescriptor() extends BridgePluginDescriptor {
       environment: environment,
     );
 
-    return switch (runtime) {
-      _GrokRuntimeReady(:final version) => PluginSetupReady.versioned(runtimeVersion: version),
-      _GrokRuntimeMissing() => PluginSetupRuntimeMissing(
-        actionHint: explicitBin == null
-            ? "Install Grok Build with xAI's official installer, then restart the bridge."
-            : "Fix the configured Grok Build binary path, then restart the bridge.",
-      ),
-      _GrokRuntimeOutdated() => PluginSetupUnavailable(
-        actionHint: explicitBin == null
-            ? "Update Grok Build with xAI's official installer, then restart the bridge."
-            : "Update the configured Grok Build binary or fix `--grok-bin`, then restart the bridge.",
-      ),
-      _GrokRuntimeUnknown() || _GrokRuntimeUnrecognized() => const PluginSetupUnknown(
-        actionHint: "Grok Build setup could not be verified. Run `grok --version` locally, then retry.",
-      ),
-    };
+    switch (runtime) {
+      case _GrokRuntimeReady(:final version):
+        return await _inspectAuthentication(
+          executablePath: explicitBin ?? GrokBinary.defaultBinary,
+          processes: processes,
+          environment: environment,
+          runtimeVersion: version,
+        );
+      case _GrokRuntimeMissing():
+        return PluginSetupRuntimeMissing(
+          actionHint: explicitBin == null
+              ? "Install Grok Build with xAI's official installer, then restart the bridge."
+              : "Fix the configured Grok Build binary path, then restart the bridge.",
+        );
+      case _GrokRuntimeOutdated():
+        return PluginSetupUnavailable(
+          actionHint: explicitBin == null
+              ? "Update Grok Build with xAI's official installer, then restart the bridge."
+              : "Update the configured Grok Build binary or fix `--grok-bin`, then restart the bridge.",
+        );
+      case _GrokRuntimeUnknown() || _GrokRuntimeUnrecognized():
+        return const PluginSetupUnknown(
+          actionHint: "Grok Build setup could not be verified. Run `grok --version` locally, then retry.",
+        );
+    }
+  }
+
+  /// Asks Grok Build whether it is signed in.
+  ///
+  /// `grok models` reports the account state ahead of a model list that is
+  /// identical whether or not credentials exist, so the authentication line is
+  /// the signal. Only that line downgrades setup: listing neither creates a
+  /// session, starts ACP, nor invokes login, and unrecognized wording leaves
+  /// setup ready rather than blocking a working install.
+  Future<PluginSetupStatus> _inspectAuthentication({
+    required String executablePath,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String runtimeVersion,
+  }) async {
+    final CommandResult result;
+    try {
+      result = await HostProcessCommandExecutor(
+        processes: processes,
+        runInShell: io.Platform.isWindows,
+        maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+      ).run(executablePath, const ["models"], environment: environment, timeout: _versionProbeTimeout);
+    } on Object catch (error, stackTrace) {
+      Log.w("[grok] model listing probe failed for '$executablePath models'", error, stackTrace);
+      return PluginSetupUnknown.versioned(
+        actionHint: "Grok Build authentication could not be determined. Run `grok models` locally, then retry.",
+        runtimeVersion: runtimeVersion,
+      );
+    }
+    final listing = "${result.stdout}\n${result.stderr}".toLowerCase();
+    if (!listing.contains("not authenticated")) return PluginSetupReady.versioned(runtimeVersion: runtimeVersion);
+    return PluginSetupAuthenticationRequired.versioned(
+      actionHint: "Run `grok login` on this machine, then retry setup detection.",
+      runtimeVersion: runtimeVersion,
+    );
   }
 
   Future<_GrokRuntimeProbe> _probeRuntime({

--- a/bridge/sesori_plugin_grok/test/grok_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_plugin_descriptor_test.dart
@@ -44,6 +44,12 @@ void main() {
             stderrBytes: const [],
             resultCode: 0,
           ),
+          _ProbeProcess.completed(
+            pid: 2,
+            stdoutBytes: utf8.encode("You are logged in with grok.com.\n\nAvailable models:\n  * grok-4.6\n"),
+            stderrBytes: const [],
+            resultCode: 0,
+          ),
         ],
         servesHeadlessAcp: false,
       );
@@ -56,10 +62,70 @@ void main() {
       );
 
       expect(result, const PluginSetupReady.versioned(runtimeVersion: "1.0.5"));
-      expect(processes.spawnedExecutables, ["grok"]);
+      expect(processes.spawnedExecutables, ["grok", "grok"]);
       expect(processes.spawnedArguments, [
         const ["--version"],
+        const ["models"],
       ]);
+    });
+
+    test("reports an unauthenticated runtime as authentication required", () async {
+      final result = await const GrokPluginDescriptor().inspectSetup(
+        config: config,
+        processes: _ProbeProcessService(
+          spawnError: null,
+          processSequence: [
+            _ProbeProcess.completed(
+              pid: 1,
+              stdoutBytes: utf8.encode("grok 1.0.5\n"),
+              stderrBytes: const [],
+              resultCode: 0,
+            ),
+            _ProbeProcess.completed(
+              pid: 2,
+              stdoutBytes: utf8.encode("You are not authenticated.\n\nAvailable models:\n  * grok-4.6\n"),
+              stderrBytes: const [],
+              resultCode: 0,
+            ),
+          ],
+          servesHeadlessAcp: false,
+        ),
+        environment: const {},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(
+        result,
+        isA<PluginSetupAuthenticationRequired>().having((s) => s.runtimeVersion, "runtimeVersion", "1.0.5"),
+      );
+    });
+
+    test("leaves setup ready when the listing does not report being unauthenticated", () async {
+      final result = await const GrokPluginDescriptor().inspectSetup(
+        config: config,
+        processes: _ProbeProcessService(
+          spawnError: null,
+          processSequence: [
+            _ProbeProcess.completed(
+              pid: 1,
+              stdoutBytes: utf8.encode("grok 1.0.5\n"),
+              stderrBytes: const [],
+              resultCode: 0,
+            ),
+            _ProbeProcess.completed(
+              pid: 2,
+              stdoutBytes: utf8.encode("wording this build does not use\n"),
+              stderrBytes: const [],
+              resultCode: 0,
+            ),
+          ],
+          servesHeadlessAcp: false,
+        ),
+        environment: const {},
+        stateDirectory: stateDirectory,
+      );
+
+      expect(result, const PluginSetupReady.versioned(runtimeVersion: "1.0.5"));
     });
 
     test("bounds noisy version output instead of parsing a version beyond the capture limit", () async {

--- a/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_omp/lib/src/runtime/omp_plugin_descriptor.dart
@@ -1,4 +1,5 @@
 import "dart:async";
+import "dart:convert";
 import "dart:io" as io;
 
 import "package:acp_plugin/acp_plugin.dart";
@@ -14,6 +15,8 @@ import "../omp_plugin_impl.dart";
 import "../repositories/omp_runtime_asset_repository.dart";
 import "../services/omp_runtime_asset_service.dart";
 import "omp_runtime_manifest.dart";
+
+const int _setupProbeOutputLimit = 64 * 1024;
 
 typedef OmpPluginFactory = OmpPlugin Function({
   required String binaryPath,
@@ -196,8 +199,13 @@ final class const OmpPluginDescriptor({
           stateDirectory: stateDirectory,
           abortSignal: StartAbortSignal.never,
         );
-    if (selection case ManagedRuntimeSelected(:final version)) {
-      return PluginSetupReady.versioned(runtimeVersion: version.raw);
+    if (selection case ManagedRuntimeSelected(:final binaryPath, :final version)) {
+      return await _inspectAuthentication(
+        binaryPath: binaryPath,
+        processes: processes,
+        environment: environment,
+        runtimeVersion: version.raw,
+      );
     }
     final notSelected = selection as ManagedRuntimeNotSelected;
     if (explicitBin != null) {
@@ -224,6 +232,64 @@ final class const OmpPluginDescriptor({
           ? "Install Oh My Pi from Sesori, or install it locally and retry setup detection."
           : "Install Oh My Pi locally, then retry setup detection.",
     );
+  }
+
+  /// Asks Oh My Pi which models it can actually use.
+  ///
+  /// OMP resolves credentials from its auth broker, its profile settings, and
+  /// the environment, so only OMP itself can answer whether any provider is
+  /// usable. Listing models neither starts a backend nor initiates
+  /// authentication.
+  Future<PluginSetupStatus> _inspectAuthentication({
+    required String binaryPath,
+    required HostProcessService processes,
+    required Map<String, String> environment,
+    required String runtimeVersion,
+  }) async {
+    final CommandResult result;
+    try {
+      result = await HostProcessCommandExecutor(
+        processes: processes,
+        runInShell: io.Platform.isWindows,
+        maxCapturedOutputCharactersPerStream: _setupProbeOutputLimit,
+      ).run(binaryPath, const ["models", "--json"], environment: environment, timeout: _versionProbeTimeout);
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "[${OmpPluginIdentity.id}] model listing probe failed for '$binaryPath models --json'",
+        error,
+        stackTrace,
+      );
+      return PluginSetupUnknown.versioned(
+        actionHint: "Oh My Pi could not list its available models. Verify the local CLI and retry.",
+        runtimeVersion: runtimeVersion,
+      );
+    }
+    if (!_listedNoModels(result)) return PluginSetupReady.versioned(runtimeVersion: runtimeVersion);
+    return PluginSetupAuthenticationRequired.versioned(
+      actionHint: "Run `omp` on this machine and log into a provider, then retry setup detection.",
+      runtimeVersion: runtimeVersion,
+    );
+  }
+
+  /// Whether the listing positively reported an empty catalog.
+  ///
+  /// Only a listing that parses and reports no models counts as logged out.
+  /// Supported releases predate the pinned target and `models --json` is not
+  /// guaranteed across that range, so an unrecognized listing leaves setup
+  /// ready rather than downgrading a working install on evidence that is not
+  /// there.
+  bool _listedNoModels(CommandResult result) {
+    if (result.exitCode != 0) return false;
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(result.stdout);
+    } on FormatException {
+      return false;
+    }
+    return switch (decoded) {
+      {"models": final List<Object?> models} => models.isEmpty,
+      _ => false,
+    };
   }
 
   bool _isUnknownRejection(ManagedRuntimeRejection rejection) {

--- a/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_omp/test/omp_plugin_descriptor_test.dart
@@ -118,10 +118,11 @@ void main() {
       expect(processes.executables, ["omp", contains("/state/omp/17.3.8/omp")]);
     });
 
-    test("reports ready from the runtime probe without an ACP or auth probe", () async {
+    test("reports ready from the runtime and model listing probes without an ACP probe", () async {
       final processes = _Processes(
         outputs: const [
           _Output(stdout: "omp/17.3.8\n", exitCode: 0),
+          _Output(stdout: '{"models":[{"provider":"deepseek","id":"deepseek-v4-flash"}]}', exitCode: 0),
         ],
       );
       final result = await OmpPluginDescriptor.production().inspectSetup(
@@ -134,15 +135,66 @@ void main() {
       expect(result, const PluginSetupReady.versioned(runtimeVersion: "17.3.8"));
       expect(processes.arguments, [
         const ["--version"],
+        const ["models", "--json"],
       ]);
-      expect(processes.environments.single, const {"OMP_PROFILE": "work"});
+      expect(processes.environments, everyElement(const {"OMP_PROFILE": "work"}));
+    });
+
+    test("reports an empty model listing as authentication required", () async {
+      final result = await OmpPluginDescriptor.production().inspectSetup(
+        config: config,
+        processes: _Processes(
+          outputs: const [
+            _Output(stdout: "omp/17.3.8\n", exitCode: 0),
+            _Output(stdout: '{"models":[]}', exitCode: 0),
+          ],
+        ),
+        environment: const {},
+        stateDirectory: "/state",
+      );
+
+      expect(
+        result,
+        isA<PluginSetupAuthenticationRequired>().having((s) => s.runtimeVersion, "runtimeVersion", "17.3.8"),
+      );
+    });
+
+    test("leaves setup ready when the model listing is unparsable or fails", () async {
+      final unparsable = await OmpPluginDescriptor.production().inspectSetup(
+        config: config,
+        processes: _Processes(
+          outputs: const [
+            _Output(stdout: "omp/17.3.8\n", exitCode: 0),
+            _Output(stdout: "error: unknown flag --json\n", exitCode: 0),
+          ],
+        ),
+        environment: const {},
+        stateDirectory: "/state",
+      );
+      final failed = await OmpPluginDescriptor.production().inspectSetup(
+        config: config,
+        processes: _Processes(
+          outputs: const [
+            _Output(stdout: "omp/17.3.8\n", exitCode: 0),
+            _Output(stdout: '{"models":[]}', exitCode: 2),
+          ],
+        ),
+        environment: const {},
+        stateDirectory: "/state",
+      );
+
+      expect(unparsable, const PluginSetupReady.versioned(runtimeVersion: "17.3.8"));
+      expect(failed, const PluginSetupReady.versioned(runtimeVersion: "17.3.8"));
     });
 
     test("uses the shared token-based version parsing", () async {
       final result = await OmpPluginDescriptor.production().inspectSetup(
         config: config,
         processes: _Processes(
-          outputs: const [_Output(stdout: "Oh My Pi omp/17.3.8 stable\n", exitCode: 0)],
+          outputs: const [
+            _Output(stdout: "Oh My Pi omp/17.3.8 stable\n", exitCode: 0),
+            _Output(stdout: '{"models":[{"id":"x"}]}', exitCode: 0),
+          ],
         ),
         environment: const {},
         stateDirectory: "/state",

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -49,7 +49,7 @@ listed variant when no default is declared) and models in plugin-defined order.
 
 | Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |
 |---|---|---|---|---|---|---|---|---|---|---|
-| Logged-out backend reported as `authenticationRequired` | ✅ | ⬜¹² | ✅ | ⬜¹³ | ✅ | ✅ | ✅¹¹ | ⬜¹⁴ | ⬜¹⁵ | ⬜¹⁶ |
+| Logged-out backend reported as `authenticationRequired` | ✅ | 🚫¹² | ✅ | ⬜¹³ | ✅ | ✅ | ✅¹¹ | ✅¹⁴ | ⬜¹⁵ | ✅¹⁶ |
 
 `inspectSetup` owns this state. Where a plugin does not probe credentials it
 returns `PluginSetupReady` as soon as it resolves a runtime, so a harness that
@@ -165,28 +165,31 @@ unusable here because it requires an explicit `--provider` or `--model` and Pi
 exposes no global variant. Verified against a fresh Sesori-managed 0.84.2
 install with no credentials.
 
-¹² OpenCode (1.18.25, probed 2026-09-05) exposes credential counts through
-`opencode auth list`, but that count does not answer this question: `opencode
-models` lists the bundled free `opencode/…` models identically with five
-credentials and with zero, so an empty credential store does not mean the
-harness is unusable. Reporting authentication required from the count alone
-would block installs that still work. This stays ⬜ rather than 🚫 because only
-those two surfaces were probed and neither is equivalent; whether the bundled
-free models actually serve a turn without credentials is unverified, so no
-claim is made that the seam cannot answer the question.
+¹² OpenCode (1.18.25, probed 2026-09-05) has no logged-out state to report.
+`opencode models` lists the bundled free `opencode/…` models identically with
+five credentials and with zero, so an install with an empty credential store
+is usable and ready is the correct state for it. `opencode auth list` counts
+credentials, but that count is not this capability: reporting authentication
+required from it would block working installs. Ready remains correct for
+OpenCode regardless of stored credentials.
 
 ¹³ Copilot has not been probed for a non-interactive credential check.
 
-¹⁴ Oh My Pi (18.1.10, probed 2026-09-05) can report this and does not yet.
-`omp models --json` returns `{"models":[]}` with no credentials and a populated
-list otherwise, which is the same signal Pi exposes in a structured form.
+¹⁴ Oh My Pi (18.1.10, probed 2026-09-05) reports it from `omp models --json`,
+which returns `{"models":[]}` with no credentials and a populated list
+otherwise — the same signal Pi exposes, in a structured form. Only a listing
+that parses and reports no models downgrades setup: supported releases reach
+back to 17.3.8 and `models --json` is not guaranteed across that range, so an
+unparsable or failing listing leaves setup ready instead of regressing a
+working older install.
 
 ¹⁵ DeepSeek already probes readiness in `inspectSetup` but maps a negative
 result to `PluginSetupUnknown`, so a logged-out install is reported as
 undetermined rather than as authentication required.
 
-¹⁶ Grok Build (1.0.5, probed 2026-09-05) can report this and does not yet.
-`grok models` prints `You are logged in with <account>.` or
-`You are not authenticated.` ahead of a model list that is identical either
-way, so the authentication line is the only signal; the listing itself is not
-one.
+¹⁶ Grok Build (1.0.5, probed 2026-09-05) reports it from `grok models`, which
+prints `You are logged in with <account>.` or `You are not authenticated.`
+ahead of a model list that is identical either way, so the authentication line
+is the signal and the listing itself is not one. Only that line downgrades
+setup; unrecognized wording leaves setup ready rather than blocking a working
+install on a phrase a later release may change.

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -57,8 +57,11 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Grok Build is a direct-CLI ACP v1 harness with no managed install. An explicit
   `--grok-bin` path is authoritative; otherwise setup uses `grok` from PATH and
   requires version `1.0.5` or newer. Setup inspection and pre-start resolution
-  run only a bounded `--version` probe: they never read credentials, invoke
-  login, create a session, or start ACP. Startup launches exactly
+  run bounded `--version` and `models` probes: they never read credentials,
+  invoke login, create a session, or start ACP. A listing that reports not
+  being authenticated is authentication-required carrying the resolved
+  version; any other wording leaves setup ready, and a listing that cannot be
+  run is unknown. Startup launches exactly
   `--no-auto-update agent --no-leader stdio` through the host process seam and
   accepts only advertised headless authentication. Interactive-only
   authentication becomes local-login-required without invoking it. An
@@ -79,6 +82,12 @@ idle suspension, the management snapshot, and lifecycle commands.
   probe never starts a backend, opens an RPC session, or invokes login, so a
   managed install with no provider credentials stops being reported as ready
   and stops offering start.
+- OMP setup inspection follows its version probe with a bounded `models --json`
+  run in the same environment. Only a listing that parses and reports an empty
+  model array is authentication-required; an unparsable or non-zero listing
+  leaves setup ready, because supported releases predate that flag and a
+  working older install must not regress. A listing that cannot be run at all
+  is unknown.
 - Backend `tui.toast.show` SSE events render through the backend-neutral toast
   surface, presented with the design-system popup alert on the root navigator's
   overlay. Session-attributed events appear only while that session's detail or


### PR DESCRIPTION
## Complexity

Straightforward. Follows #1334 exactly: one probe added to each descriptor's `inspectSetup`, reusing the existing `authenticationRequired` seam. No new types, no contract or DI changes.

## What

Extends the Pi setup probe from #1334 to the remaining harnesses whose CLI can answer the question.

**OMP** follows its version probe with `omp models --json`:
- listing parses and reports `{"models":[]}` → `PluginSetupAuthenticationRequired` with the resolved version
- listing is unparsable or exits non-zero → `PluginSetupReady` (unchanged from today)
- listing cannot be run at all → `PluginSetupUnknown`

**Grok** follows its version probe with `grok models`:
- output contains `not authenticated` → `PluginSetupAuthenticationRequired` with the resolved version
- any other wording → `PluginSetupReady`
- listing cannot be run → `PluginSetupUnknown`

**OpenCode** is reclassified in the matrix from ⬜ to 🚫 — see below.

## Why

Installing a runtime never authenticates it. Both harnesses returned ready as soon as they resolved a runtime, so an install with no credentials advertised ready and then failed every turn.

The two probes are asymmetric on purpose, and that asymmetry is the main review point:

- **OMP** treats only a *parsed empty array* as logged out. The pinned target is 17.3.8 and supported releases reach back that far, but `models --json` was only verified on 18.1.10. Mapping a non-zero exit to unknown — as Pi does — would show "undetermined" on every older install that lacks the flag. Leaving those ready preserves today's behavior.
- **Grok** treats only the explicit `not authenticated` line as logged out. The model list is byte-identical whether or not you are signed in, so the account line is the only signal, and it is English prose xAI may reword. Unrecognized wording degrades to ready.

Both follow the same principle as Pi: **only positive evidence of being logged out downgrades setup.** A false `authenticationRequired` blocks a working install, which is worse than the stale ready state being fixed.

**OpenCode is not a gap.** Per maintainer decision, its bundled free `opencode/…` models make a credential-less install genuinely usable — `opencode models` lists them identically with five credentials and with zero — so ready is the correct state there regardless of stored credentials. Marked 🚫 with that rationale rather than left as unimplemented work.

## Risk and test focus

No user-visible impact for an authenticated install of either harness. No database impact. No wire contract change — `PluginSetupState.authenticationRequired` already exists and is handled on both sides.

The deliberate behavior change: an OMP or Grok install with no credentials moves from ready to authentication-required, and `startAllowed` becomes false for it.

Worth reviewing closely:
- The Grok `inspectSetup` switch expression became a switch statement so the ready branch can await the probe. Exhaustiveness is preserved; the other three arms are unchanged.
- Grok now spawns a second process during setup inspection. The regression doc previously stated setup runs *only* a `--version` probe; that line is updated. The constraints that matter — never create a session, start ACP, or invoke login — still hold.
- OMP's fallback-to-ready on a failed listing is intentional, not an oversight.

## Expected result

A freshly installed OMP or Grok with no provider credentials reports authentication required with an action hint pointing at local login, instead of reporting ready and failing at session start. Authenticated installs are unaffected, as are older OMP releases without `models --json`.

## Verification

- `dart test` in `sesori_plugin_omp` — 59/59 pass, including four cases covering ready, empty listing, unparsable listing, and non-zero listing.
- `dart test` in `sesori_plugin_grok` — 85/85 pass, including three cases covering logged in, not authenticated, and unrecognized wording.
- `dart analyze` on both packages — no errors or warnings.
- Signals verified against real CLIs on 2026-09-05: `omp models --json` on 18.1.10 (`{"models":[]}` under an isolated profile, populated otherwise) and `grok models` on 1.0.5, which is the minimum supported version.

## Remaining after this PR

- **DeepSeek** already probes readiness in `inspectSetup` but maps a negative result to `unknown` rather than `authenticationRequired`. Not changed here; it needs the CLI to confirm the distinction is safe.
- **Copilot** has not been probed — the CLI was not available locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes OMP and Grok report a logged-out install as `authenticationRequired` instead of ready, so an unauthenticated backend no longer advertises ready and then fails at session start. OpenCode is documented as intentionally not supported because its bundled free models make an unauthenticated install usable.

- OMP probes `omp models --json`; only a parsed empty model array downgrades setup.
- Grok probes `grok models`; only the explicit "not authenticated" line downgrades setup, since the model list is identical either way.
- Unrecognized output falls back to ready on both harnesses to avoid blocking working installs.
- Authenticated installs are unaffected; older OMP releases without `models --json` stay ready.

<sup>Written for commit e54c56d7232f24efa056ec1fa50dd4a5f14fffb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

