### PR TITLE
🌿 Preserve session recency when a turn stops

### DIFF
--- a/bridge/app/lib/src/api/database/daos/session_dao.dart
+++ b/bridge/app/lib/src/api/database/daos/session_dao.dart
@@ -377,6 +377,13 @@ class SessionDao(super.attachedDatabase) extends DatabaseAccessor<AppDatabase> w
     );
   }
 
+  Future<void> advanceUpdatedAt({required String sessionId, required int updatedAt}) async {
+    await (update(sessionTable)..where(
+          (table) => table.sessionId.equals(sessionId) & table.updatedAt.isSmallerThanValue(updatedAt),
+        ))
+        .write(SessionTableCompanion(updatedAt: Value(updatedAt)));
+  }
+
   Future<bool> updateObservedSessionProjection({
     required String sessionId,
     required String directory,

--- a/bridge/app/lib/src/repositories/mappers/session_catalog_mapper.dart
+++ b/bridge/app/lib/src/repositories/mappers/session_catalog_mapper.dart
@@ -32,27 +32,19 @@ class const SessionCatalogMapper() {
 
   /// The newest instant the bridge knows about for this session.
   ///
-  /// `updated_at` only advances when a backend reports a new time: a catalog
-  /// import, or a plugin that emits an activity-bearing `session.updated`.
-  /// Codex, ACP, and OpenCode do; Claude and Pi emit one only on rename, so a
-  /// session driven entirely on the laptop kept displaying the transcript time
-  /// read at the last import — "2d ago" on a session prompted minutes earlier.
-  ///
-  /// `last_user_message_at` is written live for every plugin, so folding it in
-  /// makes the displayed recency honest for all harnesses at once. It is
-  /// blended on read rather than written into `updated_at`, because catalog
-  /// import's staleness detection depends on that column holding only
-  /// backend-reported time (see CatalogImportRepository).
+  /// `updated_at` includes backend observations, bridge-owned metadata changes,
+  /// and live turn completion (including Stop). `last_user_message_at` is
+  /// written live for every plugin, so folding it in also shows fresh prompts
+  /// before the turn settles, even without a backend `session.updated` event.
+  /// Catalog import tracks backend history freshness separately from this
+  /// displayed recency (see CatalogImportRepository).
   ///
   /// `last_activity_at` is deliberately excluded even though it covers more
   /// events: it is an unseen-formula token, not a recency one. "Mark as
   /// Unread" synthesizes it from the current clock (SessionDao.forceUnseen),
   /// which would make an untouched session claim it just changed, and
   /// SessionUnseenService coalesces it to the FIRST event of an unseen streak,
-  /// so it would not follow a long response anyway. The cost of leaving it out
-  /// is that assistant-only work does not advance the displayed time past the
-  /// prompt that started it — conservative, and self-correcting on the next
-  /// user message or import.
+  /// so it would not follow a long response anyway.
   static int _latestActivityAt(SessionDto row) {
     if (row.lastUserMessageAt case final at? when at > row.updatedAt) return at;
     return row.updatedAt;

--- a/bridge/app/lib/src/repositories/models/session_operation.dart
+++ b/bridge/app/lib/src/repositories/models/session_operation.dart
@@ -24,6 +24,7 @@ enum SessionOperation() {
   getProjectActivitySummaries,
   getSessionStatuses,
   updateObservedSessionProjection,
+  recordSessionCompletion,
   insertObservedChild,
   getProjectQuestions,
 }

--- a/bridge/app/lib/src/repositories/session_repository.dart
+++ b/bridge/app/lib/src/repositories/session_repository.dart
@@ -936,7 +936,10 @@ class SessionRepository({
           directory: session.directory,
           catalogTitle: session.title,
           createdAt: session.time?.created ?? existingBinding?.createdAt ?? projectionUpdatedAt,
-          updatedAt: session.time?.updated ?? existingBinding?.updatedAt ?? projectionUpdatedAt,
+          updatedAt: max(
+            session.time?.updated ?? existingBinding?.updatedAt ?? projectionUpdatedAt,
+            existingBinding?.updatedAt ?? 0,
+          ),
           archivedAt: session.time?.archived,
           projectionUpdatedAt: projectionUpdatedAt,
         ));
@@ -1271,6 +1274,23 @@ class SessionRepository({
     return _sessionDao.getSessionIdsByBackendIds(pluginId: pluginId, backendSessionIds: backendSessionIds);
   }
 
+  /// Records the end of live work without changing backend projection metadata
+  /// or the independent unseen/user-message markers.
+  Future<Session?> recordSessionCompletion({
+    required String sessionId,
+    required String pluginId,
+    required int generation,
+    required int completedAt,
+  }) => _runtime.commitCurrentGeneration(
+    pluginId: pluginId,
+    generation: generation,
+    operation: SessionOperation.recordSessionCompletion,
+    commit: () async {
+      await _sessionDao.advanceUpdatedAt(sessionId: sessionId, updatedAt: completedAt);
+      return await getCatalogSession(sessionId: sessionId);
+    },
+  );
+
   Future<StoredSession?> updateObservedSessionProjection({
     required String pluginId,
     required int generation,
@@ -1304,7 +1324,7 @@ class SessionRepository({
           directory: observed.directory,
           catalogTitle: observed.title,
           updateCatalogTitle: updateCatalogTitle,
-          updatedAt: observed.time?.updated ?? binding.updatedAt,
+          updatedAt: max(observed.time?.updated ?? binding.updatedAt, binding.updatedAt),
           projectionUpdatedAt: projectionUpdatedAt,
         );
         _runtime.requireCurrentGeneration(
@@ -1361,7 +1381,7 @@ class SessionRepository({
             directory: observed.directory,
             catalogTitle: observed.title,
             updateCatalogTitle: observed.title != null,
-            updatedAt: observed.time?.updated ?? existing.updatedAt,
+            updatedAt: max(observed.time?.updated ?? existing.updatedAt, existing.updatedAt),
             projectionUpdatedAt: projectionUpdatedAt,
           );
           _runtime.requireCurrentGeneration(

--- a/bridge/app/lib/src/services/session_event_service.dart
+++ b/bridge/app/lib/src/services/session_event_service.dart
@@ -122,9 +122,27 @@ class SessionEventService({
 
     final observed = _eventMapper.sessionInfo(event: source.event);
     if (observed == null) {
-      return [
-        ?await _translate(source: source, allowDuringStop: allowDuringStop),
-      ];
+      final translated = await _translate(source: source, allowDuringStop: allowDuringStop);
+      if (translated case BridgeSseSessionIdle(:final sessionID)) {
+        Session? session;
+        try {
+          session = await _sessionRepository.recordSessionCompletion(
+            sessionId: sessionID,
+            pluginId: source.pluginId,
+            generation: source.generation,
+            completedAt: source.projectionUpdatedAt,
+          );
+        } on Object catch (error, stackTrace) {
+          // Recency persistence must not hide the terminal status from clients.
+          Log.w("Failed to persist turn completion for session $sessionID", error, stackTrace);
+        }
+        if (!isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) return const [];
+        return [
+          if (session != null) BridgeSseSessionUpdated(info: session.toJson(), titleChanged: false),
+          translated,
+        ];
+      }
+      return [?translated];
     }
     if (!isCurrentGeneration(pluginId: source.pluginId, generation: source.generation)) {
       return const [];

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -512,6 +512,14 @@ class _NoopSessionRepository() implements SessionRepository {
   }) async => const {};
 
   @override
+  Future<Session?> recordSessionCompletion({
+    required String sessionId,
+    required String pluginId,
+    required int generation,
+    required int completedAt,
+  }) async => null;
+
+  @override
   Future<StoredSession?> updateObservedSessionProjection({
     required String pluginId,
     required int generation,
@@ -978,6 +986,14 @@ class FakeSessionRepository({
     required String pluginId,
     required List<String> backendSessionIds,
   }) async => const {};
+
+  @override
+  Future<Session?> recordSessionCompletion({
+    required String sessionId,
+    required String pluginId,
+    required int generation,
+    required int completedAt,
+  }) async => null;
 
   @override
   Future<StoredSession?> updateObservedSessionProjection({

--- a/bridge/app/test/bridge/services/session_event_service_test.dart
+++ b/bridge/app/test/bridge/services/session_event_service_test.dart
@@ -56,6 +56,134 @@ void main() {
       await database.close();
     });
 
+    test("settled turns publish durable recency before idle and older backend updates cannot undo it", () async {
+      await _insertRoot(
+        database: database,
+        pluginId: plugin.id,
+        sessionId: "stable-root",
+        backendSessionId: "backend-root",
+      );
+      await database.sessionDao.setUserMessageAt(sessionId: "stable-root", userMessageAt: 20);
+      const completedAt = 20 + 30 * 60 * 1000;
+
+      // Both normal completion and Stop end in this backend-neutral event,
+      // even for plugins that never publish a timestamp-bearing session update.
+      final output = await service.normalize(
+        allowDuringStop: false,
+        source: (
+          pluginId: plugin.id,
+          generation: 1,
+          projectionUpdatedAt: completedAt,
+          event: const BridgeSseSessionIdle(sessionID: "backend-root"),
+        ),
+      );
+
+      expect(output, hasLength(2));
+      final updated = output.first as BridgeSseSessionUpdated;
+      final session = Session.fromJson(updated.info);
+      expect(session.id, "stable-root");
+      expect(session.pluginId, plugin.id);
+      expect(session.time?.created, 1);
+      expect(session.time?.updated, completedAt);
+      expect(session.lastUserActivityAt, 20);
+      expect(updated.titleChanged, isFalse);
+      expect((output.last as BridgeSseSessionIdle).sessionID, "stable-root");
+      expect((await repository.getCatalogSession(sessionId: "stable-root"))?.time?.updated, completedAt);
+      final row = await database.sessionDao.getSession(sessionId: "stable-root");
+      expect(row?.lastActivityAt, isNull, reason: "recency must not change unseen bookkeeping");
+
+      final laterUpdate = await service.normalize(
+        allowDuringStop: false,
+        source: (
+          pluginId: plugin.id,
+          generation: 1,
+          projectionUpdatedAt: completedAt + 1,
+          event: BridgeSseSessionUpdated(
+            info: _sessionInfo(
+              sessionId: "backend-root",
+              parentId: null,
+              projectId: "project",
+              directory: "/project",
+            ),
+            titleChanged: true,
+          ),
+        ),
+      );
+      final renamed = Session.fromJson((laterUpdate.single as BridgeSseSessionUpdated).info);
+      expect(renamed.title, "title-backend-root");
+      expect(renamed.time?.updated, completedAt);
+      expect((await repository.getCatalogSession(sessionId: "stable-root"))?.time?.updated, completedAt);
+    });
+
+    test("still publishes idle when completion recency cannot be persisted", () async {
+      await _insertRoot(
+        database: database,
+        pluginId: plugin.id,
+        sessionId: "stable-root",
+        backendSessionId: "backend-root",
+      );
+      sessionDao.failNextCompletionUpdate = true;
+      final output = await service.normalize(
+        allowDuringStop: false,
+        source: (
+          pluginId: plugin.id,
+          generation: 1,
+          projectionUpdatedAt: 100,
+          event: const BridgeSseSessionIdle(sessionID: "backend-root"),
+        ),
+      );
+      expect((output.single as BridgeSseSessionIdle).sessionID, "stable-root");
+      expect((await repository.getCatalogSession(sessionId: "stable-root"))?.time?.updated, 1);
+    });
+
+    test("retired-generation and unknown-session idle events cannot update recency", () async {
+      await _insertRoot(
+        database: database,
+        pluginId: plugin.id,
+        sessionId: "stable-root",
+        backendSessionId: "backend-root",
+      );
+      pluginRuntime.currentGeneration = 2;
+      for (final source in [
+        (generation: 1, backendId: "backend-root"),
+        (generation: 2, backendId: "unknown-root"),
+      ]) {
+        expect(
+          await service.normalize(
+            allowDuringStop: false,
+            source: (
+              pluginId: plugin.id,
+              generation: source.generation,
+              projectionUpdatedAt: 100,
+              event: BridgeSseSessionIdle(sessionID: source.backendId),
+            ),
+          ),
+          isEmpty,
+        );
+      }
+      expect((await repository.getCatalogSession(sessionId: "stable-root"))?.time?.updated, 1);
+    });
+
+    test("an idle status snapshot does not fabricate turn completion activity", () async {
+      await _insertRoot(
+        database: database,
+        pluginId: plugin.id,
+        sessionId: "stable-root",
+        backendSessionId: "backend-root",
+      );
+      final output = await service.normalize(
+        allowDuringStop: false,
+        source: (
+          pluginId: plugin.id,
+          generation: 1,
+          projectionUpdatedAt: 100,
+          event: const BridgeSseSessionStatus(sessionID: "backend-root", status: PluginSessionStatus.idle()),
+        ),
+      );
+      expect(output.single, isA<BridgeSseSessionStatus>());
+      expect((await repository.getCatalogSession(sessionId: "stable-root"))?.time?.updated, 1);
+    });
+
     test("drops unknown roots without discovering projects and preserves backend-deleted history", () async {
       final unknown = await service.normalize(
         allowDuringStop: false,
@@ -1307,6 +1435,16 @@ class _TransactionGatedSessionDao(super.attachedDatabase) extends SessionDao {
   Completer<void>? _transactionEntered;
   Completer<void>? _releaseTransaction;
   bool _failPromptDefaultsUpdate = false;
+  bool failNextCompletionUpdate = false;
+
+  @override
+  Future<void> advanceUpdatedAt({required String sessionId, required int updatedAt}) {
+    if (failNextCompletionUpdate) {
+      failNextCompletionUpdate = false;
+      return Future<void>.error(StateError("completion write failed"));
+    }
+    return super.advanceUpdatedAt(sessionId: sessionId, updatedAt: updatedAt);
+  }
 
   Future<void> get projectionTransactionEntered => _transactionEntered!.future;
 

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -161,12 +161,16 @@ state.
   date whose field order and separators follow the user's full device locale;
   dates from the current year omit the year, while earlier years remain explicit.
 - A listed session's `session.updated` reports the newest instant the bridge
-  knows: the backend's own updated time, or the live user-message marker when
-  that is newer. A plugin that reports an updated time only at import or rename
-  — Claude and Pi, unlike Codex, ACP, and OpenCode — therefore still shows a
-  recently prompted session as recent, instead of the transcript time read at
-  the last import. Marking a session unread never moves that time, and
-  assistant-only work does not advance it past the prompt that started it.
+  knows: backend activity, bridge-owned metadata changes, live turn completion,
+  or the live user-message marker when that is newer. When a plugin reports a
+  settled turn, including after Stop, the bridge persists and publishes its
+  completion time before idle. A long-running session therefore shows when it
+  stopped instead of reverting to the old prompt time when its status icon
+  disappears. This works across plugins without a backend `session.updated`
+  event, survives list refreshes, and cannot be undone by an older backend
+  timestamp. Marking a session unread never moves that time; recording turn
+  completion changes neither unseen state nor the user-message marker. An idle
+  status snapshot alone does not count as a completed turn.
 - A newly committed session can list before generated metadata. Later generated
   title and eligible dedicated-branch refinement reuse `session.updated`; lists
   and detail adopt the durable session facts without marking unseen or moving the
@@ -328,6 +332,9 @@ leave the surface that started one. Restore harness eligibility afterwards.
 - A session prompted minutes ago reports a days-old updated time, sorts to the
   top of its list while still displaying that stale time, or an older row uses
   generic US month/day order despite a different device locale.
+- Stop or normal completion reveals the timestamp of an old prompt; a refresh
+  or later backend update moves the completed session's timestamp backward; or
+  completion changes its read/unread state or last user-message marker.
 - Unseen never clears, clears without viewing, or an unavailable plugin is idle.
 - Hiding destroys sessions, or a cancelled import destroys the committed catalog.
 - Desktop wide navigation recreates the session inventory on each selected


### PR DESCRIPTION
## Complexity
🌿 Straightforward: reuse the shared session event path and existing catalog timestamp.

## What
Record live turn completion before publishing idle, including completion caused by Stop. Keep later backend observations from moving session recency backward. Add regression coverage and update the supported session-list behavior.

## Why
The running status icon hides the timestamp. When a long turn stops, plugins that have not advanced their session timestamp reveal the old prompt time, making the session appear inactive for the entire run.

## Risk and test focus
The bridge adds a narrow timestamp write and a session update event when a live turn settles. Existing generation and identity checks remain in place; status snapshots do not count as completion. A failed recency write is logged and still publishes idle. Read/unread and last-user-message markers remain independent. There is no database schema or wire-format change; the existing stored update timestamp now includes completion.

## Expected result
After a 30-minute turn finishes or is stopped, its session row shows recent activity. Refreshing the list or receiving an older backend timestamp preserves that recency across plugins.

## Verification
- Focused event, dispatcher, repository, and persistence suites: 93 tests passed.
- Catalog mapper suite: 6 tests passed.
- Owning bridge app static analysis with fatal infos.
- Architecture plan and implementation reviews.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session recency so a long-running turn no longer appears inactive after it stops.

When a turn settles — normally or via Stop — the bridge now persists the completion time and publishes an updated session before idle. Previously, once the running status icon disappeared, sessions driven by plugins that don't emit timestamp-bearing updates reverted to the old prompt time, showing stale activity for the entire run. A later backend observation cannot undo the newer recency either.

**Behavior details**
- `recordSessionCompletion` advances recency only when the new time is newer; overlapping older backend updates never roll it back.
- A failed recency write is logged but idle still propagates; status snapshots don't count as completion.
- Read/unread state and the last user-message marker stay unchanged.
- Regression coverage added for completion, Stop, failure, and retired-generation paths; supported session-list behavior documented.

<sup>Written for commit d160164a9ff31f83aef5b6ba3324e46cb82a2ad4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

