### PR TITLE
⚙️ Retry bridge startup while the server is unreachable

### DIFF
--- a/bridge/app/lib/src/auth/auth_repository.dart
+++ b/bridge/app/lib/src/auth/auth_repository.dart
@@ -19,6 +19,7 @@ class AuthRepository({required final AuthApi _api}) {
     try {
       return AuthUserFound(response: await _api.getCurrentUser(accessToken: accessToken));
     } on AuthApiException catch (error) {
+      if (error.statusCode == 408 || error.statusCode == 429 || error.statusCode >= 500) rethrow;
       return AuthUserRejected(statusCode: error.statusCode);
     }
   }
@@ -35,6 +36,7 @@ class AuthRepository({required final AuthApi _api}) {
     try {
       return AuthTokenRefreshed(response: await _api.refreshToken(refreshToken: refreshToken));
     } on AuthApiException catch (error) {
+      if (error.statusCode == 408 || error.statusCode == 429 || error.statusCode >= 500) rethrow;
       return AuthTokenRefreshRejected(statusCode: error.statusCode);
     }
   }

--- a/bridge/app/lib/src/auth/token_refresher.dart
+++ b/bridge/app/lib/src/auth/token_refresher.dart
@@ -15,4 +15,7 @@ class const ControlTokenUnavailableException(final String reason) implements Exc
 class const ControlTokenRetryLaterException({required final Object? innerError})
     extends ControlTokenUnavailableException {
   this : super("The desktop app cannot currently supply an access token; retry later.");
+
+  @override
+  String toString() => "ControlTokenRetryLaterException: $reason${innerError == null ? "" : " ($innerError)"}";
 }

--- a/bridge/app/lib/src/auth/token_refresher.dart
+++ b/bridge/app/lib/src/auth/token_refresher.dart
@@ -3,15 +3,16 @@ abstract interface class TokenRefresher() {
 }
 
 /// The typed failure a [TokenRefresher] throws when it cannot supply any usable
-/// access token and a relay reconnect must therefore be deferred rather than
-/// proceeding from a stale/cached token. In supervised mode the GUI replied with
-/// a null token (signed out / mid-login) or the control channel was unavailable;
-/// the supervised refresher also invalidates its cache before throwing, so there
-/// is no safe token to fall back on. Distinct from a transient refresh failure
-/// (e.g. the standalone auth-refresh endpoint being momentarily down while a
-/// valid cached token is still on hand), which callers may recover from by
-/// reconnecting with the cached token.
+/// access token and a relay reconnect must therefore be deferred. A null GUI
+/// response invalidates the cached token. The retryable subtype covers temporary
+/// control-channel or token-refresh failures without treating them as sign-out.
 class const ControlTokenUnavailableException(final String reason) implements Exception {
   @override
   String toString() => "ControlTokenUnavailableException: $reason";
+}
+
+/// The GUI retains its auth session but cannot currently refresh its token.
+class const ControlTokenRetryLaterException({required final Object? innerError})
+    extends ControlTokenUnavailableException {
+  this : super("The desktop app cannot currently supply an access token; retry later.");
 }

