### PR TITLE
⚙️ [claude-inline-subtasks] DeepSeek scoped sub-agent stops [step 1/4]

### DIFF
--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -102,7 +102,7 @@ confirmation, no child session or partial stop) and gets that subset.
      by description or arrival order, so concurrent spawns stay deterministic.
   3. The scoped-stop policy, once, in `AcpPlugin.abortSession`: `confirm` with
      running children is side-effect free and rejects with their count,
-     `mainAgentRunning = pending > 0`, and `mainAgentOnlySupported` true only
+     `mainAgentRunning` from pending prompts or an active named child, and `mainAgentOnlySupported` true only
      when every running child is background. For `keep`, when only children are
      running the plugin sends no cancellation and returns
      `PluginAbortAccepted(workKept: true)` for the retained children. When the
@@ -110,13 +110,18 @@ confirmation, no child session or partial stop) and gets that subset.
      `mainAgentOnlySupported` is false, it returns the typed rejection before
      any side effect, so a stale or direct caller cannot silently cancel
      children; otherwise `keep` sends `session/cancel` only. `stop` sends
-     `session/cancel` plus `cancelChild` per cancellable child. Each running
-     child also carries `canCancel`; when a non-cancellable child survives a
-     `stop`, the result is `PluginAbortAccepted(workKept: true)` and the root
-     stays busy until that child finishes, so the partial stop is never
-     reported as complete. `interruptActiveWork` uses `stop`.
-  4. One abstract backend seam `cancelChild({sessionId, childSessionId})` on
-     the per-harness ACP API; Grok and DeepSeek supply only the request shape.
+     `session/cancel` plus `cancelChild` with each child's direct parent.
+     Outcomes are typed; no `canCancel` field is invented. Foreground children
+     are covered by cancellation of their parent; directly targeting a child
+     with no effective interrupt retains that child without cancelling siblings.
+     `workKept` means retained work, not pending lifecycle delivery. Unknown-child
+     responses do not fabricate either retained work or terminal state.
+     `interruptActiveWork` uses `stop` and waits for authoritative lifecycle.
+  4. Capability opt-in `supportsScopedStop` plus a typed `AcpPlugin.cancelChild`
+     hook matches current composition (the per-harness APIs are standalone).
+     DeepSeek supplies its typed request/response API; other ACP harnesses keep
+     their existing behavior until their transport seam lands. A child with a
+     bridge-owned standard prompt uses `session/cancel`, not its former ancestry.
   5. A narrow backend-neutral replay replacement hook on
      `AcpReplayCollector`, which consumes `session/update` frames into
      `PluginMessageWithParts` without running the live mapper. A harness
@@ -542,7 +547,7 @@ confirmation, no child session or partial stop) and gets that subset.
 | adapter | 🌿 | `protocol: carry sub-agent prompts for tile replay` | Merged PR #15 (`d7a4847`): required normalized prompt in live and replay metadata |
 | monorepo | ⚙️ | DeepSeek consumer replacement steps 1–5 below | Replaces oversized PR #1293; slice 4 also pins runtime 0.1.3 |
 | adapter | 🌱 | `release: prepare v0.1.3 for the live consumer` | PR #16 merged at `3976bcd`; v0.1.3 published with all six package/checksum checks passing |
-| monorepo | ⚙️ | `deepseek: scoped stop for sub-agents` | Pending: consume interrupt and test mixed modes; runtime pinning moves to slice 4 |
+| monorepo | ⚙️ | `deepseek: scoped stop for sub-agents` | Implemented on `claude-inline-subtasks-deepseek-stop`; typed interrupt and shared opt-in policy; review pending |
 | monorepo | 🌱 | `docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
 
 ### Consumer replacement series

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -547,8 +547,32 @@ confirmation, no child session or partial stop) and gets that subset.
 | adapter | 🌿 | `protocol: carry sub-agent prompts for tile replay` | Merged PR #15 (`d7a4847`): required normalized prompt in live and replay metadata |
 | monorepo | ⚙️ | DeepSeek consumer replacement steps 1–5 below | Replaces oversized PR #1293; slice 4 also pins runtime 0.1.3 |
 | adapter | 🌱 | `release: prepare v0.1.3 for the live consumer` | PR #16 merged at `3976bcd`; v0.1.3 published with all six package/checksum checks passing |
-| monorepo | ⚙️ | `deepseek: scoped stop for sub-agents` | Implemented on `claude-inline-subtasks-deepseek-stop`; typed interrupt and shared opt-in policy; review pending |
+| monorepo | ⚙️ | `[claude-inline-subtasks] DeepSeek scoped sub-agent stops [step 1/2]` | PR #1346: typed interrupt and shared opt-in policy; request-time child snapshot with documented late-launch limitation |
+| monorepo | 🚧 | `[claude-inline-subtasks] DeepSeek stop covers in-flight child launches [step 2/2]` | Required successor after #1346 merges; close the late-launch stop window before final DeepSeek E2E |
 | monorepo | 🌱 | `docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
+
+### Scoped-stop successor (user-approved split)
+
+The user chose a separate successor to #1346 for the late-launch stop race.
+This two-PR scoped-stop subseries does not replace the existing final regression
+reconciliation, E2E matrix, or retirement gates. Finish it before DeepSeek E2E,
+then continue Codex.
+
+Evidence is a reachable I/O interleaving, not yet a live reproduction: native
+`#notifySubagent` queues lifecycle output, while `#interruptSubagent` acknowledges
+before cancellation settles. A child launched between the bridge snapshot and
+backend cancellation can survive, remain visibly busy, and continue work. A second
+snapshot alone cannot cover announcements still queued behind the response.
+
+Step 2 must first establish a concrete, architecture-reviewed lifecycle design.
+Reuse existing prompt settlement and child-tracker facts; justify each new mutable
+piece, with no new persistence or speculative protocol fields. Target a few hundred
+changed lines including tests, remaining under the ~1,500-line soft cap. Cover late
+root and nested launches, named-child scope, non-cancellable work, failure/teardown,
+and new user turns not inheriting old stop intent. Do not broaden cancellation to
+parents or siblings or fabricate terminal state. Remove the temporary limitation
+from `docs/regression/session-turns.md` once that behavior is verified; keep final
+phone/desktop E2E outstanding until its existing matrix passes.
 
 ### Consumer replacement series
 

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -9,9 +9,9 @@
   also made the scoped stop harness-neutral (OpenCode honors it; rejections
   declare `mainAgentOnlySupported`) and added `docs/HARNESS_CAPABILITIES.md`;
   the series is retired
-- **Next action:** replace oversized DeepSeek PR #1293 with the five numbered
-  consumer slices in `HARNESS_FOLLOWUPS.md`, one open PR at a time. Preserve
-  remaining harness follow-ups and their E2E/retirement gates.
+- **Next action:** review DeepSeek scoped stop, then finish DeepSeek coverage
+  before Codex. All five replacement consumer slices merged. Preserve remaining
+  harness follow-ups and their E2E/retirement gates.
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
   Step 3 capture below (CLI 2.1.257); the completed
   `claude-code-plugin/PROTOCOL.md` is historical and is not edited
