### PR TITLE
🌱 Disable debug mode banner

### DIFF
--- a/client/app/lib/main.dart
+++ b/client/app/lib/main.dart
@@ -335,6 +335,7 @@ class const _SesoriAppShell() extends StatelessWidget {
     final themeMode = context.watch<AppearanceCubit>().state.themeMode;
 
     return MaterialApp.router(
+      debugShowCheckedModeBanner: false,
       onGenerateTitle: (context) => context.loc.appTitle,
       themeMode: themeMode,
       theme: buildPregoThemeData(brightness: Brightness.light),


### PR DESCRIPTION
## Complexity

🌱 Trivial — one Flutter application configuration flag.

## What

Disable Flutter's checked-mode banner in the mobile app shell.

## Why

Debug builds should present the product UI without the framework banner overlay.

## Risk and test focus

Low risk. The change only affects the debug banner rendered by `MaterialApp`; it does not affect application behavior, persisted data, wire contracts, or the database.

## Expected result

The mobile app no longer shows the DEBUG banner in checked-mode builds. There is no release-mode user-visible impact.

## Verification

- `dart pub get` from `client/`
- `dart format --output=none --set-exit-if-changed lib/main.dart` from `client/app/`
- `dart analyze` from `client/app/`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables Flutter's checked-mode banner in the mobile app shell so debug builds no longer overlay the product UI with the DEBUG badge. This is a UI-only change with no impact on behavior, data, or release builds.

<sup>Written for commit 78450f86587ade668b2dcf7a934ddf6e2d4d17e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

