### PR TITLE
⚙️ Support Codex async questions in the existing question flow

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -2056,7 +2056,7 @@ abstract class AcpPlugin({
     required String sessionId,
     required List<List<String>> answers,
   }) async {
-    _approvalRegistry?.replyQuestion(requestId: questionId, answers: answers);
+    await _approvalRegistry?.replyQuestion(requestId: questionId, answers: answers);
   }
 
   @override
@@ -2064,7 +2064,7 @@ abstract class AcpPlugin({
     // The registry is keyed by the bridge question id; it already knows the
     // session (and clears the pending entry, so awaiting-input drops), so the
     // sessionId argument is not needed here.
-    _approvalRegistry?.rejectQuestion(requestId: questionId);
+    await _approvalRegistry?.rejectQuestion(requestId: questionId);
   }
 
   @override

--- a/bridge/sesori_plugin_acp/test/acp_approval_registry_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_approval_registry_test.dart
@@ -269,7 +269,7 @@ void main() {
       expect(errors.single.$2, -32601);
     });
 
-    test("registered questions reply via the builder and surface as pending", () {
+    test("registered questions reply via the builder and surface as pending", () async {
       final requestId = registry.addPendingQuestion(
         acpId: 5,
         sessionId: "s1",
@@ -288,7 +288,7 @@ void main() {
 
       expect(registry.pendingForSession(sessionId: "s1"), hasLength(1));
       expect(
-        registry.replyQuestion(
+        await registry.replyQuestion(
           requestId: requestId,
           answers: [
             ["yes"],

--- a/bridge/sesori_plugin_acp/test/acp_elicitation_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_elicitation_test.dart
@@ -87,7 +87,7 @@ void main() {
       expect(asked.questions[2].options.single.description.length, lessThan(suggested.length));
 
       expect(
-        registry.replyQuestion(
+        await registry.replyQuestion(
           requestId: asked.id,
           answers: [
             ["fast"],
@@ -126,7 +126,7 @@ void main() {
 
       final asked = emitted.single as BridgeSseQuestionAsked;
       expect(asked.questions.single.options.map((option) => option.label), ["Approve", "Approve (2)"]);
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: asked.id,
         answers: [
           ["Approve (2)"],
@@ -151,7 +151,7 @@ void main() {
       await pump();
       final asked = emitted.single as BridgeSseQuestionAsked;
 
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: asked.id,
         answers: [
           ["value"],
@@ -178,7 +178,7 @@ void main() {
       await pump();
       final asked = emitted.single as BridgeSseQuestionAsked;
 
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: asked.id,
         answers: [
           const <String>[],
@@ -205,7 +205,7 @@ void main() {
       final label = asked.questions.single.options.single.label;
       expect(label, isNotEmpty);
 
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: asked.id,
         answers: [
           [label],
@@ -330,13 +330,13 @@ void main() {
       }
 
       final rejected = await ask(id: 1);
-      registry.rejectQuestion(requestId: rejected);
+      await registry.rejectQuestion(requestId: rejected);
       expect(responses.last.$2, const {"action": "decline"});
 
       final aborted = await ask(id: 2);
       registry.cancelForSession(sessionId: "session-1");
       expect(responses.last.$2, const {"action": "cancel"});
-      expect(registry.replyQuestion(requestId: aborted, answers: const []), isFalse);
+      expect(await registry.replyQuestion(requestId: aborted, answers: const []), isFalse);
 
       await ask(id: 3);
       await registry.dispose();

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_pending_input.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_pending_input.dart
@@ -1,0 +1,9 @@
+import "../../codex_app_server_client.dart";
+
+/// The two app-server sources of pending user input.
+sealed class const CodexPendingInput();
+
+final class const CodexPendingRequest({required final CodexServerRequest request}) extends CodexPendingInput;
+
+final class const CodexPendingNotification({required final CodexServerNotification notification})
+    extends CodexPendingInput;

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.dart
@@ -1,0 +1,75 @@
+import "package:freezed_annotation/freezed_annotation.dart";
+
+part "codex_user_input_dto.freezed.dart";
+part "codex_user_input_dto.g.dart";
+
+enum CodexAgentMessageDelivery() {
+  async,
+  unknown,
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexUserInputParamsDto with _$CodexUserInputParamsDto {
+  const factory({
+    required List<CodexUserInputQuestionDto> questions,
+  }) = _CodexUserInputParamsDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexUserInputParamsDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexUserInputQuestionDto with _$CodexUserInputQuestionDto {
+  const factory({
+    required String id,
+    required String header,
+    required String question,
+    required List<CodexUserInputOptionDto>? options,
+    @Default(false) bool isOther,
+  }) = _CodexUserInputQuestionDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexUserInputQuestionDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexUserInputOptionDto with _$CodexUserInputOptionDto {
+  const factory({
+    required String label,
+    required String description,
+  }) = _CodexUserInputOptionDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexUserInputOptionDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexQuestionItemParamsDto with _$CodexQuestionItemParamsDto {
+  const factory({
+    required String threadId,
+    required CodexQuestionItemDto item,
+  }) = _CodexQuestionItemParamsDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexQuestionItemParamsDtoFromJson(json);
+}
+
+@Freezed(unionKey: "type", fallbackUnion: "unknown", fromJson: true, toJson: false)
+sealed class CodexQuestionItemDto with _$CodexQuestionItemDto {
+  @FreezedUnionValue("agentMessage")
+  const factory agentMessage({
+    required String id,
+    @JsonKey(unknownEnumValue: CodexAgentMessageDelivery.unknown) required CodexAgentMessageDelivery? delivery,
+    required List<CodexAsyncUserInputQuestionDto>? questions,
+  }) = CodexAgentQuestionItemDto;
+
+  const factory unknown() = CodexUnknownQuestionItemDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexQuestionItemDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexAsyncUserInputQuestionDto with _$CodexAsyncUserInputQuestionDto {
+  const factory({
+    required String title,
+    required List<String>? options,
+  }) = _CodexAsyncUserInputQuestionDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexAsyncUserInputQuestionDtoFromJson(json);
+}

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.dart
@@ -25,6 +25,7 @@ sealed class CodexUserInputQuestionDto with _$CodexUserInputQuestionDto {
     required String question,
     required List<CodexUserInputOptionDto>? options,
     @Default(false) bool isOther,
+    @Default(false) bool isSecret,
   }) = _CodexUserInputQuestionDto;
 
   factory fromJson(Map<String, dynamic> json) => _$CodexUserInputQuestionDtoFromJson(json);

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.freezed.dart
@@ -151,7 +151,7 @@ as List<CodexUserInputQuestionDto>,
 /// @nodoc
 mixin _$CodexUserInputQuestionDto {
 
- String get id; String get header; String get question; List<CodexUserInputOptionDto>? get options; bool get isOther;
+ String get id; String get header; String get question; List<CodexUserInputOptionDto>? get options; bool get isOther; bool get isSecret;
 /// Create a copy of CodexUserInputQuestionDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -162,16 +162,16 @@ $CodexUserInputQuestionDtoCopyWith<CodexUserInputQuestionDto> get copyWith => _$
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexUserInputQuestionDto&&(identical(other.id, id) || other.id == id)&&(identical(other.header, header) || other.header == header)&&(identical(other.question, question) || other.question == question)&&const DeepCollectionEquality().equals(other.options, options)&&(identical(other.isOther, isOther) || other.isOther == isOther));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexUserInputQuestionDto&&(identical(other.id, id) || other.id == id)&&(identical(other.header, header) || other.header == header)&&(identical(other.question, question) || other.question == question)&&const DeepCollectionEquality().equals(other.options, options)&&(identical(other.isOther, isOther) || other.isOther == isOther)&&(identical(other.isSecret, isSecret) || other.isSecret == isSecret));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,header,question,const DeepCollectionEquality().hash(options),isOther);
+int get hashCode => Object.hash(runtimeType,id,header,question,const DeepCollectionEquality().hash(options),isOther,isSecret);
 
 @override
 String toString() {
-  return 'CodexUserInputQuestionDto(id: $id, header: $header, question: $question, options: $options, isOther: $isOther)';
+  return 'CodexUserInputQuestionDto(id: $id, header: $header, question: $question, options: $options, isOther: $isOther, isSecret: $isSecret)';
 }
 
 
@@ -182,7 +182,7 @@ abstract mixin class $CodexUserInputQuestionDtoCopyWith<$Res>  {
   factory $CodexUserInputQuestionDtoCopyWith(CodexUserInputQuestionDto value, $Res Function(CodexUserInputQuestionDto) _then) = _$CodexUserInputQuestionDtoCopyWithImpl;
 @useResult
 $Res call({
- String id, String header, String question, List<CodexUserInputOptionDto>? options, bool isOther
+ String id, String header, String question, List<CodexUserInputOptionDto>? options, bool isOther, bool isSecret
 });
 
 
@@ -199,13 +199,14 @@ class _$CodexUserInputQuestionDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexUserInputQuestionDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? header = null,Object? question = null,Object? options = freezed,Object? isOther = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? header = null,Object? question = null,Object? options = freezed,Object? isOther = null,Object? isSecret = null,}) {
   return _then(CodexUserInputQuestionDto(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,header: null == header ? _self.header : header // ignore: cast_nullable_to_non_nullable
 as String,question: null == question ? _self.question : question // ignore: cast_nullable_to_non_nullable
 as String,options: freezed == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
 as List<CodexUserInputOptionDto>?,isOther: null == isOther ? _self.isOther : isOther // ignore: cast_nullable_to_non_nullable
+as bool,isSecret: null == isSecret ? _self.isSecret : isSecret // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }
@@ -218,7 +219,7 @@ as bool,
 @JsonSerializable(createToJson: false)
 
 class _CodexUserInputQuestionDto implements CodexUserInputQuestionDto {
-  const _CodexUserInputQuestionDto({required this.id, required this.header, required this.question, required  List<CodexUserInputOptionDto>? options, this.isOther = false}): _options = options;
+  const _CodexUserInputQuestionDto({required this.id, required this.header, required this.question, required  List<CodexUserInputOptionDto>? options, this.isOther = false, this.isSecret = false}): _options = options;
   factory _CodexUserInputQuestionDto.fromJson(Map<String, dynamic> json) => _$CodexUserInputQuestionDtoFromJson(json);
 
 @override final  String id;
@@ -234,6 +235,7 @@ class _CodexUserInputQuestionDto implements CodexUserInputQuestionDto {
 }
 
 @override@JsonKey() final  bool isOther;
+@override@JsonKey() final  bool isSecret;
 
 /// Create a copy of CodexUserInputQuestionDto
 /// with the given fields replaced by the non-null parameter values.
@@ -245,16 +247,16 @@ _$CodexUserInputQuestionDtoCopyWith<_CodexUserInputQuestionDto> get copyWith => 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexUserInputQuestionDto&&(identical(other.id, id) || other.id == id)&&(identical(other.header, header) || other.header == header)&&(identical(other.question, question) || other.question == question)&&const DeepCollectionEquality().equals(other._options, _options)&&(identical(other.isOther, isOther) || other.isOther == isOther));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexUserInputQuestionDto&&(identical(other.id, id) || other.id == id)&&(identical(other.header, header) || other.header == header)&&(identical(other.question, question) || other.question == question)&&const DeepCollectionEquality().equals(other._options, _options)&&(identical(other.isOther, isOther) || other.isOther == isOther)&&(identical(other.isSecret, isSecret) || other.isSecret == isSecret));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,header,question,const DeepCollectionEquality().hash(_options),isOther);
+int get hashCode => Object.hash(runtimeType,id,header,question,const DeepCollectionEquality().hash(_options),isOther,isSecret);
 
 @override
 String toString() {
-  return 'CodexUserInputQuestionDto(id: $id, header: $header, question: $question, options: $options, isOther: $isOther)';
+  return 'CodexUserInputQuestionDto(id: $id, header: $header, question: $question, options: $options, isOther: $isOther, isSecret: $isSecret)';
 }
 
 
@@ -265,7 +267,7 @@ abstract mixin class _$CodexUserInputQuestionDtoCopyWith<$Res> implements $Codex
   factory _$CodexUserInputQuestionDtoCopyWith(_CodexUserInputQuestionDto value, $Res Function(_CodexUserInputQuestionDto) _then) = __$CodexUserInputQuestionDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String header, String question, List<CodexUserInputOptionDto>? options, bool isOther
+ String id, String header, String question, List<CodexUserInputOptionDto>? options, bool isOther, bool isSecret
 });
 
 
@@ -282,13 +284,14 @@ class __$CodexUserInputQuestionDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexUserInputQuestionDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? header = null,Object? question = null,Object? options = freezed,Object? isOther = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? header = null,Object? question = null,Object? options = freezed,Object? isOther = null,Object? isSecret = null,}) {
   return _then(_CodexUserInputQuestionDto(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,header: null == header ? _self.header : header // ignore: cast_nullable_to_non_nullable
 as String,question: null == question ? _self.question : question // ignore: cast_nullable_to_non_nullable
 as String,options: freezed == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
 as List<CodexUserInputOptionDto>?,isOther: null == isOther ? _self.isOther : isOther // ignore: cast_nullable_to_non_nullable
+as bool,isSecret: null == isSecret ? _self.isSecret : isSecret // ignore: cast_nullable_to_non_nullable
 as bool,
   ));
 }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.freezed.dart
@@ -1,0 +1,887 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint, type=warning, deprecated_member_use, deprecated_member_use_from_same_package
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'codex_user_input_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$CodexUserInputParamsDto {
+
+ List<CodexUserInputQuestionDto> get questions;
+/// Create a copy of CodexUserInputParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexUserInputParamsDtoCopyWith<CodexUserInputParamsDto> get copyWith => _$CodexUserInputParamsDtoCopyWithImpl<CodexUserInputParamsDto>(this as CodexUserInputParamsDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexUserInputParamsDto&&const DeepCollectionEquality().equals(other.questions, questions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(questions));
+
+@override
+String toString() {
+  return 'CodexUserInputParamsDto(questions: $questions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexUserInputParamsDtoCopyWith<$Res>  {
+  factory $CodexUserInputParamsDtoCopyWith(CodexUserInputParamsDto value, $Res Function(CodexUserInputParamsDto) _then) = _$CodexUserInputParamsDtoCopyWithImpl;
+@useResult
+$Res call({
+ List<CodexUserInputQuestionDto> questions
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexUserInputParamsDtoCopyWithImpl<$Res>
+    implements $CodexUserInputParamsDtoCopyWith<$Res> {
+  _$CodexUserInputParamsDtoCopyWithImpl(this._self, this._then);
+
+  final CodexUserInputParamsDto _self;
+  final $Res Function(CodexUserInputParamsDto) _then;
+
+/// Create a copy of CodexUserInputParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? questions = null,}) {
+  return _then(CodexUserInputParamsDto(
+questions: null == questions ? _self.questions : questions // ignore: cast_nullable_to_non_nullable
+as List<CodexUserInputQuestionDto>,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexUserInputParamsDto implements CodexUserInputParamsDto {
+  const _CodexUserInputParamsDto({required  List<CodexUserInputQuestionDto> questions}): _questions = questions;
+  factory _CodexUserInputParamsDto.fromJson(Map<String, dynamic> json) => _$CodexUserInputParamsDtoFromJson(json);
+
+ final  List<CodexUserInputQuestionDto> _questions;
+@override List<CodexUserInputQuestionDto> get questions {
+  if (_questions is EqualUnmodifiableListView) return _questions;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_questions);
+}
+
+
+/// Create a copy of CodexUserInputParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexUserInputParamsDtoCopyWith<_CodexUserInputParamsDto> get copyWith => __$CodexUserInputParamsDtoCopyWithImpl<_CodexUserInputParamsDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexUserInputParamsDto&&const DeepCollectionEquality().equals(other._questions, _questions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_questions));
+
+@override
+String toString() {
+  return 'CodexUserInputParamsDto(questions: $questions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexUserInputParamsDtoCopyWith<$Res> implements $CodexUserInputParamsDtoCopyWith<$Res> {
+  factory _$CodexUserInputParamsDtoCopyWith(_CodexUserInputParamsDto value, $Res Function(_CodexUserInputParamsDto) _then) = __$CodexUserInputParamsDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ List<CodexUserInputQuestionDto> questions
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexUserInputParamsDtoCopyWithImpl<$Res>
+    implements _$CodexUserInputParamsDtoCopyWith<$Res> {
+  __$CodexUserInputParamsDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexUserInputParamsDto _self;
+  final $Res Function(_CodexUserInputParamsDto) _then;
+
+/// Create a copy of CodexUserInputParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? questions = null,}) {
+  return _then(_CodexUserInputParamsDto(
+questions: null == questions ? _self._questions : questions // ignore: cast_nullable_to_non_nullable
+as List<CodexUserInputQuestionDto>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CodexUserInputQuestionDto {
+
+ String get id; String get header; String get question; List<CodexUserInputOptionDto>? get options; bool get isOther;
+/// Create a copy of CodexUserInputQuestionDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexUserInputQuestionDtoCopyWith<CodexUserInputQuestionDto> get copyWith => _$CodexUserInputQuestionDtoCopyWithImpl<CodexUserInputQuestionDto>(this as CodexUserInputQuestionDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexUserInputQuestionDto&&(identical(other.id, id) || other.id == id)&&(identical(other.header, header) || other.header == header)&&(identical(other.question, question) || other.question == question)&&const DeepCollectionEquality().equals(other.options, options)&&(identical(other.isOther, isOther) || other.isOther == isOther));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,header,question,const DeepCollectionEquality().hash(options),isOther);
+
+@override
+String toString() {
+  return 'CodexUserInputQuestionDto(id: $id, header: $header, question: $question, options: $options, isOther: $isOther)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexUserInputQuestionDtoCopyWith<$Res>  {
+  factory $CodexUserInputQuestionDtoCopyWith(CodexUserInputQuestionDto value, $Res Function(CodexUserInputQuestionDto) _then) = _$CodexUserInputQuestionDtoCopyWithImpl;
+@useResult
+$Res call({
+ String id, String header, String question, List<CodexUserInputOptionDto>? options, bool isOther
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexUserInputQuestionDtoCopyWithImpl<$Res>
+    implements $CodexUserInputQuestionDtoCopyWith<$Res> {
+  _$CodexUserInputQuestionDtoCopyWithImpl(this._self, this._then);
+
+  final CodexUserInputQuestionDto _self;
+  final $Res Function(CodexUserInputQuestionDto) _then;
+
+/// Create a copy of CodexUserInputQuestionDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? header = null,Object? question = null,Object? options = freezed,Object? isOther = null,}) {
+  return _then(CodexUserInputQuestionDto(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,header: null == header ? _self.header : header // ignore: cast_nullable_to_non_nullable
+as String,question: null == question ? _self.question : question // ignore: cast_nullable_to_non_nullable
+as String,options: freezed == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
+as List<CodexUserInputOptionDto>?,isOther: null == isOther ? _self.isOther : isOther // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexUserInputQuestionDto implements CodexUserInputQuestionDto {
+  const _CodexUserInputQuestionDto({required this.id, required this.header, required this.question, required  List<CodexUserInputOptionDto>? options, this.isOther = false}): _options = options;
+  factory _CodexUserInputQuestionDto.fromJson(Map<String, dynamic> json) => _$CodexUserInputQuestionDtoFromJson(json);
+
+@override final  String id;
+@override final  String header;
+@override final  String question;
+ final  List<CodexUserInputOptionDto>? _options;
+@override List<CodexUserInputOptionDto>? get options {
+  final value = _options;
+  if (value == null) return null;
+  if (_options is EqualUnmodifiableListView) return _options;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+@override@JsonKey() final  bool isOther;
+
+/// Create a copy of CodexUserInputQuestionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexUserInputQuestionDtoCopyWith<_CodexUserInputQuestionDto> get copyWith => __$CodexUserInputQuestionDtoCopyWithImpl<_CodexUserInputQuestionDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexUserInputQuestionDto&&(identical(other.id, id) || other.id == id)&&(identical(other.header, header) || other.header == header)&&(identical(other.question, question) || other.question == question)&&const DeepCollectionEquality().equals(other._options, _options)&&(identical(other.isOther, isOther) || other.isOther == isOther));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,header,question,const DeepCollectionEquality().hash(_options),isOther);
+
+@override
+String toString() {
+  return 'CodexUserInputQuestionDto(id: $id, header: $header, question: $question, options: $options, isOther: $isOther)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexUserInputQuestionDtoCopyWith<$Res> implements $CodexUserInputQuestionDtoCopyWith<$Res> {
+  factory _$CodexUserInputQuestionDtoCopyWith(_CodexUserInputQuestionDto value, $Res Function(_CodexUserInputQuestionDto) _then) = __$CodexUserInputQuestionDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String header, String question, List<CodexUserInputOptionDto>? options, bool isOther
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexUserInputQuestionDtoCopyWithImpl<$Res>
+    implements _$CodexUserInputQuestionDtoCopyWith<$Res> {
+  __$CodexUserInputQuestionDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexUserInputQuestionDto _self;
+  final $Res Function(_CodexUserInputQuestionDto) _then;
+
+/// Create a copy of CodexUserInputQuestionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? header = null,Object? question = null,Object? options = freezed,Object? isOther = null,}) {
+  return _then(_CodexUserInputQuestionDto(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,header: null == header ? _self.header : header // ignore: cast_nullable_to_non_nullable
+as String,question: null == question ? _self.question : question // ignore: cast_nullable_to_non_nullable
+as String,options: freezed == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
+as List<CodexUserInputOptionDto>?,isOther: null == isOther ? _self.isOther : isOther // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CodexUserInputOptionDto {
+
+ String get label; String get description;
+/// Create a copy of CodexUserInputOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexUserInputOptionDtoCopyWith<CodexUserInputOptionDto> get copyWith => _$CodexUserInputOptionDtoCopyWithImpl<CodexUserInputOptionDto>(this as CodexUserInputOptionDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexUserInputOptionDto&&(identical(other.label, label) || other.label == label)&&(identical(other.description, description) || other.description == description));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,label,description);
+
+@override
+String toString() {
+  return 'CodexUserInputOptionDto(label: $label, description: $description)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexUserInputOptionDtoCopyWith<$Res>  {
+  factory $CodexUserInputOptionDtoCopyWith(CodexUserInputOptionDto value, $Res Function(CodexUserInputOptionDto) _then) = _$CodexUserInputOptionDtoCopyWithImpl;
+@useResult
+$Res call({
+ String label, String description
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexUserInputOptionDtoCopyWithImpl<$Res>
+    implements $CodexUserInputOptionDtoCopyWith<$Res> {
+  _$CodexUserInputOptionDtoCopyWithImpl(this._self, this._then);
+
+  final CodexUserInputOptionDto _self;
+  final $Res Function(CodexUserInputOptionDto) _then;
+
+/// Create a copy of CodexUserInputOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? label = null,Object? description = null,}) {
+  return _then(CodexUserInputOptionDto(
+label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexUserInputOptionDto implements CodexUserInputOptionDto {
+  const _CodexUserInputOptionDto({required this.label, required this.description});
+  factory _CodexUserInputOptionDto.fromJson(Map<String, dynamic> json) => _$CodexUserInputOptionDtoFromJson(json);
+
+@override final  String label;
+@override final  String description;
+
+/// Create a copy of CodexUserInputOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexUserInputOptionDtoCopyWith<_CodexUserInputOptionDto> get copyWith => __$CodexUserInputOptionDtoCopyWithImpl<_CodexUserInputOptionDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexUserInputOptionDto&&(identical(other.label, label) || other.label == label)&&(identical(other.description, description) || other.description == description));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,label,description);
+
+@override
+String toString() {
+  return 'CodexUserInputOptionDto(label: $label, description: $description)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexUserInputOptionDtoCopyWith<$Res> implements $CodexUserInputOptionDtoCopyWith<$Res> {
+  factory _$CodexUserInputOptionDtoCopyWith(_CodexUserInputOptionDto value, $Res Function(_CodexUserInputOptionDto) _then) = __$CodexUserInputOptionDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String label, String description
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexUserInputOptionDtoCopyWithImpl<$Res>
+    implements _$CodexUserInputOptionDtoCopyWith<$Res> {
+  __$CodexUserInputOptionDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexUserInputOptionDto _self;
+  final $Res Function(_CodexUserInputOptionDto) _then;
+
+/// Create a copy of CodexUserInputOptionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? label = null,Object? description = null,}) {
+  return _then(_CodexUserInputOptionDto(
+label: null == label ? _self.label : label // ignore: cast_nullable_to_non_nullable
+as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$CodexQuestionItemParamsDto {
+
+ String get threadId; CodexQuestionItemDto get item;
+/// Create a copy of CodexQuestionItemParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexQuestionItemParamsDtoCopyWith<CodexQuestionItemParamsDto> get copyWith => _$CodexQuestionItemParamsDtoCopyWithImpl<CodexQuestionItemParamsDto>(this as CodexQuestionItemParamsDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexQuestionItemParamsDto&&(identical(other.threadId, threadId) || other.threadId == threadId)&&(identical(other.item, item) || other.item == item));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,threadId,item);
+
+@override
+String toString() {
+  return 'CodexQuestionItemParamsDto(threadId: $threadId, item: $item)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexQuestionItemParamsDtoCopyWith<$Res>  {
+  factory $CodexQuestionItemParamsDtoCopyWith(CodexQuestionItemParamsDto value, $Res Function(CodexQuestionItemParamsDto) _then) = _$CodexQuestionItemParamsDtoCopyWithImpl;
+@useResult
+$Res call({
+ String threadId, CodexQuestionItemDto item
+});
+
+
+$CodexQuestionItemDtoCopyWith<$Res> get item;
+
+}
+/// @nodoc
+class _$CodexQuestionItemParamsDtoCopyWithImpl<$Res>
+    implements $CodexQuestionItemParamsDtoCopyWith<$Res> {
+  _$CodexQuestionItemParamsDtoCopyWithImpl(this._self, this._then);
+
+  final CodexQuestionItemParamsDto _self;
+  final $Res Function(CodexQuestionItemParamsDto) _then;
+
+/// Create a copy of CodexQuestionItemParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? threadId = null,Object? item = null,}) {
+  return _then(CodexQuestionItemParamsDto(
+threadId: null == threadId ? _self.threadId : threadId // ignore: cast_nullable_to_non_nullable
+as String,item: null == item ? _self.item : item // ignore: cast_nullable_to_non_nullable
+as CodexQuestionItemDto,
+  ));
+}
+/// Create a copy of CodexQuestionItemParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexQuestionItemDtoCopyWith<$Res> get item {
+  
+  return $CodexQuestionItemDtoCopyWith<$Res>(_self.item, (value) {
+    return _then(_self.copyWith(item: value));
+  });
+}
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexQuestionItemParamsDto implements CodexQuestionItemParamsDto {
+  const _CodexQuestionItemParamsDto({required this.threadId, required this.item});
+  factory _CodexQuestionItemParamsDto.fromJson(Map<String, dynamic> json) => _$CodexQuestionItemParamsDtoFromJson(json);
+
+@override final  String threadId;
+@override final  CodexQuestionItemDto item;
+
+/// Create a copy of CodexQuestionItemParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexQuestionItemParamsDtoCopyWith<_CodexQuestionItemParamsDto> get copyWith => __$CodexQuestionItemParamsDtoCopyWithImpl<_CodexQuestionItemParamsDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexQuestionItemParamsDto&&(identical(other.threadId, threadId) || other.threadId == threadId)&&(identical(other.item, item) || other.item == item));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,threadId,item);
+
+@override
+String toString() {
+  return 'CodexQuestionItemParamsDto(threadId: $threadId, item: $item)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexQuestionItemParamsDtoCopyWith<$Res> implements $CodexQuestionItemParamsDtoCopyWith<$Res> {
+  factory _$CodexQuestionItemParamsDtoCopyWith(_CodexQuestionItemParamsDto value, $Res Function(_CodexQuestionItemParamsDto) _then) = __$CodexQuestionItemParamsDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String threadId, CodexQuestionItemDto item
+});
+
+
+@override $CodexQuestionItemDtoCopyWith<$Res> get item;
+
+}
+/// @nodoc
+class __$CodexQuestionItemParamsDtoCopyWithImpl<$Res>
+    implements _$CodexQuestionItemParamsDtoCopyWith<$Res> {
+  __$CodexQuestionItemParamsDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexQuestionItemParamsDto _self;
+  final $Res Function(_CodexQuestionItemParamsDto) _then;
+
+/// Create a copy of CodexQuestionItemParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? threadId = null,Object? item = null,}) {
+  return _then(_CodexQuestionItemParamsDto(
+threadId: null == threadId ? _self.threadId : threadId // ignore: cast_nullable_to_non_nullable
+as String,item: null == item ? _self.item : item // ignore: cast_nullable_to_non_nullable
+as CodexQuestionItemDto,
+  ));
+}
+
+/// Create a copy of CodexQuestionItemParamsDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexQuestionItemDtoCopyWith<$Res> get item {
+  
+  return $CodexQuestionItemDtoCopyWith<$Res>(_self.item, (value) {
+    return _then(_self.copyWith(item: value));
+  });
+}
+}
+
+CodexQuestionItemDto _$CodexQuestionItemDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'agentMessage':
+          return CodexAgentQuestionItemDto.fromJson(
+            json
+          );
+        
+          default:
+            return CodexUnknownQuestionItemDto.fromJson(
+  json
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$CodexQuestionItemDto {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexQuestionItemDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexQuestionItemDto()';
+}
+
+
+}
+
+/// @nodoc
+class $CodexQuestionItemDtoCopyWith<$Res>  {
+$CodexQuestionItemDtoCopyWith(CodexQuestionItemDto _, $Res Function(CodexQuestionItemDto) __);
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexAgentQuestionItemDto implements CodexQuestionItemDto {
+  const CodexAgentQuestionItemDto({required this.id, @JsonKey(unknownEnumValue: CodexAgentMessageDelivery.unknown) required this.delivery, required  List<CodexAsyncUserInputQuestionDto>? questions,  String? $type}): _questions = questions,$type = $type ?? 'agentMessage';
+  factory CodexAgentQuestionItemDto.fromJson(Map<String, dynamic> json) => _$CodexAgentQuestionItemDtoFromJson(json);
+
+ final  String id;
+@JsonKey(unknownEnumValue: CodexAgentMessageDelivery.unknown) final  CodexAgentMessageDelivery? delivery;
+ final  List<CodexAsyncUserInputQuestionDto>? _questions;
+ List<CodexAsyncUserInputQuestionDto>? get questions {
+  final value = _questions;
+  if (value == null) return null;
+  if (_questions is EqualUnmodifiableListView) return _questions;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexQuestionItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexAgentQuestionItemDtoCopyWith<CodexAgentQuestionItemDto> get copyWith => _$CodexAgentQuestionItemDtoCopyWithImpl<CodexAgentQuestionItemDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexAgentQuestionItemDto&&(identical(other.id, id) || other.id == id)&&(identical(other.delivery, delivery) || other.delivery == delivery)&&const DeepCollectionEquality().equals(other._questions, _questions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,delivery,const DeepCollectionEquality().hash(_questions));
+
+@override
+String toString() {
+  return 'CodexQuestionItemDto.agentMessage(id: $id, delivery: $delivery, questions: $questions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexAgentQuestionItemDtoCopyWith<$Res> implements $CodexQuestionItemDtoCopyWith<$Res> {
+  factory $CodexAgentQuestionItemDtoCopyWith(CodexAgentQuestionItemDto value, $Res Function(CodexAgentQuestionItemDto) _then) = _$CodexAgentQuestionItemDtoCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(unknownEnumValue: CodexAgentMessageDelivery.unknown) CodexAgentMessageDelivery? delivery, List<CodexAsyncUserInputQuestionDto>? questions
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexAgentQuestionItemDtoCopyWithImpl<$Res>
+    implements $CodexAgentQuestionItemDtoCopyWith<$Res> {
+  _$CodexAgentQuestionItemDtoCopyWithImpl(this._self, this._then);
+
+  final CodexAgentQuestionItemDto _self;
+  final $Res Function(CodexAgentQuestionItemDto) _then;
+
+/// Create a copy of CodexQuestionItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,Object? delivery = freezed,Object? questions = freezed,}) {
+  return _then(CodexAgentQuestionItemDto(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,delivery: freezed == delivery ? _self.delivery : delivery // ignore: cast_nullable_to_non_nullable
+as CodexAgentMessageDelivery?,questions: freezed == questions ? _self._questions : questions // ignore: cast_nullable_to_non_nullable
+as List<CodexAsyncUserInputQuestionDto>?,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexUnknownQuestionItemDto implements CodexQuestionItemDto {
+  const CodexUnknownQuestionItemDto({ String? $type}): $type = $type ?? 'unknown';
+  factory CodexUnknownQuestionItemDto.fromJson(Map<String, dynamic> json) => _$CodexUnknownQuestionItemDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexUnknownQuestionItemDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexQuestionItemDto.unknown()';
+}
+
+
+}
+
+
+
+
+
+/// @nodoc
+mixin _$CodexAsyncUserInputQuestionDto {
+
+ String get title; List<String>? get options;
+/// Create a copy of CodexAsyncUserInputQuestionDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexAsyncUserInputQuestionDtoCopyWith<CodexAsyncUserInputQuestionDto> get copyWith => _$CodexAsyncUserInputQuestionDtoCopyWithImpl<CodexAsyncUserInputQuestionDto>(this as CodexAsyncUserInputQuestionDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexAsyncUserInputQuestionDto&&(identical(other.title, title) || other.title == title)&&const DeepCollectionEquality().equals(other.options, options));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,title,const DeepCollectionEquality().hash(options));
+
+@override
+String toString() {
+  return 'CodexAsyncUserInputQuestionDto(title: $title, options: $options)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexAsyncUserInputQuestionDtoCopyWith<$Res>  {
+  factory $CodexAsyncUserInputQuestionDtoCopyWith(CodexAsyncUserInputQuestionDto value, $Res Function(CodexAsyncUserInputQuestionDto) _then) = _$CodexAsyncUserInputQuestionDtoCopyWithImpl;
+@useResult
+$Res call({
+ String title, List<String>? options
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexAsyncUserInputQuestionDtoCopyWithImpl<$Res>
+    implements $CodexAsyncUserInputQuestionDtoCopyWith<$Res> {
+  _$CodexAsyncUserInputQuestionDtoCopyWithImpl(this._self, this._then);
+
+  final CodexAsyncUserInputQuestionDto _self;
+  final $Res Function(CodexAsyncUserInputQuestionDto) _then;
+
+/// Create a copy of CodexAsyncUserInputQuestionDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? title = null,Object? options = freezed,}) {
+  return _then(CodexAsyncUserInputQuestionDto(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,options: freezed == options ? _self.options : options // ignore: cast_nullable_to_non_nullable
+as List<String>?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexAsyncUserInputQuestionDto implements CodexAsyncUserInputQuestionDto {
+  const _CodexAsyncUserInputQuestionDto({required this.title, required  List<String>? options}): _options = options;
+  factory _CodexAsyncUserInputQuestionDto.fromJson(Map<String, dynamic> json) => _$CodexAsyncUserInputQuestionDtoFromJson(json);
+
+@override final  String title;
+ final  List<String>? _options;
+@override List<String>? get options {
+  final value = _options;
+  if (value == null) return null;
+  if (_options is EqualUnmodifiableListView) return _options;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
+
+/// Create a copy of CodexAsyncUserInputQuestionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexAsyncUserInputQuestionDtoCopyWith<_CodexAsyncUserInputQuestionDto> get copyWith => __$CodexAsyncUserInputQuestionDtoCopyWithImpl<_CodexAsyncUserInputQuestionDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexAsyncUserInputQuestionDto&&(identical(other.title, title) || other.title == title)&&const DeepCollectionEquality().equals(other._options, _options));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,title,const DeepCollectionEquality().hash(_options));
+
+@override
+String toString() {
+  return 'CodexAsyncUserInputQuestionDto(title: $title, options: $options)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexAsyncUserInputQuestionDtoCopyWith<$Res> implements $CodexAsyncUserInputQuestionDtoCopyWith<$Res> {
+  factory _$CodexAsyncUserInputQuestionDtoCopyWith(_CodexAsyncUserInputQuestionDto value, $Res Function(_CodexAsyncUserInputQuestionDto) _then) = __$CodexAsyncUserInputQuestionDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String title, List<String>? options
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexAsyncUserInputQuestionDtoCopyWithImpl<$Res>
+    implements _$CodexAsyncUserInputQuestionDtoCopyWith<$Res> {
+  __$CodexAsyncUserInputQuestionDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexAsyncUserInputQuestionDto _self;
+  final $Res Function(_CodexAsyncUserInputQuestionDto) _then;
+
+/// Create a copy of CodexAsyncUserInputQuestionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? title = null,Object? options = freezed,}) {
+  return _then(_CodexAsyncUserInputQuestionDto(
+title: null == title ? _self.title : title // ignore: cast_nullable_to_non_nullable
+as String,options: freezed == options ? _self._options : options // ignore: cast_nullable_to_non_nullable
+as List<String>?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.g.dart
@@ -1,0 +1,82 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'codex_user_input_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_CodexUserInputParamsDto _$CodexUserInputParamsDtoFromJson(Map json) =>
+    _CodexUserInputParamsDto(
+      questions: (json['questions'] as List<dynamic>)
+          .map(
+            (e) => CodexUserInputQuestionDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
+    );
+
+_CodexUserInputQuestionDto _$CodexUserInputQuestionDtoFromJson(Map json) =>
+    _CodexUserInputQuestionDto(
+      id: json['id'] as String,
+      header: json['header'] as String,
+      question: json['question'] as String,
+      options: (json['options'] as List<dynamic>?)
+          ?.map(
+            (e) => CodexUserInputOptionDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
+      isOther: json['isOther'] as bool? ?? false,
+    );
+
+_CodexUserInputOptionDto _$CodexUserInputOptionDtoFromJson(Map json) =>
+    _CodexUserInputOptionDto(
+      label: json['label'] as String,
+      description: json['description'] as String,
+    );
+
+_CodexQuestionItemParamsDto _$CodexQuestionItemParamsDtoFromJson(Map json) =>
+    _CodexQuestionItemParamsDto(
+      threadId: json['threadId'] as String,
+      item: CodexQuestionItemDto.fromJson(
+        Map<String, dynamic>.from(json['item'] as Map),
+      ),
+    );
+
+CodexAgentQuestionItemDto _$CodexAgentQuestionItemDtoFromJson(Map json) =>
+    CodexAgentQuestionItemDto(
+      id: json['id'] as String,
+      delivery: $enumDecodeNullable(
+        _$CodexAgentMessageDeliveryEnumMap,
+        json['delivery'],
+        unknownValue: CodexAgentMessageDelivery.unknown,
+      ),
+      questions: (json['questions'] as List<dynamic>?)
+          ?.map(
+            (e) => CodexAsyncUserInputQuestionDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
+      $type: json['type'] as String?,
+    );
+
+const _$CodexAgentMessageDeliveryEnumMap = {
+  CodexAgentMessageDelivery.async: 'async',
+  CodexAgentMessageDelivery.unknown: 'unknown',
+};
+
+CodexUnknownQuestionItemDto _$CodexUnknownQuestionItemDtoFromJson(Map json) =>
+    CodexUnknownQuestionItemDto($type: json['type'] as String?);
+
+_CodexAsyncUserInputQuestionDto _$CodexAsyncUserInputQuestionDtoFromJson(
+  Map json,
+) => _CodexAsyncUserInputQuestionDto(
+  title: json['title'] as String,
+  options: (json['options'] as List<dynamic>?)
+      ?.map((e) => e as String)
+      .toList(),
+);

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_user_input_dto.g.dart
@@ -30,6 +30,7 @@ _CodexUserInputQuestionDto _$CodexUserInputQuestionDtoFromJson(Map json) =>
           )
           .toList(),
       isOther: json['isOther'] as bool? ?? false,
+      isSecret: json['isSecret'] as bool? ?? false,
     );
 
 _CodexUserInputOptionDto _$CodexUserInputOptionDtoFromJson(Map json) =>

--- a/bridge/sesori_plugin_codex/lib/src/api/parsers/codex_question_parser.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/parsers/codex_question_parser.dart
@@ -1,0 +1,29 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
+
+import "../../codex_app_server_client.dart";
+import "../models/codex_user_input_dto.dart";
+
+class const CodexQuestionParser() {
+  CodexUserInputParamsDto parseUserInput({required Map<String, dynamic> params}) =>
+      CodexUserInputParamsDto.fromJson(params);
+
+  ({String threadId, List<CodexAsyncUserInputQuestionDto> questions})? parseAsyncQuestion({
+    required CodexServerNotification notification,
+  }) {
+    if (notification.method != "item/completed") return null;
+    try {
+      final params = CodexQuestionItemParamsDto.fromJson(notification.params);
+      if (params.item
+          case CodexAgentQuestionItemDto(
+            delivery: CodexAgentMessageDelivery.async,
+            questions: final questions?,
+          )
+          when questions.isNotEmpty) {
+        return (threadId: params.threadId, questions: questions);
+      }
+    } on Object catch (error, stackTrace) {
+      Log.w("[codex] failed to decode question item notification", error, stackTrace);
+    }
+    return null;
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
+++ b/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
@@ -232,6 +232,10 @@ class ApprovalRegistry({
       );
     } else if (method == _userInputMethod) {
       final input = _questionParser.parseUserInput(params: request.params);
+      if (input.questions.any((question) => question.isSecret)) {
+        _respondError(request.id, -32602, "Secret question input is not supported by Sesori.");
+        return;
+      }
       registerPendingQuestion(
         payload: _PendingUserInput(codexId: request.id, input: input, respond: _respond, respondError: _respondError),
         sessionId: resolvedSessionId,

--- a/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
+++ b/bridge/sesori_plugin_codex/lib/src/approval_registry.dart
@@ -1,6 +1,12 @@
+import "dart:async";
+
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
+import "api/models/codex_pending_input.dart";
+import "api/models/codex_user_input_dto.dart";
+import "api/parsers/codex_question_parser.dart";
 import "codex_app_server_client.dart";
+import "repositories/mappers/codex_question_mapper.dart";
 
 /// Codex methods that always surface as permission asks.
 ///
@@ -49,43 +55,97 @@ enum _ElicitationApprovalKind() {
   toolSuggestion,
 }
 
-class _PendingApproval({
+sealed class _PendingCodexInput();
+
+final class _PendingApproval({
   required final Object codexId,
   required final String method,
   required final Map<String, dynamic> params,
   required final ApprovalResponder respond,
   required final ApprovalErrorResponder respondError,
-});
+}) extends _PendingCodexInput;
+
+final class _PendingAsyncQuestion({
+  required final String sessionId,
+  required final List<PluginQuestionInfo> questions,
+  required final AsyncQuestionResponder respond,
+  required final CodexQuestionMapper mapper,
+}) extends _PendingCodexInput {
+  Future<void> answer({required List<List<String>> answers}) => respond(
+    sessionId: sessionId,
+    text: mapper.asyncAnswerText(questions: questions, answers: answers),
+  );
+}
+
+final class _PendingUserInput({
+  required final Object codexId,
+  required final CodexUserInputParamsDto input,
+  required final ApprovalResponder respond,
+  required final ApprovalErrorResponder respondError,
+}) extends _PendingCodexInput;
 
 /// Per-request reply functions injected at construction time so the
 /// registry stays decoupled from [CodexAppServerClient].
 typedef ApprovalResponder = void Function(Object id, Object? result);
 typedef ApprovalErrorResponder = void Function(Object id, int code, String message);
+typedef AsyncQuestionResponder = Future<void> Function({required String sessionId, required String text});
 typedef PendingInputScopeResolver = ({String displaySessionId, List<String> sourceSessionIds}) Function({
   required String sessionId,
 });
 
-void _resolveCodexPermission({required _PendingApproval payload, required PluginPermissionReply reply}) {
-  payload.respond(payload.codexId, ApprovalRegistry._permissionResponse(payload, reply));
+void _resolveCodexPermission({required _PendingCodexInput payload, required PluginPermissionReply reply}) {
+  final approval = payload as _PendingApproval;
+  approval.respond(approval.codexId, ApprovalRegistry._permissionResponse(approval, reply));
 }
 
-PendingQuestionReplyOutcome _resolveCodexQuestion({
-  required _PendingApproval payload,
+FutureOr<PendingQuestionReplyOutcome> _resolveCodexQuestion({
+  required _PendingCodexInput payload,
   required List<List<String>> answers,
 }) {
-  payload.respond(payload.codexId, ApprovalRegistry._questionResponse(payload, answers));
-  return PendingQuestionReplyOutcome.replied;
+  switch (payload) {
+    case _PendingApproval():
+      payload.respond(payload.codexId, ApprovalRegistry._questionResponse(payload, answers));
+      return PendingQuestionReplyOutcome.replied;
+    case _PendingAsyncQuestion():
+      return payload.answer(answers: answers).then((_) => PendingQuestionReplyOutcome.replied);
+    case _PendingUserInput():
+      final questions = payload.input.questions;
+      payload.respond(payload.codexId, {
+        "answers": {
+          for (var i = 0; i < questions.length; i++)
+            questions[i].id: {"answers": i < answers.length ? answers[i] : const <String>[]},
+        },
+      });
+      return PendingQuestionReplyOutcome.replied;
+  }
 }
 
-void _rejectCodexQuestion({required _PendingApproval payload}) {
-  if (payload.method == _elicitationMethod) {
-    payload.respond(payload.codexId, const {"action": "decline"});
+FutureOr<void> _rejectCodexQuestion({
+  required _PendingCodexInput payload,
+}) {
+  switch (payload) {
+    case _PendingAsyncQuestion():
+      return payload.answer(answers: const []);
+    case _PendingUserInput():
+      payload.respondError(payload.codexId, -32603, "user rejected");
+    case _PendingApproval():
+      if (payload.method == _elicitationMethod) {
+        payload.respond(payload.codexId, const {"action": "decline"});
+      } else {
+        payload.respondError(payload.codexId, -32603, "user rejected");
+      }
+  }
+}
+
+void _cancelCodexPending({required _PendingCodexInput payload, required PendingCancellationReason reason}) {
+  // Async questions have no suspended server request. Teardown only retires
+  // their local card; it must not start a new turn to send a cancellation.
+  if (payload is _PendingAsyncQuestion) return;
+  if (payload is _PendingUserInput) {
+    payload.respondError(payload.codexId, -32000, _cancellationMessage(reason: reason));
     return;
   }
-  payload.respondError(payload.codexId, -32603, "user rejected");
-}
-
-void _cancelCodexPending({required _PendingApproval payload, required PendingCancellationReason reason}) {
+  payload as _PendingApproval;
   if (_permissionMethods.contains(payload.method) ||
       payload.method == _elicitationMethod && ApprovalRegistry._isMcpToolApproval(payload.params)) {
     payload.respond(payload.codexId, ApprovalRegistry._permissionResponse(payload, PluginPermissionReply.reject));
@@ -95,13 +155,15 @@ void _cancelCodexPending({required _PendingApproval payload, required PendingCan
     payload.respondError(
       payload.codexId,
       -32000,
-      switch (reason) {
-        PendingCancellationReason.sessionCancelled => "thread closed",
-        PendingCancellationReason.disposed => "bridge dispose",
-      },
+      _cancellationMessage(reason: reason),
     );
   }
 }
+
+String _cancellationMessage({required PendingCancellationReason reason}) => switch (reason) {
+  PendingCancellationReason.sessionCancelled => "thread closed",
+  PendingCancellationReason.disposed => "bridge dispose",
+};
 
 /// Routes codex server-originated approval requests to the bridge SSE
 /// stream and answers them when the bridge consumer replies.
@@ -112,8 +174,11 @@ class ApprovalRegistry({
   required final ApprovalResponder _respond,
   required final ApprovalErrorResponder _respondError,
   required final PendingInputScopeResolver _resolvePendingInputScope,
+  required final AsyncQuestionResponder _sendAsyncAnswer,
+  required final CodexQuestionParser _questionParser,
+  required final CodexQuestionMapper _questionMapper,
   super.idGenerator,
-}) extends PendingPermissionRegistry<CodexServerRequest, _PendingApproval> {
+}) extends PendingPermissionRegistry<CodexPendingInput, _PendingCodexInput> {
   this
     : super(
         logContext: "[codex]",
@@ -124,7 +189,16 @@ class ApprovalRegistry({
       );
 
   @override
-  void handleRequest(CodexServerRequest request) {
+  void handleRequest(CodexPendingInput input) {
+    switch (input) {
+      case CodexPendingRequest(:final request):
+        _handleServerRequest(request: request);
+      case CodexPendingNotification(:final notification):
+        _handleNotification(notification: notification);
+    }
+  }
+
+  void _handleServerRequest({required CodexServerRequest request}) {
     final method = request.method;
     final isMcpToolApproval = method == _elicitationMethod && _isMcpToolApproval(request.params);
     final isPermission = _permissionMethods.contains(method) || isMcpToolApproval;
@@ -156,12 +230,40 @@ class ApprovalRegistry({
         description: _permissionDescriptionFor(entry),
         allowAlways: allowAlways,
       );
+    } else if (method == _userInputMethod) {
+      final input = _questionParser.parseUserInput(params: request.params);
+      registerPendingQuestion(
+        payload: _PendingUserInput(codexId: request.id, input: input, respond: _respond, respondError: _respondError),
+        sessionId: resolvedSessionId,
+        displaySessionId: displaySessionId,
+        questions: _questionMapper.mapUserInput(request: input),
+      );
     } else {
       registerPendingQuestion(
         payload: entry,
         sessionId: resolvedSessionId,
         displaySessionId: displaySessionId,
-        questions: [_questionInfoFor(entry)],
+        questions: _questionInfoFor(entry),
+      );
+    }
+  }
+
+  /// `request_user_input_async` is delivered as an assistant message, not a
+  /// server request. Both forms share the existing pending-question surface.
+  void _handleNotification({required CodexServerNotification notification}) {
+    final request = _questionParser.parseAsyncQuestion(notification: notification);
+    if (request != null) {
+      final questions = _questionMapper.mapAsyncQuestions(questions: request.questions);
+      registerPendingQuestion(
+        payload: _PendingAsyncQuestion(
+          sessionId: request.threadId,
+          questions: questions,
+          respond: _sendAsyncAnswer,
+          mapper: _questionMapper,
+        ),
+        sessionId: request.threadId,
+        displaySessionId: _resolvePendingInputScope(sessionId: request.threadId).displaySessionId,
+        questions: questions,
       );
     }
   }
@@ -190,21 +292,20 @@ class ApprovalRegistry({
     return persist is List && persist.contains("always");
   }
 
-  /// Builds the single free-form question payload for a codex elicitation /
-  /// user-input request: codex supplies no structured option set, so it is
-  /// always a [PluginQuestionInfo.custom] question headed by the wire method.
-  PluginQuestionInfo _questionInfoFor(_PendingApproval entry) {
+  List<PluginQuestionInfo> _questionInfoFor(_PendingApproval entry) {
     final reason =
         (entry.params["message"] as String?) ??
         (entry.params["reason"] as String?) ??
         _descriptionFallback(entry.method, entry.params);
-    return PluginQuestionInfo(
-      question: reason,
-      header: entry.method,
-      options: const [],
-      multiple: false,
-      custom: true,
-    );
+    return [
+      PluginQuestionInfo(
+        question: reason,
+        header: entry.method,
+        options: const [],
+        multiple: false,
+        custom: true,
+      ),
+    ];
   }
 
   /// Human-readable description for a permission ask, shared by the
@@ -278,25 +379,11 @@ class ApprovalRegistry({
   }
 
   /// Builds the JSON-RPC result for a question reply, keyed by wire method:
-  ///   - `item/tool/requestUserInput` → `{answers: {<qid>: {answers: [..]}}}`
   ///   - `mcpServer/elicitation/request` → `{action: accept, content}`
   static Map<String, dynamic> _questionResponse(
     _PendingApproval entry,
     List<List<String>> answers,
   ) {
-    if (entry.method == _userInputMethod) {
-      // Map answers to codex's question-id-keyed shape, pairing each answer row
-      // with its question by order (the mobile prompt preserves question order).
-      final questions = (entry.params["questions"] as List?) ?? const [];
-      final out = <String, dynamic>{};
-      for (var i = 0; i < questions.length; i++) {
-        final qid = _asMap(questions[i])?["id"] as String?;
-        if (qid == null) continue;
-        out[qid] = {"answers": i < answers.length ? answers[i] : const <String>[]};
-      }
-      return {"answers": out};
-    }
-
     if (entry.method == _elicitationMethod) {
       // Accept the elicitation. `content` mirrors the server-defined form
       // schema, which the bridge cannot model generically; pass the flattened

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -267,6 +267,12 @@ class CodexPlugin._({
     _eventMapper.resetLiveItemTimes();
     _keepaliveTimer?.cancel();
     _keepaliveTimer = null;
+    unawaited(
+      _serverRequestSubscription?.cancel().catchError((Object error, StackTrace stackTrace) {
+        Log.w("[codex] failed to cancel server-request subscription after disconnect", error, stackTrace);
+      }),
+    );
+    _serverRequestSubscription = null;
     _approvalRegistry = null;
     unawaited(registry?.dispose());
     _sessionStatuses.clear();

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -7,12 +7,14 @@ import "package:sesori_shared/sesori_shared.dart" show Harness;
 import "api/codex_app_server_api.dart";
 import "api/models/codex_correlatable_item_event_dto.dart";
 import "api/models/codex_image_bearing_item_dto.dart";
+import "api/models/codex_pending_input.dart";
 import "api/models/codex_rollout_dto.dart";
 import "api/models/codex_sub_agent_item_dto.dart";
 import "api/models/codex_sub_agent_item_event_dto.dart";
 import "api/parsers/codex_command_execution_parser.dart";
 import "api/parsers/codex_file_change_parser.dart";
 import "api/parsers/codex_image_bearing_item_parser.dart";
+import "api/parsers/codex_question_parser.dart";
 import "api/parsers/codex_sub_agent_item_parser.dart";
 import "approval_registry.dart";
 import "codex_app_server_client.dart";
@@ -23,6 +25,7 @@ import "repositories/codex_skill_repository.dart";
 import "repositories/codex_thread_repository.dart";
 import "repositories/codex_tool_lifecycle_tracker.dart";
 import "repositories/codex_tool_outcome_repository.dart";
+import "repositories/mappers/codex_question_mapper.dart";
 import "repositories/models/codex_thread_record.dart";
 import "runtime/codex_managed_api.dart";
 import "services/codex_rollout_tailer.dart";
@@ -86,6 +89,7 @@ class CodexPlugin._({
   CodexAppServerClient? _client;
   Future<bool>? _connectFuture;
   StreamSubscription<CodexServerNotification>? _notificationSubscription;
+  StreamSubscription<CodexServerRequest>? _serverRequestSubscription;
   Future<void> _notificationWork = Future<void>.value();
   StreamSubscription<CodexRolloutAppend>? _rolloutSubscription;
   ApprovalRegistry? _approvalRegistry;
@@ -322,6 +326,7 @@ class CodexPlugin._({
       return;
     }
     if (_isSupersededTurnLifecycleNotification(notification)) return;
+    _approvalRegistry?.handleRequest(CodexPendingNotification(notification: notification));
     final subAgentItem = _subAgentItemParser.parse(notification: notification);
     if (subAgentItem case CodexSubAgentActivity(
       lifecycle: CodexCorrelatableItemLifecycle.started,
@@ -540,9 +545,22 @@ class CodexPlugin._({
         message: message,
       ),
       resolvePendingInputScope: _sessionService.pendingInputScope,
+      questionParser: const CodexQuestionParser(),
+      questionMapper: const CodexQuestionMapper(),
+      sendAsyncAnswer: ({required sessionId, required text}) => _startTurn(
+        threadId: sessionId,
+        promptId: null,
+        parts: [PluginPromptPart.text(text: text)],
+        collaborationMode: null,
+      ),
     );
     _approvalRegistry = registry;
-    registry.attach(stream: client.serverRequests);
+    // This plugin owns both app-server streams. Both pending-input sources
+    // enter the same registry, with notifications retaining their serialized
+    // lifecycle/child-scope processing above.
+    _serverRequestSubscription = client.serverRequests.listen(
+      (request) => registry.handleRequest(CodexPendingRequest(request: request)),
+    );
   }
 
   void _emitApprovalEvent({required ApprovalRegistry registry, required BridgeSseEvent event}) {
@@ -1474,7 +1492,7 @@ class CodexPlugin._({
   }) async {
     final registry = _approvalRegistry;
     if (registry == null) return;
-    registry.replyQuestion(requestId: questionId, answers: answers);
+    await registry.replyQuestion(requestId: questionId, answers: answers);
   }
 
   @override
@@ -1484,7 +1502,7 @@ class CodexPlugin._({
   }) async {
     // sessionId is unused: the approval registry keys pending requests by their
     // bridge request id alone (codex requests are globally unique per session).
-    _approvalRegistry?.rejectQuestion(requestId: questionId);
+    await _approvalRegistry?.rejectQuestion(requestId: questionId);
   }
 
   @override
@@ -1529,6 +1547,8 @@ class CodexPlugin._({
 
     await capture(() => _notificationSubscription?.cancel() ?? Future<void>.value());
     _notificationSubscription = null;
+    await capture(() => _serverRequestSubscription?.cancel() ?? Future<void>.value());
+    _serverRequestSubscription = null;
     await capture(() => _notificationWork);
     await capture(() => _rolloutSubscription?.cancel() ?? Future<void>.value());
     _rolloutSubscription = null;

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_question_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_question_mapper.dart
@@ -1,0 +1,45 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../../api/models/codex_user_input_dto.dart";
+
+/// Both Codex question forms use the same backend-neutral question contract.
+class const CodexQuestionMapper() {
+  List<PluginQuestionInfo> mapUserInput({required CodexUserInputParamsDto request}) => [
+    for (final item in request.questions)
+      PluginQuestionInfo(
+        question: item.question,
+        header: item.header,
+        options: [
+          for (final option in item.options ?? const <CodexUserInputOptionDto>[])
+            PluginQuestionOption(label: option.label, description: option.description),
+        ],
+        multiple: false,
+        custom: item.isOther || (item.options?.isEmpty ?? true),
+      ),
+  ];
+
+  List<PluginQuestionInfo> mapAsyncQuestions({required List<CodexAsyncUserInputQuestionDto> questions}) => [
+    for (final item in questions)
+      PluginQuestionInfo(
+        question: item.title,
+        header: "Question",
+        options: [
+          // Async choices supply labels only. The existing question wire
+          // contract uses blank description text for label-only choices.
+          for (final option in item.options ?? const <String>[]) PluginQuestionOption(label: option, description: ""),
+        ],
+        multiple: false,
+        custom: true,
+      ),
+  ];
+
+  String asyncAnswerText({required List<PluginQuestionInfo> questions, required List<List<String>> answers}) {
+    final text = StringBuffer("User answers to your questions:\n");
+    for (var i = 0; i < questions.length; i++) {
+      text.writeln("\nQuestion: ${questions[i].question}");
+      final row = i < answers.length ? answers[i] : const <String>[];
+      text.writeln(row.isEmpty ? "Answer: Declined to answer." : "Answer: ${row.join('\n')}");
+    }
+    return text.toString().trimRight();
+  }
+}

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -265,7 +265,12 @@ class const CodexRolloutToolMapper({
     required CodexRolloutResponseItemDto payload,
   }) {
     return switch (payload) {
-      CodexRolloutFunctionCallDto(:final name) => name.toLowerCase() == "wait",
+      // Async input is an assistant question. Its immediate `accepted` tool
+      // output acknowledges delivery and must not look like a user's answer.
+      CodexRolloutFunctionCallDto(:final name) => switch (name.toLowerCase()) {
+        "wait" || "request_user_input_async" => true,
+        _ => false,
+      },
       CodexRolloutCustomToolCallDto(:final name, :final input) =>
         name.toLowerCase() == "exec" && _isGeneratedImageInvocation(input),
       CodexRolloutMessageDto() ||

--- a/bridge/sesori_plugin_codex/test/approval_registry_test.dart
+++ b/bridge/sesori_plugin_codex/test/approval_registry_test.dart
@@ -405,6 +405,29 @@ void main() {
       });
     });
 
+    test("secret input fails explicitly without presenting a plain-text question", () async {
+      requests.add(
+        const CodexServerRequest(
+          id: 191,
+          method: "item/tool/requestUserInput",
+          params: {
+            "threadId": "t-3",
+            "questions": [
+              {"id": "details", "header": "Details", "question": "Any constraints?"},
+              {"id": "token", "header": "Token", "question": "Enter token", "isSecret": true},
+            ],
+          },
+        ),
+      );
+      await pump();
+      expect(emitted, isEmpty);
+      expect(registry.pendingForSession(sessionId: "t-3"), isEmpty);
+      expect(respondCalls, isEmpty);
+      expect(errorCalls.single.id, 191);
+      expect(errorCalls.single.code, -32602);
+      expect(errorCalls.single.message, "Secret question input is not supported by Sesori.");
+    });
+
     test("async assistant questions use the same pending surface and submit contextual answers", () async {
       registry.handleRequest(
         const CodexPendingNotification(

--- a/bridge/sesori_plugin_codex/test/approval_registry_test.dart
+++ b/bridge/sesori_plugin_codex/test/approval_registry_test.dart
@@ -3,6 +3,9 @@
 import "dart:async";
 
 import "package:codex_plugin/codex_plugin.dart";
+import "package:codex_plugin/src/api/models/codex_pending_input.dart";
+import "package:codex_plugin/src/api/parsers/codex_question_parser.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_question_mapper.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -12,6 +15,7 @@ void main() {
     late List<BridgeSseEvent> emitted;
     late List<_RespondCall> respondCalls;
     late List<_RespondError> errorCalls;
+    late List<({String sessionId, String text})> asyncAnswers;
     late ApprovalRegistry registry;
 
     setUp(() {
@@ -19,16 +23,21 @@ void main() {
       emitted = [];
       respondCalls = [];
       errorCalls = [];
+      asyncAnswers = [];
       registry = ApprovalRegistry(
         emit: emitted.add,
+        questionParser: const CodexQuestionParser(),
+        questionMapper: const CodexQuestionMapper(),
         respond: (id, result) => respondCalls.add(_RespondCall(id, result)),
         respondError: (id, code, message) => errorCalls.add(_RespondError(id, code, message)),
+        sendAsyncAnswer: ({required sessionId, required text}) async =>
+            asyncAnswers.add((sessionId: sessionId, text: text)),
         resolvePendingInputScope: ({required sessionId}) => (
           displaySessionId: sessionId,
           sourceSessionIds: [sessionId],
         ),
       );
-      registry.attach(stream: requests.stream);
+      registry.attach(stream: requests.stream.map((request) => CodexPendingRequest(request: request)));
     });
 
     tearDown(() async {
@@ -332,6 +341,186 @@ void main() {
 
     // --- v2 elicitation + user input questions ---
 
+    test("structured input preserves every question, option and question-id reply", () async {
+      requests.add(
+        const CodexServerRequest(
+          id: 190,
+          method: "item/tool/requestUserInput",
+          params: {
+            "threadId": "t-3",
+            "questions": [
+              {
+                "id": "interface",
+                "header": "Interface",
+                "question": "Which Hermes interface?",
+                "isOther": true,
+                "options": [
+                  {"label": "Sesori", "description": "Use the ACP adapter"},
+                  {"label": "CLI", "description": "Use the terminal"},
+                ],
+              },
+              {"id": "details", "header": "Details", "question": "Any constraints?"},
+              {
+                "id": "scope",
+                "header": "Scope",
+                "question": "Choose a scope",
+                "options": [
+                  {"label": "Local", "description": "On this machine"},
+                ],
+              },
+            ],
+          },
+        ),
+      );
+      await pump();
+      final asked = emitted.single as BridgeSseQuestionAsked;
+      expect(asked.questions.map((q) => q.question), ["Which Hermes interface?", "Any constraints?", "Choose a scope"]);
+      expect(asked.questions.map((q) => q.header), ["Interface", "Details", "Scope"]);
+      expect(asked.questions.first.options.map((o) => o.label), ["Sesori", "CLI"]);
+      expect(asked.questions.first.options.first.description, "Use the ACP adapter");
+      expect(asked.questions.map((q) => q.custom), [true, true, false]);
+      expect(asked.questions.every((q) => !q.multiple), isTrue);
+      expect(registry.pendingForSession(sessionId: "t-3").single.questions, asked.questions);
+      expect(registry.pendingPermissionsForSession(sessionId: "t-3"), isEmpty);
+      expect(respondCalls, isEmpty);
+
+      await registry.replyQuestion(
+        requestId: asked.id,
+        answers: const [
+          ["CLI"],
+          ["Keep it local"],
+          [],
+        ],
+      );
+      expect(respondCalls.single.result, {
+        "answers": {
+          "interface": {
+            "answers": ["CLI"],
+          },
+          "details": {
+            "answers": ["Keep it local"],
+          },
+          "scope": {"answers": <String>[]},
+        },
+      });
+    });
+
+    test("async assistant questions use the same pending surface and submit contextual answers", () async {
+      registry.handleRequest(
+        const CodexPendingNotification(
+          notification: CodexServerNotification(
+            method: "item/completed",
+            params: {
+              "threadId": "t-3",
+              "item": {
+                "type": "agentMessage",
+                "id": "call-question",
+                "delivery": "async",
+                "text": "Which Hermes interface?",
+                "questions": [
+                  {
+                    "title": "Which Hermes interface?",
+                    "options": ["Sesori", "CLI", "Desktop"],
+                  },
+                  {"title": "Any constraints?"},
+                ],
+              },
+            },
+          ),
+        ),
+      );
+      final asked = emitted.single as BridgeSseQuestionAsked;
+      expect(asked.questions.map((q) => q.question), ["Which Hermes interface?", "Any constraints?"]);
+      expect(asked.questions.first.options.map((o) => o.label), ["Sesori", "CLI", "Desktop"]);
+      expect(asked.questions.every((q) => q.custom && !q.multiple), isTrue);
+      expect(registry.pendingForSession(sessionId: "t-3").single.questions, asked.questions);
+      expect(registry.pendingPermissionsForSession(sessionId: "t-3"), isEmpty);
+      expect(asyncAnswers, isEmpty);
+      expect(respondCalls, isEmpty);
+
+      await registry.replyQuestion(
+        requestId: asked.id,
+        answers: const [
+          ["CLI"],
+          ["Custom answer"],
+        ],
+      );
+      expect(asyncAnswers.single, (
+        sessionId: "t-3",
+        text: "User answers to your questions:\n\nQuestion: Which Hermes interface?\nAnswer: CLI\n\nQuestion: Any constraints?\nAnswer: Custom answer",
+      ));
+      expect(registry.pendingForSession(sessionId: "t-3"), isEmpty);
+      expect(emitted.last, isA<BridgeSseQuestionReplied>());
+      expect(respondCalls, isEmpty);
+      expect(errorCalls, isEmpty);
+    });
+
+    test("ordinary assistant text and unfinished async items do not create questions", () {
+      for (final method in ["item/started", "item/completed"]) {
+        registry.handleRequest(
+          CodexPendingNotification(
+            notification: CodexServerNotification(
+              method: method,
+              params: {
+                "threadId": "t-3",
+                "item": {"type": "agentMessage", "id": "ordinary", "text": "Hello"},
+              },
+            ),
+          ),
+        );
+      }
+      registry.handleRequest(
+        const CodexPendingNotification(
+          notification: CodexServerNotification(
+            method: "item/started",
+            params: {
+              "threadId": "t-3",
+              "item": {
+                "type": "agentMessage",
+                "id": "question",
+                "delivery": "async",
+                "questions": [
+                  {"title": "Which interface?"},
+                ],
+              },
+            },
+          ),
+        ),
+      );
+      expect(emitted, isEmpty);
+    });
+
+    test("async rejection informs the agent but session cleanup does not start work", () async {
+      void ask() => registry.handleRequest(
+        const CodexPendingNotification(
+          notification: CodexServerNotification(
+            method: "item/completed",
+            params: {
+              "threadId": "t-3",
+              "item": {
+                "type": "agentMessage",
+                "id": "question",
+                "delivery": "async",
+                "questions": [
+                  {"title": "Which interface?"},
+                ],
+              },
+            },
+          ),
+        ),
+      );
+      ask();
+      final id = registry.pendingForSession(sessionId: "t-3").single.id;
+      await registry.rejectQuestion(requestId: id);
+      expect(asyncAnswers.single.text, contains("Answer: Declined to answer."));
+      expect(emitted.last, isA<BridgeSseQuestionRejected>());
+      ask();
+      registry.cancelForSession(sessionId: "t-3");
+      expect(asyncAnswers, hasLength(1));
+      expect(registry.hasAnyPendingInput, isFalse);
+      expect(errorCalls, isEmpty);
+    });
+
     test(
       "empty MCP tool-call elicitation surfaces as an approvable permission",
       () async {
@@ -521,7 +710,7 @@ void main() {
         await pump();
         final askedId = (emitted.single as BridgeSseQuestionAsked).id;
 
-        final ok = registry.replyQuestion(
+        final ok = await registry.replyQuestion(
           requestId: askedId,
           answers: const [
             ["Daniil"],
@@ -558,7 +747,7 @@ void main() {
         await pump();
         final askedId = (emitted.single as BridgeSseQuestionAsked).id;
 
-        registry.replyQuestion(
+        await registry.replyQuestion(
           requestId: askedId,
           answers: const [
             ["/tmp/out"],
@@ -589,7 +778,7 @@ void main() {
         await pump();
         final askedId = (emitted.single as BridgeSseQuestionAsked).id;
 
-        final ok = registry.rejectQuestion(requestId: askedId);
+        final ok = await registry.rejectQuestion(requestId: askedId);
         expect(ok, isTrue);
         expect((respondCalls.single.result as Map)["action"], equals("decline"));
         expect(errorCalls, isEmpty);
@@ -614,7 +803,7 @@ void main() {
         await pump();
         final askedId = (emitted.single as BridgeSseQuestionAsked).id;
 
-        final ok = registry.rejectQuestion(requestId: askedId);
+        final ok = await registry.rejectQuestion(requestId: askedId);
         expect(ok, isTrue);
         expect(respondCalls, isEmpty);
         expect(errorCalls.single.id, equals(204));

--- a/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_impl_test.dart
@@ -380,6 +380,31 @@ void main() {
       );
       await secondAsk.timeout(const Duration(seconds: 2));
 
+      final asyncAsk = plugin.events.where((event) => event is BridgeSseQuestionAsked).first;
+      socket.add(
+        jsonEncode({
+          "jsonrpc": "2.0",
+          "method": "item/completed",
+          "params": {
+            "threadId": "t-running",
+            "item": {
+              "type": "agentMessage",
+              "id": "async-question",
+              "text": "Which interface?",
+              "delivery": "async",
+              "questions": [
+                {
+                  "title": "Which interface?",
+                  "options": ["CLI", "Desktop"],
+                },
+              ],
+            },
+          },
+        }),
+      );
+      await asyncAsk.timeout(const Duration(seconds: 2));
+      expect(await plugin.getPendingQuestions(sessionId: "t-running"), hasLength(1));
+
       final disconnectWorkStates = <PluginWorkState>[];
       final workStateSubscription = plugin.workState.listen(disconnectWorkStates.add);
       addTearDown(workStateSubscription.cancel);
@@ -397,6 +422,7 @@ void main() {
         "t-running",
       );
       expect(plugin.getActiveSessionsSummary(), isEmpty);
+      expect(await plugin.getPendingQuestions(sessionId: "t-running"), isEmpty);
       expect(
         await plugin.getPendingPermissions(sessionId: "t-running"),
         isEmpty,

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -82,6 +82,142 @@ void main() {
       expect(plugin.currentWorkState, PluginWorkState.busy);
     }
 
+    for (final running in [true, false]) {
+      test("async question answers reach the owning ${running ? 'running' : 'completed'} conversation", () async {
+        fake.respondInOrder([const _Response(result: _initOk)]);
+        await plugin.healthCheck();
+        fake.pushNotification("thread/started", {
+          "thread": {"id": "t-question", "cwd": "/work/sample"},
+        });
+        fake.pushNotification("turn/started", {
+          "threadId": "t-question",
+          "turn": {"id": "u-question"},
+        });
+        final asked = plugin.events.where((e) => e is BridgeSseQuestionAsked).cast<BridgeSseQuestionAsked>().first;
+        fake.pushNotification("item/completed", {
+          "threadId": "t-question",
+          "turnId": "u-question",
+          "item": {
+            "type": "agentMessage",
+            "id": "call-question",
+            "delivery": "async",
+            "text": "Which Hermes interface?",
+            "questions": [
+              {
+                "title": "Which Hermes interface?",
+                "options": ["Sesori", "CLI"],
+              },
+            ],
+          },
+        });
+        final question = await asked.timeout(const Duration(seconds: 2));
+        expect(question.questions.single.options.map((o) => o.label), ["Sesori", "CLI"]);
+        expect(plugin.getActiveSessionsSummary().single.activeSessions.single.awaitingInput, isTrue);
+        if (!running) {
+          final idle = plugin.events.where((e) => e is BridgeSseSessionIdle).first;
+          fake.pushNotification("turn/completed", {
+            "threadId": "t-question",
+            "turn": {"id": "u-question"},
+          });
+          await idle.timeout(const Duration(seconds: 3));
+        }
+        expect((await plugin.getPendingQuestions(sessionId: "t-question")).single.id, question.id);
+        expect(await plugin.getPendingPermissions(sessionId: "t-question"), isEmpty);
+
+        fake.respondInOrder([
+          const _Response(
+            result: {
+              "thread": {"id": "t-question", "cwd": "/work/sample"},
+            },
+          ),
+          _Response(
+            result: {
+              "turn": {"id": running ? "u-question" : "u-answer"},
+            },
+          ),
+        ]);
+        await plugin.replyToQuestion(
+          questionId: question.id,
+          sessionId: "t-question",
+          answers: const [
+            ["CLI"],
+          ],
+        );
+        final params = fake.sentParamsFor("turn/start");
+        expect(params["threadId"], "t-question");
+        expect((params["input"] as List).single, {
+          "type": "text",
+          "text": "User answers to your questions:\n\nQuestion: Which Hermes interface?\nAnswer: CLI",
+          "text_elements": <Object?>[],
+        });
+        expect(params.containsKey("model"), isFalse);
+        expect(params.containsKey("collaborationMode"), isFalse);
+        expect(await plugin.getPendingQuestions(sessionId: "t-question"), isEmpty);
+        // A second client answering the retired card cannot submit again.
+        await plugin.replyToQuestion(
+          questionId: question.id,
+          sessionId: "t-question",
+          answers: const [
+            ["Sesori"],
+          ],
+        );
+        expect(fake.sentParamsForAll(method: "turn/start"), hasLength(1));
+      });
+    }
+
+    test("async question submission failure leaves the card available for retry", () async {
+      fake.respondInOrder([const _Response(result: _initOk)]);
+      await plugin.healthCheck();
+      final asked = plugin.events.where((e) => e is BridgeSseQuestionAsked).cast<BridgeSseQuestionAsked>().first;
+      fake.pushNotification("item/completed", {
+        "threadId": "t-question",
+        "item": {
+          "type": "agentMessage",
+          "id": "call-question",
+          "delivery": "async",
+          "text": "Which interface?",
+          "questions": [
+            {"title": "Which interface?"},
+          ],
+        },
+      });
+      final question = await asked.timeout(const Duration(seconds: 2));
+      fake.respondInOrder([
+        const _Response(
+          result: {
+            "thread": {"id": "t-question", "cwd": "/work/sample"},
+          },
+        ),
+        const _Response(error: {"code": -32603, "message": "submission failed"}),
+      ]);
+      await expectLater(
+        plugin.replyToQuestion(
+          questionId: question.id,
+          sessionId: "t-question",
+          answers: const [
+            ["CLI"],
+          ],
+        ),
+        throwsA(isA<CodexThreadRequestException>()),
+      );
+      expect((await plugin.getPendingQuestions(sessionId: "t-question")).single.id, question.id);
+      fake.respondInOrder([
+        const _Response(
+          result: {
+            "turn": {"id": "u-answer"},
+          },
+        ),
+      ]);
+      await plugin.replyToQuestion(
+        questionId: question.id,
+        sessionId: "t-question",
+        answers: const [
+          ["CLI"],
+        ],
+      );
+      expect(await plugin.getPendingQuestions(sessionId: "t-question"), isEmpty);
+    });
+
     test("createSession preserves a Default turn when no model resolves", () async {
       // Respond to: initialize, thread/start, turn/start.
       fake.respondInOrder([
@@ -2834,6 +2970,48 @@ void main() {
         ],
       );
       expect(await plugin.getPendingPermissions(sessionId: "root-1"), isEmpty);
+      expect(await plugin.getPendingQuestions(sessionId: "root-1"), isEmpty);
+
+      final asyncQuestionAsked = next<BridgeSseQuestionAsked>((event) => event.sessionID == "child-1");
+      fake.pushNotification("item/completed", {
+        "threadId": "child-1",
+        "turnId": "u-child",
+        "item": {
+          "type": "agentMessage",
+          "id": "child-question",
+          "delivery": "async",
+          "text": "Which interface?",
+          "questions": [
+            {
+              "title": "Which interface?",
+              "options": ["CLI", "Desktop"],
+            },
+          ],
+        },
+      });
+      final asyncQuestion = await asyncQuestionAsked;
+      expect(asyncQuestion.displaySessionId, "root-1");
+      expect((await plugin.getPendingQuestions(sessionId: "root-1")).single.sessionID, "child-1");
+      fake.respondInOrder([
+        const _Response(
+          result: {
+            "thread": {"id": "child-1", "cwd": "/work/other"},
+          },
+        ),
+        const _Response(
+          result: {
+            "turn": {"id": "u-child"},
+          },
+        ),
+      ]);
+      await plugin.replyToQuestion(
+        questionId: asyncQuestion.id,
+        sessionId: "child-1",
+        answers: const [
+          ["CLI"],
+        ],
+      );
+      expect(fake.sentParamsForAll(method: "turn/start").last["threadId"], "child-1");
       expect(await plugin.getPendingQuestions(sessionId: "root-1"), isEmpty);
 
       // A no-active-turn interrupt reconciles the child to idle and releases

--- a/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_rollout_api_test.dart
@@ -2119,6 +2119,57 @@ IMPORTANT: Perform all work for this task in this dedicated worktree. You may us
       expect(idleActiveCall.parts.single.state.status, PluginToolStatus.error);
     });
 
+    test("async question acknowledgements do not become completed tool cards", () {
+      final path = _writeRollout(
+        codexHome,
+        path: "sessions/2026/09/07/rollout-async-question.jsonl",
+        sessionId: "async-question-thread",
+        cwd: "/repo/app",
+        cliVersion: "0.153.4",
+        extraLines: [
+          jsonEncode({
+            "type": "response_item",
+            "payload": {
+              "type": "function_call",
+              "name": "request_user_input_async",
+              "call_id": "call-question",
+              "arguments": jsonEncode({
+                "questions": [
+                  {
+                    "title": "Which interface?",
+                    "options": ["Sesori", "CLI"],
+                  },
+                ],
+              }),
+            },
+          }),
+          jsonEncode({
+            "type": "response_item",
+            "payload": {"type": "function_call_output", "call_id": "call-question", "output": '{"accepted":true}'},
+          }),
+          jsonEncode({
+            "type": "response_item",
+            "payload": {
+              "type": "message",
+              "id": "assistant",
+              "role": "assistant",
+              "content": [
+                {"type": "output_text", "text": "I will keep investigating."},
+              ],
+            },
+          }),
+        ],
+      );
+      final messages = messageRepository.readMessages(
+        rolloutPath: path,
+        sessionId: "async-question-thread",
+        children: const [],
+        replayToolDisposition: CodexReplayToolDisposition.terminalize,
+        structuredToolStatusByCallId: const {},
+      );
+      expect(messages.single.parts.single.text, "I will keep investigating.");
+    });
+
     test("readMessages restores current calls around malformed content items", () {
       final path = _writeRollout(
         codexHome,

--- a/bridge/sesori_plugin_cursor/test/cursor_approval_registry_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_approval_registry_test.dart
@@ -84,7 +84,7 @@ void main() {
 
       expect(registry.pendingForSession(sessionId: "s1"), hasLength(1));
 
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: asked.id,
         answers: [
           ["Yes"],
@@ -108,7 +108,7 @@ void main() {
       final asked = emitted.single as BridgeSseQuestionAsked;
       expect(asked.questions.single.header, "Plan A");
 
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: asked.id,
         answers: [
           ["Accept"],

--- a/bridge/sesori_plugin_deepseek/test/deepseek_approval_registry_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_approval_registry_test.dart
@@ -93,7 +93,7 @@ void main() {
     await built.dispose();
     await plugin.dispose();
   });
-  test("option, custom, and free-form answers preserve ordered question IDs", () {
+  test("option, custom, and free-form answers preserve ordered question IDs", () async {
     registry.handleExtensionRequest(
       questionRequest(7, const {
         "sessionId": "session-1",
@@ -112,7 +112,7 @@ void main() {
     expect(questions.first.custom, isTrue);
     expect(questions.last.question, "Why?\n\nExplain the tradeoff.");
     expect(
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: "request-1",
         answers: const [
           ["Yes", "With safeguards"],
@@ -154,7 +154,7 @@ void main() {
       "outcome": {"outcome": "selected", "optionId": "allow-once"},
     });
   });
-  test("two sessions retain exact question and request correlation", () {
+  test("two sessions retain exact question and request correlation", () async {
     for (final entry in [(11, "session-1", "q1"), (12, "session-2", "q2")]) {
       registry.handleExtensionRequest(
         questionRequest(entry.$1, {
@@ -172,7 +172,7 @@ void main() {
 
     expect(events.whereType<BridgeSseQuestionAsked>().map((event) => event.sessionID), ["session-1", "session-2"]);
     expect(
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: "request-2",
         answers: const [
           ["No"],
@@ -181,7 +181,7 @@ void main() {
       isTrue,
     );
     expect(
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: "request-1",
         answers: const [
           ["Yes"],
@@ -216,7 +216,7 @@ void main() {
     registry.cancelForSession(sessionId: "session-1");
     await Future<void>.delayed(Duration.zero);
     expect(
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: "request-1",
         answers: const [
           ["Yes"],
@@ -248,7 +248,7 @@ void main() {
 
     final logs = await _captureWarnings(() async {
       expect(
-        registry.replyQuestion(
+        await registry.replyQuestion(
           requestId: "request-1",
           answers: const [
             ["Change it"],
@@ -261,7 +261,7 @@ void main() {
     expect(logs, contains("DeepSeek plan-review questions do not accept custom answers"));
     expect(fake.written.single["error"], {"code": -32603, "message": "invalid answer"});
     expect(
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: "request-1",
         answers: const [
           ["Approve"],
@@ -286,7 +286,7 @@ void main() {
     );
     final logs = await _captureWarnings(() async {
       expect(
-        registry.replyQuestion(
+        await registry.replyQuestion(
           requestId: "request-1",
           answers: const [
             ["A", "A"],
@@ -313,7 +313,7 @@ void main() {
         ],
       }),
     );
-    expect(registry.replyQuestion(requestId: "request-1", answers: const [<String>[]]), isTrue);
+    expect(await registry.replyQuestion(requestId: "request-1", answers: const [<String>[]]), isTrue);
     await Future<void>.delayed(Duration.zero);
     expect(fake.written.single["error"], {"code": -32603, "message": "invalid answer"});
     expect(registry.hasAnyPendingInput, isFalse);
@@ -328,7 +328,7 @@ void main() {
       }),
     );
     expect(
-      registry.replyQuestion(
+      await registry.replyQuestion(
         requestId: "request-1",
         answers: [
           ["x".padRight(2049, "x")],

--- a/bridge/sesori_plugin_interface/lib/src/pending_permission_registry.dart
+++ b/bridge/sesori_plugin_interface/lib/src/pending_permission_registry.dart
@@ -8,19 +8,25 @@ import "models/plugin_pending_permission.dart";
 import "models/plugin_pending_question.dart";
 import "plugin_permission_reply.dart";
 
-enum PendingCancellationReason() { sessionCancelled, disposed }
+enum PendingCancellationReason() {
+  sessionCancelled,
+  disposed,
+}
 
-enum PendingQuestionReplyOutcome() { replied, rejected }
+enum PendingQuestionReplyOutcome() {
+  replied,
+  rejected,
+}
 
 typedef PendingPermissionResolver<TPayload extends Object> = void Function({
   required TPayload payload,
   required PluginPermissionReply reply,
 });
-typedef PendingQuestionResolver<TPayload extends Object> = PendingQuestionReplyOutcome Function({
+typedef PendingQuestionResolver<TPayload extends Object> = FutureOr<PendingQuestionReplyOutcome> Function({
   required TPayload payload,
   required List<List<String>> answers,
 });
-typedef PendingQuestionRejecter<TPayload extends Object> = void Function({required TPayload payload});
+typedef PendingQuestionRejecter<TPayload extends Object> = FutureOr<void> Function({required TPayload payload});
 typedef PendingInputCanceller<TPayload extends Object> = void Function({
   required TPayload payload,
   required PendingCancellationReason reason,
@@ -185,11 +191,15 @@ abstract class PendingPermissionRegistry<TRequest, TPayload extends Object>({
     return true;
   }
 
-  bool replyQuestion({required String requestId, required List<List<String>> answers}) {
+  Future<bool> replyQuestion({required String requestId, required List<List<String>> answers}) async {
     final entry = _pending[requestId];
     if (entry is! _PendingQuestionEntry<TPayload>) return false;
+    // An asynchronous backend must accept the answer before the card retires.
+    // A failed submission leaves it pending so the user can retry.
+    final resolution = _resolveQuestion(payload: entry.payload, answers: answers);
+    final outcome = resolution is Future<PendingQuestionReplyOutcome> ? await resolution : resolution;
+    if (!identical(_pending[requestId], entry)) return false;
     _pending.remove(requestId);
-    final outcome = _resolveQuestion(payload: entry.payload, answers: answers);
     final snapshot = entry.snapshot;
     _emit(
       switch (outcome) {
@@ -208,11 +218,13 @@ abstract class PendingPermissionRegistry<TRequest, TPayload extends Object>({
     return true;
   }
 
-  bool rejectQuestion({required String requestId}) {
+  Future<bool> rejectQuestion({required String requestId}) async {
     final entry = _pending[requestId];
     if (entry is! _PendingQuestionEntry<TPayload>) return false;
+    final resolution = _rejectQuestion(payload: entry.payload);
+    if (resolution is Future<void>) await resolution;
+    if (!identical(_pending[requestId], entry)) return false;
     _pending.remove(requestId);
-    _rejectQuestion(payload: entry.payload);
     final snapshot = entry.snapshot;
     _emit(
       BridgeSseQuestionRejected(

--- a/bridge/sesori_plugin_interface/lib/src/pending_permission_registry.dart
+++ b/bridge/sesori_plugin_interface/lib/src/pending_permission_registry.dart
@@ -56,6 +56,7 @@ abstract class PendingPermissionRegistry<TRequest, TPayload extends Object>({
 
   StreamSubscription<TRequest>? _subscription;
   final Map<String, _PendingEntry<TPayload>> _pending = {};
+  final Set<_PendingQuestionEntry<TPayload>> _questionSubmissions = {};
   int _sequence = 0;
 
   @protected
@@ -194,46 +195,57 @@ abstract class PendingPermissionRegistry<TRequest, TPayload extends Object>({
   Future<bool> replyQuestion({required String requestId, required List<List<String>> answers}) async {
     final entry = _pending[requestId];
     if (entry is! _PendingQuestionEntry<TPayload>) return false;
-    // An asynchronous backend must accept the answer before the card retires.
-    // A failed submission leaves it pending so the user can retry.
-    final resolution = _resolveQuestion(payload: entry.payload, answers: answers);
-    final outcome = resolution is Future<PendingQuestionReplyOutcome> ? await resolution : resolution;
-    if (!identical(_pending[requestId], entry)) return false;
-    _pending.remove(requestId);
-    final snapshot = entry.snapshot;
-    _emit(
-      switch (outcome) {
-        PendingQuestionReplyOutcome.replied => BridgeSseQuestionReplied(
-          requestID: requestId,
-          sessionID: snapshot.sessionID,
-          displaySessionId: snapshot.displaySessionId,
-        ),
-        PendingQuestionReplyOutcome.rejected => BridgeSseQuestionRejected(
-          requestID: requestId,
-          sessionID: snapshot.sessionID,
-          displaySessionId: snapshot.displaySessionId,
-        ),
-      },
-    );
-    return true;
+    // Phone and desktop can submit the same card before backend acceptance.
+    if (!_questionSubmissions.add(entry)) return false;
+    try {
+      // An asynchronous backend must accept the answer before the card retires.
+      // A failed submission leaves it pending so the user can retry.
+      final resolution = _resolveQuestion(payload: entry.payload, answers: answers);
+      final outcome = resolution is Future<PendingQuestionReplyOutcome> ? await resolution : resolution;
+      if (!identical(_pending[requestId], entry)) return false;
+      _pending.remove(requestId);
+      final snapshot = entry.snapshot;
+      _emit(
+        switch (outcome) {
+          PendingQuestionReplyOutcome.replied => BridgeSseQuestionReplied(
+            requestID: requestId,
+            sessionID: snapshot.sessionID,
+            displaySessionId: snapshot.displaySessionId,
+          ),
+          PendingQuestionReplyOutcome.rejected => BridgeSseQuestionRejected(
+            requestID: requestId,
+            sessionID: snapshot.sessionID,
+            displaySessionId: snapshot.displaySessionId,
+          ),
+        },
+      );
+      return true;
+    } finally {
+      _questionSubmissions.remove(entry);
+    }
   }
 
   Future<bool> rejectQuestion({required String requestId}) async {
     final entry = _pending[requestId];
     if (entry is! _PendingQuestionEntry<TPayload>) return false;
-    final resolution = _rejectQuestion(payload: entry.payload);
-    if (resolution is Future<void>) await resolution;
-    if (!identical(_pending[requestId], entry)) return false;
-    _pending.remove(requestId);
-    final snapshot = entry.snapshot;
-    _emit(
-      BridgeSseQuestionRejected(
-        requestID: requestId,
-        sessionID: snapshot.sessionID,
-        displaySessionId: snapshot.displaySessionId,
-      ),
-    );
-    return true;
+    if (!_questionSubmissions.add(entry)) return false;
+    try {
+      final resolution = _rejectQuestion(payload: entry.payload);
+      if (resolution is Future<void>) await resolution;
+      if (!identical(_pending[requestId], entry)) return false;
+      _pending.remove(requestId);
+      final snapshot = entry.snapshot;
+      _emit(
+        BridgeSseQuestionRejected(
+          requestID: requestId,
+          sessionID: snapshot.sessionID,
+          displaySessionId: snapshot.displaySessionId,
+        ),
+      );
+      return true;
+    } finally {
+      _questionSubmissions.remove(entry);
+    }
   }
 
   String _generateId() {

--- a/bridge/sesori_plugin_interface/test/pending_permission_registry_test.dart
+++ b/bridge/sesori_plugin_interface/test/pending_permission_registry_test.dart
@@ -55,7 +55,7 @@ void main() {
     cancelPending: cancelPending ?? ({required payload, required reason}) {},
   );
 
-  test("registers exact snapshots and settles replies with clearing events", () {
+  test("registers exact snapshots and settles replies with clearing events", () async {
     final events = <BridgeSseEvent>[];
     final permissions = <(String, PluginPermissionReply)>[];
     final questions = <String>[];
@@ -81,7 +81,7 @@ void main() {
       isTrue,
     );
     expect(
-      subject.replyQuestion(
+      await subject.replyQuestion(
         requestId: questionId,
         answers: const [
           ["yes"],
@@ -97,20 +97,20 @@ void main() {
     expect(subject.hasAnyPendingInput, isFalse);
   });
 
-  test("a kind-mismatched reply leaves the entry pending and answerable", () {
+  test("a kind-mismatched reply leaves the entry pending and answerable", () async {
     final events = <BridgeSseEvent>[];
     final subject = registry(events: events);
     final permissionId = subject.addPermission(payload: "permission", sessionId: "s1");
     final questionId = subject.addQuestion(payload: "question", sessionId: "s1");
     events.clear();
 
-    expect(subject.replyQuestion(requestId: permissionId, answers: const []), isFalse);
-    expect(subject.rejectQuestion(requestId: permissionId), isFalse);
+    expect(await subject.replyQuestion(requestId: permissionId, answers: const []), isFalse);
+    expect(await subject.rejectQuestion(requestId: permissionId), isFalse);
     expect(subject.replyPermission(requestId: questionId, reply: PluginPermissionReply.once), isFalse);
     expect(events, isEmpty);
 
     expect(subject.replyPermission(requestId: permissionId, reply: PluginPermissionReply.once), isTrue);
-    expect(subject.rejectQuestion(requestId: questionId), isTrue);
+    expect(await subject.rejectQuestion(requestId: questionId), isTrue);
     expect(subject.hasAnyPendingInput, isFalse);
   });
 
@@ -139,6 +139,61 @@ void main() {
     expect(events, [isA<BridgeSsePermissionReplied>(), isA<BridgeSseQuestionRejected>()]);
     expect(subject.pendingForSession(sessionId: "s2"), hasLength(1));
     expect(stderrLines.join("\n"), contains("[test] failed to resolve cancelled pending input"));
+  });
+
+  test("an async answer stays pending until accepted and remains retryable on failure", () async {
+    final events = <BridgeSseEvent>[];
+    var completion = Completer<PendingQuestionReplyOutcome>();
+    final subject = registry(
+      events: events,
+      resolveQuestion: ({required payload, required answers}) => completion.future,
+    );
+    final id = subject.addQuestion(payload: "async", sessionId: "s1");
+    final reply = subject.replyQuestion(
+      requestId: id,
+      answers: const [
+        ["Choice"],
+      ],
+    );
+    final failure = expectLater(reply, throwsStateError);
+    expect(subject.pendingForSession(sessionId: "s1").single.id, id);
+    expect(events.whereType<BridgeSseQuestionReplied>(), isEmpty);
+    completion.completeError(StateError("send failed"));
+    await failure;
+    expect(subject.pendingForSession(sessionId: "s1").single.id, id);
+    completion = Completer<PendingQuestionReplyOutcome>();
+    final retry = subject.replyQuestion(
+      requestId: id,
+      answers: const [
+        ["Choice"],
+      ],
+    );
+    completion.complete(PendingQuestionReplyOutcome.replied);
+    expect(await retry, isTrue);
+    expect(subject.hasAnyPendingInput, isFalse);
+    expect(events.whereType<BridgeSseQuestionReplied>(), hasLength(1));
+  });
+
+  test("async rejection failure keeps the question and teardown prevents late settlement", () async {
+    final events = <BridgeSseEvent>[];
+    var completion = Completer<void>();
+    final subject = registry(
+      events: events,
+      rejectQuestion: ({required payload}) => completion.future,
+    );
+    final id = subject.addQuestion(payload: "async", sessionId: "s1");
+    final rejection = subject.rejectQuestion(requestId: id);
+    final failure = expectLater(rejection, throwsStateError);
+    completion.completeError(StateError("send failed"));
+    await failure;
+    expect(subject.pendingForSession(sessionId: "s1").single.id, id);
+    completion = Completer<void>();
+    final retry = subject.rejectQuestion(requestId: id);
+    await subject.dispose();
+    completion.complete();
+    expect(await retry, isFalse);
+    expect(subject.hasAnyPendingInput, isFalse);
+    expect(events.whereType<BridgeSseQuestionRejected>(), hasLength(1));
   });
 
   test("dispose settles pending input after subscription cancellation fails", () async {

--- a/bridge/sesori_plugin_interface/test/pending_permission_registry_test.dart
+++ b/bridge/sesori_plugin_interface/test/pending_permission_registry_test.dart
@@ -196,6 +196,43 @@ void main() {
     expect(events.whereType<BridgeSseQuestionRejected>(), hasLength(1));
   });
 
+  for (final rejectFirst in [false, true]) {
+    for (final rejectSecond in [false, true]) {
+      test("competing questions settle once (reject first: $rejectFirst, second: $rejectSecond)", () async {
+        final events = <BridgeSseEvent>[];
+        final completion = Completer<PendingQuestionReplyOutcome>();
+        var submissions = 0;
+        final subject = registry(
+          events: events,
+          resolveQuestion: ({required payload, required answers}) {
+            submissions++;
+            return completion.future;
+          },
+          rejectQuestion: ({required payload}) {
+            submissions++;
+            return completion.future.then((_) {});
+          },
+        );
+        final id = subject.addQuestion(payload: "async", sessionId: "s1");
+        final first = rejectFirst
+            ? subject.rejectQuestion(requestId: id)
+            : subject.replyQuestion(requestId: id, answers: const []);
+        final second = rejectSecond
+            ? subject.rejectQuestion(requestId: id)
+            : subject.replyQuestion(requestId: id, answers: const []);
+        completion.complete(PendingQuestionReplyOutcome.replied);
+        expect(await first, isTrue);
+        expect(await second, isFalse);
+        expect(submissions, 1);
+        expect(subject.hasAnyPendingInput, isFalse);
+        expect(
+          events.where((event) => event is BridgeSseQuestionReplied || event is BridgeSseQuestionRejected),
+          hasLength(1),
+        );
+      });
+    }
+  }
+
   test("dispose settles pending input after subscription cancellation fails", () async {
     final events = <BridgeSseEvent>[];
     final cancelled = <String>[];

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -54,6 +54,10 @@ running conversation or resume it while idle; the immediate tool acknowledgement
 does not answer the question. Async message metadata was verified against Codex
 0.153.4. Older runtimes continue to use their synchronous request path.
 
+**Not implemented:** Masked secret-question entry. Codex requests containing an
+`isSecret` question receive an explicit unsupported-input error before any
+question card is shown; secret prompts are never downgraded to plain text.
+
 ## Setup detection
 
 | Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -45,6 +45,15 @@ release first, which is the best signal its catalog offers. Other plugins
 still declare variants default-first (the client falls back to the first
 listed variant when no default is declared) and models in plugin-defined order.
 
+## Codex question input
+
+**Implemented:** Codex synchronous user-input requests and asynchronous
+assistant-message questions use the existing Sesori question UI and reply API.
+Both preserve multiple questions and ordered choices. Async answers steer a
+running conversation or resume it while idle; the immediate tool acknowledgement
+does not answer the question. Async message metadata was verified against Codex
+0.153.4. Older runtimes continue to use their synchronous request path.
+
 ## Setup detection
 
 | Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -12,6 +12,24 @@ reaches the backend so the turn continues.
   root session, and whether an "always" answer is offered. A pending question
   carries its header, prompt, options, and whether multiple or custom answers
   are allowed.
+- Codex synchronous `request_user_input` requests preserve every question,
+  header, ordered option and description. Replies preserve the original
+  question IDs and answer ordering, including custom answers and declined rows.
+- Codex `request_user_input_async` assistant messages create the same pending
+  questions on mobile and desktop. Their options remain selectable and custom
+  answers remain available. The tool's immediate `accepted` acknowledgement
+  is not shown as a completed question/answer tool card and never counts as
+  user input or permission approval.
+- An async Codex question remains pending after its originating turn completes.
+  Reply and reject send contextual user input to the owning conversation through
+  normal turn submission, steering a running turn or starting a turn while idle
+  without overriding its model or collaboration mode. A child question appears
+  under its display root but the answer goes to that child.
+- A question settles only after its backend submission succeeds; a failed async
+  submission remains pending for retry. Explicit rejection tells Codex which
+  questions were declined. Abort, thread close, disconnect and disposal retire
+  connection-local async cards without starting new work to report cleanup.
+  Historical transcript reads do not recreate already-finished question cards.
 - Allow once, allow always, and reject each reach the backend with the meaning
   the user chose. Once is never escalated to a broader grant.
 - A plugin advertising ACP form elicitation maps supported string, string-enum,
@@ -101,6 +119,11 @@ reaches the backend so the turn continues.
   that ownership.
 
 ## Regression Levels
+
+Codex focused coverage includes live async-message routing, synchronous
+multi-question choices, answers during an active turn and after completion,
+failed-submission retry, child routing, cleanup, and omission of the async tool
+acknowledgement from replayed tool history.
 
 | Level | Additional coverage |
 |---|---|

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -26,10 +26,14 @@ reaches the backend so the turn continues.
   without overriding its model or collaboration mode. A child question appears
   under its display root but the answer goes to that child.
 - A question settles only after its backend submission succeeds; a failed async
-  submission remains pending for retry. Explicit rejection tells Codex which
-  questions were declined. Abort, thread close, disconnect and disposal retire
+  submission remains pending for retry. Competing replies or rejections submit
+  only once while backend acceptance is pending. Explicit rejection tells Codex
+  which questions were declined. Abort, thread close, disconnect and disposal retire
   connection-local async cards without starting new work to report cleanup.
   Historical transcript reads do not recreate already-finished question cards.
+- Codex requests containing a secret-input question fail explicitly before any
+  card is presented. Masked secret entry is not yet supported; these requests
+  must never appear as ordinary plain-text input.
 - Allow once, allow always, and reject each reach the backend with the meaning
   the user chose. Once is never escalated to a broader grant.
 - A plugin advertising ACP form elicitation maps supported string, string-enum,
@@ -120,15 +124,10 @@ reaches the backend so the turn continues.
 
 ## Regression Levels
 
-Codex focused coverage includes live async-message routing, synchronous
-multi-question choices, answers during an active turn and after completion,
-failed-submission retry, child routing, cleanup, and omission of the async tool
-acknowledgement from replayed tool history.
-
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Automated shared presentation and desktop shell coverage: question and permission modals render through the shared session-detail owner, and a pending desktop question opens over its session. Live plugin, one representative plugin: a permission raised by a real turn appears as pending and one reply lets the turn proceed. |
-| L2 Routine | Live plugin, representative: question variants (single, multiple, custom, reject), typed ACP scalar forms where supported, unsupported-form decline, abort cancellation, per-session and per-project pending listing, repeated or unknown request ids answered without corrupting state. Automated Pi coverage: select/confirm/input/editor prompt placement, exact replies, and timeout cleanup. Automated DeepSeek coverage: exact two-session question correlation, permission once/reject, ordered multi/custom/free-form and plan-review answers, invalid-answer settlement, abort, late reply, and disposal. |
+| L2 Routine | Live plugin, representative: question variants (single, multiple, custom, reject), typed ACP scalar forms where supported, unsupported-form decline, abort cancellation, per-session and per-project pending listing, repeated or unknown request ids answered without corrupting state. Automated Codex coverage: structured multi-question choices, explicit secret-input refusal, async answers during a turn and after completion, retry after failed submission, child routing, teardown, and async acknowledgement omission from history. Automated Pi coverage: select/confirm/input/editor prompt placement, exact replies, and timeout cleanup. Automated DeepSeek coverage: exact two-session question correlation, permission once/reject, ordered multi/custom/free-form and plan-review answers, invalid-answer settlement, abort, late reply, and disposal. |
 | L3 Release | Client end to end on each release-target client surface that exposes session detail, every supporting production plugin: every request kind the plugin exposes, per-plugin "always" availability, child attribution, archived-session refusal, and pending requests suppressing completion notifications until resolved. Copilot covers the always-visible Once/Reject actions, Always only when advertised, exact selected-or-cancelled ACP outcomes, and an honestly absent question capability. Grok covers a real ask-mode tool request, Once and Reject plus every advertised scope, exact session/tool correlation, abort cleanup, and no implicit auto-approval. |
 | L4 Extended | Relay integration, every supporting production plugin: per-session empty lists while stopped or terminally failed, project-wide question unavailability with no active plugin, pending state re-read after restart, competing replies to one request, two logical clients observing one request and its retirement, and reconnect inside the replay window. |
 | L5 Full | Headless bridge and live plugin for malformed requests and degenerate option sets; packaged or external on alternate client platforms for an older bridge not declaring "always". Every supporting production plugin where applicable. |


### PR DESCRIPTION
## Complexity
⚙️ Moderate: two Codex question sources share one pending-input flow, with asynchronous backend settlement.

## What
Render Codex async assistant-message questions through Sesori's existing question UI and reply API. Preserve all synchronous questions, options, descriptions, and answer IDs. Hide the async tool's immediate `accepted` acknowledgement from tool cards.

## Why
`request_user_input_async` emits question metadata on an assistant message and returns immediately. Sesori previously rendered its text and completed tool card, leaving users without an interactive answer surface.

## Risk and test focus
Async answers must reach the owning conversation while running or idle, including child sessions displayed under a parent. Failed submissions retain the question for retry; cleanup retires it without starting work. Shared registry reply/reject methods now await backend acceptance, with ACP callers updated together. YOLO still handles permissions only.

No database or client/bridge wire-contract changes.

## Expected result
Users can select options, provide custom answers, or decline Codex questions through the same mobile and desktop question flow, whether Codex asks synchronously or asynchronously. Async questions remain available after turn completion.

## Verification
- Focused Codex approval, write-path, and rollout-history tests.
- Shared pending-input tests covering awaited acceptance, retry, and teardown.
- ACP, Cursor, and DeepSeek question/approval regressions.
- Fatal-info analysis for Codex, the shared plugin interface, and ACP.
- Question regression documentation and harness capability notes updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders Codex `request_user_input_async` assistant-message questions through the existing question UI and reply API. Previously they appeared only as text with an immediate `accepted` tool card and no answer surface; now users can choose options, provide custom answers, or decline on mobile and desktop.

- Parses synchronous `request_user_input` with structured DTOs so questions, options, descriptions, and answer IDs round-trip in order.
- Registry reply and reject now await backend acceptance; failed async submissions keep the question pending for retry.
- `replyQuestion` and `rejectQuestion` now return `Future<bool>`; ACP callers updated to await them.
- Async questions stay pending after turn completion and answers route to the owning conversation, including child sessions under a display root.
- The async tool's `accepted` acknowledgement no longer renders as a completed tool card or replays in transcripts.
- Competing question submissions are blocked so only one pending question settles at a time.
- Secret (`isSecret`) questions are rejected with an explicit unsupported-input error and never shown as cards.
- Cleanup, thread close, disconnect, and disposal retire async cards without starting new work; the dedicated server-request subscription is cancelled on disconnect.
- No database or client/bridge wire-contract changes.

<sup>Written for commit b33a49260766ffa580b9ae4f6fbb00a7770fd1f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

