### PR TITLE
🌿 Skip origin refresh for local-only Git projects

### DIFF
--- a/bridge/app/lib/src/api/git_cli_api.dart
+++ b/bridge/app/lib/src/api/git_cli_api.dart
@@ -198,22 +198,7 @@ class GitCliApi({
     if (!await _isInsideGitWorkTreeForRemote(projectPath: projectPath)) {
       return null;
     }
-    const remoteArguments = ["remote"];
-    final remotesResult = await runGit(projectPath: projectPath, arguments: remoteArguments);
-    if (remotesResult.exitCode != 0) {
-      throw ProcessException(
-        "git",
-        remoteArguments,
-        remotesResult.stderr.toString(),
-        remotesResult.exitCode,
-      );
-    }
-    final remotes = remotesResult.stdout
-        .toString()
-        .split("\n")
-        .map((line) => line.trim())
-        .where((line) => line.isNotEmpty)
-        .toList();
+    final remotes = await _listRemotes(projectPath: projectPath);
     if (remotes.isEmpty) {
       return null;
     }
@@ -230,6 +215,20 @@ class GitCliApi({
     }
     final url = urlResult.stdout.toString().trim();
     return url.isEmpty ? null : url;
+  }
+
+  Future<List<String>> _listRemotes({required String projectPath}) async {
+    const arguments = ["remote"];
+    final result = await runGit(projectPath: projectPath, arguments: arguments);
+    if (result.exitCode != 0) {
+      throw ProcessException("git", arguments, result.stderr.toString(), result.exitCode);
+    }
+    return result.stdout
+        .toString()
+        .split("\n")
+        .map((remote) => remote.trim())
+        .where((remote) => remote.isNotEmpty)
+        .toList();
   }
 
   Future<bool> _isInsideGitWorkTreeForRemote({required String projectPath}) async {
@@ -280,16 +279,7 @@ class GitCliApi({
     required String projectPath,
     required String branchName,
   }) async {
-    const remoteArguments = ["remote"];
-    final remotesResult = await runGit(projectPath: projectPath, arguments: remoteArguments);
-    if (remotesResult.exitCode != 0) {
-      throw ProcessException("git", remoteArguments, remotesResult.stderr.toString(), remotesResult.exitCode);
-    }
-    final remoteNames = remotesResult.stdout
-        .toString()
-        .split("\n")
-        .map((remote) => remote.trim())
-        .where((remote) => remote.isNotEmpty);
+    final remoteNames = await _listRemotes(projectPath: projectPath);
     final matchingRefs = {for (final remote in remoteNames) "refs/remotes/$remote/$branchName"};
     if (matchingRefs.isEmpty) return false;
 
@@ -351,13 +341,8 @@ class GitCliApi({
     if (branchName.contains("*")) {
       throw ArgumentError.value(branchName, "branchName", "must name one exact branch");
     }
-    const remoteArguments = ["remote"];
-    final remotesResult = await runGit(projectPath: projectPath, arguments: remoteArguments);
-    if (remotesResult.exitCode != 0) {
-      throw ProcessException("git", remoteArguments, remotesResult.stderr.toString(), remotesResult.exitCode);
-    }
-    final hasOrigin = remotesResult.stdout.toString().split("\n").any((remote) => remote.trim() == "origin");
-    if (!hasOrigin) return;
+    final remotes = await _listRemotes(projectPath: projectPath);
+    if (!remotes.contains("origin")) return;
 
     final arguments = [
       "fetch",

--- a/bridge/app/lib/src/api/git_cli_api.dart
+++ b/bridge/app/lib/src/api/git_cli_api.dart
@@ -343,6 +343,7 @@ class GitCliApi({
     );
   }
 
+  /// Refreshes the selected origin branch, skipping repositories without origin.
   Future<void> fetchOriginBranch({
     required String projectPath,
     required String branchName,
@@ -350,6 +351,14 @@ class GitCliApi({
     if (branchName.contains("*")) {
       throw ArgumentError.value(branchName, "branchName", "must name one exact branch");
     }
+    const remoteArguments = ["remote"];
+    final remotesResult = await runGit(projectPath: projectPath, arguments: remoteArguments);
+    if (remotesResult.exitCode != 0) {
+      throw ProcessException("git", remoteArguments, remotesResult.stderr.toString(), remotesResult.exitCode);
+    }
+    final hasOrigin = remotesResult.stdout.toString().split("\n").any((remote) => remote.trim() == "origin");
+    if (!hasOrigin) return;
+
     final arguments = [
       "fetch",
       "--no-write-fetch-head",

--- a/bridge/app/test/bridge/worktree_service_git_test.dart
+++ b/bridge/app/test/bridge/worktree_service_git_test.dart
@@ -343,6 +343,7 @@ void main() {
     });
 
     test("fetchOriginBranch refreshes only the selected origin branch", () async {
+      processRunner.enqueue(result: _processResult(exitCode: 0, stdout: "upstream\norigin\n"));
       processRunner.enqueue(result: _processResult(exitCode: 0));
 
       await service.fetchOriginBranch(
@@ -350,9 +351,10 @@ void main() {
         branchName: "main",
       );
 
-      expect(processRunner.invocations, hasLength(1));
+      expect(processRunner.invocations, hasLength(2));
+      expect(processRunner.invocations.first.arguments, ["remote"]);
       expect(
-        processRunner.invocations.single.arguments,
+        processRunner.invocations.last.arguments,
         equals([
           "fetch",
           "--no-write-fetch-head",
@@ -362,10 +364,10 @@ void main() {
           "+refs/heads/main:refs/remotes/origin/main",
         ]),
       );
-      expect(processRunner.invocations.single.workingDirectory, equals("/repo/project"));
-      expect(processRunner.invocations.single.timeout, const Duration(seconds: 30));
+      expect(processRunner.invocations.last.workingDirectory, equals("/repo/project"));
+      expect(processRunner.invocations.last.timeout, const Duration(seconds: 30));
       expect(
-        processRunner.invocations.single.environment,
+        processRunner.invocations.last.environment,
         const {"GIT_TERMINAL_PROMPT": "0"},
       );
     });
@@ -383,6 +385,7 @@ void main() {
     });
 
     test("fetchOriginBranch throws ProcessException when git fails", () async {
+      processRunner.enqueue(result: _processResult(exitCode: 0, stdout: "origin\n"));
       processRunner.enqueue(result: _processResult(exitCode: 1, stderr: "offline"));
 
       await expectLater(
@@ -396,6 +399,33 @@ void main() {
               .having((error) => error.message, "message", "offline"),
         ),
       );
+    });
+
+    for (final remotes in ["", "upstream\nmy-origin\n"]) {
+      test("fetchOriginBranch skips fetching without origin (remotes: $remotes)", () async {
+        processRunner.enqueue(result: _processResult(exitCode: 0, stdout: remotes));
+
+        await service.fetchOriginBranch(projectPath: "/repo/project", branchName: "main");
+
+        expect(processRunner.invocations, hasLength(1));
+        expect(processRunner.invocations.single.arguments, ["remote"]);
+        expect(processRunner.invocations.single.workingDirectory, "/repo/project");
+      });
+    }
+
+    test("fetchOriginBranch preserves remote discovery failures", () async {
+      processRunner.enqueue(result: _processResult(exitCode: 128, stderr: "cannot read config"));
+
+      await expectLater(
+        service.fetchOriginBranch(projectPath: "/repo/project", branchName: "main"),
+        throwsA(
+          isA<ProcessException>()
+              .having((error) => error.arguments, "arguments", ["remote"])
+              .having((error) => error.errorCode, "errorCode", 128)
+              .having((error) => error.message, "message", "cannot read config"),
+        ),
+      );
+      expect(processRunner.invocations, hasLength(1));
     });
 
     group("inspectWorktreeSafety", () {

--- a/bridge/app/test/bridge/worktree_service_test.dart
+++ b/bridge/app/test/bridge/worktree_service_test.dart
@@ -60,6 +60,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // git symbolic-ref refs/remotes/origin/HEAD → "refs/remotes/origin/main"
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // git fetch origin/main → unavailable; continue with existing refs
       processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
@@ -103,6 +105,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // git symbolic-ref refs/remotes/origin/HEAD → "refs/remotes/origin/main"
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // git fetch origin/main → unavailable; continue with existing refs
       processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
@@ -166,6 +170,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // git symbolic-ref refs/remotes/origin/HEAD → "refs/remotes/origin/main"
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // git fetch origin/main → unavailable; continue with existing refs
       processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
@@ -235,6 +241,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/main → unavailable; continue with existing refs
       processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
@@ -285,6 +293,7 @@ void main() {
         ..generatedPathsToOccupy = 1
         ..enqueue(result: _ok())
         ..enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"))
+        ..enqueue(result: _ok(stdout: "origin\n"))
         ..enqueue(result: _fail(exitCode: 1))
         ..enqueue(result: _ok(stdout: "abc123def456\n"))
         ..enqueue(result: _fail(exitCode: 128))
@@ -318,6 +327,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/main → unavailable; continue with existing refs
       processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
@@ -369,6 +380,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // branch --list develop → non-empty (exists)
       processRunner.enqueue(result: _ok(stdout: "  develop\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/develop → unavailable; continue with existing refs
       processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse develop → base commit SHA
@@ -418,6 +431,8 @@ void main() {
       processRunner.enqueue(result: _ok(stdout: ""));
       // symbolic-ref refs/remotes/origin/HEAD → "refs/remotes/origin/main"
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/main → unavailable; continue with existing refs
       processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
@@ -451,6 +466,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/main → unavailable; continue with existing refs
       processRunner.enqueue(result: _fail(exitCode: 1));
       // git rev-parse main → base commit SHA
@@ -504,6 +521,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/main → refreshes the stale remote-tracking ref
       processRunner.enqueue(result: _ok());
       // rev-parse main → local commit
@@ -528,7 +547,7 @@ void main() {
       expect(success.baseCommit, equals("origin222"));
 
       expect(
-        processRunner.invocations[2].arguments,
+        processRunner.invocations[3].arguments,
         equals([
           "fetch",
           "--no-write-fetch-head",
@@ -549,6 +568,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/main → success
       processRunner.enqueue(result: _ok());
       // rev-parse main → local commit
@@ -582,6 +603,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/main → success
       processRunner.enqueue(result: _ok());
       // rev-parse main → local commit
@@ -612,6 +635,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/main → success
       processRunner.enqueue(result: _ok());
       // rev-parse main → local commit
@@ -643,6 +668,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/main → unavailable; continue with existing refs
       processRunner.enqueue(result: _fail(exitCode: 1));
       // rev-parse main → local commit
@@ -667,9 +694,35 @@ void main() {
       expect(worktreeAddArgs.last, equals("main"));
     });
 
+    test("local-only repository creates a worktree without fetching", () async {
+      await projectsDao.setBaseBranch(projectId: _projectId, baseBranch: "main");
+      processRunner.enqueue(result: _ok()); // rev-parse HEAD
+      processRunner.enqueue(result: _ok(stdout: "  main\n")); // branch --list main
+      processRunner.enqueue(result: _ok()); // remote: none configured
+      processRunner.enqueue(result: _ok(stdout: "local111\n")); // rev-parse main
+      processRunner.enqueue(result: _fail(exitCode: 128)); // no origin/main ref
+      processRunner.enqueue(result: _ok()); // generated branch is available
+      processRunner.enqueue(result: _ok()); // worktree add
+
+      final result = await service.prepareWorktreeForSession(
+        projectId: _projectId,
+        parentSessionId: null,
+      );
+
+      expect(result, isA<WorktreeSuccess>());
+      final success = result as WorktreeSuccess;
+      expect(success.baseBranch, "main");
+      expect(success.baseCommit, "local111");
+      expect(processRunner.invocations[2].arguments, ["remote"]);
+      expect(processRunner.invocations.any((invocation) => invocation.arguments.first == "fetch"), isFalse);
+      expect(processRunner.invocations.last.arguments.take(2), ["worktree", "add"]);
+      expect(processRunner.invocations.last.arguments.last, "main");
+    });
+
     test("unexpected fetch error aborts worktree creation", () async {
       processRunner.enqueue(result: _ok()); // rev-parse HEAD
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n")); // symbolic-ref
+      processRunner.enqueue(result: _ok(stdout: "origin\n")); // remote
       processRunner.enqueueError(error: StateError("broken process runner")); // fetch
       // These would let creation succeed if the unexpected error were swallowed.
       processRunner.enqueue(result: _ok(stdout: "local111\n"));
@@ -684,7 +737,7 @@ void main() {
 
       expect(result, isA<WorktreeFallback>());
       expect((result as WorktreeFallback).reason, equals("failed to resolve base branch/commit"));
-      expect(processRunner.invocations, hasLength(3));
+      expect(processRunner.invocations, hasLength(4));
     });
 
     test("merge-base fails: worktree starts from origin ref", () async {
@@ -692,6 +745,8 @@ void main() {
       processRunner.enqueue(result: _ok());
       // symbolic-ref → main
       processRunner.enqueue(result: _ok(stdout: "refs/remotes/origin/main\n"));
+      // git remote → origin is configured
+      processRunner.enqueue(result: _ok(stdout: "origin\n"));
       // fetch origin/main → success
       processRunner.enqueue(result: _ok());
       // rev-parse main → local commit

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -170,6 +170,10 @@ variant, and worktree mode, and creating the session with its first input.
   directory when the repository is absent, commitless, or creation fails, and
   records worktree, branch, base branch, and base commit; in-place mode records
   the HEAD commit as baseline.
+- Base-branch refresh skips fetching when the repository has no `origin`, so
+  local-only Git projects can create dedicated worktrees without a fetch warning.
+  A configured origin that cannot be fetched still logs the failure and uses
+  existing refs.
 - Prompt and slash-command starts are exclusive; only user-authored text is
   user-visible, and attachments appear only where declared. The session keys on
   the stable project identifier and carries title, defaults, and worktree facts.


### PR DESCRIPTION
## Complexity
🌿 Straightforward: a local check and private helper in the existing Git API class.

## What
Skip the origin branch fetch when `git remote` lists no `origin`. Share remote discovery across the three Git API callers. Cover absent origin and discovery failures, update service fixtures for the remote check, and verify local-only worktree creation at the service level. Document the behavior.

## Why
Creating a dedicated session in a local-only Git project currently attempts to fetch origin and logs a misleading failure before continuing with existing refs.

## Risk and test focus
Low risk. Repositories with origin retain the exact-branch fetch, timeout, and noninteractive settings. Discovery errors and actual fetch failures remain observable. Service fixtures explicitly exercise origin fetching and fallback after failure.

## Expected result
Local-only projects create dedicated worktrees without the origin-fetch warning. The user-visible change is removal of that unnecessary warning. No database or wire-contract impact.

## Verification
- Git API, worktree service, and worktree repository suites: 96 tests passed, including the test that failed in CI.
- Bridge app: `dart analyze --fatal-infos`.
- Dart formatting and `git diff --check`.