@@ -173,9 +173,9 @@ post-merge E2E gates are unchanged.
 | [x] | DeepSeek (adapter) | `⚙️ sessions: sub-agent lifecycle notifications and child transcripts` | [sesori-deepseek-acp #13](https://github.com/sesori-ai/sesori-deepseek-acp/pull/13) merged at `0a85fb2` |
 | [x] | DeepSeek (adapter) | `⚙️ sessions: per-child interrupt; release v0.1.3` | [sesori-deepseek-acp #14](https://github.com/sesori-ai/sesori-deepseek-acp/pull/14) merged at `1f839c3`; release completed through #16 |
 | [x] | DeepSeek (adapter) | `🌿 protocol: carry sub-agent prompts for tile replay` | [sesori-deepseek-acp #15](https://github.com/sesori-ai/sesori-deepseek-acp/pull/15) merged at `d7a4847` |
-| [ ] | DeepSeek | Consumer replacement steps 1–5 | PR #1293 superseded; fixed titles and budgets in `HARNESS_FOLLOWUPS.md` |
+| [x] | DeepSeek | Consumer replacement steps 1–5 | #1298, #1301, #1304, #1306, #1317 merged; oversized #1293 replaced |
 | [x] | DeepSeek (adapter) | `🌱 release: prepare v0.1.3 for the live consumer` | [Adapter #16](https://github.com/sesori-ai/sesori-deepseek-acp/pull/16) merged at `3976bcd`; v0.1.3 published and six assets verified |
-| [ ] | DeepSeek | `⚙️ [claude-inline-subtasks] deepseek: scoped stop for sub-agents` | Pending consumer replay slice; adapter v0.1.3 available |
+| [ ] | DeepSeek | `⚙️ [claude-inline-subtasks] deepseek: scoped stop for sub-agents` | Implemented on `claude-inline-subtasks-deepseek-stop`; review pending |
 | [ ] | DeepSeek | `🌱 [claude-inline-subtasks] docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
 | [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: subtask tiles and stop confirmation for task subagents` | Not started |
 | [ ] | Cursor | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage` | Not started |
@@ -610,7 +610,7 @@ packaging-only change.
 | 2/5 | Verbatim protocol-v2 fixtures and integrity | [PR #1301](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1301) merged at `cde00fdf90` |
 | 3/5 | Typed protocol boundary and conformance | [PR #1304](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1304) merged at `747fbd3eb9` |
 | 4/5 | Live lifecycle, correlation, catalogs, runtime 0.1.3 | [PR #1306](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1306) merged at `400dcbe01a` |
-| 5/5 | Replay callback, history, remaining consumer docs | Implemented on `claude-inline-subtasks-deepseek-replay`; architecture approved |
+| 5/5 | Replay callback, history, remaining consumer docs | [PR #1317](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1317) merged at `4514b0b6d9` |
 
 Slice 1 verification: ACP analyze + 310 tests, unchanged DeepSeek analyze +
 42 tests, and Grok analyze + 83 tests passed. The replay callback and its
@@ -697,3 +697,19 @@ the planned 800–1,100 range without omitting required callers or replay covera
 Reproduce with `git diff --numstat 8bdc2345e301e8bf7da906299df622bb9d650e19 fa4f7aaa8fa80eaf68df6b27f904d7672c1cb2fb`;
 PR-opening head `f6c319e5c` adds five review-bookkeeping lines: **+546/-30 = 576**.
 These are fixed historical measurements, not totals for subsequent revisions.
+
+DeepSeek scoped stop: the shared ACP policy is capability-gated (DeepSeek only
+for now), with typed direct-parent interrupt transport and authoritative lifecycle
+settlement. No wire `canCancel` field or per-harness policy copy was introduced.
+Foreground children covered by parent cancellation are not reported as kept merely
+because their end event is pending. A directly targeted non-cancellable child is
+retained without widening cancellation; unknown-child does not synthesize a finish.
+Opened children's new standard prompts use standard cancellation, including during
+whole-plugin interruption. Existing ACP/Grok behavior remains outside the opt-in.
+Validation: ACP analysis + 312 tests, DeepSeek analysis + 103 tests, and Grok
+analysis + 85 tests pass. Twelve scoped-stop tests cover confirmation, keep,
+nested ownership, parent-covered cancellation, reopened children, unknown-child,
+RPC failure context, and whole-plugin settlement. Interrupt DTO serializers were
+regenerated and v2 conformance consumes the frozen interrupt fixtures. Both fixture
+versions and published runtime 0.1.3 pins are untouched. Architecture review and
+final feature E2E remain pending; managed runtime upgrades remain separately owned.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -9,9 +9,11 @@
   also made the scoped stop harness-neutral (OpenCode honors it; rejections
   declare `mainAgentOnlySupported`) and added `docs/HARNESS_CAPABILITIES.md`;
   the series is retired
-- **Next action:** review DeepSeek scoped stop, then finish DeepSeek coverage
-  before Codex. All five replacement consumer slices merged. Preserve remaining
-  harness follow-ups and their E2E/retirement gates.
+- **Next action:** finish review of DeepSeek scoped-stop step 1/2 (#1346), then
+  after human merge deliver required step 2/2 for in-flight child launches.
+  Complete DeepSeek E2E only after both steps, then continue Codex. All five
+  replacement consumer slices merged; remaining harness and retirement gates stay
+  required.
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
   Step 3 capture below (CLI 2.1.257); the completed
   `claude-code-plugin/PROTOCOL.md` is historical and is not edited
@@ -175,7 +177,8 @@ post-merge E2E gates are unchanged.
 | [x] | DeepSeek (adapter) | `🌿 protocol: carry sub-agent prompts for tile replay` | [sesori-deepseek-acp #15](https://github.com/sesori-ai/sesori-deepseek-acp/pull/15) merged at `d7a4847` |
 | [x] | DeepSeek | Consumer replacement steps 1–5 | #1298, #1301, #1304, #1306, #1317 merged; oversized #1293 replaced |
 | [x] | DeepSeek (adapter) | `🌱 release: prepare v0.1.3 for the live consumer` | [Adapter #16](https://github.com/sesori-ai/sesori-deepseek-acp/pull/16) merged at `3976bcd`; v0.1.3 published and six assets verified |
-| [ ] | DeepSeek | `⚙️ [claude-inline-subtasks] deepseek: scoped stop for sub-agents` | Implemented on `claude-inline-subtasks-deepseek-stop`; review pending |
+| [ ] | DeepSeek | `⚙️ [claude-inline-subtasks] DeepSeek scoped sub-agent stops [step 1/2]` | [#1346](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1346): review pending; request-time snapshot limitation documented |
+| [ ] | DeepSeek | `🚧 [claude-inline-subtasks] DeepSeek stop covers in-flight child launches [step 2/2]` | Required after #1346 merges and before DeepSeek E2E; concrete lifecycle design/review and implementation pending |
 | [ ] | DeepSeek | `🌱 [claude-inline-subtasks] docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
 | [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: subtask tiles and stop confirmation for task subagents` | Not started |
 | [ ] | Cursor | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage` | Not started |

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -711,5 +711,8 @@ analysis + 85 tests pass. Twelve scoped-stop tests cover confirmation, keep,
 nested ownership, parent-covered cancellation, reopened children, unknown-child,
 RPC failure context, and whole-plugin settlement. Interrupt DTO serializers were
 regenerated and v2 conformance consumes the frozen interrupt fixtures. Both fixture
-versions and published runtime 0.1.3 pins are untouched. Architecture review and
-final feature E2E remain pending; managed runtime upgrades remain separately owned.
+versions and published runtime 0.1.3 pins are untouched. Architecture review found
+an API-to-domain mapping bypass; `99949afd2` routes cancellation through the existing
+session repository/service, and the final architecture pass approved. DeepSeek
+analysis and 103 tests pass after that correction. Final feature E2E remains pending;
+managed runtime upgrades remain separately owned.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -716,5 +716,8 @@ an API-to-domain mapping bypass; `99949afd2` routes cancellation through the exi
 session repository/service, and the final architecture pass approved. DeepSeek
 analysis and 103 tests pass after that correction. Review follow-up permits additive
 interrupt response fields while retaining required/known-result checks; analysis
-and 104 tests pass. Final feature E2E remains pending; managed runtime upgrades
-remain separately owned.
+and 104 tests pass. Named foreground children now correctly reject main-only stop
+even when all descendants are background; background named-child keep remains
+supported. ACP analysis + 312 tests and DeepSeek analysis + 106 tests pass.
+The in-flight late-child stop window awaits a scope decision. Final feature E2E
+remains pending; managed runtime upgrades remain separately owned.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -719,5 +719,13 @@ interrupt response fields while retaining required/known-result checks; analysis
 and 104 tests pass. Named foreground children now correctly reject main-only stop
 even when all descendants are background; background named-child keep remains
 supported. ACP analysis + 312 tests and DeepSeek analysis + 106 tests pass.
-The in-flight late-child stop window awaits a scope decision. Final feature E2E
-remains pending; managed runtime upgrades remain separately owned.
+The user chose a separate successor for the in-flight late-child stop window.
+PR #1346 is scoped-stop step 1/2 with the request-time snapshot limitation documented.
+- [ ] After #1346 merges, deliver scoped-stop step 2/2: close late root/nested child
+  launches with bounded lifecycle ownership, then remove the documented limitation.
+  Establish and review the concrete design before implementation; do not start the
+  successor before human merge. Final DeepSeek E2E follows, then Codex.
+Merged actual `origin/main` in `a341dd144`, preserving upstream's required launch
+setting in the extracted DeepSeek test builder. ACP analysis + 323 tests and
+DeepSeek analysis + 106 tests pass after the merge.
+Managed runtime upgrades remain separately owned.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -714,5 +714,7 @@ regenerated and v2 conformance consumes the frozen interrupt fixtures. Both fixt
 versions and published runtime 0.1.3 pins are untouched. Architecture review found
 an API-to-domain mapping bypass; `99949afd2` routes cancellation through the existing
 session repository/service, and the final architecture pass approved. DeepSeek
-analysis and 103 tests pass after that correction. Final feature E2E remains pending;
-managed runtime upgrades remain separately owned.
+analysis and 103 tests pass after that correction. Review follow-up permits additive
+interrupt response fields while retaining required/known-result checks; analysis
+and 104 tests pass. Final feature E2E remains pending; managed runtime upgrades
+remain separately owned.

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1703,8 +1703,11 @@ abstract class AcpPlugin({
     }
     final children = childSessionTracker.runningChildren(sessionId: sessionId);
     final namedChild = childSessionTracker.runningChild(sessionId: sessionId);
-    final mainRunning = (_turnStates[sessionId]?.pending ?? 0) > 0 || namedChild != null;
-    final mainOnlySupported = children.every((child) => child.isBackground);
+    final hasOwnPrompt = (_turnStates[sessionId]?.pending ?? 0) > 0;
+    final mainRunning = hasOwnPrompt || namedChild != null;
+    final mainOnlySupported =
+        (hasOwnPrompt || namedChild == null || namedChild.isBackground) &&
+        children.every((child) => child.isBackground);
     if (children.isNotEmpty &&
         (subAgents == PluginAbortSubAgentPolicy.confirm ||
             subAgents == PluginAbortSubAgentPolicy.keep && mainRunning && !mainOnlySupported)) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -18,6 +18,13 @@ import "api/acp_agent_api.dart";
 import "repositories/acp_session_config_repository.dart";
 import "repositories/trackers/acp_child_session_tracker.dart";
 
+/// An interrupt request's outcome, not a synthetic child lifecycle transition.
+enum AcpChildCancelResult() {
+  interrupted,
+  notCancellable,
+  unknownChild,
+}
+
 /// Base [BridgeDerivedProjectsPluginApi] implementation for any ACP (Agent
 /// Client Protocol) agent driven over stdio.
 ///
@@ -1676,16 +1683,99 @@ abstract class AcpPlugin({
     return {"type": type, "mimeType": mime, "data": base64};
   }
 
+  /// Capability opt-in: standard ACP alone cannot promise scoped child stops.
+  bool get supportsScopedStop => false;
+
+  Future<AcpChildCancelResult> cancelChild({
+    required AcpStdioClient client,
+    required String sessionId,
+    required String childSessionId,
+  }) => throw UnsupportedError("$id does not support scoped child cancellation");
+
   @override
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
   }) async {
-    await _abortSession(sessionId: sessionId);
-    return const PluginAbortAccepted(workKept: false);
+    if (!supportsScopedStop) {
+      await _abortSession(sessionId: sessionId, sendSessionCancel: true);
+      return const PluginAbortAccepted(workKept: false);
+    }
+    final children = childSessionTracker.runningChildren(sessionId: sessionId);
+    final namedChild = childSessionTracker.runningChild(sessionId: sessionId);
+    final mainRunning = (_turnStates[sessionId]?.pending ?? 0) > 0 || namedChild != null;
+    final mainOnlySupported = children.every((child) => child.isBackground);
+    if (children.isNotEmpty &&
+        (subAgents == PluginAbortSubAgentPolicy.confirm ||
+            subAgents == PluginAbortSubAgentPolicy.keep && mainRunning && !mainOnlySupported)) {
+      return PluginAbortRejectedSubAgentsRunning(
+        runningSubAgentCount: children.length,
+        mainAgentRunning: mainRunning,
+        mainAgentOnlySupported: mainOnlySupported,
+      );
+    }
+    if (subAgents == PluginAbortSubAgentPolicy.keep && children.isNotEmpty && !mainRunning) {
+      return const PluginAbortAccepted(workKept: true);
+    }
+    final mainResult = await _cancelScopedSession(
+      sessionId: sessionId,
+      parentSessionId: namedChild?.parentSessionId,
+    );
+    if (subAgents != PluginAbortSubAgentPolicy.stop) {
+      return PluginAbortAccepted(
+        workKept: children.isNotEmpty || mainResult == AcpChildCancelResult.notCancellable,
+      );
+    }
+    final results = await Future.wait([
+      for (final child in children)
+        _cancelScopedSession(sessionId: child.childSessionId, parentSessionId: child.parentSessionId),
+    ]);
+    final cancelled = <String>{
+      if (mainResult != AcpChildCancelResult.notCancellable) sessionId,
+      for (var i = 0; i < children.length; i++)
+        if (results[i] != AcpChildCancelResult.notCancellable) children[i].childSessionId,
+    };
+    final byId = {for (final child in children) child.childSessionId: child};
+    bool coveredByParent({required AcpRunningChild child}) {
+      var current = child;
+      while (!current.isBackground) {
+        if (cancelled.contains(current.parentSessionId)) return true;
+        final parent = byId[current.parentSessionId];
+        if (parent == null) return false;
+        current = parent;
+      }
+      return false;
+    }
+
+    // Pending lifecycle delivery is not retained work. A foreground descendant
+    // is covered by its parent's cancellation even when it has no own interrupt.
+    return PluginAbortAccepted(
+      workKept:
+          mainResult == AcpChildCancelResult.notCancellable ||
+          children.any((child) => !cancelled.contains(child.childSessionId) && !coveredByParent(child: child)),
+    );
   }
 
-  Future<void> _abortSession({required String sessionId}) async {
+  Future<AcpChildCancelResult> _cancelScopedSession({
+    required String sessionId,
+    required String? parentSessionId,
+  }) async {
+    // An opened child may own a new standard prompt after its delegation ends.
+    // Prompt ownership, not ancestry alone, determines cancellation transport.
+    final standardCancel = parentSessionId == null || (_turnStates[sessionId]?.pending ?? 0) > 0;
+    await _abortSession(sessionId: sessionId, sendSessionCancel: standardCancel);
+    if (standardCancel) return AcpChildCancelResult.interrupted;
+    final client = _client;
+    if (client == null) return AcpChildCancelResult.unknownChild;
+    try {
+      return await cancelChild(client: client, sessionId: parentSessionId, childSessionId: sessionId);
+    } on Object catch (error, stackTrace) {
+      Log.w("[$id] child cancellation failed: parent=$parentSessionId child=$sessionId", error, stackTrace);
+      rethrow;
+    }
+  }
+
+  Future<void> _abortSession({required String sessionId, required bool sendSessionCancel}) async {
     // Aborting means "stop this conversation now": drop the queued-but-
     // undispatched turns first so they don't dispatch after the cancel. The
     // in-flight turn (if any) ends via the agent's cancellation, which
@@ -1709,10 +1799,9 @@ abstract class AcpPlugin({
     if (_isPromptFrameWriting(sessionId: sessionId)) _cancelledPromptWriteSessions.add(sessionId);
     final client = _client;
     if (client == null) return;
-    client.notify(
-      method: AcpMethods.sessionCancel,
-      params: {"sessionId": sessionId},
-    );
+    if (sendSessionCancel) {
+      client.notify(method: AcpMethods.sessionCancel, params: {"sessionId": sessionId});
+    }
     // ACP requires the client to resolve any permission/question the cancelled
     // turn was blocked on; otherwise the agent keeps waiting on that JSON-RPC
     // request and the phone shows a stale prompt.
@@ -1722,6 +1811,9 @@ abstract class AcpPlugin({
   Future<Set<String>> interruptActiveWork({required Duration budget}) {
     return () async {
       final activeSessionIds = <String>{
+        if (supportsScopedStop)
+          for (final entry in _turnStates.entries)
+            if (entry.value.pending > 0) entry.key,
         for (final summary in getActiveSessionsSummary())
           for (final session in summary.activeSessions) ...[session.id, ...session.childSessionIds],
         for (final rootSessionId in childSessionTracker.activeRootSessionIds) ...[
@@ -1732,10 +1824,23 @@ abstract class AcpPlugin({
       };
       if (activeSessionIds.isEmpty) return const <String>{};
 
-      await Future.wait([
-        for (final sessionId in activeSessionIds) _abortSession(sessionId: sessionId),
-      ]);
-      childSessionTracker.cancelAll().forEach(_eventBuffer.add);
+      if (supportsScopedStop) {
+        final roots = {
+          for (final sessionId in activeSessionIds) childSessionTracker.rootOf(sessionId: sessionId),
+          // A finished delegated child can now own a directly prompted turn,
+          // which is no longer covered by the root's running-child snapshot.
+          for (final entry in _turnStates.entries)
+            if (entry.value.pending > 0 && childSessionTracker.runningChild(sessionId: entry.key) == null) entry.key,
+        };
+        await Future.wait([
+          for (final sessionId in roots) abortSession(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop),
+        ]);
+      } else {
+        await Future.wait([
+          for (final sessionId in activeSessionIds) _abortSession(sessionId: sessionId, sendSessionCancel: true),
+        ]);
+        childSessionTracker.cancelAll().forEach(_eventBuffer.add);
+      }
       if (currentWorkState != PluginWorkState.idle) {
         await workState.firstWhere((state) => state == PluginWorkState.idle);
       }
@@ -1765,7 +1870,7 @@ abstract class AcpPlugin({
   Future<void> deleteSession(String sessionId) async {
     final state = _turnStates[sessionId];
     if ((state?.pending ?? 0) > 0) {
-      await _abortSession(sessionId: sessionId);
+      await _abortSession(sessionId: sessionId, sendSessionCancel: true);
     }
     _approvalRegistry?.cancelForSession(sessionId: sessionId);
     final canClose = _initResult?.agentCapabilities.closeSession ?? false;

--- a/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_child_session_tracker.dart
@@ -15,6 +15,7 @@ final class const AcpChildSpawn({
 
 /// One child that has not finished, as the plugin's stop policy sees it.
 final class const AcpRunningChild({
+  required final String parentSessionId,
   required final String childSessionId,
   required final bool isBackground,
 });
@@ -322,11 +323,21 @@ final class AcpChildSessionTracker() {
     for (final child in runningChildren(sessionId: sessionId)) child.childSessionId,
   };
 
-  /// The children of [sessionId] still running, with their launch mode.
+  AcpRunningChild? runningChild({required String sessionId}) {
+    final child = _byChild[sessionId];
+    return child == null || child.status.isTerminal
+        ? null
+        : AcpRunningChild(
+            parentSessionId: child.parentSessionId,
+            childSessionId: child.childSessionId,
+            isBackground: child.isBackground,
+          );
+  }
+
+  /// Running descendants, with the direct parent needed for scoped cancellation.
   List<AcpRunningChild> runningChildren({required String sessionId}) => [
-    for (final child in _byRoot[sessionId] ?? const <_Child>[])
-      if (!child.status.isTerminal)
-        AcpRunningChild(childSessionId: child.childSessionId, isBackground: child.isBackground),
+    for (final child in _byRoot[sessionId] ?? _descendantsOf(sessionId: sessionId))
+      ?runningChild(sessionId: child.childSessionId),
   ];
 
   /// Drops every record of a deleted root or child subtree. Emits nothing:

--- a/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
@@ -9,6 +9,7 @@ class const DeepSeekAcpApi({required final String pluginId}) {
   static const String askUserQuestionMethod = "deepseek/ask_user_question";
   static const String sessionStatusMethod = "deepseek/session/status";
   static const String subagentMethod = "deepseek/subagent";
+  static const String subagentInterruptMethod = "deepseek/subagent/interrupt";
   static const String initializeMetadataKey = deepSeekExtensionMetadataKey;
   static const int extensionProtocolVersion = 2;
 
@@ -170,6 +171,40 @@ class const DeepSeekAcpApi({required final String pluginId}) {
         }
     }
     return notification;
+  }
+
+  // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
+  DeepSeekSubagentInterruptRequestDto parseSubagentInterruptRequest(Map<String, dynamic> json) {
+    final request = DeepSeekSubagentInterruptRequestDto.fromJson(json);
+    _validateSubagentInterruptRequest(request: request);
+    return request;
+  }
+
+  void _validateSubagentInterruptRequest({required DeepSeekSubagentInterruptRequestDto request}) {
+    if (!_validSubagentText(request.sessionId, maxScalars: 256) ||
+        !_validSubagentText(request.childSessionId, maxScalars: 256)) {
+      throw const FormatException("Invalid DeepSeek sub-agent interrupt request");
+    }
+  }
+
+  // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
+  DeepSeekSubagentInterruptResponseDto parseSubagentInterruptResponse(Map<String, dynamic> json) {
+    final response = DeepSeekSubagentInterruptResponseDto.fromJson(json);
+    if (response.result == DeepSeekSubagentInterruptResult.unknown) {
+      throw const FormatException("Invalid DeepSeek sub-agent interrupt response");
+    }
+    return response;
+  }
+
+  Future<DeepSeekSubagentInterruptResult> interruptSubagent({
+    required AcpStdioClient client,
+    required String sessionId,
+    required String childSessionId,
+  }) async {
+    final request = DeepSeekSubagentInterruptRequestDto(sessionId: sessionId, childSessionId: childSessionId);
+    _validateSubagentInterruptRequest(request: request);
+    final raw = await client.request(method: subagentInterruptMethod, params: request.toJson());
+    return parseSubagentInterruptResponse(_json(raw, method: subagentInterruptMethod)).result;
   }
 
   // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
@@ -29,6 +29,33 @@ enum DeepSeekSubagentStopReason() {
   unknown,
 }
 
+enum DeepSeekSubagentInterruptResult() {
+  interrupted,
+  @JsonValue("not_cancellable")
+  notCancellable,
+  @JsonValue("unknown_child")
+  unknownChild,
+  unknown,
+}
+
+@JsonSerializable(disallowUnrecognizedKeys: true)
+class const DeepSeekSubagentInterruptRequestDto({
+  required final String sessionId,
+  required final String childSessionId,
+}) {
+  factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentInterruptRequestDtoFromJson(json);
+  Map<String, dynamic> toJson() => _$DeepSeekSubagentInterruptRequestDtoToJson(this);
+}
+
+@JsonSerializable(disallowUnrecognizedKeys: true)
+class const DeepSeekSubagentInterruptResponseDto({
+  @JsonKey(unknownEnumValue: DeepSeekSubagentInterruptResult.unknown)
+  required final DeepSeekSubagentInterruptResult result,
+}) {
+  factory fromJson(Map<String, dynamic> json) => _$DeepSeekSubagentInterruptResponseDtoFromJson(json);
+  Map<String, dynamic> toJson() => _$DeepSeekSubagentInterruptResponseDtoToJson(this);
+}
+
 @JsonSerializable()
 class const DeepSeekInitializeMetadataDto({
   @JsonKey(fromJson: _integer) required final int extensionProtocolVersion,

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.dart
@@ -47,7 +47,7 @@ class const DeepSeekSubagentInterruptRequestDto({
   Map<String, dynamic> toJson() => _$DeepSeekSubagentInterruptRequestDtoToJson(this);
 }
 
-@JsonSerializable(disallowUnrecognizedKeys: true)
+@JsonSerializable()
 class const DeepSeekSubagentInterruptResponseDto({
   @JsonKey(unknownEnumValue: DeepSeekSubagentInterruptResult.unknown)
   required final DeepSeekSubagentInterruptResult result,

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
@@ -23,16 +23,14 @@ Map<String, dynamic> _$DeepSeekSubagentInterruptRequestDtoToJson(
 };
 
 DeepSeekSubagentInterruptResponseDto
-_$DeepSeekSubagentInterruptResponseDtoFromJson(Map json) {
-  $checkKeys(json, allowedKeys: const ['result']);
-  return DeepSeekSubagentInterruptResponseDto(
-    result: $enumDecode(
-      _$DeepSeekSubagentInterruptResultEnumMap,
-      json['result'],
-      unknownValue: DeepSeekSubagentInterruptResult.unknown,
-    ),
-  );
-}
+_$DeepSeekSubagentInterruptResponseDtoFromJson(Map json) =>
+    DeepSeekSubagentInterruptResponseDto(
+      result: $enumDecode(
+        _$DeepSeekSubagentInterruptResultEnumMap,
+        json['result'],
+        unknownValue: DeepSeekSubagentInterruptResult.unknown,
+      ),
+    );
 
 Map<String, dynamic> _$DeepSeekSubagentInterruptResponseDtoToJson(
   DeepSeekSubagentInterruptResponseDto instance,

--- a/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/models/deepseek_protocol_dto.g.dart
@@ -6,6 +6,47 @@ part of 'deepseek_protocol_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+DeepSeekSubagentInterruptRequestDto
+_$DeepSeekSubagentInterruptRequestDtoFromJson(Map json) {
+  $checkKeys(json, allowedKeys: const ['sessionId', 'childSessionId']);
+  return DeepSeekSubagentInterruptRequestDto(
+    sessionId: json['sessionId'] as String,
+    childSessionId: json['childSessionId'] as String,
+  );
+}
+
+Map<String, dynamic> _$DeepSeekSubagentInterruptRequestDtoToJson(
+  DeepSeekSubagentInterruptRequestDto instance,
+) => <String, dynamic>{
+  'sessionId': instance.sessionId,
+  'childSessionId': instance.childSessionId,
+};
+
+DeepSeekSubagentInterruptResponseDto
+_$DeepSeekSubagentInterruptResponseDtoFromJson(Map json) {
+  $checkKeys(json, allowedKeys: const ['result']);
+  return DeepSeekSubagentInterruptResponseDto(
+    result: $enumDecode(
+      _$DeepSeekSubagentInterruptResultEnumMap,
+      json['result'],
+      unknownValue: DeepSeekSubagentInterruptResult.unknown,
+    ),
+  );
+}
+
+Map<String, dynamic> _$DeepSeekSubagentInterruptResponseDtoToJson(
+  DeepSeekSubagentInterruptResponseDto instance,
+) => <String, dynamic>{
+  'result': _$DeepSeekSubagentInterruptResultEnumMap[instance.result]!,
+};
+
+const _$DeepSeekSubagentInterruptResultEnumMap = {
+  DeepSeekSubagentInterruptResult.interrupted: 'interrupted',
+  DeepSeekSubagentInterruptResult.notCancellable: 'not_cancellable',
+  DeepSeekSubagentInterruptResult.unknownChild: 'unknown_child',
+  DeepSeekSubagentInterruptResult.unknown: 'unknown',
+};
+
 DeepSeekInitializeMetadataDto _$DeepSeekInitializeMetadataDtoFromJson(
   Map json,
 ) => DeepSeekInitializeMetadataDto(

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -2,7 +2,6 @@ import "package:acp_plugin/acp_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "api/deepseek_acp_api.dart";
-import "api/models/deepseek_protocol_dto.dart";
 import "deepseek_approval_registry.dart";
 import "deepseek_event_mapper.dart";
 import "repositories/deepseek_history_repository.dart";
@@ -45,16 +44,7 @@ class DeepSeekPlugin({
     required AcpStdioClient client,
     required String sessionId,
     required String childSessionId,
-  }) async => switch (await api.interruptSubagent(
-    client: client,
-    sessionId: sessionId,
-    childSessionId: childSessionId,
-  )) {
-    DeepSeekSubagentInterruptResult.interrupted => AcpChildCancelResult.interrupted,
-    DeepSeekSubagentInterruptResult.notCancellable => AcpChildCancelResult.notCancellable,
-    DeepSeekSubagentInterruptResult.unknownChild => AcpChildCancelResult.unknownChild,
-    DeepSeekSubagentInterruptResult.unknown => throw const FormatException("Unknown DeepSeek interrupt outcome"),
-  };
+  }) => deepSeekSessionService.cancelChild(client: client, sessionId: sessionId, childSessionId: childSessionId);
 
   @override
   void captureLiveInitializeResult(AcpInitializeResult result) => mapper.resetLiveState();

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -2,6 +2,7 @@ import "package:acp_plugin/acp_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "api/deepseek_acp_api.dart";
+import "api/models/deepseek_protocol_dto.dart";
 import "deepseek_approval_registry.dart";
 import "deepseek_event_mapper.dart";
 import "repositories/deepseek_history_repository.dart";
@@ -35,6 +36,25 @@ class DeepSeekPlugin({
     activeSessionResolver: () => activeTurnSessionId,
     api: api,
   );
+
+  @override
+  bool get supportsScopedStop => true;
+
+  @override
+  Future<AcpChildCancelResult> cancelChild({
+    required AcpStdioClient client,
+    required String sessionId,
+    required String childSessionId,
+  }) async => switch (await api.interruptSubagent(
+    client: client,
+    sessionId: sessionId,
+    childSessionId: childSessionId,
+  )) {
+    DeepSeekSubagentInterruptResult.interrupted => AcpChildCancelResult.interrupted,
+    DeepSeekSubagentInterruptResult.notCancellable => AcpChildCancelResult.notCancellable,
+    DeepSeekSubagentInterruptResult.unknownChild => AcpChildCancelResult.unknownChild,
+    DeepSeekSubagentInterruptResult.unknown => throw const FormatException("Unknown DeepSeek interrupt outcome"),
+  };
 
   @override
   void captureLiveInitializeResult(AcpInitializeResult result) => mapper.resetLiveState();

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_session_repository.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_session_repository.dart
@@ -2,8 +2,24 @@ import "package:acp_plugin/acp_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../api/deepseek_acp_api.dart";
+import "../api/models/deepseek_protocol_dto.dart";
 
 class const DeepSeekSessionRepository({required final DeepSeekAcpApi api}) {
+  Future<AcpChildCancelResult> cancelChild({
+    required AcpStdioClient client,
+    required String sessionId,
+    required String childSessionId,
+  }) async => switch (await api.interruptSubagent(
+    client: client,
+    sessionId: sessionId,
+    childSessionId: childSessionId,
+  )) {
+    DeepSeekSubagentInterruptResult.interrupted => AcpChildCancelResult.interrupted,
+    DeepSeekSubagentInterruptResult.notCancellable => AcpChildCancelResult.notCancellable,
+    DeepSeekSubagentInterruptResult.unknownChild => AcpChildCancelResult.unknownChild,
+    DeepSeekSubagentInterruptResult.unknown => throw const FormatException("Unknown DeepSeek interrupt outcome"),
+  };
+
   Future<String> rename({
     required AcpStdioClient client,
     required String sessionId,

--- a/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
@@ -7,6 +7,12 @@ class const DeepSeekSessionService({
   required final DeepSeekSessionRepository repository,
   required final AcpChildSessionTracker childSessions,
 }) {
+  Future<AcpChildCancelResult> cancelChild({
+    required AcpStdioClient client,
+    required String sessionId,
+    required String childSessionId,
+  }) => repository.cancelChild(client: client, sessionId: sessionId, childSessionId: childSessionId);
+
   List<PluginSession> getChildSessions({
     required String sessionId,
     required String directory,

--- a/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
@@ -1,14 +1,15 @@
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:deepseek_plugin/deepseek_plugin.dart";
-import "package:deepseek_plugin/deepseek_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
+
+import "support/deepseek_test_plugin.dart";
 
 void main() {
   test("a busy follow-up cancels before replacement prompt dispatch", () async {
     final fake = FakeAcpProcess();
-    final plugin = _buildPlugin(fake);
+    final plugin = buildDeepSeekTestPlugin(fake: fake);
     final handledFrames = <Map<String, dynamic>>{};
 
     Future<Map<String, dynamic>> waitForFrame({required String method}) async {
@@ -108,53 +109,4 @@ void main() {
       await fake.close();
     }
   });
-}
-
-DeepSeekPlugin _buildPlugin(FakeAcpProcess fake) {
-  final configurationTracker = AcpSessionConfigurationTracker();
-  final commandTracker = AcpCommandTracker();
-  final childSessionTracker = AcpChildSessionTracker();
-  const api = DeepSeekAcpApi(pluginId: DeepSeekIdentity.id);
-  final mapper = DeepSeekEventMapper(
-    launchDirectory: "/repo",
-    pluginId: DeepSeekIdentity.id,
-    configurationTracker: configurationTracker,
-    childSessions: childSessionTracker,
-    api: api,
-    messageTimeParser: const DeepSeekMessageTimeParser(),
-    subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
-    delegationTracker: DeepSeekDelegationTracker(),
-  );
-  return DeepSeekPlugin(
-    launchSpec: const AcpLaunchSpec(command: "deepseek", args: [], cwd: "/repo", environment: {}),
-    launchDirectory: "/repo",
-    childSessionTracker: childSessionTracker,
-    mapper: mapper,
-    api: api,
-    historyRepository: DeepSeekHistoryRepository(
-      api: api,
-      eventMapper: mapper,
-      pluginId: DeepSeekIdentity.id,
-      messageTimeParser: const DeepSeekMessageTimeParser(),
-      subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
-    ),
-    deepSeekSessionService: DeepSeekSessionService(
-      repository: const DeepSeekSessionRepository(api: api),
-      childSessions: childSessionTracker,
-    ),
-    deepSeekSessionOptionsService: DeepSeekSessionOptionsService(
-      repository: const DeepSeekCatalogRepository(api: api, mapper: DeepSeekCatalogMapper()),
-      configurationTracker: configurationTracker,
-      pluginId: DeepSeekIdentity.id,
-      discoveryTimeout: const Duration(seconds: 30),
-    ),
-    commandTracker: commandTracker,
-    sessionOptionsService: AcpSessionOptionsService(
-      configurationTracker: configurationTracker,
-      commandTracker: commandTracker,
-      pluginId: DeepSeekIdentity.id,
-      agentDisplayName: DeepSeekIdentity.displayName,
-    ),
-    processFactory: (_) async => fake,
-  );
 }

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
@@ -97,6 +97,19 @@ void main() {
     expect(() => api.parseQuestionRequest(questions), throwsFormatException);
   });
 
+  test("interrupt responses allow additive fields but require a known result", () {
+    final response = api.parseSubagentInterruptResponse({"result": "interrupted", "futureField": true});
+    expect(response.result, DeepSeekSubagentInterruptResult.interrupted);
+    for (final invalid in <Map<String, dynamic>>[
+      {"futureField": true},
+      {"result": null},
+      {"result": 1},
+      {"result": "unknown"},
+    ]) {
+      expect(() => api.parseSubagentInterruptResponse(invalid), throwsA(anything));
+    }
+  });
+
   test("initialization requires protocol v2", () {
     Map<String, dynamic> metadata({required int version}) => {
       "extensionProtocolVersion": version,

--- a/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_protocol_conformance_test.dart
@@ -282,7 +282,7 @@ Set<String> _definitionsFor({required int protocolVersion}) => {
   "askUserQuestionRequest",
   "askUserQuestionResponse",
   "sessionStatusNotification",
-  if (protocolVersion == 2) "subagentNotification",
+  if (protocolVersion == 2) ...["subagentNotification", "subagentInterruptRequest", "subagentInterruptResponse"],
 };
 
 Map<String, dynamic> _decode({
@@ -302,6 +302,8 @@ Map<String, dynamic> _decode({
   "askUserQuestionResponse" => api.parseQuestionResponse(value).toJson(),
   "sessionStatusNotification" => api.parseSessionStatus(value).toJson(),
   "subagentNotification" => api.parseSubagentNotification(value).toJson(),
+  "subagentInterruptRequest" => api.parseSubagentInterruptRequest(value).toJson(),
+  "subagentInterruptResponse" => api.parseSubagentInterruptResponse(value).toJson(),
   _ => throw StateError("Unknown fixture definition $definition"),
 };
 

--- a/bridge/sesori_plugin_deepseek/test/deepseek_scoped_stop_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_scoped_stop_test.dart
@@ -44,6 +44,34 @@ void main() {
       expect(harness.fake.written, hasLength(before));
     });
 
+    test("foreground named child cannot offer main-only stop even with background descendants", () async {
+      await harness.spawn(child: "foreground", parent: "root", background: false);
+      await harness.spawn(child: "background", parent: "foreground", background: true);
+      final before = harness.fake.written.length;
+      for (final policy in [PluginAbortSubAgentPolicy.confirm, PluginAbortSubAgentPolicy.keep]) {
+        final result = await harness.plugin.abortSession(sessionId: "foreground", subAgents: policy);
+        expect(
+          result,
+          isA<PluginAbortRejectedSubAgentsRunning>()
+              .having((r) => r.runningSubAgentCount, "children", 1)
+              .having((r) => r.mainAgentRunning, "main", true)
+              .having((r) => r.mainAgentOnlySupported, "keep supported", false),
+        );
+        expect(harness.fake.written, hasLength(before));
+      }
+    });
+
+    test("background named child can be interrupted while retaining its background descendant", () async {
+      await harness.spawn(child: "parent", parent: "root", background: true);
+      await harness.spawn(child: "child", parent: "parent", background: true);
+      final stopping = harness.plugin.abortSession(sessionId: "parent", subAgents: PluginAbortSubAgentPolicy.keep);
+      await harness.replyInterrupts(results: const {"parent": "interrupted"});
+      expect(await stopping, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", true));
+      expect(harness.cancels, isEmpty);
+      expect(harness.interrupts.single["params"], {"sessionId": "root", "childSessionId": "parent"});
+      expect(harness.plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"parent", "child"});
+    });
+
     test("keep cancels only main when every child is background", () async {
       await harness.prompt(sessionId: "root");
       await harness.spawn(child: "child", parent: "root", background: true);

--- a/bridge/sesori_plugin_deepseek/test/deepseek_scoped_stop_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_scoped_stop_test.dart
@@ -1,0 +1,293 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:deepseek_plugin/deepseek_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+import "support/deepseek_test_plugin.dart";
+
+void main() {
+  group("DeepSeek scoped stop", () {
+    late _StopHarness harness;
+    setUp(() async {
+      harness = _StopHarness();
+      await harness.connect();
+    });
+    tearDown(() => harness.close());
+
+    test("confirm is side-effect free and reports main/background capability", () async {
+      await harness.prompt(sessionId: "root");
+      await harness.spawn(child: "child", parent: "root", background: true);
+      final before = harness.fake.written.length;
+      final result = await harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.confirm);
+      expect(
+        result,
+        isA<PluginAbortRejectedSubAgentsRunning>()
+            .having((r) => r.runningSubAgentCount, "children", 1)
+            .having((r) => r.mainAgentRunning, "main", true)
+            .having((r) => r.mainAgentOnlySupported, "keep supported", true),
+      );
+      expect(harness.fake.written, hasLength(before));
+      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isTrue);
+    });
+
+    test("keep rejects mixed foreground work without side effects", () async {
+      await harness.prompt(sessionId: "root");
+      await harness.spawn(child: "foreground", parent: "root", background: false);
+      await harness.spawn(child: "background", parent: "root", background: true);
+      final before = harness.fake.written.length;
+      final result = await harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.keep);
+      expect(
+        result,
+        isA<PluginAbortRejectedSubAgentsRunning>().having((r) => r.mainAgentOnlySupported, "keep supported", false),
+      );
+      expect(harness.fake.written, hasLength(before));
+    });
+
+    test("keep cancels only main when every child is background", () async {
+      await harness.prompt(sessionId: "root");
+      await harness.spawn(child: "child", parent: "root", background: true);
+      final result = await harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.keep);
+      expect(result, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", true));
+      expect(harness.cancels.single["params"], {"sessionId": "root"});
+      expect(harness.interrupts, isEmpty);
+      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isTrue);
+    });
+
+    test("child-only keep sends no cancellation", () async {
+      await harness.spawn(child: "child", parent: "root", background: true);
+      final before = harness.fake.written.length;
+      final result = await harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.keep);
+      expect(result, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", true));
+      expect(harness.fake.written, hasLength(before));
+    });
+
+    test("stop uses each direct parent and keeps cancellation settlement authoritative", () async {
+      await harness.prompt(sessionId: "root");
+      await harness.spawn(child: "background", parent: "root", background: true);
+      await harness.spawn(child: "foreground", parent: "background", background: false);
+      final stopping = harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.stop);
+      await harness.replyInterrupts(results: const {"background": "interrupted", "foreground": "not_cancellable"});
+      expect(await stopping, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", false));
+      expect(
+        harness.interrupts.map((f) => f["params"]),
+        unorderedEquals([
+          {"sessionId": "root", "childSessionId": "background"},
+          {"sessionId": "background", "childSessionId": "foreground"},
+        ]),
+      );
+      expect(harness.cancels.single["params"], {"sessionId": "root"});
+      expect(harness.plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"background", "foreground"});
+      await harness.end(child: "foreground", parent: "background");
+      await harness.end(child: "background", parent: "root");
+      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isFalse);
+    });
+
+    test("unknown child during settlement is neither kept nor synthetically finished", () async {
+      await harness.spawn(child: "child", parent: "root", background: true);
+      final stopping = harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.stop);
+      await harness.replyInterrupts(results: const {"child": "unknown_child"});
+      expect(await stopping, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", false));
+      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isTrue);
+      await harness.end(child: "child", parent: "root");
+      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isFalse);
+    });
+
+    test("non-cancellable named child is retained without cancelling its parent or sibling", () async {
+      await harness.spawn(child: "child", parent: "root", background: false);
+      await harness.spawn(child: "sibling", parent: "root", background: true);
+      final stopping = harness.plugin.abortSession(sessionId: "child", subAgents: PluginAbortSubAgentPolicy.stop);
+      await harness.replyInterrupts(results: const {"child": "not_cancellable"});
+      expect(await stopping, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", true));
+      expect(harness.cancels, isEmpty);
+      expect(harness.interrupts, hasLength(1));
+      expect(harness.plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"child", "sibling"});
+    });
+
+    test("a finished child opened for a new user turn uses standard cancellation", () async {
+      await harness.spawn(child: "child", parent: "root", background: true);
+      await harness.end(child: "child", parent: "root");
+      await harness.prompt(sessionId: "child");
+      final result = await harness.plugin.abortSession(sessionId: "child", subAgents: PluginAbortSubAgentPolicy.stop);
+      expect(result, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", false));
+      expect(harness.cancels.single["params"], {"sessionId": "child"});
+      expect(harness.interrupts, isEmpty);
+    });
+
+    test("whole-plugin stop also cancels a new user turn on a finished child", () async {
+      await harness.spawn(child: "child", parent: "root", background: true);
+      await harness.end(child: "child", parent: "root");
+      await harness.prompt(sessionId: "child");
+      final stopping = harness.plugin.interruptActiveWork(budget: const Duration(seconds: 2));
+      await harness.waitFor(method: AcpMethods.sessionCancel, count: 2);
+      expect(harness.cancels.map((frame) => (frame["params"] as Map)["sessionId"]), contains("child"));
+      final prompt = await harness.waitFor(method: AcpMethods.sessionPrompt, count: 1);
+      harness.fake.emit({
+        "jsonrpc": "2.0",
+        "id": prompt["id"],
+        "result": {"stopReason": "cancelled"},
+      });
+      expect(await stopping, contains("child"));
+      expect(harness.interrupts, isEmpty);
+    });
+
+    test("foreground descendants are covered by root cancellation", () async {
+      await harness.spawn(child: "parent", parent: "root", background: false);
+      await harness.spawn(child: "child", parent: "parent", background: false);
+      final stopping = harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.stop);
+      await harness.replyInterrupts(results: const {"parent": "not_cancellable", "child": "not_cancellable"});
+      expect(await stopping, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", false));
+      expect(harness.plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"parent", "child"});
+    });
+
+    test("interrupt failure keeps original RPC error and busy child state", () async {
+      await harness.spawn(child: "child", parent: "root", background: true);
+      final stopping = harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.stop);
+      final failure = expectLater(
+        stopping,
+        throwsA(
+          isA<AcpRpcException>()
+              .having((error) => error.code, "code", -32603)
+              .having((error) => error.message, "message", "interrupt failed"),
+        ),
+      );
+      final request = await harness.waitFor(method: DeepSeekAcpApi.subagentInterruptMethod, count: 1);
+      harness.fake.emit({
+        "jsonrpc": "2.0",
+        "id": request["id"],
+        "error": {"code": -32603, "message": "interrupt failed"},
+      });
+      await failure;
+      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isTrue);
+    });
+
+    test("whole-plugin interruption waits for lifecycle instead of fabricating idle", () async {
+      await harness.spawn(child: "child", parent: "root", background: true);
+      var settled = false;
+      final stopping = harness.plugin.interruptActiveWork(budget: const Duration(seconds: 2)).then((value) {
+        settled = true;
+        return value;
+      });
+      await harness.replyInterrupts(results: const {"child": "interrupted"});
+      await Future<void>.delayed(Duration.zero);
+      expect(settled, isFalse);
+      expect(harness.plugin.currentWorkState, isNot(PluginWorkState.idle));
+      await harness.end(child: "child", parent: "root");
+      expect(await stopping, containsAll(["root", "child"]));
+      expect(harness.plugin.currentWorkState, PluginWorkState.idle);
+    });
+  });
+}
+
+class _StopHarness() {
+  final fake = FakeAcpProcess();
+  late final DeepSeekPlugin plugin = buildDeepSeekTestPlugin(fake: fake);
+
+  List<Map<String, dynamic>> get cancels => fake.written.where((f) => f["method"] == AcpMethods.sessionCancel).toList();
+  List<Map<String, dynamic>> get interrupts =>
+      fake.written.where((f) => f["method"] == DeepSeekAcpApi.subagentInterruptMethod).toList();
+
+  Future<Map<String, dynamic>> waitFor({required String method, required int count}) async {
+    for (var i = 0; i < 100; i++) {
+      final frames = fake.written.where((frame) => frame["method"] == method).toList();
+      if (frames.length >= count) return frames[count - 1];
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    throw StateError("Missing frame $count: $method");
+  }
+
+  Future<void> connect() async {
+    final connecting = plugin.ensureConnected();
+    final frame = await waitFor(method: AcpMethods.initialize, count: 1);
+    fake.emit({
+      "jsonrpc": "2.0",
+      "id": frame["id"],
+      "result": {
+        "protocolVersion": 1,
+        "agentCapabilities": <String, dynamic>{"loadSession": true},
+        "authMethods": <Object?>[],
+        "_meta": {
+          "sesori.ai/deepseek": {
+            "extensionProtocolVersion": 2,
+            "adapterVersion": "0.1.3",
+            "harnessVersion": "0.1.1-rc.2",
+            "persistenceOwner": "sesori",
+          },
+        },
+      },
+    });
+    expect(await connecting, isTrue);
+    plugin.mapper.setSessionProject("root", "/repo");
+  }
+
+  Future<void> prompt({required String sessionId}) async {
+    await plugin.sendPrompt(
+      sessionId: sessionId,
+      promptId: "prompt",
+      parts: const [PluginPromptPart.text(text: "Work")],
+      variant: null,
+      agent: null,
+      model: null,
+    );
+    final loading = await waitFor(method: AcpMethods.sessionLoad, count: 1);
+    expect((loading["params"] as Map)["sessionId"], sessionId);
+    fake.emit({"jsonrpc": "2.0", "id": loading["id"], "result": <String, dynamic>{}});
+    await waitFor(method: AcpMethods.sessionPrompt, count: 1);
+  }
+
+  Future<void> spawn({required String child, required String parent, required bool background}) async {
+    fake.emit({
+      "jsonrpc": "2.0",
+      "method": DeepSeekAcpApi.subagentMethod,
+      "params": {
+        "kind": "started",
+        "sessionId": parent,
+        "childSessionId": child,
+        "toolCallId": "call-$child",
+        "prompt": "Work",
+        "label": "Child",
+        "mode": background ? "background" : "foreground",
+      },
+    });
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> end({required String child, required String parent}) async {
+    fake.emit({
+      "jsonrpc": "2.0",
+      "method": DeepSeekAcpApi.subagentMethod,
+      "params": {
+        "kind": "ended",
+        "sessionId": parent,
+        "childSessionId": child,
+        "stopReason": "aborted",
+      },
+    });
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  Future<void> replyInterrupts({required Map<String, String> results}) async {
+    await waitFor(method: DeepSeekAcpApi.subagentInterruptMethod, count: results.length);
+    for (final frame in interrupts) {
+      final child = (frame["params"] as Map)["childSessionId"];
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": frame["id"],
+        "result": {"result": results[child]},
+      });
+    }
+  }
+
+  Future<void> close() async {
+    for (final frame in fake.written.where((frame) => frame["method"] == AcpMethods.sessionPrompt)) {
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": frame["id"],
+        "result": {"stopReason": "cancelled"},
+      });
+    }
+    await Future<void>.delayed(Duration.zero);
+    await plugin.dispose();
+    await fake.close();
+  }
+}

--- a/bridge/sesori_plugin_deepseek/test/support/deepseek_test_plugin.dart
+++ b/bridge/sesori_plugin_deepseek/test/support/deepseek_test_plugin.dart
@@ -1,0 +1,53 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:acp_plugin/acp_testing.dart";
+import "package:deepseek_plugin/deepseek_plugin.dart";
+import "package:deepseek_plugin/deepseek_testing.dart";
+
+DeepSeekPlugin buildDeepSeekTestPlugin({required FakeAcpProcess fake}) {
+  final configurationTracker = AcpSessionConfigurationTracker();
+  final commandTracker = AcpCommandTracker();
+  final childSessionTracker = AcpChildSessionTracker();
+  const api = DeepSeekAcpApi(pluginId: DeepSeekIdentity.id);
+  final mapper = DeepSeekEventMapper(
+    launchDirectory: "/repo",
+    pluginId: DeepSeekIdentity.id,
+    configurationTracker: configurationTracker,
+    childSessions: childSessionTracker,
+    api: api,
+    messageTimeParser: const DeepSeekMessageTimeParser(),
+    subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
+    delegationTracker: DeepSeekDelegationTracker(),
+  );
+  return DeepSeekPlugin(
+    launchSpec: const AcpLaunchSpec(command: "deepseek", args: [], cwd: "/repo", environment: {}),
+    launchDirectory: "/repo",
+    childSessionTracker: childSessionTracker,
+    mapper: mapper,
+    api: api,
+    historyRepository: DeepSeekHistoryRepository(
+      api: api,
+      eventMapper: mapper,
+      pluginId: DeepSeekIdentity.id,
+      messageTimeParser: const DeepSeekMessageTimeParser(),
+      subagentMapper: const DeepSeekSubagentMapper(agentId: DeepSeekIdentity.id),
+    ),
+    deepSeekSessionService: DeepSeekSessionService(
+      repository: const DeepSeekSessionRepository(api: api),
+      childSessions: childSessionTracker,
+    ),
+    deepSeekSessionOptionsService: DeepSeekSessionOptionsService(
+      repository: const DeepSeekCatalogRepository(api: api, mapper: DeepSeekCatalogMapper()),
+      configurationTracker: configurationTracker,
+      pluginId: DeepSeekIdentity.id,
+      discoveryTimeout: const Duration(seconds: 30),
+    ),
+    commandTracker: commandTracker,
+    sessionOptionsService: AcpSessionOptionsService(
+      configurationTracker: configurationTracker,
+      commandTracker: commandTracker,
+      pluginId: DeepSeekIdentity.id,
+      agentDisplayName: DeepSeekIdentity.displayName,
+    ),
+    processFactory: (_) async => fake,
+  );
+}

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -144,7 +144,9 @@ requires all running children to be background. Foreground children stop through
 parent cancellation; background children use direct-parent-authorized interrupt.
 Directly stopping a non-cancellable child leaves it running rather than widening
 to its parent/siblings. Busy state follows lifecycle, not interrupt acceptance.
-Final feature E2E coverage remains pending.
+Stop currently uses the request-time child snapshot; late-announced children can
+remain running. Closing that window is a required successor to #1346, before
+final DeepSeek feature E2E coverage.
 
 ¹⁰ Grok Build (1.0.5, probed 2026-09-03) sends `subagent_spawned`/`subagent_progress`/
 `subagent_finished` with parent and child session ids as

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -82,9 +82,9 @@ prompt, and skill commands remain available.
 |---|---|---|---|---|---|---|---|---|---|---|
 | Sub-agents rendered as inline subtask tiles | ✅ | ✅ | ✅³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ⬜¹⁰ |
 | Sub-agent transcripts exposed as child sessions | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ⬜¹⁰ |
-| Scoped stop: confirmation while sub-agents run, `stop` cancels them all | ✅ | ✅ | ⬜³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
-| Stop the sub-agents only while the main agent is idle (`stop`) | ✅ | ✅ | ⬜³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | ⬜¹⁰ |
-| Stop the main agent only while it runs, keeping its sub-agents | 🚫¹ | 🚫² | ⬜³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ⬜⁹ | 🚫¹⁰ |
+| Scoped stop: confirmation while sub-agents run, `stop` cancels them all | ✅ | ✅ | ⬜³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ⬜¹⁰ |
+| Stop the sub-agents only while the main agent is idle (`stop`) | ✅ | ✅ | ⬜³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ⬜¹⁰ |
+| Stop the main agent only while it runs, keeping its sub-agents | 🚫¹ | 🚫² | ⬜³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | 🚫¹⁰ |
 
 Plugins that report a scoped-stop rejection declare whether "main agent only"
 is honored through `mainAgentOnlySupported`; the app offers the action only
@@ -139,11 +139,12 @@ turn.
 and minimum accepted runtime. The consumer requires extension protocol v2 and
 implements live/replayed correlated tiles and child transcripts/catalogs.
 Replay retains direct-parent tile identities and ordered ordinary-content runs
-without changing live child state. Scoped stop remains an unimplemented consumer
-follow-up, although the adapter supplies its contract. Foreground children die
-with the parent; background children survive, making main-agent-only stop
-supportable when all running children are background. Final feature E2E coverage
-remains pending.
+without changing live child state. Scoped stop is implemented: main-only stop
+requires all running children to be background. Foreground children stop through
+parent cancellation; background children use direct-parent-authorized interrupt.
+Directly stopping a non-cancellable child leaves it running rather than widening
+to its parent/siblings. Busy state follows lifecycle, not interrupt acceptance.
+Final feature E2E coverage remains pending.
 
 ¹⁰ Grok Build (1.0.5, probed 2026-09-03) sends `subagent_spawned`/`subagent_progress`/
 `subagent_finished` with parent and child session ids as

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -124,6 +124,9 @@ defaults and queued client sends coherent.
   Neither accepted nor unknown-child interrupt responses fabricate terminal
   tiles/idle state. Whole-plugin interruption waits for authoritative lifecycle;
   transport failure preserves its original error and logs parent/child context.
+  Stop currently targets children known at request time: a child announced while
+  cancellation is in flight can continue running, remains visible as busy, and
+  can be stopped again. Closing that late-launch window is a required follow-up.
   Other ACP harnesses retain their existing policy until they opt in.
 - Pi keeps at most one lazy resident RPC process per active session and allows
   different sessions to run concurrently. A cold resident starts with the

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -99,14 +99,14 @@ defaults and queued client sends coherent.
   matching subtask and are never rendered as user messages, while user text
   that merely discusses the envelope stays visible. Forwarded sub-agent frames
   render in the sub-agent's child session, never as a root turn.
-- Stop is scoped for every harness that runs sub-agents (Claude tasks, OpenCode
-  child sessions). The client first asks with `confirm`; while sub-agents
+- Claude tasks and OpenCode child sessions expose scoped stop. The client
+  first asks with `confirm`; while sub-agents
   run the bridge refuses with the running count and whether the main agent is
   mid-turn, and the app shows a confirmation: with the main agent idle, "Stop N
   sub-agents"; with the main agent running, "Stop main agent and N sub-agents".
   Dismissing leaves everything running. "Stop main agent only" (`keep`) is
   offered only when the rejection declares `mainAgentOnlySupported`; neither
-  current harness can interrupt a running main agent without its sub-agents,
+  of these harnesses can interrupt a running main agent without its sub-agents,
   so both report false and refuse `keep` during a live main turn with the
   running count. With the main agent idle `keep` is honored: the Claude process
   stays resident, the sub-agents continue, their later wake-up turn renders,
@@ -114,6 +114,17 @@ defaults and queued client sends coherent.
   down, cancelling every sub-agent. With no sub-agents running, stop behaves
   as before with no dialog. An older app stops everything; an older bridge
   ignores the scope.
+- DeepSeek 0.1.3 supports side-effect-free `confirm` rejection and child-only
+  `keep`. A running main turn can be kept separate only when all running children
+  are background; unsupported `keep` rejects before cancelling prompts or input.
+  `stop` cancels standard prompts and interrupts delegated children using each
+  child's direct parent. Foreground children stop through their parent; stopping
+  a non-cancellable child directly does not widen to its parent or siblings and
+  reports retained work. An opened child's new user prompt uses standard cancel.
+  Neither accepted nor unknown-child interrupt responses fabricate terminal
+  tiles/idle state. Whole-plugin interruption waits for authoritative lifecycle;
+  transport failure preserves its original error and logs parent/child context.
+  Other ACP harnesses retain their existing policy until they opt in.
 - Pi keeps at most one lazy resident RPC process per active session and allows
   different sessions to run concurrently. A cold resident starts with the
   turn's requested model and thinking level on Pi's command line so


### PR DESCRIPTION
## Complexity

⚙️ Moderate — shared scoped-stop policy with backend-local typed cancellation transport and authoritative asynchronous settlement.

## What

- Implement `confirm` / `keep` / `stop` once in `AcpPlugin`, behind the explicit `supportsScopedStop` capability. DeepSeek opts in; other ACP harnesses retain existing behavior.
- Reject confirmation and unsupported main-only stops before cancellation side effects. Child-only `keep` leaves work running without sending cancellation.
- Cancel standard bridge-owned prompts through `session/cancel`; interrupt actively delegated children using their actual direct parent and the published `deepseek/subagent/interrupt` contract.
- Route native transport/result mapping through the existing DeepSeek session repository and service. No per-harness policy copy or invented `canCancel` metadata.
- Keep lifecycle settlement authoritative. Pending cancellation is not deliberately retained work; genuinely non-cancellable directly targeted children remain alive without widening cancellation to parents/siblings.
- Route whole-plugin interruption through stop policy and wait for authoritative idle instead of clearing child state optimistically.

**Size: +774/-100 = 874 changed lines**, including generated serializers, tests, and docs. Follows merged DeepSeek replay #1317 and the completed five-slice consumer series. This is scoped-stop step 1/4. After merge, the user approved native adapter implementation (step 2/4), a separately reviewed release preparation/publication (step 3/4), then bridge completion (step 4/4).

## Why

Users need to choose whether to retain background children or stop owned work, without misleading success/idle state or cancelling unrelated sessions. Reopened child sessions must also remain stoppable when they own a new user-started prompt.

## Risk and test focus

- Moderate/high behavioral risk around cancellation: side-effect-free rejection, foreground/background mixtures, nested authority, pending input/queues, and delayed terminal notifications.
- `not_cancellable` and `unknown_child` do not fabricate completion. Original RPC errors and useful local parent/child context remain observable.
- No database/schema change, client/bridge wire-shape change, runtime pin change, automatic-upgrade work, or Grok/Codex transport enhancement.
- Both authoritative fixture versions and published runtime 0.1.3 digests remain unchanged.

## Expected result

DeepSeek can ask for confirmation while descendants run, retain background children when stopping the main turn, stop child-only work, and interrupt nested children with correct authorization. A directly targeted non-cancellable child reports retained work without cancelling its parent. New user turns in opened former child sessions use standard cancellation. Busy state persists until backend lifecycle confirms settlement. No database impact.

## Verification

- ACP analyzer clean; 323 tests passed after merging actual `origin/main`.
- DeepSeek analyzer clean; 106 tests passed, including 14 scoped-stop tests, typed interrupt conformance, and additive-response-field coverage.
- Unchanged Grok analyzer clean; 85 tests passed.
- Serializers regenerated; formatting and `git diff --check` pass.
- Architecture review initially found an API-to-domain boundary bypass; fixed via the existing repository/service. Final architecture pass approved with no findings.

**User-approved scope split:** this PR targets the request-time child snapshot. Children announced while cancellation is in flight may continue running; they remain visibly busy and can be stopped again. This limitation is documented in the capability matrix and regression guide. Required native steps 2/4–3/4 and bridge step 4/4 will close the late-launch window before final DeepSeek E2E. The user approved this expanded sequence after investigation identified native atomic cancellation as the appropriate boundary. The updated plan is recorded in `followups/deepseek-atomic-stop.md` on branch `claude-inline-subtasks-deepseek-stop-race`; this merged PR's implementation and measured size remain unchanged.

Merged actual `origin/main` without rebasing; preserved upstream's required `includeParentEnvironment` setting in the extracted DeepSeek test builder. Owning-package analyzers and tests pass after conflict resolution.

Final feature E2E remains pending. Complete DeepSeek coverage before moving to Codex; automatic managed-runtime upgrades remain owned by another session.