--- a/bridge/app/lib/src/control/bridge_control_message_dispatcher.dart
+++ b/bridge/app/lib/src/control/bridge_control_message_dispatcher.dart
@@ -54,6 +54,8 @@ class BridgeControlMessageDispatcher({
     switch (message) {
       case ControlTokenResponse(:final id, :final accessToken):
         _tokenService.handleTokenResponse(id: id, accessToken: accessToken);
+      case ControlTokenRetryLater(:final id):
+        _tokenService.handleTokenRetryLater(id: id);
       case ControlPromptResponse(:final id, :final accepted):
         _promptService.handlePromptResponse(id: id, accepted: accepted);
       case ControlShutdown():

--- a/bridge/app/lib/src/control/control_status_notifier.dart
+++ b/bridge/app/lib/src/control/control_status_notifier.dart
@@ -14,6 +14,7 @@ import "../foundation/relay_client.dart";
 /// `ControlChannelClient.send` directly.
 ///
 /// Observed triggers — all push-based, no timers:
+/// - startup: authentication/registration/relay progress, including server waits;
 /// - plugin health: the lifecycle service's ordered eligible-plugin metadata
 ///   snapshots, reduced to degraded when any eligible plugin is degraded or
 ///   failed and healthy otherwise (eligibility is not runtime residency);
@@ -34,9 +35,7 @@ import "../foundation/relay_client.dart";
 /// pushed exactly once (no periodic spam).
 class ControlStatusNotifier({
   required final ControlChannelClient _client,
-  required final Stream<List<PluginMetadata>> _pluginMetadata,
-  required final Stream<RelayConnectionState> _relayConnectionState,
-  required final Stream<String> _registrations,
+  required final Stream<ControlStartupState> _startupState,
 }) {
   final CompositeSubscription _subscriptions = CompositeSubscription();
 
@@ -46,6 +45,7 @@ class ControlStatusNotifier({
   ControlRelayConnectionState _relay = ControlRelayConnectionState.disconnected;
   ControlPluginHealthState _plugin = ControlPluginHealthState.unknown;
   int _activeSessionCount = 0;
+  ControlStartupState _startup = ControlStartupState.starting;
   ControlStatus? _lastSentStatus;
   String? _bridgeId;
   bool _started = false;
@@ -55,10 +55,25 @@ class ControlStatusNotifier({
   void start() {
     if (_started) return;
     _started = true;
-    _pluginMetadata.listen(_handlePluginMetadata).addTo(_subscriptions);
-    _relayConnectionState.listen(_handleRelayConnectionState).addTo(_subscriptions);
-    _registrations.listen(_handleRegistered).addTo(_subscriptions);
+    _startupState
+        .listen((state) {
+          _startup = state;
+          _pushStatus();
+        })
+        .addTo(_subscriptions);
     _client.connectionState.listen(_handleControlChannelState).addTo(_subscriptions);
+  }
+
+  /// Attach live runtime sources once composition completes. Startup status is
+  /// already available while authentication is waiting for the network.
+  void observeRuntime({
+    required Stream<List<PluginMetadata>> pluginMetadata,
+    required Stream<RelayConnectionState> relayConnectionState,
+    required Stream<String> registrations,
+  }) {
+    pluginMetadata.listen(_handlePluginMetadata).addTo(_subscriptions);
+    relayConnectionState.listen(_handleRelayConnectionState).addTo(_subscriptions);
+    registrations.listen(_handleRegistered).addTo(_subscriptions);
   }
 
   Future<void> dispose() async {
@@ -118,6 +133,7 @@ class ControlStatusNotifier({
 
   void _pushStatus({bool force = false}) {
     final status = ControlStatus(
+      startup: _startup,
       relay: _relay,
       plugin: _plugin,
       activeSessionCount: _activeSessionCount,

--- a/bridge/app/lib/src/orchestrator.dart
+++ b/bridge/app/lib/src/orchestrator.dart
@@ -143,6 +143,7 @@ import "routing/update_session_archive_status_handler.dart";
 import "runtime/plugin_runtime.dart";
 import "server/services/bridge_restart_service.dart";
 import "services/archived_session_validator.dart";
+import "services/bridge_startup_retry_service.dart";
 import "services/catalog_import_service.dart";
 import "services/chat_history_reconcile_service.dart";
 import "services/chat_history_service.dart";
@@ -223,6 +224,7 @@ class Orchestrator({
   // Standalone has no control channel, so this is null there.
   required final ControlStatusNotifier? _statusNotifier,
   required final ReconnectBackoffPolicy _reconnectBackoff,
+  required final BridgeStartupRetryService _startupRetryService,
 }) {
   /// Creates a new session with a fresh room key and SSE manager.
   OrchestratorComposition create() {
@@ -736,6 +738,7 @@ class Orchestrator({
       restartDispatcher: restartDispatcher,
       statusNotifier: _statusNotifier,
       reconnectBackoff: _reconnectBackoff,
+      startupRetryService: _startupRetryService,
     );
     return (
       session: session,
@@ -845,6 +848,7 @@ class OrchestratorSession._({
   required final BridgeRestartDispatcher _restartDispatcher,
   required final ControlStatusNotifier? _statusNotifier,
   required final ReconnectBackoffPolicy _reconnectBackoff,
+  required final BridgeStartupRetryService _startupRetryService,
 }) {
   // ignore: cancel_subscriptions - cancelled by the failure-isolated session drain.
   final CompositeSubscription _subscriptions = CompositeSubscription();
@@ -1060,12 +1064,12 @@ class OrchestratorSession._({
     final activePhoneIncarnations = <int, Object>{};
 
     Log.d("registering bridge with auth server...");
-    await _bridgeRegistrationService.ensureRegistered();
+    await _startupRetryService.run(operation: _bridgeRegistrationService.ensureRegistered);
     Log.d("bridge registered");
     if (_cancelled) return;
 
     Log.d("connecting to relay...");
-    final relayConnection = await _client.connect();
+    final relayConnection = await _startupRetryService.run(operation: _client.connect);
     _relayConnection = relayConnection;
     Log.d("relay connected");
     if (_cancelled) {
@@ -1264,6 +1268,7 @@ class OrchestratorSession._({
       );
       final firstRead = iterator.moveNext();
       if (!readiness.isCompleted) {
+        _startupRetryService.markReady();
         readiness.complete(OrchestratorSessionStartResult.ready);
       }
 
@@ -1379,6 +1384,7 @@ class OrchestratorSession._({
   }
 
   void beginShutdown() {
+    _startupRetryService.cancel();
     _routedRequestDispatcher.beginShutdown();
     _sessionCreationService.beginShutdown();
     _prSyncService.beginShutdown();

--- a/bridge/app/lib/src/runtime/bridge_runtime.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime.dart
@@ -113,7 +113,7 @@ Future<void> startDebugServerIfRequested({
 }
 
 void registerSignalHandlers({
-  required OrchestratorSession session,
+  required Future<void> Function() requestShutdown,
   required CompositeSubscription subscriptions,
 }) {
   var shutdownSignalCount = 0;
@@ -124,7 +124,7 @@ void registerSignalHandlers({
       exit(1);
     }
     Log.i("[shutdown] $name received (#$shutdownSignalCount) - cancelling session");
-    unawaited(session.cancel());
+    unawaited(requestShutdown());
   }
 
   ProcessSignal.sigint.watch().listen((_) => handleShutdownSignal("SIGINT")).addTo(subscriptions);

--- a/bridge/app/lib/src/runtime/bridge_runtime_auth.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_auth.dart
@@ -1,13 +1,13 @@
 import 'dart:io';
 
 import 'package:sesori_plugin_interface/sesori_plugin_interface.dart' show Console, Log;
-
 import 'package:sesori_shared/sesori_shared.dart';
 
 import '../auth/auth_repository.dart';
 import '../auth/login_email_repository.dart';
 import '../auth/login_oauth_service.dart';
 import '../auth/token.dart';
+import '../services/bridge_startup_retry_service.dart';
 import 'bridge_cli_options.dart';
 
 const Duration _oAuthAckTimeout = Duration(seconds: 5);
@@ -16,6 +16,7 @@ class const BridgeRuntimeAuthService({
   required final LoginEmailRepository _loginEmailRepository,
   required final LoginOAuthService _loginOAuthService,
   required final AuthRepository _authRepository,
+  required final BridgeStartupRetryService _startupRetryService,
   required final Future<TokenData> Function() _loadTokens,
   required final Future<void> Function(TokenData tokens) _saveTokens,
   required final Future<void> Function() _clearTokens,
@@ -49,50 +50,23 @@ class const BridgeRuntimeAuthService({
     TokenData? storedTokens;
     try {
       storedTokens = await _loadTokens();
-      try {
-        final lookup = await _authRepository.lookupCurrentUser(accessToken: storedTokens.accessToken);
-        switch (lookup) {
-          case AuthUserFound():
-            final tokensToSave = TokenData(
-              accessToken: storedTokens.accessToken,
-              refreshToken: storedTokens.refreshToken,
-              lastProvider: storedTokens.lastProvider,
-            );
-            await _saveTokens(tokensToSave);
-            return tokensToSave;
-          case AuthUserRejected(statusCode: 401):
-            final refresh = await _authRepository.refreshToken(refreshToken: storedTokens.refreshToken);
-            switch (refresh) {
-              case AuthTokenRefreshed(:final response):
-                final tokensToSave = TokenData(
-                  accessToken: response.accessToken,
-                  refreshToken: response.refreshToken,
-                  lastProvider: storedTokens.lastProvider,
-                );
-                await _saveTokens(tokensToSave);
-                return tokensToSave;
-              case AuthTokenRefreshRejected():
-                break;
-            }
-          case AuthUserRejected():
-            break;
-        }
-      } catch (error) {
-        throw Exception('validate stored tokens: $error');
-      }
     } on PathNotFoundException {
       // Token file or its parent directory does not exist — fall through to
       // login below. PathNotFoundException is the portable "missing path"
       // signal: POSIX ENOENT, Windows ERROR_FILE_NOT_FOUND (errno 2), and
       // Windows ERROR_PATH_NOT_FOUND (errno 3, e.g. the %LOCALAPPDATA%\sesori
       // directory missing on first run) all surface as this type.
-    } on FileSystemException catch (error) {
-      throw Exception('load stored tokens: $error');
     } on FormatException {
       // Invalid token data (e.g., missing/invalid lastProvider) — treat as no valid tokens
       await _clearTokens();
       storedTokens = null;
       // Fall through to login below
+    }
+
+    final tokens = storedTokens;
+    if (tokens != null) {
+      final validated = await _startupRetryService.run(operation: () => _validateStoredTokens(tokens: tokens));
+      if (validated != null) return validated;
     }
 
     final provider = storedTokens?.lastProvider ?? await promptForProvider();
@@ -101,6 +75,37 @@ class const BridgeRuntimeAuthService({
       authBackendUrl: options.authBackendUrl,
       provider: provider,
     );
+  }
+
+  Future<TokenData?> _validateStoredTokens({required TokenData tokens}) async {
+    final lookup = await _authRepository.lookupCurrentUser(accessToken: tokens.accessToken);
+    switch (lookup) {
+      case AuthUserFound():
+        final tokensToSave = TokenData(
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+          lastProvider: tokens.lastProvider,
+        );
+        await _saveTokens(tokensToSave);
+        return tokensToSave;
+      case AuthUserRejected(statusCode: 401):
+        final refresh = await _authRepository.refreshToken(refreshToken: tokens.refreshToken);
+        switch (refresh) {
+          case AuthTokenRefreshed(:final response):
+            final tokensToSave = TokenData(
+              accessToken: response.accessToken,
+              refreshToken: response.refreshToken,
+              lastProvider: tokens.lastProvider,
+            );
+            await _saveTokens(tokensToSave);
+            return tokensToSave;
+          case AuthTokenRefreshRejected():
+            break;
+        }
+      case AuthUserRejected():
+        break;
+    }
+    return null;
   }
 
   Future<void> logAuthenticatedUser({

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -88,6 +88,7 @@ import "../server/repositories/terminal_prompt_repository.dart";
 import "../server/services/bridge_instance_service.dart";
 import "../server/services/bridge_restart_service.dart";
 import "../services/app_client_onboarding_service.dart";
+import "../services/bridge_startup_retry_service.dart";
 import "../services/control_channel_token_service.dart";
 import "../services/control_prompt_service.dart";
 import "../services/control_unregister_service.dart";
@@ -236,7 +237,18 @@ class const BridgeRuntimeRunner._() {
         phase: BridgeShutdownPhase.shared,
         action: () => runtime?.close(),
       );
+    final startupRetryService = BridgeStartupRetryService();
+    shutdownCoordinator.addPhase(phase: BridgeShutdownPhase.signal, action: startupRetryService.cancel);
+    shutdownCoordinator.add(disposable: startupRetryService.dispose);
     final subscriptions = CompositeSubscription();
+    registerSignalHandlers(
+      requestShutdown: () async {
+        startAbortController.abort();
+        startupRetryService.cancel();
+        await runtime?.session.cancel();
+      },
+      subscriptions: subscriptions,
+    );
     shutdownCoordinator.add(disposable: subscriptions.cancel);
     final httpClient = http.Client();
     final processRunner = ProcessRunner();
@@ -298,6 +310,7 @@ class const BridgeRuntimeRunner._() {
     );
     final authRepository = AuthRepository(api: authApi);
     final runtimeAuthService = BridgeRuntimeAuthService(
+      startupRetryService: startupRetryService,
       authRepository: authRepository,
       loginEmailRepository: LoginEmailRepository(
         emailAuthApi: LoginEmailApi(authBackendUrl: options.authBackendUrl),
@@ -337,6 +350,7 @@ class const BridgeRuntimeRunner._() {
       // Kept in scope past this block: the ControlStatusNotifier (built later,
       // once the plugin exists) shares this client.
       ControlChannelClient? controlChannelClient;
+      ControlStatusNotifier? controlStatusNotifier;
       // Built early in supervised mode so the dispatcher can route the logout
       // `unregister_and_exit` command; reused as THE registration service later.
       // Standalone builds it after the interactive auth flow yields its token
@@ -350,6 +364,11 @@ class const BridgeRuntimeRunner._() {
           // exit (restart/auth/logout/contention) to the abnormal code.
           requestAbnormalExit: () => requestedSupervisedExit ??= BridgeSupervisedExitCode.controlChannelLost,
         );
+        controlStatusNotifier = ControlStatusNotifier(
+          client: controlChannelClient,
+          startupState: startupRetryService.states,
+        )..start();
+        shutdownCoordinator.add(disposable: controlStatusNotifier.dispose);
         // The GUI is the token authority in supervised mode: the bridge pulls
         // its access token from the control channel instead of the interactive
         // terminal login. Shares the same client the loss listener observes.
@@ -495,7 +514,7 @@ class const BridgeRuntimeRunner._() {
       final supervisedTokenService = controlChannelTokenService;
       if (supervisedTokenService != null) {
         try {
-          authAccessToken = await supervisedTokenService.getAccessToken();
+          authAccessToken = await startupRetryService.run(operation: supervisedTokenService.getAccessToken);
         } on ControlTokenUnavailableException catch (error, stackTrace) {
           final bool exitAlreadyRequested = requestedSupervisedExit != null;
           final BridgeSupervisedExitCode tokenUnavailableExit = resolveSupervisedTokenUnavailableExit(
@@ -537,6 +556,7 @@ class const BridgeRuntimeRunner._() {
         accessTokenProvider = tokenService;
         tokenRefresher = tokenService;
       }
+      if (startAbortController.isAborted) throw const PluginStartAbortedException();
       await runtimeAuthService.logAuthenticatedUser(
         accessToken: authAccessToken,
       );
@@ -706,7 +726,7 @@ class const BridgeRuntimeRunner._() {
           .addTo(subscriptions);
       await generationFactory.enforceBridgeOwnership();
       if (startAbortController.isAborted) {
-        Log.i("Plugin start aborted as requested.");
+        Log.i("Bridge startup aborted as requested.");
         return 0;
       }
       // After ownership is settled, so no other live bridge is using this
@@ -731,17 +751,11 @@ class const BridgeRuntimeRunner._() {
       // observing the plugin's lifecycle stream, the relay's connection-state
       // stream, and registration successes. Started before the session runs so
       // the initial registration and relay connect are never missed.
-      ControlStatusNotifier? controlStatusNotifier;
-      if (controlChannelClient != null) {
-        controlStatusNotifier = ControlStatusNotifier(
-          client: controlChannelClient,
-          pluginMetadata: activePluginLifecycleService.metadataSnapshots,
-          relayConnectionState: relayClient.connectionState,
-          registrations: bridgeRegistrationService.registrations,
-        );
-        controlStatusNotifier.start();
-        shutdownCoordinator.add(disposable: controlStatusNotifier.dispose);
-      }
+      controlStatusNotifier?.observeRuntime(
+        pluginMetadata: activePluginLifecycleService.metadataSnapshots,
+        relayConnectionState: relayClient.connectionState,
+        registrations: bridgeRegistrationService.registrations,
+      );
 
       final restartService = BridgeRestartService(
         processRepository: processRepository,
@@ -815,6 +829,7 @@ class const BridgeRuntimeRunner._() {
         filesystemAccessOk: filesystemAccessOk,
         statusNotifier: controlStatusNotifier,
         reconnectBackoff: ReconnectBackoffPolicy.standard,
+        startupRetryService: startupRetryService,
       ).create();
       runtime = BridgeRuntime(
         database: database,
@@ -839,7 +854,6 @@ class const BridgeRuntimeRunner._() {
       }
       activeRuntime.catalogHydrationListener.start();
 
-      registerSignalHandlers(session: activeRuntime.session, subscriptions: subscriptions);
       // start() synchronously subscribes local route-trigger listeners before
       // the debug server can expose mutation routes.
       final sessionStart = activeRuntime.session.start();
@@ -914,7 +928,7 @@ class const BridgeRuntimeRunner._() {
       return requestedSupervisedExit?.code ?? 0;
     } on PluginStartAbortedException {
       if (startAbortController.isAborted) {
-        Log.i("Plugin start aborted as requested.");
+        Log.i("Bridge startup aborted as requested.");
         return 0;
       }
       rethrow;
@@ -939,7 +953,7 @@ class const BridgeRuntimeRunner._() {
         Log.w("Session teardown failed after a supervised restart handoff", error, stackTrace);
         return BridgeSupervisedExitCode.restart.code;
       }
-      Log.e("$error");
+      Log.e("Bridge startup or session failed", error, stackTrace);
       return 1;
     } finally {
       try {

--- a/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
+++ b/bridge/app/lib/src/runtime/bridge_runtime_runner.dart
@@ -789,6 +789,10 @@ class const BridgeRuntimeRunner._() {
         Log.w("Startup diagnostics failed; continuing without a degraded-access warning", error, stackTrace);
       }
 
+      // A signal received during diagnostics had no session to cancel yet.
+      // Honor the latched request before constructing the runtime.
+      if (startAbortController.isAborted) throw const PluginStartAbortedException();
+
       final database = AppDatabase.create(
         dataDirectory: options.dataDirectory,
       );

--- a/bridge/app/lib/src/services/bridge_startup_retry_service.dart
+++ b/bridge/app/lib/src/services/bridge_startup_retry_service.dart
@@ -1,0 +1,75 @@
+import "dart:async";
+import "dart:io";
+
+import "package:http/http.dart" as http;
+import "package:rxdart/rxdart.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:web_socket_channel/web_socket_channel.dart";
+
+import "../auth/auth_api.dart";
+import "../auth/token_refresher.dart";
+
+/// Owns startup outage recovery, independently of the supervisor crash budget.
+class BridgeStartupRetryService() {
+  static const retryInterval = Duration(minutes: 1);
+
+  final BehaviorSubject<ControlStartupState> _state = BehaviorSubject.seeded(ControlStartupState.starting);
+  final StartAbortController _abort = StartAbortController();
+
+  ValueStream<ControlStartupState> get states => _state.stream;
+
+  Future<T> run<T>({required Future<T> Function() operation}) async {
+    while (true) {
+      _checkCancelled();
+      try {
+        final result = await operation();
+        // Return acquired resources to their caller even during cancellation:
+        // the session owns closing a relay connection that just completed.
+        if (!_abort.isAborted) _state.add(ControlStartupState.starting);
+        return result;
+      } on Object catch (error, stackTrace) {
+        _checkCancelled();
+        if (!_isRetryable(error: error)) rethrow;
+        _state.add(ControlStartupState.waitingForServer);
+        Console.warning(
+          "Could not reach the Sesori server during startup. Your internet connection may be unavailable. "
+          "The bridge is waiting and will retry in 1 minute.",
+        );
+        Log.w("Startup server request failed; retrying in 1 minute", error, stackTrace);
+        final elapsed = Completer<void>();
+        final timer = Timer(retryInterval, elapsed.complete);
+        try {
+          await Future.any<void>([elapsed.future, _abort.signal.whenAborted]);
+        } finally {
+          timer.cancel();
+        }
+      }
+    }
+  }
+
+  void markReady() => _state.add(ControlStartupState.ready);
+
+  void cancel() => _abort.abort();
+
+  Future<void> dispose() async {
+    cancel();
+    await _state.close();
+  }
+
+  void _checkCancelled() {
+    if (_abort.isAborted) throw const PluginStartAbortedException();
+  }
+
+  bool _isRetryable({required Object error}) => switch (error) {
+    http.ClientException() ||
+    SocketException() ||
+    WebSocketException() ||
+    TimeoutException() ||
+    ControlTokenRetryLaterException() => true,
+    WebSocketChannelException(:final inner) when inner is Exception => _isRetryable(error: inner),
+    AuthApiException(:final statusCode) ||
+    BridgeRegistrationException(:final statusCode) => statusCode == 408 || statusCode == 429 || statusCode >= 500,
+    _ => false,
+  };
+}

--- a/bridge/app/lib/src/services/bridge_startup_retry_service.dart
+++ b/bridge/app/lib/src/services/bridge_startup_retry_service.dart
@@ -15,7 +15,7 @@ class BridgeStartupRetryService() {
   static const retryInterval = Duration(minutes: 1);
 
   final BehaviorSubject<ControlStartupState> _state = BehaviorSubject.seeded(ControlStartupState.starting);
-  final StartAbortController _abort = StartAbortController();
+  final StreamController<void> _cancellation = StreamController<void>.broadcast(sync: true);
 
   ValueStream<ControlStartupState> get states => _state.stream;
 
@@ -26,23 +26,34 @@ class BridgeStartupRetryService() {
         final result = await operation();
         // Return acquired resources to their caller even during cancellation:
         // the session owns closing a relay connection that just completed.
-        if (!_abort.isAborted) _state.add(ControlStartupState.starting);
+        if (!_cancellation.isClosed) _state.add(ControlStartupState.starting);
         return result;
       } on Object catch (error, stackTrace) {
         _checkCancelled();
         if (!_isRetryable(error: error)) rethrow;
-        _state.add(ControlStartupState.waitingForServer);
+        final waitingForToken = error is ControlTokenRetryLaterException;
+        _state.add(
+          waitingForToken ? ControlStartupState.waitingForAuthentication : ControlStartupState.waitingForServer,
+        );
         Console.warning(
-          "Could not reach the Sesori server during startup. Your internet connection may be unavailable. "
-          "The bridge is waiting and will retry in 1 minute.",
+          waitingForToken
+              ? "Waiting for the desktop app to supply an access token. The bridge will retry in 1 minute."
+              : "Could not reach the Sesori server during startup. Your internet connection may be unavailable. "
+                    "The bridge is waiting and will retry in 1 minute.",
         );
         Log.w("Startup server request failed; retrying in 1 minute", error, stackTrace);
         final elapsed = Completer<void>();
-        final timer = Timer(retryInterval, elapsed.complete);
+        void wake() {
+          if (!elapsed.isCompleted) elapsed.complete();
+        }
+
+        final cancellation = _cancellation.stream.listen(null, onDone: wake);
+        final timer = Timer(retryInterval, wake);
         try {
-          await Future.any<void>([elapsed.future, _abort.signal.whenAborted]);
+          await elapsed.future;
         } finally {
           timer.cancel();
+          unawaited(cancellation.cancel());
         }
       }
     }
@@ -50,7 +61,7 @@ class BridgeStartupRetryService() {
 
   void markReady() => _state.add(ControlStartupState.ready);
 
-  void cancel() => _abort.abort();
+  void cancel() => unawaited(_cancellation.close());
 
   Future<void> dispose() async {
     cancel();
@@ -58,18 +69,17 @@ class BridgeStartupRetryService() {
   }
 
   void _checkCancelled() {
-    if (_abort.isAborted) throw const PluginStartAbortedException();
+    if (_cancellation.isClosed) throw const PluginStartAbortedException();
   }
 
   bool _isRetryable({required Object error}) => switch (error) {
-    http.ClientException() ||
-    SocketException() ||
-    WebSocketException() ||
-    TimeoutException() ||
-    ControlTokenRetryLaterException() => true,
+    http.ClientException() || SocketException() || TimeoutException() || ControlTokenRetryLaterException() => true,
     WebSocketChannelException(:final inner) when inner is Exception => _isRetryable(error: inner),
     AuthApiException(:final statusCode) ||
-    BridgeRegistrationException(:final statusCode) => statusCode == 408 || statusCode == 429 || statusCode >= 500,
+    BridgeRegistrationException(:final statusCode) ||
+    WebSocketException(
+      httpStatusCode: final statusCode?,
+    ) => statusCode == 408 || statusCode == 429 || statusCode >= 500,
     _ => false,
   };
 }

--- a/bridge/app/lib/src/services/control_channel_token_service.dart
+++ b/bridge/app/lib/src/services/control_channel_token_service.dart
@@ -87,7 +87,8 @@ class ControlChannelTokenService({
   /// for the correlated reply, forwarding [forceRefresh] so the GUI can mint a
   /// fresh token instead of returning a cached one. Throws
   /// [ControlTokenUnavailableException] when the GUI replies with no token
-  /// (signed out / mid-login) or does not reply within the request timeout.
+  /// (signed out / mid-login). Temporary failures, including a request timeout,
+  /// use its [ControlTokenRetryLaterException] subtype so startup can retry.
   /// Does not log on failure — the caller surfaces it once.
   @override
   Future<String> getAccessToken({bool forceRefresh = false}) async {
@@ -110,13 +111,8 @@ class ControlChannelTokenService({
     try {
       try {
         _client.send(jsonEncode(ControlMessage.tokenRequest(id: id, forceRefresh: forceRefresh).toJson()));
-      } on ControlChannelNotConnectedException {
-        // The loopback channel is down (GUI outage / mid-reconnect). Surface the
-        // documented typed failure so refresh callers (e.g. relay re-auth) handle
-        // a GUI-unavailable pull uniformly instead of a raw transport error.
-        throw const ControlTokenUnavailableException(
-          "The desktop app control channel is not connected.",
-        );
+      } on ControlChannelNotConnectedException catch (error) {
+        throw ControlTokenRetryLaterException(innerError: error);
       }
       final accessToken = await completer.future.timeout(_requestTimeout);
       if (accessToken == null) {
@@ -135,10 +131,10 @@ class ControlChannelTokenService({
       // caller still receives this pull's own token below regardless.
       _applyWrite(seq, () => _cacheToken(accessToken));
       return accessToken;
-    } on TimeoutException {
-      throw const ControlTokenUnavailableException(
-        "Timed out waiting for the desktop app to supply an access token.",
-      );
+    } on TimeoutException catch (error) {
+      // An offline desktop refresh may outlast this local request deadline.
+      // A missing reply is not evidence that the account has signed out.
+      throw ControlTokenRetryLaterException(innerError: error);
     } finally {
       _pending.remove(id);
     }
@@ -177,6 +173,11 @@ class ControlChannelTokenService({
     if (completer != null && !completer.isCompleted) {
       completer.complete(accessToken);
     }
+  }
+
+  void handleTokenRetryLater({required String id}) {
+    final completer = _pending.remove(id);
+    completer?.completeError(const ControlTokenRetryLaterException(innerError: null));
   }
 
   /// Runs [write] only if [seq] is newer than the write currently reflected in

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -25,6 +25,7 @@ import "package:sesori_bridge/src/server/foundation/bridge_restart_command_build
 import "package:sesori_bridge/src/server/foundation/bridge_restart_env.dart";
 import "package:sesori_bridge/src/server/repositories/process_repository.dart";
 import "package:sesori_bridge/src/server/services/bridge_restart_service.dart";
+import "package:sesori_bridge/src/services/bridge_startup_retry_service.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -79,6 +80,7 @@ Future<_DebugServerHarness> _createDebugServerHarness({
     restartService: effectiveRestartService,
     filesystemAccessOk: true,
     statusNotifier: null,
+    startupRetryService: BridgeStartupRetryService(),
     reconnectBackoff: ReconnectBackoffPolicy.standard,
   ).create();
   final runtime = BridgeRuntime(

--- a/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
+++ b/bridge/app/test/bridge/orchestrator_emit_bridge_event_test.dart
@@ -11,6 +11,7 @@ import "package:sesori_bridge/src/orchestrator.dart";
 import "package:sesori_bridge/src/routing/routed_request_dispatcher.dart";
 import "package:sesori_bridge/src/runtime/bridge_runtime.dart";
 import "package:sesori_bridge/src/runtime/plugin_runtime.dart" as runtime show PluginRuntimeState;
+import "package:sesori_bridge/src/services/bridge_startup_retry_service.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -1118,6 +1119,7 @@ class const _OrchestratorHarness({
       restartService: restartService,
       filesystemAccessOk: true,
       statusNotifier: null,
+      startupRetryService: BridgeStartupRetryService(),
       reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create();
     final runtime = BridgeRuntime(

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -8,6 +8,7 @@ import "package:sesori_bridge/src/foundation/relay_client.dart";
 import "package:sesori_bridge/src/models/bridge_config.dart";
 import "package:sesori_bridge/src/orchestrator.dart";
 import "package:sesori_bridge/src/repositories/plugin_lifecycle_repository.dart";
+import "package:sesori_bridge/src/services/bridge_startup_retry_service.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -85,6 +86,7 @@ void main() {
       restartService: buildTestRestartService(),
       filesystemAccessOk: true,
       statusNotifier: null,
+      startupRetryService: BridgeStartupRetryService(),
       reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create();
     final running = await startTestOrchestratorSession(session: composition.session);
@@ -164,6 +166,7 @@ void main() {
       restartService: buildTestRestartService(),
       filesystemAccessOk: true,
       statusNotifier: null,
+      startupRetryService: BridgeStartupRetryService(),
       reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create().session;
 
@@ -222,6 +225,7 @@ void main() {
         restartService: buildTestRestartService(),
         filesystemAccessOk: true,
         statusNotifier: null,
+        startupRetryService: BridgeStartupRetryService(),
         reconnectBackoff: ReconnectBackoffPolicy.standard,
       );
 
@@ -345,6 +349,7 @@ class _TestHarness._({
       restartService: buildTestRestartService(),
       filesystemAccessOk: true,
       statusNotifier: null,
+      startupRetryService: BridgeStartupRetryService(),
       reconnectBackoff: ReconnectBackoffPolicy.standard,
     );
 

--- a/bridge/app/test/bridge/orchestrator_live_attachment_test.dart
+++ b/bridge/app/test/bridge/orchestrator_live_attachment_test.dart
@@ -8,6 +8,7 @@ import "package:sesori_bridge/src/foundation/relay_client.dart";
 import "package:sesori_bridge/src/models/bridge_config.dart";
 import "package:sesori_bridge/src/orchestrator.dart";
 import "package:sesori_bridge/src/runtime/bridge_runtime.dart";
+import "package:sesori_bridge/src/services/bridge_startup_retry_service.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -342,6 +343,7 @@ class _LiveAttachmentHarness({
       restartService: buildTestRestartService(),
       filesystemAccessOk: true,
       statusNotifier: null,
+      startupRetryService: BridgeStartupRetryService(),
       reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create();
     final runtime = BridgeRuntime(

--- a/bridge/app/test/bridge/orchestrator_registration_test.dart
+++ b/bridge/app/test/bridge/orchestrator_registration_test.dart
@@ -14,6 +14,7 @@ import "package:sesori_bridge/src/models/bridge_config.dart";
 import "package:sesori_bridge/src/orchestrator.dart";
 import "package:sesori_bridge/src/routing/bridge_restart_dispatcher.dart";
 import "package:sesori_bridge/src/server/services/bridge_restart_service.dart";
+import "package:sesori_bridge/src/services/bridge_startup_retry_service.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log, LogLevel, ServerClock;
@@ -28,9 +29,9 @@ import "routing/routing_test_helpers.dart";
 
 void main() {
   group("OrchestratorSession bridge registration", () {
-    test("startup registration failure fails startup and lifecycle without connecting to the relay", () async {
+    test("non-retryable startup registration failure fails without connecting to the relay", () async {
       final repository = FakeBridgeRegistrationRepository()
-        ..registerError = BridgeRegistrationException(statusCode: 500, body: "boom");
+        ..registerError = BridgeRegistrationException(statusCode: 400, body: "boom");
       final harness = await _RegistrationHarness.start(repository: repository);
       addTearDown(harness.close);
 
@@ -39,6 +40,18 @@ void main() {
 
       expect(repository.registeredBridgeIds, equals([null]));
       expect(harness.relayServer.connectedClientCount, equals(0));
+    });
+
+    test("offline startup waits without connecting and can be cancelled promptly", () async {
+      final repository = FakeBridgeRegistrationRepository()..registerError = const SocketException("offline");
+      final harness = await _RegistrationHarness.start(repository: repository);
+      addTearDown(harness.close);
+      await _waitFor(() => repository.registeredBridgeIds.isNotEmpty, reason: "first registration attempt");
+      expect(harness.relayServer.connectedClientCount, 0);
+      await harness.session.cancel().timeout(const Duration(seconds: 2));
+      expect(await harness.startFuture, OrchestratorSessionStartResult.cancelled);
+      await harness.runFuture;
+      expect(repository.registeredBridgeIds, [null]);
     });
 
     test("registers before the initial connect and sends the bridge id in the auth message", () async {
@@ -563,6 +576,7 @@ class _RegistrationHarness._({
       restartService: restartService,
       filesystemAccessOk: true,
       statusNotifier: null,
+      startupRetryService: BridgeStartupRetryService(),
       reconnectBackoff: backoffPolicy,
     );
 

--- a/bridge/app/test/bridge/orchestrator_request_concurrency_test.dart
+++ b/bridge/app/test/bridge/orchestrator_request_concurrency_test.dart
@@ -12,6 +12,7 @@ import "package:sesori_bridge/src/models/bridge_config.dart";
 import "package:sesori_bridge/src/orchestrator.dart";
 import "package:sesori_bridge/src/runtime/bridge_runtime.dart";
 import "package:sesori_bridge/src/server/services/bridge_restart_service.dart";
+import "package:sesori_bridge/src/services/bridge_startup_retry_service.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
@@ -308,6 +309,7 @@ class _ConcurrencyHarness._({
       restartService: restartService,
       filesystemAccessOk: true,
       statusNotifier: null,
+      startupRetryService: BridgeStartupRetryService(),
       reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create();
     final runtime = BridgeRuntime(

--- a/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
+++ b/bridge/app/test/bridge/orchestrator_token_reauth_test.dart
@@ -11,6 +11,7 @@ import "package:sesori_bridge/src/foundation/process_runner.dart";
 import "package:sesori_bridge/src/foundation/relay_client.dart";
 import "package:sesori_bridge/src/models/bridge_config.dart";
 import "package:sesori_bridge/src/orchestrator.dart";
+import "package:sesori_bridge/src/services/bridge_startup_retry_service.dart";
 import "package:sesori_bridge/src/services/plugin_lifecycle_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show ServerClock;
 import "package:sesori_shared/sesori_shared.dart" hide PermissionReply;
@@ -346,6 +347,7 @@ class _ReauthHarness._({
       restartService: buildTestRestartService(),
       filesystemAccessOk: true,
       statusNotifier: null,
+      startupRetryService: BridgeStartupRetryService(),
       reconnectBackoff: backoffPolicy,
     );
 

--- a/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_auth_test.dart
@@ -1,3 +1,6 @@
+import "dart:async";
+
+import "package:fake_async/fake_async.dart";
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:sesori_bridge/src/auth/auth_api.dart';
@@ -9,11 +12,103 @@ import 'package:sesori_bridge/src/auth/token.dart';
 import 'package:sesori_bridge/src/foundation/abortable_request.dart';
 import 'package:sesori_bridge/src/runtime/bridge_cli_options.dart';
 import 'package:sesori_bridge/src/runtime/bridge_runtime_auth.dart';
+import "package:sesori_bridge/src/services/bridge_startup_retry_service.dart";
 import 'package:sesori_shared/sesori_shared.dart';
 import 'package:test/test.dart';
 
 void main() {
   group('BridgeRuntimeAuthService', () {
+    for (final refreshFails in [false, true]) {
+      for (final serverUnavailable in [false, true]) {
+        test(
+          'stored token ${refreshFails ? "refresh" : "lookup"} recovers after ${serverUnavailable ? "503" : "DNS failure"}',
+          () {
+            fakeAsync((time) {
+              final retry = BridgeStartupRetryService();
+              var attempts = 0;
+              var loads = 0;
+              var clears = 0;
+              TokenData? saved;
+              TokenData? result;
+              final client = MockClient((request) async {
+                if (refreshFails && request.url.path == '/auth/me') return http.Response('', 401);
+                attempts++;
+                if (attempts == 1) {
+                  if (serverUnavailable) return http.Response('', 503);
+                  throw http.ClientException('Failed host lookup', request.url);
+                }
+                return http.Response(
+                  refreshFails
+                      ? '{"accessToken":"refreshed","refreshToken":"new-refresh","user":{"id":"1","provider":"github","providerUserId":"1"}}'
+                      : '{"user":{"id":"1","provider":"github","providerUserId":"1"}}',
+                  200,
+                );
+              });
+              final service = BridgeRuntimeAuthService(
+                startupRetryService: retry,
+                loginEmailRepository: _FakeLoginEmailRepository(),
+                loginOAuthService: _FakeLoginOAuthService(),
+                authRepository: AuthRepository(
+                  api: AuthApi(
+                    authBackendUrl: 'https://auth.example.test',
+                    client: client,
+                    requestDeadline: AuthApi.defaultRequestDeadline,
+                    sendRequest: sendRequestWithDeadline,
+                  ),
+                ),
+                loadTokens: () async {
+                  loads++;
+                  return TokenData(accessToken: 'stored', refreshToken: 'refresh', lastProvider: AuthProvider.github);
+                },
+                saveTokens: (tokens) async {
+                  saved = tokens;
+                },
+                clearTokens: () async {
+                  clears++;
+                },
+              );
+              service
+                  .ensureAuthenticated(options: _options(authBackendUrl: 'https://auth.example.test'))
+                  .then((tokens) => result = tokens);
+              time.flushMicrotasks();
+              expect(retry.states.value, ControlStartupState.waitingForServer);
+              expect(saved, isNull);
+              expect(clears, 0);
+              time.elapse(const Duration(minutes: 1));
+              expect(result?.accessToken, refreshFails ? 'refreshed' : 'stored');
+              expect(saved, result);
+              expect(loads, 1);
+              expect(attempts, 2);
+              client.close();
+              unawaited(retry.dispose());
+              time.flushMicrotasks();
+            });
+          },
+        );
+      }
+    }
+
+    test('interactive OAuth timeout is not retried', () async {
+      final retry = BridgeStartupRetryService();
+      addTearDown(retry.dispose);
+      final timeout = TimeoutException('timed out waiting for authorization');
+      final service = BridgeRuntimeAuthService(
+        startupRetryService: retry,
+        loginEmailRepository: _FakeLoginEmailRepository(),
+        loginOAuthService: _FakeLoginOAuthService(error: timeout),
+        authRepository: _expiredTokensAuthRepository(),
+        loadTokens: () async =>
+            TokenData(accessToken: 'expired', refreshToken: 'expired', lastProvider: AuthProvider.github),
+        saveTokens: (_) async {},
+        clearTokens: () async {},
+      );
+      await expectLater(
+        service.ensureAuthenticated(options: _options(authBackendUrl: 'https://auth.example.test')),
+        throwsA(same(timeout)),
+      );
+      expect(retry.states.value, ControlStartupState.starting);
+    });
+
     test('OAuth login ACK is sent only after tokens are persisted', () async {
       final storedTokens = TokenData(
         accessToken: 'expired-access-token',
@@ -36,6 +131,7 @@ void main() {
         },
       );
       final service = BridgeRuntimeAuthService(
+        startupRetryService: BridgeStartupRetryService(),
         loginEmailRepository: _FakeLoginEmailRepository(),
         loginOAuthService: oauthService,
         authRepository: _expiredTokensAuthRepository(),
@@ -82,6 +178,7 @@ void main() {
         ),
       );
       final service = BridgeRuntimeAuthService(
+        startupRetryService: BridgeStartupRetryService(),
         loginEmailRepository: _FakeLoginEmailRepository(),
         loginOAuthService: _FakeLoginOAuthService(),
         authRepository: repository,
@@ -112,6 +209,7 @@ void main() {
       );
       final oauthService = _FakeLoginOAuthService(error: Exception('authorization denied'));
       final service = BridgeRuntimeAuthService(
+        startupRetryService: BridgeStartupRetryService(),
         loginEmailRepository: _FakeLoginEmailRepository(),
         loginOAuthService: oauthService,
         authRepository: _expiredTokensAuthRepository(),
@@ -145,6 +243,7 @@ void main() {
         ackError: Exception('ack failed'),
       );
       final service = BridgeRuntimeAuthService(
+        startupRetryService: BridgeStartupRetryService(),
         loginEmailRepository: _FakeLoginEmailRepository(),
         loginOAuthService: oauthService,
         authRepository: _expiredTokensAuthRepository(),

--- a/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
+++ b/bridge/app/test/bridge/runtime/bridge_runtime_builder_test.dart
@@ -17,6 +17,7 @@ import "package:sesori_bridge/src/push/push_rate_limiter.dart";
 import "package:sesori_bridge/src/push/push_session_state_tracker.dart";
 import "package:sesori_bridge/src/routing/routed_request_dispatcher.dart";
 import "package:sesori_bridge/src/runtime/bridge_runtime.dart";
+import "package:sesori_bridge/src/services/bridge_startup_retry_service.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show ServerClock;
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
@@ -83,6 +84,7 @@ void main() {
       restartService: restartService,
       filesystemAccessOk: true,
       statusNotifier: null,
+      startupRetryService: BridgeStartupRetryService(),
       reconnectBackoff: ReconnectBackoffPolicy.standard,
     ).create();
     final runtime = BridgeRuntime(

--- a/bridge/app/test/control/bridge_control_message_dispatcher_test.dart
+++ b/bridge/app/test/control/bridge_control_message_dispatcher_test.dart
@@ -100,6 +100,7 @@ void main() {
       client.emit(
         _encode(
           const ControlMessage.status(
+            startup: ControlStartupState.ready,
             relay: ControlRelayConnectionState.connected,
             plugin: ControlPluginHealthState.healthy,
           ),

--- a/bridge/app/test/control/control_status_notifier_test.dart
+++ b/bridge/app/test/control/control_status_notifier_test.dart
@@ -14,14 +14,19 @@ void main() {
   late StreamController<RelayConnectionState> relayState;
   late StreamController<String> registrations;
   late ControlStatusNotifier notifier;
+  late StreamController<ControlStartupState> startupState;
 
   setUp(() {
     client = FakeControlChannelClient();
     pluginMetadata = StreamController<List<PluginMetadata>>.broadcast();
     relayState = StreamController<RelayConnectionState>.broadcast();
     registrations = StreamController<String>.broadcast();
+    startupState = StreamController<ControlStartupState>.broadcast();
     notifier = ControlStatusNotifier(
       client: client,
+      startupState: startupState.stream,
+    );
+    notifier.observeRuntime(
       pluginMetadata: pluginMetadata.stream,
       relayConnectionState: relayState.stream,
       registrations: registrations.stream,
@@ -31,6 +36,7 @@ void main() {
 
   tearDown(() async {
     await notifier.dispose();
+    await startupState.close();
     await pluginMetadata.close();
     await relayState.close();
     await registrations.close();
@@ -44,6 +50,26 @@ void main() {
       PluginMetadata(id: "plugin", displayName: "Plugin", isDefault: true, state: state, actionHint: null),
     ]);
   }
+
+  test("reports waiting before runtime attachment and resends it on reconnect", () async {
+    await notifier.dispose();
+    notifier = ControlStatusNotifier(client: client, startupState: startupState.stream)..start();
+    startupState.add(ControlStartupState.waitingForServer);
+    await pump();
+    expect((client.sentMessages.last as ControlStatus).startup, ControlStartupState.waitingForServer);
+    client.sentFrames.clear();
+    client.emitConnectionState(ControlChannelConnectionState.connected);
+    await pump();
+    expect((client.sentMessages.single as ControlStatus).startup, ControlStartupState.waitingForServer);
+    notifier.observeRuntime(
+      pluginMetadata: pluginMetadata.stream,
+      relayConnectionState: relayState.stream,
+      registrations: registrations.stream,
+    );
+    startupState.add(ControlStartupState.ready);
+    await pump();
+    expect((client.sentMessages.last as ControlStatus).startup, ControlStartupState.ready);
+  });
 
   group("status pushes", () {
     test("a plugin status change pushes a status with the mapped health", () async {
@@ -299,6 +325,7 @@ void main() {
 
     test("dispose cancels the subscriptions — later events push nothing", () async {
       await notifier.dispose();
+      await startupState.close();
 
       emitPluginState(PluginLifecycleState.ready);
       relayState.add(const RelayConnected());

--- a/bridge/app/test/integration/supervised_e2e_test.dart
+++ b/bridge/app/test/integration/supervised_e2e_test.dart
@@ -501,6 +501,7 @@ class _ControlHost({
           ),
         );
       case ControlTokenResponse() ||
+          ControlTokenRetryLater() ||
           ControlStatus() ||
           ControlPromptRequest() ||
           ControlPromptResponse() ||

--- a/bridge/app/test/services/bridge_startup_retry_service_test.dart
+++ b/bridge/app/test/services/bridge_startup_retry_service_test.dart
@@ -77,7 +77,7 @@ void main() {
     TimeoutException("deadline"),
     http.RequestAbortedException(Uri.parse("https://auth.test")),
     WebSocketChannelException.from(const SocketException("offline")),
-    WebSocketChannelException.from(const WebSocketException("Service unavailable")),
+    WebSocketChannelException.from(const WebSocketException("Service unavailable", 503)),
     const ControlTokenRetryLaterException(innerError: null),
     AuthApiException(method: "GET", uri: Uri.parse("https://auth.test"), statusCode: 503, body: ""),
     BridgeRegistrationException(statusCode: 429, body: ""),
@@ -92,7 +92,12 @@ void main() {
           },
         );
         time.flushMicrotasks();
-        expect(service.states.value, ControlStartupState.waitingForServer);
+        expect(
+          service.states.value,
+          error is ControlTokenRetryLaterException
+              ? ControlStartupState.waitingForAuthentication
+              : ControlStartupState.waitingForServer,
+        );
         time.elapse(const Duration(minutes: 1));
         expect(attempts, 2);
         unawaited(service.dispose());
@@ -104,6 +109,9 @@ void main() {
   for (final error in <Object>[
     StateError("configuration"),
     const FormatException("malformed response"),
+    const WebSocketException("Not found", 404),
+    const WebSocketException("Invalid upgrade"),
+    const HandshakeException("Certificate verification failed"),
     const FileSystemException("permission denied"),
     const ControlTokenUnavailableException("signed out"),
     AuthApiException(method: "GET", uri: Uri.parse("https://auth.test"), statusCode: 401, body: ""),

--- a/bridge/app/test/services/bridge_startup_retry_service_test.dart
+++ b/bridge/app/test/services/bridge_startup_retry_service_test.dart
@@ -1,0 +1,117 @@
+import "dart:async";
+import "dart:io";
+
+import "package:fake_async/fake_async.dart";
+import "package:http/http.dart" as http;
+import "package:sesori_bridge/src/auth/auth_api.dart";
+import "package:sesori_bridge/src/auth/token_refresher.dart";
+import "package:sesori_bridge/src/services/bridge_startup_retry_service.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+import "package:web_socket_channel/web_socket_channel.dart";
+
+void main() {
+  test("retries every minute without a limit and resumes when the server returns", () {
+    fakeAsync((time) {
+      final service = BridgeStartupRetryService();
+      var attempts = 0;
+      String? result;
+      service
+          .run(
+            operation: () async {
+              if (++attempts <= 12) throw http.ClientException("Failed host lookup");
+              return "online";
+            },
+          )
+          .then((value) => result = value);
+      time.flushMicrotasks();
+      expect(service.states.value, ControlStartupState.waitingForServer);
+      for (var i = 0; i < 12; i++) {
+        time.elapse(const Duration(seconds: 59));
+        expect(attempts, i + 1);
+        time.elapse(const Duration(seconds: 1));
+        expect(attempts, i + 2);
+      }
+      expect(result, "online");
+      expect(service.states.value, ControlStartupState.starting);
+      service.markReady();
+      expect(service.states.value, ControlStartupState.ready);
+      unawaited(service.dispose());
+      time.flushMicrotasks();
+      expect(time.pendingTimers, isEmpty);
+    });
+  });
+
+  test("cancellation wakes the retry immediately and removes its timer", () {
+    fakeAsync((time) {
+      final service = BridgeStartupRetryService();
+      Object? failure;
+      var attempts = 0;
+      service
+          .run<void>(
+            operation: () async {
+              attempts++;
+              throw const SocketException("offline");
+            },
+          )
+          .then<void>(
+            (_) {},
+            onError: (Object error) {
+              failure = error;
+            },
+          );
+      time.flushMicrotasks();
+      service.cancel();
+      time.flushMicrotasks();
+      expect(failure, isA<PluginStartAbortedException>());
+      expect(time.pendingTimers, isEmpty);
+      time.elapse(const Duration(minutes: 5));
+      expect(attempts, 1);
+      unawaited(service.dispose());
+      time.flushMicrotasks();
+    });
+  });
+
+  for (final error in <Object>[
+    TimeoutException("deadline"),
+    http.RequestAbortedException(Uri.parse("https://auth.test")),
+    WebSocketChannelException.from(const SocketException("offline")),
+    WebSocketChannelException.from(const WebSocketException("Service unavailable")),
+    const ControlTokenRetryLaterException(innerError: null),
+    AuthApiException(method: "GET", uri: Uri.parse("https://auth.test"), statusCode: 503, body: ""),
+    BridgeRegistrationException(statusCode: 429, body: ""),
+  ]) {
+    test("waits for transient ${error.runtimeType}", () {
+      fakeAsync((time) {
+        final service = BridgeStartupRetryService();
+        var attempts = 0;
+        service.run<void>(
+          operation: () async {
+            if (++attempts == 1) throw error;
+          },
+        );
+        time.flushMicrotasks();
+        expect(service.states.value, ControlStartupState.waitingForServer);
+        time.elapse(const Duration(minutes: 1));
+        expect(attempts, 2);
+        unawaited(service.dispose());
+        time.flushMicrotasks();
+      });
+    });
+  }
+
+  for (final error in <Object>[
+    StateError("configuration"),
+    const FormatException("malformed response"),
+    const FileSystemException("permission denied"),
+    const ControlTokenUnavailableException("signed out"),
+    AuthApiException(method: "GET", uri: Uri.parse("https://auth.test"), statusCode: 401, body: ""),
+  ]) {
+    test("preserves non-network ${error.runtimeType} failures", () async {
+      final service = BridgeStartupRetryService();
+      addTearDown(service.dispose);
+      await expectLater(service.run<void>(operation: () async => throw error), throwsA(same(error)));
+    });
+  }
+}

--- a/bridge/app/test/services/control_channel_token_service_test.dart
+++ b/bridge/app/test/services/control_channel_token_service_test.dart
@@ -34,6 +34,23 @@ void main() {
   }
 
   group("ControlChannelTokenService", () {
+    test("a temporary GUI token failure remains retryable and the next request succeeds", () async {
+      final client = FakeControlChannelClient();
+      final service = buildService(client);
+      addTearDown(service.dispose);
+      final failed = service.getAccessToken();
+      final expectation = expectLater(failed, throwsA(isA<ControlTokenRetryLaterException>()));
+      await pumpEventQueue();
+      final first = client.sentMessages.last as ControlTokenRequest;
+      service.handleTokenRetryLater(id: first.id);
+      await expectation;
+      final recovered = service.getAccessToken();
+      await pumpEventQueue();
+      final second = client.sentMessages.last as ControlTokenRequest;
+      service.handleTokenResponse(id: second.id, accessToken: "recovered");
+      expect(await recovered, "recovered");
+    });
+
     test("sends a token_request and resolves with the matching token_response", () async {
       final client = FakeControlChannelClient();
       final service = buildService(client);
@@ -226,14 +243,20 @@ void main() {
       expect(service.accessToken, equals("newer"));
     });
 
-    test("times out with a typed failure when no response arrives", () async {
+    test("an offline desktop refresh that outlasts the deadline remains retryable", () async {
       final client = FakeControlChannelClient();
       final service = buildService(client, requestTimeout: const Duration(milliseconds: 20));
       addTearDown(service.dispose);
 
       await expectLater(
         service.getAccessToken(),
-        throwsA(isA<ControlTokenUnavailableException>()),
+        throwsA(
+          isA<ControlTokenRetryLaterException>().having(
+            (error) => error.innerError,
+            "original timeout",
+            isA<TimeoutException>(),
+          ),
+        ),
       );
     });
 
@@ -265,6 +288,7 @@ void main() {
       client.emit(
         _encode(
           const ControlMessage.status(
+            startup: ControlStartupState.ready,
             relay: ControlRelayConnectionState.connected,
             plugin: ControlPluginHealthState.healthy,
           ),

--- a/client/desktop/test/core/widgets/desktop_cockpit_shell_test.dart
+++ b/client/desktop/test/core/widgets/desktop_cockpit_shell_test.dart
@@ -183,6 +183,7 @@ BridgeControlState _state({
   toggleTarget: BridgeProcessDesiredState.off,
   launchAtLoginEnabled: false,
   controlStatus: BridgeControlStatus(
+    startup: ControlStartupState.ready,
     helperOnline: false,
     bridgeId: null,
     relay: relay,

--- a/client/desktop/test/features/home/desktop_home_test.dart
+++ b/client/desktop/test/features/home/desktop_home_test.dart
@@ -66,6 +66,7 @@ void main() {
         processState: const BridgeProcessRunning(pid: 42),
         desiredState: BridgeProcessDesiredState.on,
         status: const BridgeControlStatus(
+          startup: ControlStartupState.ready,
           helperOnline: true,
           relay: ControlRelayConnectionState.connected,
           plugin: ControlPluginHealthState.healthy,
@@ -120,6 +121,7 @@ void main() {
         processState: const BridgeProcessRunning(pid: 42),
         desiredState: BridgeProcessDesiredState.on,
         status: const BridgeControlStatus(
+          startup: ControlStartupState.ready,
           helperOnline: true,
           relay: ControlRelayConnectionState.takenOver,
           plugin: ControlPluginHealthState.healthy,

--- a/client/module_desktop_core/lib/src/control/control_message_dispatcher.dart
+++ b/client/module_desktop_core/lib/src/control/control_message_dispatcher.dart
@@ -85,7 +85,11 @@ class ControlMessageDispatcher({
         }
       case ControlPromptRequest():
         _promptTracker.addPrompt(prompt: message);
-      case ControlTokenResponse() || ControlPromptResponse() || ControlShutdown() || ControlUnregisterAndExit():
+      case ControlTokenRetryLater() ||
+          ControlTokenResponse() ||
+          ControlPromptResponse() ||
+          ControlShutdown() ||
+          ControlUnregisterAndExit():
         // GUI→helper-direction variants are never inbound commands.
         logd("Ignoring a GUI-direction control message arriving inbound");
     }
@@ -97,9 +101,7 @@ class ControlMessageDispatcher({
     try {
       accessToken = await _tokenProvider.getFreshAccessToken(forceRefresh: request.forceRefresh);
     } on Object catch (error, stackTrace) {
-      // Answer signed-out rather than leaving the helper's pull hanging on
-      // its timeout; the helper surfaces its typed token-unavailable path.
-      logw("Token refresh for the helper failed; answering signed-out", error, stackTrace);
+      logw("Token refresh for the helper failed", error, stackTrace);
       accessToken = null;
     }
     if (_eventSubscription == null || epoch != _connectionEpoch) {
@@ -111,7 +113,9 @@ class ControlMessageDispatcher({
       return;
     }
     _send(
-      message: ControlMessage.tokenResponse(id: request.id, accessToken: accessToken),
+      message: accessToken == null && _authSession.currentState is AuthAuthenticated
+          ? ControlMessage.tokenRetryLater(id: request.id)
+          : ControlMessage.tokenResponse(id: request.id, accessToken: accessToken),
     );
   }
 

--- a/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_cubit.dart
+++ b/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_cubit.dart
@@ -468,10 +468,14 @@ class BridgeControlCubit._create({
       return "Bridge: Connecting";
     }
     switch (status.startup) {
+      case ControlStartupState.unknown:
+        return "Bridge: Status unknown";
       case ControlStartupState.starting:
         return "Bridge: Starting";
       case ControlStartupState.waitingForServer:
         return "Bridge: Starting — waiting for server (retrying every minute)";
+      case ControlStartupState.waitingForAuthentication:
+        return "Bridge: Starting — waiting for desktop authentication (retrying every minute)";
       case ControlStartupState.ready:
         break;
     }

--- a/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_cubit.dart
+++ b/client/module_desktop_core/lib/src/cubits/bridge_control/bridge_control_cubit.dart
@@ -467,6 +467,14 @@ class BridgeControlCubit._create({
     if (!status.helperOnline) {
       return "Bridge: Connecting";
     }
+    switch (status.startup) {
+      case ControlStartupState.starting:
+        return "Bridge: Starting";
+      case ControlStartupState.waitingForServer:
+        return "Bridge: Starting — waiting for server (retrying every minute)";
+      case ControlStartupState.ready:
+        break;
+    }
     return switch (status.relay) {
       ControlRelayConnectionState.connected =>
         status.plugin == ControlPluginHealthState.degraded ? "Bridge: Degraded" : "Bridge: Connected",

--- a/client/module_desktop_core/lib/src/trackers/bridge_control_status.dart
+++ b/client/module_desktop_core/lib/src/trackers/bridge_control_status.dart
@@ -26,7 +26,7 @@ sealed class BridgeControlStatus with _$BridgeControlStatus {
 
   /// Baseline before any helper has connected: bridge off, nothing known.
   static const BridgeControlStatus offline = BridgeControlStatus(
-    startup: ControlStartupState.ready,
+    startup: ControlStartupState.unknown,
     helperOnline: false,
     relay: ControlRelayConnectionState.disconnected,
     plugin: ControlPluginHealthState.unknown,

--- a/client/module_desktop_core/lib/src/trackers/bridge_control_status.dart
+++ b/client/module_desktop_core/lib/src/trackers/bridge_control_status.dart
@@ -13,6 +13,7 @@ sealed class BridgeControlStatus with _$BridgeControlStatus {
   const factory({
     /// Whether a helper is currently connected to the GUI's control channel.
     required bool helperOnline,
+    required ControlStartupState startup,
     required ControlRelayConnectionState relay,
     required ControlPluginHealthState plugin,
     required int activeSessionCount,
@@ -25,6 +26,7 @@ sealed class BridgeControlStatus with _$BridgeControlStatus {
 
   /// Baseline before any helper has connected: bridge off, nothing known.
   static const BridgeControlStatus offline = BridgeControlStatus(
+    startup: ControlStartupState.ready,
     helperOnline: false,
     relay: ControlRelayConnectionState.disconnected,
     plugin: ControlPluginHealthState.unknown,

--- a/client/module_desktop_core/lib/src/trackers/bridge_control_status.freezed.dart
+++ b/client/module_desktop_core/lib/src/trackers/bridge_control_status.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 mixin _$BridgeControlStatus {
 
 /// Whether a helper is currently connected to the GUI's control channel.
- bool get helperOnline; ControlRelayConnectionState get relay; ControlPluginHealthState get plugin; int get activeSessionCount;/// Readable copy of the helper's bridge id (from the `registered` event).
+ bool get helperOnline; ControlStartupState get startup; ControlRelayConnectionState get relay; ControlPluginHealthState get plugin; int get activeSessionCount;/// Readable copy of the helper's bridge id (from the `registered` event).
 /// Retained across helper disconnects — the offline-unregister fallback
 /// needs it exactly when the helper is gone.
  String? get bridgeId;
@@ -30,16 +30,16 @@ $BridgeControlStatusCopyWith<BridgeControlStatus> get copyWith => _$BridgeContro
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is BridgeControlStatus&&(identical(other.helperOnline, helperOnline) || other.helperOnline == helperOnline)&&(identical(other.relay, relay) || other.relay == relay)&&(identical(other.plugin, plugin) || other.plugin == plugin)&&(identical(other.activeSessionCount, activeSessionCount) || other.activeSessionCount == activeSessionCount)&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is BridgeControlStatus&&(identical(other.helperOnline, helperOnline) || other.helperOnline == helperOnline)&&(identical(other.startup, startup) || other.startup == startup)&&(identical(other.relay, relay) || other.relay == relay)&&(identical(other.plugin, plugin) || other.plugin == plugin)&&(identical(other.activeSessionCount, activeSessionCount) || other.activeSessionCount == activeSessionCount)&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,helperOnline,relay,plugin,activeSessionCount,bridgeId);
+int get hashCode => Object.hash(runtimeType,helperOnline,startup,relay,plugin,activeSessionCount,bridgeId);
 
 @override
 String toString() {
-  return 'BridgeControlStatus(helperOnline: $helperOnline, relay: $relay, plugin: $plugin, activeSessionCount: $activeSessionCount, bridgeId: $bridgeId)';
+  return 'BridgeControlStatus(helperOnline: $helperOnline, startup: $startup, relay: $relay, plugin: $plugin, activeSessionCount: $activeSessionCount, bridgeId: $bridgeId)';
 }
 
 
@@ -50,7 +50,7 @@ abstract mixin class $BridgeControlStatusCopyWith<$Res>  {
   factory $BridgeControlStatusCopyWith(BridgeControlStatus value, $Res Function(BridgeControlStatus) _then) = _$BridgeControlStatusCopyWithImpl;
 @useResult
 $Res call({
- bool helperOnline, ControlRelayConnectionState relay, ControlPluginHealthState plugin, int activeSessionCount, String? bridgeId
+ bool helperOnline, ControlStartupState startup, ControlRelayConnectionState relay, ControlPluginHealthState plugin, int activeSessionCount, String? bridgeId
 });
 
 
@@ -67,10 +67,11 @@ class _$BridgeControlStatusCopyWithImpl<$Res>
 
 /// Create a copy of BridgeControlStatus
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? helperOnline = null,Object? relay = null,Object? plugin = null,Object? activeSessionCount = null,Object? bridgeId = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? helperOnline = null,Object? startup = null,Object? relay = null,Object? plugin = null,Object? activeSessionCount = null,Object? bridgeId = freezed,}) {
   return _then(BridgeControlStatus(
 helperOnline: null == helperOnline ? _self.helperOnline : helperOnline // ignore: cast_nullable_to_non_nullable
-as bool,relay: null == relay ? _self.relay : relay // ignore: cast_nullable_to_non_nullable
+as bool,startup: null == startup ? _self.startup : startup // ignore: cast_nullable_to_non_nullable
+as ControlStartupState,relay: null == relay ? _self.relay : relay // ignore: cast_nullable_to_non_nullable
 as ControlRelayConnectionState,plugin: null == plugin ? _self.plugin : plugin // ignore: cast_nullable_to_non_nullable
 as ControlPluginHealthState,activeSessionCount: null == activeSessionCount ? _self.activeSessionCount : activeSessionCount // ignore: cast_nullable_to_non_nullable
 as int,bridgeId: freezed == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable
@@ -86,11 +87,12 @@ as String?,
 
 
 class _BridgeControlStatus implements BridgeControlStatus {
-  const _BridgeControlStatus({required this.helperOnline, required this.relay, required this.plugin, required this.activeSessionCount, required this.bridgeId});
+  const _BridgeControlStatus({required this.helperOnline, required this.startup, required this.relay, required this.plugin, required this.activeSessionCount, required this.bridgeId});
   
 
 /// Whether a helper is currently connected to the GUI's control channel.
 @override final  bool helperOnline;
+@override final  ControlStartupState startup;
 @override final  ControlRelayConnectionState relay;
 @override final  ControlPluginHealthState plugin;
 @override final  int activeSessionCount;
@@ -109,16 +111,16 @@ _$BridgeControlStatusCopyWith<_BridgeControlStatus> get copyWith => __$BridgeCon
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BridgeControlStatus&&(identical(other.helperOnline, helperOnline) || other.helperOnline == helperOnline)&&(identical(other.relay, relay) || other.relay == relay)&&(identical(other.plugin, plugin) || other.plugin == plugin)&&(identical(other.activeSessionCount, activeSessionCount) || other.activeSessionCount == activeSessionCount)&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _BridgeControlStatus&&(identical(other.helperOnline, helperOnline) || other.helperOnline == helperOnline)&&(identical(other.startup, startup) || other.startup == startup)&&(identical(other.relay, relay) || other.relay == relay)&&(identical(other.plugin, plugin) || other.plugin == plugin)&&(identical(other.activeSessionCount, activeSessionCount) || other.activeSessionCount == activeSessionCount)&&(identical(other.bridgeId, bridgeId) || other.bridgeId == bridgeId));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,helperOnline,relay,plugin,activeSessionCount,bridgeId);
+int get hashCode => Object.hash(runtimeType,helperOnline,startup,relay,plugin,activeSessionCount,bridgeId);
 
 @override
 String toString() {
-  return 'BridgeControlStatus(helperOnline: $helperOnline, relay: $relay, plugin: $plugin, activeSessionCount: $activeSessionCount, bridgeId: $bridgeId)';
+  return 'BridgeControlStatus(helperOnline: $helperOnline, startup: $startup, relay: $relay, plugin: $plugin, activeSessionCount: $activeSessionCount, bridgeId: $bridgeId)';
 }
 
 
@@ -129,7 +131,7 @@ abstract mixin class _$BridgeControlStatusCopyWith<$Res> implements $BridgeContr
   factory _$BridgeControlStatusCopyWith(_BridgeControlStatus value, $Res Function(_BridgeControlStatus) _then) = __$BridgeControlStatusCopyWithImpl;
 @override @useResult
 $Res call({
- bool helperOnline, ControlRelayConnectionState relay, ControlPluginHealthState plugin, int activeSessionCount, String? bridgeId
+ bool helperOnline, ControlStartupState startup, ControlRelayConnectionState relay, ControlPluginHealthState plugin, int activeSessionCount, String? bridgeId
 });
 
 
@@ -146,10 +148,11 @@ class __$BridgeControlStatusCopyWithImpl<$Res>
 
 /// Create a copy of BridgeControlStatus
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? helperOnline = null,Object? relay = null,Object? plugin = null,Object? activeSessionCount = null,Object? bridgeId = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? helperOnline = null,Object? startup = null,Object? relay = null,Object? plugin = null,Object? activeSessionCount = null,Object? bridgeId = freezed,}) {
   return _then(_BridgeControlStatus(
 helperOnline: null == helperOnline ? _self.helperOnline : helperOnline // ignore: cast_nullable_to_non_nullable
-as bool,relay: null == relay ? _self.relay : relay // ignore: cast_nullable_to_non_nullable
+as bool,startup: null == startup ? _self.startup : startup // ignore: cast_nullable_to_non_nullable
+as ControlStartupState,relay: null == relay ? _self.relay : relay // ignore: cast_nullable_to_non_nullable
 as ControlRelayConnectionState,plugin: null == plugin ? _self.plugin : plugin // ignore: cast_nullable_to_non_nullable
 as ControlPluginHealthState,activeSessionCount: null == activeSessionCount ? _self.activeSessionCount : activeSessionCount // ignore: cast_nullable_to_non_nullable
 as int,bridgeId: freezed == bridgeId ? _self.bridgeId : bridgeId // ignore: cast_nullable_to_non_nullable

--- a/client/module_desktop_core/lib/src/trackers/bridge_status_tracker.dart
+++ b/client/module_desktop_core/lib/src/trackers/bridge_status_tracker.dart
@@ -70,7 +70,7 @@ class BridgeStatusTracker({required BridgeIdStorage bridgeIdStorage}) {
     if (_status.isClosed) {
       return;
     }
-    _status.add(status.copyWith(helperOnline: true));
+    _status.add(status.copyWith(helperOnline: true, startup: ControlStartupState.starting));
   }
 
   /// The helper's control socket dropped: its last-known status is stale, so
@@ -96,6 +96,7 @@ class BridgeStatusTracker({required BridgeIdStorage bridgeIdStorage}) {
     }
     _status.add(
       this.status.copyWith(
+        startup: status.startup,
         relay: status.relay,
         plugin: status.plugin,
         activeSessionCount: status.activeSessionCount,

--- a/client/module_desktop_core/test/control/control_message_dispatcher_test.dart
+++ b/client/module_desktop_core/test/control/control_message_dispatcher_test.dart
@@ -93,6 +93,7 @@ void main() {
   });
 
   test("a signed-out session answers with a null accessToken", () async {
+    when(() => authSession.currentState).thenReturn(const AuthState.unauthenticated());
     when(() => tokenProvider.getFreshAccessToken(forceRefresh: false)).thenAnswer((_) async => null);
     final WebSocket helper = await connectHelper();
     final Future<Object?> reply = helper.first;
@@ -103,7 +104,7 @@ void main() {
     expect(response, const ControlMessage.tokenResponse(id: "44", accessToken: null));
   });
 
-  test("a throwing token seam degrades to a signed-out response", () async {
+  test("a throwing token seam retains the authenticated session and asks the helper to retry", () async {
     when(() => tokenProvider.getFreshAccessToken(forceRefresh: false)).thenThrow(StateError("refresh broke"));
     final WebSocket helper = await connectHelper();
     final Future<Object?> reply = helper.first;
@@ -111,7 +112,16 @@ void main() {
     sendFromHelper(helper, const ControlMessage.tokenRequest(id: "45"));
 
     final ControlMessage response = ControlMessage.fromJson(jsonDecodeMap(await reply as String? ?? ""));
-    expect(response, const ControlMessage.tokenResponse(id: "45", accessToken: null));
+    expect(response, const ControlMessage.tokenRetryLater(id: "45"));
+  });
+
+  test("a null refresh while still signed in asks the helper to retry", () async {
+    when(() => tokenProvider.getFreshAccessToken(forceRefresh: false)).thenAnswer((_) async => null);
+    final WebSocket helper = await connectHelper();
+    final Future<Object?> reply = helper.first;
+    sendFromHelper(helper, const ControlMessage.tokenRequest(id: "offline"));
+    final ControlMessage response = ControlMessage.fromJson(jsonDecodeMap(await reply as String? ?? ""));
+    expect(response, const ControlMessage.tokenRetryLater(id: "offline"));
   });
 
   test("status frames land in the status tracker", () async {
@@ -120,6 +130,7 @@ void main() {
     sendFromHelper(
       helper,
       const ControlMessage.status(
+        startup: ControlStartupState.ready,
         relay: ControlRelayConnectionState.connected,
         plugin: ControlPluginHealthState.healthy,
         activeSessionCount: 2,

--- a/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
+++ b/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
@@ -67,6 +67,30 @@ void main() {
       await logoutTracker.dispose();
     });
 
+    test("a live helper waiting for the server stays starting until readiness", () async {
+      await cubit.initialize();
+      statusTracker.markHelperConnected();
+      processService.emit(state: const BridgeProcessRunning(pid: 123), desiredState: BridgeProcessDesiredState.on);
+      statusTracker.applyStatus(
+        status: const ControlStatus(
+          startup: ControlStartupState.waitingForServer,
+          relay: ControlRelayConnectionState.disconnected,
+          plugin: ControlPluginHealthState.unknown,
+        ),
+      );
+      await pumpEventQueue();
+      expect(cubit.state.statusLabel, "Bridge: Starting — waiting for server (retrying every minute)");
+      statusTracker.applyStatus(
+        status: const ControlStatus(
+          startup: ControlStartupState.ready,
+          relay: ControlRelayConnectionState.connected,
+          plugin: ControlPluginHealthState.healthy,
+        ),
+      );
+      await pumpEventQueue();
+      expect(cubit.state.statusLabel, "Bridge: Connected");
+    });
+
     test("initializes a typed tray menu and reacts to process/status snapshots", () async {
       await cubit.initialize();
 
@@ -83,6 +107,7 @@ void main() {
       statusTracker.markHelperConnected();
       statusTracker.applyStatus(
         status: const ControlStatus(
+          startup: ControlStartupState.ready,
           relay: ControlRelayConnectionState.connected,
           plugin: ControlPluginHealthState.degraded,
           activeSessionCount: 3,
@@ -120,6 +145,7 @@ void main() {
       statusTracker.markHelperConnected();
       statusTracker.applyStatus(
         status: const ControlStatus(
+          startup: ControlStartupState.ready,
           relay: ControlRelayConnectionState.takenOver,
           plugin: ControlPluginHealthState.healthy,
           activeSessionCount: 0,

--- a/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
+++ b/client/module_desktop_core/test/cubits/bridge_control/bridge_control_cubit_test.dart
@@ -91,6 +91,21 @@ void main() {
       expect(cubit.state.statusLabel, "Bridge: Connected");
     });
 
+    test("a temporary desktop token failure shows an authentication wait", () async {
+      await cubit.initialize();
+      statusTracker.markHelperConnected();
+      processService.emit(state: const BridgeProcessRunning(pid: 123), desiredState: BridgeProcessDesiredState.on);
+      statusTracker.applyStatus(
+        status: const ControlStatus(
+          startup: ControlStartupState.waitingForAuthentication,
+          relay: ControlRelayConnectionState.disconnected,
+          plugin: ControlPluginHealthState.unknown,
+        ),
+      );
+      await pumpEventQueue();
+      expect(cubit.state.statusLabel, "Bridge: Starting — waiting for desktop authentication (retrying every minute)");
+    });
+
     test("initializes a typed tray menu and reacts to process/status snapshots", () async {
       await cubit.initialize();
 

--- a/client/module_desktop_core/test/trackers/bridge_status_tracker_test.dart
+++ b/client/module_desktop_core/test/trackers/bridge_status_tracker_test.dart
@@ -24,6 +24,7 @@ void main() {
     tracker.markHelperConnected();
     tracker.applyStatus(
       status: const ControlStatus(
+        startup: ControlStartupState.ready,
         relay: ControlRelayConnectionState.connected,
         plugin: ControlPluginHealthState.healthy,
         activeSessionCount: 3,
@@ -42,6 +43,7 @@ void main() {
     await pumpEventQueue();
     tracker.applyStatus(
       status: const ControlStatus(
+        startup: ControlStartupState.ready,
         relay: ControlRelayConnectionState.connected,
         plugin: ControlPluginHealthState.healthy,
         activeSessionCount: 2,
@@ -61,6 +63,7 @@ void main() {
     tracker.markHelperConnected();
     tracker.applyStatus(
       status: const ControlStatus(
+        startup: ControlStartupState.ready,
         relay: ControlRelayConnectionState.unknown,
         plugin: ControlPluginHealthState.unknown,
         activeSessionCount: 0,
@@ -77,6 +80,7 @@ void main() {
 
     tracker.applyStatus(
       status: const ControlStatus(
+        startup: ControlStartupState.ready,
         relay: ControlRelayConnectionState.connected,
         plugin: ControlPluginHealthState.healthy,
         activeSessionCount: 5,
@@ -164,6 +168,7 @@ void main() {
     expect(
       () => disposed.applyStatus(
         status: const ControlStatus(
+          startup: ControlStartupState.ready,
           relay: ControlRelayConnectionState.connected,
           plugin: ControlPluginHealthState.healthy,
           activeSessionCount: 1,

--- a/client/module_desktop_core/test/trackers/bridge_status_tracker_test.dart
+++ b/client/module_desktop_core/test/trackers/bridge_status_tracker_test.dart
@@ -17,6 +17,7 @@ void main() {
   test("defaults to the offline baseline before any helper connects", () {
     expect(tracker.status, BridgeControlStatus.offline);
     expect(tracker.status.helperOnline, isFalse);
+    expect(tracker.status.startup, ControlStartupState.unknown);
     expect(tracker.statusStream.value, BridgeControlStatus.offline);
   });
 
@@ -53,6 +54,7 @@ void main() {
     tracker.markHelperDisconnected();
 
     expect(tracker.status.helperOnline, isFalse);
+    expect(tracker.status.startup, ControlStartupState.unknown);
     expect(tracker.status.relay, ControlRelayConnectionState.disconnected);
     expect(tracker.status.plugin, ControlPluginHealthState.unknown);
     expect(tracker.status.activeSessionCount, 0);
@@ -88,6 +90,7 @@ void main() {
     );
 
     expect(tracker.status.helperOnline, isFalse);
+    expect(tracker.status.startup, ControlStartupState.unknown);
     expect(tracker.status.relay, ControlRelayConnectionState.disconnected);
     expect(tracker.status.activeSessionCount, 0);
   });

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -124,7 +124,7 @@ explicit restart, and the connection states the app presents.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | A started bridge reaches readiness and answers a health request; a connected client reports connected. Headless bridge plus relay integration for the client-visible state; no plugin. |
-| L2 Routine | Relay integration for key exchange, a normal drop and reconnect, and clean shutdown; automated and headless bridge for stable machine-name registration plus sleep-policy enable, disable, warning, and wake-lock release. No plugin. |
+| L2 Routine | Relay integration for key exchange, a normal drop and reconnect, and clean shutdown; automated minute-spaced startup outage recovery, cancellation, and definitive auth/protocol failure handling; automated and headless bridge for stable machine-name registration plus sleep-policy enable, disable, warning, and wake-lock release. No plugin. |
 | L3 Release | The full connection state machine as presented, explicit restart with successor handoff, second-start ownership resolution, and a slow in-flight request not blocking key exchange or further requests. Client end to end plus headless bridge; a representative harness supplies the slow operation. |
 | L4 Extended | Relay integration or client end to end for takeover, revocation, pull-driven live token re-authentication, handshake shutdown, app/network recovery, several clients, and alternate client platforms; the cross-platform supervised E2E suite builds and runs a real helper against fake auth/relay/control endpoints for control authentication, token pulls, registration, restart sentinel 86, fresh respawn, unregister, and process cleanup; desktop tests for authenticated spawn gating, first-token handshake, transactional spawn rollback/retry, every supervised exit class, bounded crash retry/give-up, stable-runtime budget reset, manual retry cancellation, prompt-answer ownership, account-bound persisted registration, concurrent logout/stop ordering, token-only deletion verification, tray menu/status updates, Linux host detection, ordered Quit, malformed/newline-free output, bounded persistence, rotation, permissions, and transient storage-path failure recovery. |
 | L5 Full | Store-distributed app against a released bridge over production relay, older app against newer bridge and the reverse for the client/bridge wire contract, and a long-lived headless VM run over repeated reconnects. Packaged or external. |
@@ -136,6 +136,11 @@ backgrounding, token expiry, competing bridge. Vary whether a client is connecte
 the bridge starts, how many clients are present, and whether restart is explicit.
 
 ## Failure Signals
+
+- A temporary startup outage exits the process or exhausts the supervisor crash
+  budget; retries stop, run faster than one minute, or fail to recover when the
+  server returns. Rejected credentials or a permanent WebSocket upgrade error
+  retry forever. Shutdown during a retry wait fails to stop promptly.
 
 - Readiness claimed before registration, auth send, listener setup, or read arming.
 - Plaintext session content crossing the relay, or a client served without key exchange.

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -9,8 +9,13 @@ explicit restart, and the connection states the app presents.
 ## Required Behavior
 
 - A start is ready only after registration, socket open, auth frame sent, listeners and
-  initial summary set up, and the first inbound read armed; earlier failure tears down
-  what was acquired and surfaces the error.
+  initial summary set up, and the first inbound read armed. During startup, temporary
+  authentication, registration and relay connection failures keep the process alive
+  and retry after one minute, without an attempt limit. Every failed attempt prints
+  a Console warning that the server could not be reached and the internet connection
+  may be unavailable; local diagnostics retain the original error and stack trace.
+  Shutdown interrupts the retry wait. Rejected credentials still use the normal login
+  flow, and non-network startup failures surface normally.
 - Relay traffic is end-to-end encrypted and a joining client completes key exchange
   before it is served; one room-key encryptor is shared across that bridge
   session while every encrypted frame receives a fresh nonce.

--- a/docs/regression/desktop-bridge-supervision.md
+++ b/docs/regression/desktop-bridge-supervision.md
@@ -9,13 +9,13 @@ and keep native close/quit behavior safe.
 ## Required Behavior
 
 - A connected helper process is distinct from a ready bridge. The control channel
-  reports starting, waiting for the server, and ready; desktop shows
+  reports starting, waiting for the server or desktop authentication, and ready; desktop shows
   "Starting — waiting for server (retrying every minute)" during an outage.
   Waiting does not exit the helper or spend the supervisor's crash-retry budget.
   Startup status is available before authentication and is replayed after a
   control-channel reconnect. Stop and Quit remain available during the wait.
 - If desktop cannot obtain a fresh token while its account remains authenticated,
-  it asks the helper to retry later. Only a missing/signed-out session takes the
+  it asks the helper to retry later and desktop shows waiting for authentication. Only a missing/signed-out session takes the
   existing login-required path; an offline token refresh must not be treated as
   a logout.
 
@@ -139,7 +139,7 @@ and keep native close/quit behavior safe.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Automated desktop startup proves eager tray initialization, Prego theme assembly, signed-out login rendering, signed-in cockpit/sidebar supervision rendering, shared desktop Settings with mobile push omitted and native attention exposed, and the typed session-detail route. No plugin. |
-| L2 Routine | Automated cubit/adapter coverage for Open/focus, close-to-hide, no-tray close-to-Quit, ordered Quit, quit-preserved desired state, failed-stop/persistence refusal to exit, On/Off recovery, explicit idempotent Start, diagnostics launch, bounds restore/clamp/debounce/terminal flush before first show, durable-Off-before-local-logout, notification cancel-all before credential clear, helper unregister command, no-competing-shutdown expected stop, account-bound persisted bridge-id restart, owner-mismatch protection, 404-idempotent deletion, offline deletion failure, explicit Take Over, cockpit-wide exceptional supervision, both project recovery variants omitting CLI copy, adaptive session split ownership, desktop Enter/Shift+Enter and safe Escape behavior, selectable transcript/diff content, SSE-derived attention gating/routing/cancellation/toggle, desktop transcript rendering and pending-question presentation without dead composer/diff controls, app-wide preference persistence, desktop settings/harness composition, profile logout delegation, analytics-before-auth logout ordering, and failed-logout analytics recovery; cross-process lock/activation, killed-owner recovery, persisted desired state, and auth-gated startup restoration. No plugin. |
+| L2 Routine | Automated outage-state, offline-readiness, token-wait/recovery and control-channel status replay coverage; cubit/adapter coverage for Open/focus, close-to-hide, no-tray close-to-Quit, ordered Quit, quit-preserved desired state, failed-stop/persistence refusal to exit, On/Off recovery, explicit idempotent Start, diagnostics launch, bounds restore/clamp/debounce/terminal flush before first show, durable-Off-before-local-logout, notification cancel-all before credential clear, helper unregister command, no-competing-shutdown expected stop, account-bound persisted bridge-id restart, owner-mismatch protection, 404-idempotent deletion, offline deletion failure, explicit Take Over, cockpit-wide exceptional supervision, both project recovery variants omitting CLI copy, adaptive session split ownership, desktop Enter/Shift+Enter and safe Escape behavior, selectable transcript/diff content, SSE-derived attention gating/routing/cancellation/toggle, desktop transcript rendering and pending-question presentation without dead composer/diff controls, app-wide preference persistence, desktop settings/harness composition, profile logout delegation, analytics-before-auth logout ordering, and failed-logout analytics recovery; cross-process lock/activation, killed-owner recovery, persisted desired state, and auth-gated startup restoration. No plugin. |
 | L3 Release | Client end to end on macOS with a dev-built helper and representative live plugin: browser login/relaunch restore, healthy handshake, phone session round-trip, helper crash/backoff, exit-86 restart, login-required behavior, Off/close/Quit orphan checks, and standalone CLI coexistence. |
 | L4 Extended | Client end to end on Windows and Linux, including a Linux StatusNotifier host and a no-host windowed fallback; vary helper startup/stop failures, relay takeover, crash give-up output, and default log-file application availability. |
 | L5 Full | Packaged desktop artifacts on every release target, including native tray/window appearance, signing/install behavior, and long-running supervision through repeated sleep, reconnect, restart, hide/show, and relaunch cycles. |
@@ -156,6 +156,11 @@ last-On restoration. Kill the helper at different handshake phases and inspect
 the status and bounded recent output.
 
 ## Failure Signals
+
+- An outage leaves the helper claiming ready, hides the startup wait, consumes
+  the crash budget, or loses the waiting status after control-channel reconnect.
+  A disconnected helper claims ready, or a temporary desktop token refresh is
+  treated as logout/login-required instead of waiting for authentication.
 
 - No tray or command subscriptions until a signed-in screen reads the cubit.
 - A second process creates another tray/helper, fails to focus the owner, or a

--- a/docs/regression/desktop-bridge-supervision.md
+++ b/docs/regression/desktop-bridge-supervision.md
@@ -8,6 +8,17 @@ and keep native close/quit behavior safe.
 
 ## Required Behavior
 
+- A connected helper process is distinct from a ready bridge. The control channel
+  reports starting, waiting for the server, and ready; desktop shows
+  "Starting — waiting for server (retrying every minute)" during an outage.
+  Waiting does not exit the helper or spend the supervisor's crash-retry budget.
+  Startup status is available before authentication and is replayed after a
+  control-channel reconnect. Stop and Quit remain available during the wait.
+- If desktop cannot obtain a fresh token while its account remains authenticated,
+  it asks the helper to retry later. Only a missing/signed-out session takes the
+  existing login-required path; an offline token refresh must not be treated as
+  a logout.
+
 - The desktop boots a visible Prego-themed window and eagerly initializes tray
   supervision even while signed out. Exactly one process owns the desktop
   instance lock and activation listener. The macOS tray uses the transparent

--- a/shared/sesori_shared/lib/src/protocol/control_message.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.dart
@@ -123,8 +123,11 @@ enum ControlPromptKind() {
 
 /// Startup readiness is separate from the helper process and relay socket.
 enum ControlStartupState() {
+  unknown,
   starting,
   @JsonValue("waiting_for_server")
   waitingForServer,
+  @JsonValue("waiting_for_authentication")
+  waitingForAuthentication,
   ready,
 }

--- a/shared/sesori_shared/lib/src/protocol/control_message.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.dart
@@ -30,13 +30,16 @@ sealed class ControlMessage with _$ControlMessage {
     required String? accessToken,
   }) = ControlTokenResponse;
 
-  /// helper → GUI (push): current relay/plugin health + active-session summary.
+  /// GUI → helper: the signed-in session temporarily cannot supply a token.
+  @FreezedUnionValue("token_retry_later")
+  const factory tokenRetryLater({required String id}) = ControlTokenRetryLater;
+
+  /// helper → GUI (push): startup, relay/plugin health and active sessions.
   @FreezedUnionValue("status")
   const factory status({
-    @JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown)
-    required ControlRelayConnectionState relay,
-    @JsonKey(unknownEnumValue: ControlPluginHealthState.unknown)
-    required ControlPluginHealthState plugin,
+    required ControlStartupState startup,
+    @JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown) required ControlRelayConnectionState relay,
+    @JsonKey(unknownEnumValue: ControlPluginHealthState.unknown) required ControlPluginHealthState plugin,
     @Default(0) int activeSessionCount,
   }) = ControlStatus;
 
@@ -116,4 +119,12 @@ enum ControlPromptKind() {
   loginNeeded,
   @JsonValue("unknown")
   unknown,
+}
+
+/// Startup readiness is separate from the helper process and relay socket.
+enum ControlStartupState() {
+  starting,
+  @JsonValue("waiting_for_server")
+  waitingForServer,
+  ready,
 }

--- a/shared/sesori_shared/lib/src/protocol/control_message.freezed.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.freezed.dart
@@ -24,6 +24,10 @@ ControlMessage _$ControlMessageFromJson(
           return ControlTokenResponse.fromJson(
             json
           );
+                case 'token_retry_later':
+          return ControlTokenRetryLater.fromJson(
+            json
+          );
                 case 'status':
           return ControlStatus.fromJson(
             json
@@ -246,10 +250,84 @@ as String?,
 /// @nodoc
 @JsonSerializable()
 
+class ControlTokenRetryLater implements ControlMessage {
+  const ControlTokenRetryLater({required this.id,  String? $type}): $type = $type ?? 'token_retry_later';
+  factory ControlTokenRetryLater.fromJson(Map<String, dynamic> json) => _$ControlTokenRetryLaterFromJson(json);
+
+ final  String id;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$ControlTokenRetryLaterCopyWith<ControlTokenRetryLater> get copyWith => _$ControlTokenRetryLaterCopyWithImpl<ControlTokenRetryLater>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$ControlTokenRetryLaterToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlTokenRetryLater&&(identical(other.id, id) || other.id == id));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id);
+
+@override
+String toString() {
+  return 'ControlMessage.tokenRetryLater(id: $id)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $ControlTokenRetryLaterCopyWith<$Res> implements $ControlMessageCopyWith<$Res> {
+  factory $ControlTokenRetryLaterCopyWith(ControlTokenRetryLater value, $Res Function(ControlTokenRetryLater) _then) = _$ControlTokenRetryLaterCopyWithImpl;
+@useResult
+$Res call({
+ String id
+});
+
+
+
+
+}
+/// @nodoc
+class _$ControlTokenRetryLaterCopyWithImpl<$Res>
+    implements $ControlTokenRetryLaterCopyWith<$Res> {
+  _$ControlTokenRetryLaterCopyWithImpl(this._self, this._then);
+
+  final ControlTokenRetryLater _self;
+  final $Res Function(ControlTokenRetryLater) _then;
+
+/// Create a copy of ControlMessage
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,}) {
+  return _then(ControlTokenRetryLater(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
 class ControlStatus implements ControlMessage {
-  const ControlStatus({@JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown) required this.relay, @JsonKey(unknownEnumValue: ControlPluginHealthState.unknown) required this.plugin, this.activeSessionCount = 0,  String? $type}): $type = $type ?? 'status';
+  const ControlStatus({required this.startup, @JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown) required this.relay, @JsonKey(unknownEnumValue: ControlPluginHealthState.unknown) required this.plugin, this.activeSessionCount = 0,  String? $type}): $type = $type ?? 'status';
   factory ControlStatus.fromJson(Map<String, dynamic> json) => _$ControlStatusFromJson(json);
 
+ final  ControlStartupState startup;
 @JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown) final  ControlRelayConnectionState relay;
 @JsonKey(unknownEnumValue: ControlPluginHealthState.unknown) final  ControlPluginHealthState plugin;
 @JsonKey() final  int activeSessionCount;
@@ -271,16 +349,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlStatus&&(identical(other.relay, relay) || other.relay == relay)&&(identical(other.plugin, plugin) || other.plugin == plugin)&&(identical(other.activeSessionCount, activeSessionCount) || other.activeSessionCount == activeSessionCount));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ControlStatus&&(identical(other.startup, startup) || other.startup == startup)&&(identical(other.relay, relay) || other.relay == relay)&&(identical(other.plugin, plugin) || other.plugin == plugin)&&(identical(other.activeSessionCount, activeSessionCount) || other.activeSessionCount == activeSessionCount));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,relay,plugin,activeSessionCount);
+int get hashCode => Object.hash(runtimeType,startup,relay,plugin,activeSessionCount);
 
 @override
 String toString() {
-  return 'ControlMessage.status(relay: $relay, plugin: $plugin, activeSessionCount: $activeSessionCount)';
+  return 'ControlMessage.status(startup: $startup, relay: $relay, plugin: $plugin, activeSessionCount: $activeSessionCount)';
 }
 
 
@@ -291,7 +369,7 @@ abstract mixin class $ControlStatusCopyWith<$Res> implements $ControlMessageCopy
   factory $ControlStatusCopyWith(ControlStatus value, $Res Function(ControlStatus) _then) = _$ControlStatusCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown) ControlRelayConnectionState relay,@JsonKey(unknownEnumValue: ControlPluginHealthState.unknown) ControlPluginHealthState plugin, int activeSessionCount
+ ControlStartupState startup,@JsonKey(unknownEnumValue: ControlRelayConnectionState.unknown) ControlRelayConnectionState relay,@JsonKey(unknownEnumValue: ControlPluginHealthState.unknown) ControlPluginHealthState plugin, int activeSessionCount
 });
 
 
@@ -308,9 +386,10 @@ class _$ControlStatusCopyWithImpl<$Res>
 
 /// Create a copy of ControlMessage
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? relay = null,Object? plugin = null,Object? activeSessionCount = null,}) {
+@pragma('vm:prefer-inline') $Res call({Object? startup = null,Object? relay = null,Object? plugin = null,Object? activeSessionCount = null,}) {
   return _then(ControlStatus(
-relay: null == relay ? _self.relay : relay // ignore: cast_nullable_to_non_nullable
+startup: null == startup ? _self.startup : startup // ignore: cast_nullable_to_non_nullable
+as ControlStartupState,relay: null == relay ? _self.relay : relay // ignore: cast_nullable_to_non_nullable
 as ControlRelayConnectionState,plugin: null == plugin ? _self.plugin : plugin // ignore: cast_nullable_to_non_nullable
 as ControlPluginHealthState,activeSessionCount: null == activeSessionCount ? _self.activeSessionCount : activeSessionCount // ignore: cast_nullable_to_non_nullable
 as int,

--- a/shared/sesori_shared/lib/src/protocol/control_message.g.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.g.dart
@@ -72,8 +72,10 @@ Map<String, dynamic> _$ControlStatusToJson(ControlStatus instance) =>
     };
 
 const _$ControlStartupStateEnumMap = {
+  ControlStartupState.unknown: 'unknown',
   ControlStartupState.starting: 'starting',
   ControlStartupState.waitingForServer: 'waiting_for_server',
+  ControlStartupState.waitingForAuthentication: 'waiting_for_authentication',
   ControlStartupState.ready: 'ready',
 };
 

--- a/shared/sesori_shared/lib/src/protocol/control_message.g.dart
+++ b/shared/sesori_shared/lib/src/protocol/control_message.g.dart
@@ -36,7 +36,18 @@ Map<String, dynamic> _$ControlTokenResponseToJson(
   'type': instance.$type,
 };
 
+ControlTokenRetryLater _$ControlTokenRetryLaterFromJson(Map json) =>
+    ControlTokenRetryLater(
+      id: json['id'] as String,
+      $type: json['type'] as String?,
+    );
+
+Map<String, dynamic> _$ControlTokenRetryLaterToJson(
+  ControlTokenRetryLater instance,
+) => <String, dynamic>{'id': instance.id, 'type': instance.$type};
+
 ControlStatus _$ControlStatusFromJson(Map json) => ControlStatus(
+  startup: $enumDecode(_$ControlStartupStateEnumMap, json['startup']),
   relay: $enumDecode(
     _$ControlRelayConnectionStateEnumMap,
     json['relay'],
@@ -53,11 +64,18 @@ ControlStatus _$ControlStatusFromJson(Map json) => ControlStatus(
 
 Map<String, dynamic> _$ControlStatusToJson(ControlStatus instance) =>
     <String, dynamic>{
+      'startup': _$ControlStartupStateEnumMap[instance.startup]!,
       'relay': _$ControlRelayConnectionStateEnumMap[instance.relay]!,
       'plugin': _$ControlPluginHealthStateEnumMap[instance.plugin]!,
       'activeSessionCount': instance.activeSessionCount,
       'type': instance.$type,
     };
+
+const _$ControlStartupStateEnumMap = {
+  ControlStartupState.starting: 'starting',
+  ControlStartupState.waitingForServer: 'waiting_for_server',
+  ControlStartupState.ready: 'ready',
+};
 
 const _$ControlRelayConnectionStateEnumMap = {
   ControlRelayConnectionState.connected: 'connected',

--- a/shared/sesori_shared/test/protocol/control_message_test.dart
+++ b/shared/sesori_shared/test/protocol/control_message_test.dart
@@ -100,6 +100,17 @@ void main() {
       });
     });
 
+    for (final startup in ControlStartupState.values) {
+      test("status round-trips startup state $startup", () {
+        final original = ControlMessage.status(
+          startup: startup,
+          relay: ControlRelayConnectionState.disconnected,
+          plugin: ControlPluginHealthState.unknown,
+        );
+        expect(ControlMessage.fromJson(original.toJson()), original);
+      });
+    }
+
     test("status round-trips the takenOver relay state", () {
       const original = ControlMessage.status(
         startup: ControlStartupState.ready,

--- a/shared/sesori_shared/test/protocol/control_message_test.dart
+++ b/shared/sesori_shared/test/protocol/control_message_test.dart
@@ -5,8 +5,10 @@ void main() {
   group("ControlMessage", () {
     final variants = <String, ControlMessage>{
       "token_request": const ControlMessage.tokenRequest(id: "req-1", forceRefresh: true),
+      "token_retry_later": const ControlMessage.tokenRetryLater(id: "req-1"),
       "token_response": const ControlMessage.tokenResponse(id: "req-1", accessToken: "jwt"),
       "status": const ControlMessage.status(
+        startup: ControlStartupState.ready,
         relay: ControlRelayConnectionState.connected,
         plugin: ControlPluginHealthState.degraded,
         activeSessionCount: 3,
@@ -64,6 +66,7 @@ void main() {
       test("relay enum falls back to unknown for an unrecognized value", () {
         final parsed = ControlMessage.fromJson({
           "type": "status",
+          "startup": "ready",
           "relay": "rebooting",
           "plugin": "healthy",
         });
@@ -77,6 +80,7 @@ void main() {
       test("plugin-health enum falls back to unknown for an unrecognized value", () {
         final parsed = ControlMessage.fromJson({
           "type": "status",
+          "startup": "ready",
           "relay": "connected",
           "plugin": "future_health",
         });
@@ -98,6 +102,7 @@ void main() {
 
     test("status round-trips the takenOver relay state", () {
       const original = ControlMessage.status(
+        startup: ControlStartupState.ready,
         relay: ControlRelayConnectionState.takenOver,
         plugin: ControlPluginHealthState.healthy,
       );


### PR DESCRIPTION
## Complexity
Moderate: startup retry and cancellation now span bridge authentication, session startup, and the desktop control channel.

## What
- Keep the bridge alive through temporary stored-token validation/refresh, registration, and initial relay connection failures. Retry every minute without a limit, with an always-visible Console warning and diagnostic error/stack logging.
- Report starting, waiting for the server or desktop authentication, and ready over the supervisor channel; display the waiting state in desktop.
- Distinguish temporary desktop token failures and timeouts from sign-out. Keep interactive login timeouts outside the retry loop.

## Why
Starting without internet currently exits during stored-token validation. A bridge started at login should recover automatically when connectivity returns, without consuming the supervisor crash budget.

## Risk and test focus
Startup cancellation and authentication classification are the main risks. Tests cover repeated minute-spaced failures, DNS/503 recovery during validation and refresh, registration cancellation, relay-handle cleanup during shutdown, desktop token failures/timeouts, status propagation, and existing token reauthentication behavior. Permanent WebSocket upgrade errors surface; 408/429/5xx handshakes retry. The unpublished control protocol updates both in-repository peers together.

## Expected result
An offline start remains alive and visibly waits, retries every minute, and starts automatically after the server becomes reachable. Desktop distinguishes helper connectivity from bridge readiness, and Stop/Shutdown interrupt the wait. Rejected credentials and interactive login keep their existing flows. This is user-visible behavior; there is no database or persisted-schema impact.

## Verification
- Relevant bridge startup/authentication, registration, control-channel, cancellation, and token-reauthentication tests passed.
- Desktop supervisor/tracker/cubit tests and affected desktop widget tests passed.
- Shared control-protocol round-trip tests passed.
- Bridge app, desktop core, desktop shell, and shared package analyzers passed.
- Architecture implementation review approved; regression documents updated.
