### PR TITLE
⚙️ Redesign harness settings overview and details

### DIFF
--- a/client/app/lib/core/routing/app_router.dart
+++ b/client/app/lib/core/routing/app_router.dart
@@ -34,7 +34,6 @@ const _sessionsRouteSegment = ":$projectIdPathParam/sessions";
 const _sessionDetailRouteSegment = ":$sessionIdPathParam";
 const _sessionDiffsRouteSegment = "diffs";
 const _settingsNotificationsRouteSegment = "notifications";
-const _settingsHarnessesRouteSegment = "harnesses";
 const _settingsProfileRouteSegment = "profile";
 
 extension AppRouteToGoRoute on AppRouteDef {
@@ -367,13 +366,13 @@ List<RouteBase> _buildAppRoutes({
         ),
       ],
     ),
+    buildHarnessSettingsRoute(),
     AppRouteDef.settings.toGoRoute(
       routes: [
         GoRoute(
           path: _settingsNotificationsRouteSegment,
           builder: (context, state) => AppRouteDef.settingsNotifications._buildScreen(context: context, state: state),
         ),
-        buildHarnessSettingsRoute(),
         GoRoute(
           path: _settingsProfileRouteSegment,
           builder: (context, state) => AppRouteDef.settingsProfile._buildScreen(context: context, state: state),
@@ -437,56 +436,21 @@ final appRouter = GoRouter(
 @visibleForTesting
 ShellRoute buildHarnessSettingsRoute() {
   final navigatorKey = GlobalKey<NavigatorState>();
-  late final ShellRoute flow;
   void close({required BuildContext context}) {
-    // ignore: no_slop_linter/avoid_raw_go_router, shell-owned stack boundary
-    final router = GoRouter.of(context);
-    final settingsKeys = <LocalKey>{};
-    void collect({required List<RouteMatchBase> matches}) {
-      for (final match in matches) {
-        if (match is ShellRouteMatch) {
-          if (match.route == flow) settingsKeys.add(match.pageKey);
-          collect(matches: match.matches);
-        } else if (match.matchedLocation == AppRouteDef.settings.path ||
-            match.matchedLocation.startsWith("${AppRouteDef.settings.path}/")) {
-          settingsKeys.add(match.pageKey);
-        }
-      }
-    }
-
-    collect(matches: router.routerDelegate.currentConfiguration.matches);
-    var needsHome = false;
-    // The context of the nested Navigator belongs to the outer navigator.
-    // Popping its shell page removes the entire flow, including owned sheets.
-    final outerNavigator =
-        navigatorKey.currentContext?.findAncestorStateOfType<NavigatorState>() ??
-        (throw StateError("Harness flow is not mounted"));
-    outerNavigator.popUntil((route) {
-      final page = route.settings;
-      if (page is! Page) return false;
-      if (!settingsKeys.contains(page.key)) return true;
-      if (route.isFirst) {
-        needsHome = true;
-        return true;
-      }
-      return false;
-    });
-    if (needsHome) {
-      // ignore: no_slop_linter/avoid_raw_go_router, direct links have no signed-in opener
-      router.go(const AppRoute.projects().buildPath());
-    }
-  }
-
-  void back({required BuildContext context}) {
-    if (context.canPop()) {
-      context.pop();
+    // The nested Navigator's context belongs to the stable outer flow page.
+    final flowContext = navigatorKey.currentContext ?? (throw StateError("Harness flow is not mounted"));
+    final flowRoute = ModalRoute.of(flowContext) ?? (throw StateError("Harness flow has no owning route"));
+    final outerNavigator = flowRoute.navigator ?? (throw StateError("Harness flow has no navigator"));
+    // Remove owned pageless sheets first, without touching the opener.
+    outerNavigator.popUntil((route) => route == flowRoute);
+    if (flowRoute.isFirst) {
+      context.goRoute(const AppRoute.projects());
     } else {
-      // ignore: no_slop_linter/avoid_raw_go_router, typed route boundary
-      GoRouter.of(context).go(const AppRoute.settings().buildPath());
+      outerNavigator.pop();
     }
   }
 
-  return flow = ShellRoute(
+  return ShellRoute(
     navigatorKey: navigatorKey,
     pageBuilder: (context, state, child) {
       final presentation = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters).presentation;
@@ -497,7 +461,7 @@ ShellRoute buildHarnessSettingsRoute() {
     },
     routes: [
       GoRoute(
-        path: _settingsHarnessesRouteSegment,
+        path: AppRouteDef.settingsHarnesses.path,
         builder: (context, state) {
           final presentation = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters)
               .presentation;
@@ -505,27 +469,28 @@ ShellRoute buildHarnessSettingsRoute() {
             presentation: presentation,
             connectionBanner: ConnectionBanner.maybeFor(context),
             onClose: () => close(context: context),
-            onBack: () => back(context: context),
-            onOpenHarness: ({required pluginId}) {
-              // ignore: no_slop_linter/avoid_raw_go_router, typed route boundary
-              GoRouter.of(
-                context,
-              ).push<void>(AppRoute.settingsHarnessDetail(pluginId: pluginId, presentation: presentation).buildPath());
-            },
+            onBack: () => close(context: context),
+            onOpenHarness: ({required pluginId}) => context.pushRoute(
+              AppRoute.settingsHarnessDetail(pluginId: pluginId, presentation: presentation),
+            ),
           );
         },
         routes: [
           GoRoute(
             path: ":$pluginIdPathParam",
-            builder: (context, state) => HarnessSettingsDetailView(
-              pluginId: AppRouteSettingsHarnessDetail.fromParams(
+            builder: (context, state) {
+              final route = AppRouteSettingsHarnessDetail.fromParams(
                 pathParams: state.pathParameters,
                 queryParams: state.uri.queryParameters,
-              ).pluginId,
-              connectionBanner: ConnectionBanner.maybeFor(context),
-              onBack: () => context.pop(),
-              onClose: () => close(context: context),
-            ),
+              );
+              return HarnessSettingsDetailView(
+                pluginId: route.pluginId,
+                presentation: route.presentation,
+                connectionBanner: ConnectionBanner.maybeFor(context),
+                onBack: () => context.pop(),
+                onClose: () => close(context: context),
+              );
+            },
           ),
         ],
       ),

--- a/client/app/lib/core/routing/app_router.dart
+++ b/client/app/lib/core/routing/app_router.dart
@@ -102,7 +102,8 @@ extension on AppRoute {
       AppRouteProjects() => const ProjectListScreen(),
       AppRouteSettings() => const SettingsScreen(),
       AppRouteSettingsNotifications() => const NotificationSettingsScreen(),
-      AppRouteSettingsHarnesses(:final presentation) => HarnessesSettingsScreen(presentation: presentation),
+      AppRouteSettingsHarnesses() ||
+      AppRouteSettingsHarnessDetail() => throw StateError("Harness pages belong to their flow shell"),
       AppRouteSettingsProfile() => const ProfileScreen(),
       AppRouteSessions(:final projectId, :final projectName) => SessionListScreen(
         projectId: projectId,
@@ -372,38 +373,7 @@ List<RouteBase> _buildAppRoutes({
           path: _settingsNotificationsRouteSegment,
           builder: (context, state) => AppRouteDef.settingsNotifications._buildScreen(context: context, state: state),
         ),
-        GoRoute(
-          path: _settingsHarnessesRouteSegment,
-          // Harness settings are reached from two places, and the route says
-          // which one. From the settings list they are the next page of that
-          // stack, so they push in like every other settings page. From the
-          // new-session harness menu they are a detour from an unrelated
-          // screen, so they rise as a modal and close back onto it.
-          //
-          // The modal is a CupertinoPage for the same reason settings itself
-          // uses one: only the Cupertino route honours `fullscreenDialog` on
-          // Android too. Choosing per presentation requires a pageBuilder, so
-          // the pushed branch spells out the MaterialPage that go_router would
-          // otherwise supply, keeping the platform's push transition.
-          pageBuilder: (context, state) {
-            final route = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters);
-            final child = route.screen;
-            return switch (route.presentation) {
-              HarnessSettingsPresentation.modal => CupertinoPage<void>(
-                key: state.pageKey,
-                fullscreenDialog: true,
-                child: child,
-              ),
-              HarnessSettingsPresentation.pushed => MaterialPage<void>(
-                key: state.pageKey,
-                name: state.name ?? state.path,
-                arguments: <String, String>{...state.pathParameters, ...state.uri.queryParameters},
-                restorationId: state.pageKey.value,
-                child: child,
-              ),
-            };
-          },
-        ),
+        buildHarnessSettingsRoute(),
         GoRoute(
           path: _settingsProfileRouteSegment,
           builder: (context, state) => AppRouteDef.settingsProfile._buildScreen(context: context, state: state),
@@ -462,3 +432,103 @@ final appRouter = GoRouter(
   },
   routes: buildAppRoutes(),
 );
+
+/// Harness-only navigator and provider shared by overview and URL detail pages.
+@visibleForTesting
+ShellRoute buildHarnessSettingsRoute() {
+  final navigatorKey = GlobalKey<NavigatorState>();
+  late final ShellRoute flow;
+  void close({required BuildContext context}) {
+    // ignore: no_slop_linter/avoid_raw_go_router, shell-owned stack boundary
+    final router = GoRouter.of(context);
+    final settingsKeys = <LocalKey>{};
+    void collect({required List<RouteMatchBase> matches}) {
+      for (final match in matches) {
+        if (match is ShellRouteMatch) {
+          if (match.route == flow) settingsKeys.add(match.pageKey);
+          collect(matches: match.matches);
+        } else if (match.matchedLocation == AppRouteDef.settings.path ||
+            match.matchedLocation.startsWith("${AppRouteDef.settings.path}/")) {
+          settingsKeys.add(match.pageKey);
+        }
+      }
+    }
+
+    collect(matches: router.routerDelegate.currentConfiguration.matches);
+    var needsHome = false;
+    // The context of the nested Navigator belongs to the outer navigator.
+    // Popping its shell page removes the entire flow, including owned sheets.
+    final outerNavigator =
+        navigatorKey.currentContext?.findAncestorStateOfType<NavigatorState>() ??
+        (throw StateError("Harness flow is not mounted"));
+    outerNavigator.popUntil((route) {
+      final page = route.settings;
+      if (page is! Page) return false;
+      if (!settingsKeys.contains(page.key)) return true;
+      if (route.isFirst) {
+        needsHome = true;
+        return true;
+      }
+      return false;
+    });
+    if (needsHome) {
+      // ignore: no_slop_linter/avoid_raw_go_router, direct links have no signed-in opener
+      router.go(const AppRoute.projects().buildPath());
+    }
+  }
+
+  void back({required BuildContext context}) {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      // ignore: no_slop_linter/avoid_raw_go_router, typed route boundary
+      GoRouter.of(context).go(const AppRoute.settings().buildPath());
+    }
+  }
+
+  return flow = ShellRoute(
+    navigatorKey: navigatorKey,
+    pageBuilder: (context, state, child) {
+      final presentation = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters).presentation;
+      final content = HarnessesSettingsScreen(child: child);
+      return presentation == HarnessSettingsPresentation.modal
+          ? CupertinoPage<void>(key: state.pageKey, fullscreenDialog: true, child: content)
+          : MaterialPage<void>(key: state.pageKey, child: content);
+    },
+    routes: [
+      GoRoute(
+        path: _settingsHarnessesRouteSegment,
+        builder: (context, state) {
+          final presentation = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters)
+              .presentation;
+          return HarnessesSettingsView(
+            presentation: presentation,
+            connectionBanner: ConnectionBanner.maybeFor(context),
+            onClose: () => close(context: context),
+            onBack: () => back(context: context),
+            onOpenHarness: ({required pluginId}) {
+              // ignore: no_slop_linter/avoid_raw_go_router, typed route boundary
+              GoRouter.of(
+                context,
+              ).push<void>(AppRoute.settingsHarnessDetail(pluginId: pluginId, presentation: presentation).buildPath());
+            },
+          );
+        },
+        routes: [
+          GoRoute(
+            path: ":$pluginIdPathParam",
+            builder: (context, state) => HarnessSettingsDetailView(
+              pluginId: AppRouteSettingsHarnessDetail.fromParams(
+                pathParams: state.pathParameters,
+                queryParams: state.uri.queryParameters,
+              ).pluginId,
+              connectionBanner: ConnectionBanner.maybeFor(context),
+              onBack: () => context.pop(),
+              onClose: () => close(context: context),
+            ),
+          ),
+        ],
+      ),
+    ],
+  );
+}

--- a/client/app/lib/features/settings/harnesses_settings_screen.dart
+++ b/client/app/lib/features/settings/harnesses_settings_screen.dart
@@ -1,32 +1,19 @@
 import "package:flutter_bloc/flutter_bloc.dart";
-import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
 import "package:sesori_app_ui/sesori_app_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../../core/di/injection.dart";
-import "../../core/routing/app_router.dart";
 
-/// Mobile-shell composition for shared harness management.
-class const HarnessesSettingsScreen({
-  super.key,
-  required final HarnessSettingsPresentation presentation,
-}) extends StatelessWidget {
+/// The mobile harness-flow lifetime, above its nested navigator.
+class const HarnessesSettingsScreen({super.key, required final Widget child}) extends StatelessWidget {
   @override
-  Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (_) => PluginManagementCubit(
-        service: getIt<PluginManagementService>(),
-        urlLauncher: getIt<UrlLauncher>(),
-        catalogRescanService: getIt<CatalogRescanService>(),
-      ),
-      child: HarnessesSettingsView(
-        presentation: presentation,
-        connectionBanner: ConnectionBanner.maybeFor(context),
-        // A modal normally pops to its opener. A direct deep link has no
-        // opener and therefore falls back to the mobile signed-in home.
-        onModalClose: () => context.canPop() ? context.pop() : context.goRoute(const AppRoute.projects()),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => BlocProvider(
+    create: (_) => PluginManagementCubit(
+      service: getIt<PluginManagementService>(),
+      urlLauncher: getIt<UrlLauncher>(),
+      catalogRescanService: getIt<CatalogRescanService>(),
+    ),
+    child: HarnessSettingsFlowView(child: child),
+  );
 }

--- a/client/app/test/core/routing/app_route_test.dart
+++ b/client/app/test/core/routing/app_route_test.dart
@@ -15,8 +15,6 @@ import "package:sesori_mobile/features/session_detail/session_detail_screen.dart
 import "package:sesori_mobile/features/session_diffs/session_diffs_screen.dart";
 import "package:sesori_mobile/features/session_list/session_list_cubit_provider.dart";
 import "package:sesori_mobile/features/settings/harnesses_settings_screen.dart";
-import "package:sesori_mobile/features/settings/notification_settings_screen.dart";
-import "package:sesori_mobile/features/settings/profile_screen.dart";
 import "package:sesori_mobile/features/settings/settings_screen.dart";
 import "package:sesori_mobile/features/splash/splash_screen.dart";
 
@@ -171,51 +169,31 @@ void main() {
       expect(settingsPage.child, isA<SettingsScreen>());
     });
 
-    test("settings child routes build their screens without management nesting", () {
+    test("settings retains its hierarchy around the harness-only shell", () {
       final settingsRoute = buildAppRoutes().whereType<GoRoute>().singleWhere(
         (route) => route.path == AppRouteDef.settings.path,
       );
-      final children = settingsRoute.routes.whereType<GoRoute>().toList();
-
-      expect(
-        children.map((route) => route.path),
-        equals(["notifications", "harnesses", "profile"]),
-      );
-      final notificationsWidget = children[0].builder!(_FakeBuildContext(), _FakeGoRouterState());
-      expect(notificationsWidget, isA<NotificationSettingsScreen>());
-      // Harnesses rise as a modal from the new-session harness menu and push
-      // in from the settings list, so the route builds its own page per
-      // presentation instead of taking the default push for both.
-      final harnessesModalPage = children[1].pageBuilder!(
+      final children = settingsRoute.routes;
+      expect((children[0] as GoRoute).path, "notifications");
+      expect((children[2] as GoRoute).path, "profile");
+      final harnessShell = children[1] as ShellRoute;
+      final overview = harnessShell.routes.single as GoRoute;
+      expect(overview.path, "harnesses");
+      expect((overview.routes.single as GoRoute).path, ":$pluginIdPathParam");
+      const child = SizedBox();
+      final modal = harnessShell.pageBuilder!(
         _FakeBuildContext(),
         _FakeGoRouterState(queryParameters: {harnessSettingsPresentationQueryParam: "modal"}),
+        child,
       ) as CupertinoPage<void>;
-      expect(harnessesModalPage.fullscreenDialog, isTrue);
-      expect(harnessesModalPage.child, isA<HarnessesSettingsScreen>());
-      final harnessesPushedPage = children[1].pageBuilder!(
+      expect(modal.fullscreenDialog, isTrue);
+      expect(modal.child, isA<HarnessesSettingsScreen>());
+      final pushed = harnessShell.pageBuilder!(
         _FakeBuildContext(),
         _FakeGoRouterState(queryParameters: {harnessSettingsPresentationQueryParam: "pushed"}),
+        child,
       ) as MaterialPage<void>;
-      expect(harnessesPushedPage.child, isA<HarnessesSettingsScreen>());
-      expect(
-        (harnessesPushedPage.child as HarnessesSettingsScreen).presentation,
-        HarnessSettingsPresentation.pushed,
-      );
-      expect(children[1].routes, isEmpty);
-      final profileWidget = children[2].builder!(_FakeBuildContext(), _FakeGoRouterState());
-      expect(profileWidget, isA<ProfileScreen>());
-      expect(
-        _composeRoutePath(parentPath: AppRouteDef.settings.path, path: children[0].path),
-        AppRouteDef.settingsNotifications.path,
-      );
-      expect(
-        _composeRoutePath(parentPath: AppRouteDef.settings.path, path: children[1].path),
-        AppRouteDef.settingsHarnesses.path,
-      );
-      expect(
-        _composeRoutePath(parentPath: AppRouteDef.settings.path, path: children[2].path),
-        AppRouteDef.settingsProfile.path,
-      );
+      expect((pushed.child as HarnessesSettingsScreen).child, same(child));
     });
 
     test("newSession route builds NewSessionScreen", () {
@@ -272,6 +250,7 @@ void main() {
           AppRouteDef.settings.path,
           AppRouteDef.settingsNotifications.path,
           AppRouteDef.settingsHarnesses.path,
+          AppRouteDef.settingsHarnessDetail.path,
           AppRouteDef.settingsProfile.path,
         ]),
       );
@@ -356,8 +335,8 @@ void main() {
     });
 
     group("nested route tree invariants", () {
-      test("registers exactly one shell route", () {
-        expect(_collectShellRoutes(routes: buildAppRoutes()), hasLength(1));
+      test("registers separate session and harness shell routes", () {
+        expect(_collectShellRoutes(routes: buildAppRoutes()), hasLength(2));
       });
 
       test("shell owns exactly one first-level session route", () {
@@ -531,7 +510,9 @@ List<ShellRoute> _collectShellRoutes({required List<RouteBase> routes}) {
   return shells;
 }
 
-ShellRoute _sessionShellRoute() => _collectShellRoutes(routes: buildAppRoutes()).single;
+ShellRoute _sessionShellRoute() =>
+    _collectShellRoutes(routes: buildAppRoutes())
+        .singleWhere((shell) => (shell.routes.first as GoRoute).path == ":$projectIdPathParam/sessions");
 
 String _composeRoutePath({required String parentPath, required String path}) {
   if (path.startsWith("/")) return path;

--- a/client/app/test/core/routing/app_route_test.dart
+++ b/client/app/test/core/routing/app_route_test.dart
@@ -169,16 +169,17 @@ void main() {
       expect(settingsPage.child, isA<SettingsScreen>());
     });
 
-    test("settings retains its hierarchy around the harness-only shell", () {
+    test("harness-only shell is a sibling of Settings with overview ancestry", () {
       final settingsRoute = buildAppRoutes().whereType<GoRoute>().singleWhere(
         (route) => route.path == AppRouteDef.settings.path,
       );
       final children = settingsRoute.routes;
       expect((children[0] as GoRoute).path, "notifications");
-      expect((children[2] as GoRoute).path, "profile");
-      final harnessShell = children[1] as ShellRoute;
+      expect((children[1] as GoRoute).path, "profile");
+      expect(children, hasLength(2));
+      final harnessShell = buildAppRoutes().whereType<ShellRoute>().single;
       final overview = harnessShell.routes.single as GoRoute;
-      expect(overview.path, "harnesses");
+      expect(overview.path, AppRouteDef.settingsHarnesses.path);
       expect((overview.routes.single as GoRoute).path, ":$pluginIdPathParam");
       const child = SizedBox();
       final modal = harnessShell.pageBuilder!(
@@ -247,10 +248,10 @@ void main() {
           AppRouteDef.newSession.path,
           AppRouteDef.sessionDetail.path,
           AppRouteDef.sessionDiffs.path,
-          AppRouteDef.settings.path,
-          AppRouteDef.settingsNotifications.path,
           AppRouteDef.settingsHarnesses.path,
           AppRouteDef.settingsHarnessDetail.path,
+          AppRouteDef.settings.path,
+          AppRouteDef.settingsNotifications.path,
           AppRouteDef.settingsProfile.path,
         ]),
       );

--- a/client/app/test/features/new_session/new_session_screen_test.dart
+++ b/client/app/test/features/new_session/new_session_screen_test.dart
@@ -17,6 +17,7 @@ import "package:sesori_dart_core/src/foundation/models/session_options/session_o
 import "package:sesori_dart_core/src/repositories/models/plugin_discovery_snapshot.dart";
 import "package:sesori_dart_core/src/repositories/models/session_options_repository_result.dart";
 import "package:sesori_dart_core/src/repositories/plugin_preference_repository.dart";
+import "package:sesori_mobile/core/routing/app_router.dart";
 import "package:sesori_mobile/features/new_session/new_session_screen.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
@@ -28,6 +29,10 @@ import "../../helpers/voice_test_helpers.dart";
 class MockComposerAttachmentDispatcher() extends Mock implements ComposerAttachmentDispatcher;
 
 class MockImageClipboard() extends Mock implements ImageClipboard;
+
+class _MockPluginManagementService() extends Mock implements PluginManagementService;
+
+class _MockUrlLauncher() extends Mock implements UrlLauncher;
 
 class MockPluginRepository() extends Mock implements PluginRepository;
 
@@ -149,6 +154,7 @@ Future<void> closeHarnessMenu(WidgetTester tester) async {
 }
 
 Widget _buildApp({
+  bool useHarnessFlow = false,
   ThemeMode themeMode = ThemeMode.light,
   SessionListState sessionListState = const SessionListState.loaded(
     sessions: [],
@@ -172,10 +178,13 @@ Widget _buildApp({
           ),
         ],
       ),
-      GoRoute(
-        path: "/settings/harnesses",
-        builder: (context, state) => const Material(child: Text("harnesses-settings")),
-      ),
+      if (useHarnessFlow)
+        buildHarnessSettingsRoute()
+      else
+        GoRoute(
+          path: "/settings/harnesses",
+          builder: (context, state) => const Material(child: Text("harnesses-settings")),
+        ),
       GoRoute(
         path: "/projects/:projectId/sessions/:sessionId",
         builder: (context, state) {
@@ -1003,6 +1012,73 @@ void main() {
 
     expect(find.text("harnesses-settings"), findsOneWidget);
   });
+
+  for (final closeFromDetail in [false, true]) {
+    testWidgets("harness modal X retains the same New Session and draft (detail: $closeFromDetail)", (tester) async {
+      final service = _MockPluginManagementService();
+      when(service.onDispose).thenAnswer((_) async {});
+      final snapshots = BehaviorSubject<PluginManagementLoadResult>.seeded(
+        const PluginManagementLoadResult.supported(
+          response: PluginManagementResponse(
+            snapshotToken: "navigation-test",
+            bridgeId: "bridge-1",
+            defaultPluginId: "test-harness",
+            defaultIdleTimeoutMins: 10,
+            plugins: [],
+          ),
+          refreshError: null,
+        ),
+      );
+      when(() => service.snapshots).thenAnswer((_) => snapshots.stream);
+      final installs = BehaviorSubject<Map<String, PluginInstallState>>.seeded(const {});
+      addTearDown(installs.close);
+      when(() => service.installStates).thenAnswer((_) => installs.stream);
+      when(() => service.authenticationTerminal)
+          .thenAnswer((_) => const Stream<PluginAuthenticationTerminalUpdate>.empty());
+      GetIt.instance.registerSingleton<PluginManagementService>(service);
+      GetIt.instance.registerSingleton<UrlLauncher>(_MockUrlLauncher());
+      addTearDown(snapshots.close);
+      await tester.pumpWidget(_buildApp(useHarnessFlow: true));
+      await tester.pumpAndSettle();
+      await enterTypingMode(tester);
+      await tester.enterText(find.byType(EditableText), "half-written idea");
+      await tester.pump();
+      final opener = tester.element(find.byType(NewSessionScreen));
+      final composer = tester.element(find.byType(PromptInput));
+      final newSessionCubit = composer.read<NewSessionCubit>();
+      await openHarnessMenu(tester);
+      await tester.tap(find.byKey(const Key("new_session_harness_settings")));
+      await tester.pumpAndSettle();
+      final overview = tester.element(find.byType(HarnessesSettingsView));
+      final harnessCubit = overview.read<PluginManagementCubit>();
+      if (closeFromDetail) {
+        unawaited(
+          overview.pushRoute(
+            const AppRoute.settingsHarnessDetail(
+              pluginId: "removed",
+              presentation: HarnessSettingsPresentation.modal,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(
+          tester.element(find.byType(HarnessSettingsDetailView)).read<PluginManagementCubit>(),
+          same(harnessCubit),
+        );
+      }
+      await tester.tap(find.bySemanticsLabel("Close settings"));
+      await tester.pumpAndSettle();
+      expect(tester.element(find.byType(NewSessionScreen)), same(opener));
+      expect(tester.element(find.byType(PromptInput)), same(composer));
+      expect(tester.element(find.byType(PromptInput)).read<NewSessionCubit>(), same(newSessionCubit));
+      expect(newSessionCubit.composerDraft, ComposerDraft.typed(text: "half-written idea"));
+      expect(find.text("half-written idea"), findsOneWidget);
+      // Stream cancellation completes outside the widget-test clock.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      expect(harnessCubit.isClosed, isTrue);
+      expect(snapshots.hasListener, isFalse);
+    });
+  }
 
   testWidgets("keeps the harness settings icon layout-safe on hover", (tester) async {
     final semantics = tester.ensureSemantics();

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -90,28 +90,35 @@ const _conflict = PluginLifecycleConflict(
   current: _managed,
 );
 
-Widget _app() {
+Widget _app({String initialLocation = "/settings/harnesses"}) {
+  final rootNavigatorKey = GlobalKey<NavigatorState>();
   final router = GoRouter(
+    navigatorKey: rootNavigatorKey,
+    initialLocation: initialLocation,
     routes: [
       GoRoute(
-        path: "/",
-        builder: (context, state) => BlocProvider<ConnectionOverlayCubit>.value(
-          value: StubConnectionOverlayCubit(),
-          child: const HarnessesSettingsScreen(presentation: HarnessSettingsPresentation.modal),
-        ),
-      ),
-      GoRoute(
         path: "/projects",
-        builder: (context, state) => const Scaffold(body: Text("projects-route")),
+        builder: (_, _) => const Scaffold(body: Text("projects-route")),
+      ),
+      ...buildAppRoutesForTesting(rootNavigatorKey: rootNavigatorKey).map(
+        (route) => route is GoRoute && route.path == AppRouteDef.settings.path
+            ? GoRoute(
+                path: route.path,
+                routes: route.routes,
+                builder: (_, _) => const Scaffold(body: Text("settings-ancestor")),
+              )
+            : route,
       ),
     ],
   );
-
-  return MaterialApp.router(
-    routerConfig: router,
-    theme: ThemeData(extensions: [PregoDesignSystem.light]),
-    localizationsDelegates: AppLocalizations.localizationsDelegates,
-    supportedLocales: AppLocalizations.supportedLocales,
+  return BlocProvider<ConnectionOverlayCubit>.value(
+    value: StubConnectionOverlayCubit(),
+    child: MaterialApp.router(
+      routerConfig: router,
+      theme: ThemeData(extensions: [PregoDesignSystem.light]),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+    ),
   );
 }
 
@@ -120,17 +127,21 @@ Widget _app() {
 /// close button's pop branch, which `_app` (mounted at the router root) cannot.
 Widget _appPushedFromOpener({
   HarnessSettingsPresentation presentation = HarnessSettingsPresentation.modal,
+  String openerPath = "/opener",
+  bool throughSettings = false,
 }) {
   final rootNavigatorKey = GlobalKey<NavigatorState>();
   final router = GoRouter(
     navigatorKey: rootNavigatorKey,
-    initialLocation: "/opener",
+    initialLocation: openerPath,
     routes: [
       GoRoute(
-        path: "/opener",
+        path: openerPath,
         builder: (context, state) => Scaffold(
           body: TextButton(
-            onPressed: () => context.pushRoute(AppRoute.settingsHarnesses(presentation: presentation)),
+            onPressed: () => context.pushRoute(
+              throughSettings ? const AppRoute.settings() : AppRoute.settingsHarnesses(presentation: presentation),
+            ),
             child: const Text("open-harnesses"),
           ),
         ),
@@ -139,7 +150,20 @@ Widget _appPushedFromOpener({
         path: "/projects",
         builder: (context, state) => const Scaffold(body: Text("projects-route")),
       ),
-      ...buildAppRoutesForTesting(rootNavigatorKey: rootNavigatorKey),
+      ...buildAppRoutesForTesting(rootNavigatorKey: rootNavigatorKey).map(
+        (route) => throughSettings && route is GoRoute && route.path == AppRouteDef.settings.path
+            ? GoRoute(
+                path: route.path,
+                routes: route.routes,
+                builder: (context, _) => Scaffold(
+                  body: TextButton(
+                    onPressed: () => context.pushRoute(AppRoute.settingsHarnesses(presentation: presentation)),
+                    child: const Text("settings-open-harnesses"),
+                  ),
+                ),
+              )
+            : route,
+      ),
     ],
   );
 
@@ -161,6 +185,10 @@ void _useTallSurface(WidgetTester tester) {
 }
 
 Future<void> _openRow(WidgetTester tester, String key) async {
+  if (find.byKey(Key(key)).evaluate().isEmpty && !key.contains("default_timeout")) {
+    final pluginId = key.substring(key.lastIndexOf("_") + 1);
+    await _showDetail(tester, pluginId);
+  }
   final row = find.byKey(Key(key));
   await tester.ensureVisible(row);
   await tester.pumpAndSettle();
@@ -168,10 +196,19 @@ Future<void> _openRow(WidgetTester tester, String key) async {
   await tester.pumpAndSettle();
 }
 
-Finder _switchFor(String pluginId) => find.descendant(
-  of: find.byKey(Key("harness_management_enabled_$pluginId")),
-  matching: find.byType(PregoSwitch),
-);
+Finder _switchFor(String pluginId) => find.byKey(Key("harness_management_enabled_$pluginId"));
+
+Future<void> _showDetail(WidgetTester tester, String pluginId) async {
+  if (find.byType(HarnessSettingsDetailView).evaluate().isNotEmpty) {
+    if (tester.widget<HarnessSettingsDetailView>(find.byType(HarnessSettingsDetailView)).pluginId == pluginId) return;
+    GoRouter.of(tester.element(find.byType(HarnessSettingsDetailView))).pop();
+    await tester.pumpAndSettle();
+  }
+  final row = find.byKey(Key("harnesses_card_$pluginId"));
+  await tester.ensureVisible(row);
+  await tester.tap(find.descendant(of: row, matching: find.byType(Text)).first);
+  await tester.pumpAndSettle();
+}
 
 Finder _timeoutField() => find.descendant(
   of: find.byKey(const Key("harness_management_timeout_input")),
@@ -189,7 +226,7 @@ int? _timeoutMinutes(PluginManagementIdleTimeoutInput input) => switch (input) {
 void main() {
   late _MockPluginManagementService service;
   late BehaviorSubject<PluginManagementLoadResult> snapshots;
-  late BehaviorSubject<Map<String, PluginInstallProgress>> installProgress;
+  late BehaviorSubject<Map<String, PluginInstallState>> installStates;
   late BehaviorSubject<Map<String, PluginAuthenticationChallenge>> authenticationChallenges;
   late StreamController<PluginAuthenticationTerminalUpdate> authenticationTerminal;
   late _MockUrlLauncher urlLauncher;
@@ -212,11 +249,11 @@ void main() {
     urlLauncher = _MockUrlLauncher();
     rescan = FakeCatalogRescanService();
     snapshots = BehaviorSubject();
-    installProgress = BehaviorSubject.seeded(const {});
+    installStates = BehaviorSubject.seeded(const {});
     authenticationChallenges = BehaviorSubject.seeded(const {});
     authenticationTerminal = StreamController.broadcast(sync: true);
     when(() => service.snapshots).thenAnswer((_) => snapshots.stream);
-    when(() => service.installProgress).thenAnswer((_) => installProgress.stream);
+    when(() => service.installStates).thenAnswer((_) => installStates.stream);
     when(() => service.authenticationChallenges).thenAnswer((_) => authenticationChallenges.stream);
     when(() => service.authenticationTerminal).thenAnswer((_) => authenticationTerminal.stream);
     when(() => service.refresh()).thenAnswer((_) async {});
@@ -298,7 +335,7 @@ void main() {
   tearDown(() async {
     await GetIt.instance.reset();
     await snapshots.close();
-    await installProgress.close();
+    await installStates.close();
     await authenticationChallenges.close();
     await authenticationTerminal.close();
   });
@@ -334,6 +371,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    await _showDetail(tester, "codex");
     expect(find.byKey(const Key("harness_authentication_codex")), findsOneWidget);
     expect(find.text("Log in"), findsOneWidget);
     expect(find.text("0.42.0"), findsOneWidget);
@@ -373,14 +411,18 @@ void main() {
     );
     await tester.pumpAndSettle();
 
+    await _showDetail(tester, "codex");
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     await tester.pump();
 
+    await _showDetail(tester, "claude");
     expect(
       tester.widget<PregoGroupedRow>(find.byKey(const Key("harness_authentication_claude"))).onTap,
       isNull,
     );
     verifyNever(() => service.startAuthentication(pluginId: "claude"));
+    await _showDetail(tester, "codex");
 
     authenticationChallenges.add({
       "codex": PluginAuthenticationDeviceCodeChallenge(
@@ -419,6 +461,8 @@ void main() {
     });
     await tester.pumpAndSettle();
 
+    await _showDetail(tester, "codex");
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     await tester.pumpAndSettle();
     expect(find.text("ABCD-EFGH"), findsOneWidget);
@@ -433,11 +477,13 @@ void main() {
     await tester.tapAt(const Offset(10, 10));
     await tester.pumpAndSettle();
     verifyNever(() => service.cancelAuthentication(pluginId: any(named: "pluginId")));
+    await _showDetail(tester, "claude");
     expect(
       tester.widget<PregoGroupedRow>(find.byKey(const Key("harness_authentication_claude"))).onTap,
       isNull,
     );
 
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     await tester.pumpAndSettle();
     expect(find.text("ABCD-EFGH"), findsOneWidget);
@@ -466,6 +512,8 @@ void main() {
       ),
     });
     await tester.pumpAndSettle();
+    await _showDetail(tester, "codex");
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     await tester.pumpAndSettle();
 
@@ -493,6 +541,8 @@ void main() {
       ),
     });
     await tester.pumpAndSettle();
+    await _showDetail(tester, "codex");
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     await tester.pumpAndSettle();
 
@@ -512,9 +562,14 @@ void main() {
     verify(
       () => urlLauncher.launch(Uri.parse("https://accounts.example/authorize"), mode: UrlLaunchMode.externalApp),
     ).called(1);
-    final captured = verify(
-      () => service.submitAuthenticationRedirect(pluginId: "codex", intent: captureAny(named: "intent")),
-    ).captured.single as PluginAuthenticationPastedContinuationIntent;
+    final captured =
+        verify(
+              () => service.submitAuthenticationRedirect(
+                pluginId: "codex",
+                intent: captureAny(named: "intent"),
+              ),
+            ).captured.single
+            as PluginAuthenticationPastedContinuationIntent;
     expect(captured.rawInput, "http://127.0.0.1/callback?code=opaque");
   });
 
@@ -534,6 +589,8 @@ void main() {
       ),
     });
     await tester.pumpAndSettle();
+    await _showDetail(tester, "codex");
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     await tester.pumpAndSettle();
 
@@ -564,6 +621,8 @@ void main() {
       ),
     });
     await tester.pumpAndSettle();
+    await _showDetail(tester, "codex");
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     await tester.pumpAndSettle();
 
@@ -595,6 +654,8 @@ void main() {
         userCode: "ABCD-EFGH",
       ),
     });
+    await _showDetail(tester, "codex");
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     authenticationTerminal.add((
       pluginId: "codex",
@@ -627,6 +688,8 @@ void main() {
       ),
     });
     await tester.pumpAndSettle();
+    await _showDetail(tester, "codex");
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     await tester.pumpAndSettle();
 
@@ -658,6 +721,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text("Log in to harness"), findsNothing);
 
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     await tester.pumpAndSettle();
     expect(find.text("ABCD-EFGH"), findsOneWidget);
@@ -684,6 +748,8 @@ void main() {
       ),
     });
     await tester.pumpAndSettle();
+    await _showDetail(tester, "codex");
+    await _showDetail(tester, "codex");
     await tester.tap(find.byKey(const Key("harness_authentication_codex")));
     await tester.pumpAndSettle();
     await tester.tap(find.byKey(const Key("harness_authentication_cancel")));
@@ -722,12 +788,13 @@ void main() {
 
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
+    await _showDetail(tester, "future-harness");
 
-    expect(find.text("Runtime missing"), findsOneWidget);
+    expect(find.text("Not installed"), findsOneWidget);
     expect(find.text("Install the harness runtime."), findsOneWidget);
     expect(find.byKey(const Key("harness_management_enabled_future-harness")), findsOneWidget);
     expect(tester.widget<PregoSwitch>(_switchFor("future-harness")).value, isTrue);
-    expect(find.byKey(const Key("harness_management_refresh_future-harness")), findsOneWidget);
+    expect(find.byKey(const Key("harness_management_refresh_future-harness")), findsNothing);
     expect(find.byKey(const Key("harness_management_restart_future-harness")), findsNothing);
     expect(find.byKey(const Key("harness_management_timeout_future-harness")), findsNothing);
     expect(find.byKey(const Key("harness_management_default_timeout")), findsNothing);
@@ -766,7 +833,7 @@ void main() {
 
     final installRow = find.byKey(const Key("harness_management_install_future-harness"));
     expect(installRow, findsOneWidget);
-    expect(find.text("Download this harness for Sesori only. Your system stays untouched."), findsOneWidget);
+    expect(find.byType(HarnessSettingsDetailView), findsNothing);
 
     await _openRow(tester, "harness_management_install_future-harness");
     verify(
@@ -776,26 +843,32 @@ void main() {
       ),
     ).called(1);
 
+    await _showDetail(tester, "future-harness");
+
     // The service marks the install in flight from the tap; the streamed
     // phases are what the user sees. Two pumps: one delivers the stream event
     // to the cubit, the next rebuilds with it. The progress row animates
     // continuously, so never settle here.
-    installProgress.add(const {
-      "future-harness": PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 42),
+    installStates.add(const {
+      "future-harness": PluginInstallState.inProgress(
+        progress: PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 42),
+      ),
     });
     await tester.pump();
     await tester.pump();
     expect(find.text("Downloading… 42%"), findsOneWidget);
 
-    installProgress.add(const {
-      "future-harness": PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null),
+    installStates.add(const {
+      "future-harness": PluginInstallState.inProgress(
+        progress: PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null),
+      ),
     });
     await tester.pump();
     await tester.pump();
     expect(find.text("Extracting…"), findsOneWidget);
 
     // A second tap while installing must not send another command.
-    await tester.tap(find.byKey(const Key("harness_management_install_future-harness")));
+    expect(find.byKey(const Key("harness_management_install_future-harness")), findsNothing);
     await tester.pump();
     verifyNever(
       () => service.command(
@@ -805,8 +878,10 @@ void main() {
     );
 
     // A phase only a newer bridge names still reads as work in progress.
-    installProgress.add(const {
-      "future-harness": PluginInstallProgress(phase: PluginInstallPhase.unknown, percent: null),
+    installStates.add(const {
+      "future-harness": PluginInstallState.inProgress(
+        progress: PluginInstallProgress(phase: PluginInstallPhase.unknown, percent: null),
+      ),
     });
     await tester.pump();
     await tester.pump();
@@ -858,8 +933,9 @@ void main() {
 
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
+    await _showDetail(tester, "future-harness");
 
-    expect(find.text("Ready"), findsOneWidget);
+    expect(find.text("Disabled"), findsOneWidget);
     expect(find.byKey(const Key("harness_management_enabled_future-harness")), findsOneWidget);
     expect(tester.widget<PregoSwitch>(_switchFor("future-harness")).value, isFalse);
     expect(find.byKey(const Key("harness_management_refresh_future-harness")), findsOneWidget);
@@ -882,32 +958,22 @@ void main() {
     ).called(1);
   });
 
-  testWidgets("setup-ready enabled renders known facts, controls, logos, and default badge", (tester) async {
+  testWidgets("overview opens known detail facts without a default badge", (tester) async {
     _useTallSurface(tester);
     snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
-
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
-
-    final scaffold = tester.widget<PregoGlassScaffold>(find.byType(PregoGlassScaffold));
-    expect(scaffold.title, "Harnesses");
-    expect(scaffold.titleMode, PregoTopNavigationTitleMode.inline);
-    expect(find.byKey(const Key("harnesses_manage")), findsNothing);
-    expect(find.byKey(const Key("harnesses_card_opencode")), findsOneWidget);
-    expect(find.byKey(const Key("harnesses_card_future-harness")), findsOneWidget);
-    expect(find.byKey(const Key("harness_management_card_future-harness")), findsOneWidget);
     expect(findBrandLogo("opencode"), findsOneWidget);
-    expect(find.byIcon(TablerRegular.plug), findsOneWidget);
-    expect(find.text("Default"), findsOneWidget);
-    expect(find.text("Run login if requests fail."), findsOneWidget);
+    expect(find.text("Default"), findsNothing);
+    expect(find.text("9.8.7"), findsNothing);
+    expect(find.byKey(const Key("harness_management_default_timeout")), findsOneWidget);
+    await _showDetail(tester, "future-harness");
     expect(find.text("Version"), findsOneWidget);
     expect(find.text("9.8.7"), findsOneWidget);
-    expect(find.text("Active"), findsNWidgets(2));
-    expect(find.text("Idle"), findsNWidgets(2));
-    expect(find.byKey(const Key("harness_management_enabled_future-harness")), findsOneWidget);
+    expect(find.text("Running"), findsOneWidget);
+    expect(find.text("Idle"), findsOneWidget);
     expect(find.byKey(const Key("harness_management_restart_future-harness")), findsOneWidget);
     expect(find.byKey(const Key("harness_management_timeout_future-harness")), findsOneWidget);
-    expect(find.byKey(const Key("harness_management_default_timeout")), findsOneWidget);
     expect(find.text("20 min"), findsOneWidget);
   });
 
@@ -922,6 +988,7 @@ void main() {
 
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
+    await _showDetail(tester, "opencode");
 
     expect(find.byKey(const Key("harness_management_external_opencode")), findsOneWidget);
     expect(find.text("Managed outside Sesori"), findsOneWidget);
@@ -930,7 +997,7 @@ void main() {
     expect(find.byKey(const Key("harness_management_restart_opencode")), findsNothing);
     expect(find.byKey(const Key("harness_management_timeout_opencode")), findsNothing);
     expect(find.byKey(const Key("harness_management_default_timeout")), findsNothing);
-    expect(find.text("Active"), findsOneWidget);
+    expect(find.text("Running"), findsOneWidget);
     expect(find.text("Idle"), findsOneWidget);
     expect(find.text("Version"), findsNothing);
 
@@ -974,8 +1041,9 @@ void main() {
 
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
+    await _showDetail(tester, "future-harness");
 
-    expect(find.text("Unknown"), findsNothing);
+    expect(find.text("Unknown"), findsOneWidget);
     expect(find.text("Runtime"), findsNothing);
     expect(find.text("Work"), findsNothing);
     expect(find.byKey(const Key("harness_management_enabled_future-harness")), findsNothing);
@@ -995,7 +1063,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text("Active"), findsOneWidget);
+    expect(find.text("Running"), findsOneWidget);
     expect(find.text("Work"), findsNothing);
     expect(find.text("Unknown"), findsNothing);
   });
@@ -1043,6 +1111,7 @@ void main() {
     expect(find.byKey(const Key("harnesses_refresh_error")), findsNothing);
     expect(find.text("OpenCode"), findsOneWidget);
 
+    await _showDetail(tester, "opencode");
     await tester.tap(find.byKey(const Key("harness_management_refresh_opencode")));
     await tester.pumpAndSettle();
     expect(find.byKey(const Key("harness_management_action_error")), findsOneWidget);
@@ -1051,7 +1120,7 @@ void main() {
     await tester.tap(find.byTooltip("Dismiss action error"));
     await tester.pump();
     expect(find.byKey(const Key("harness_management_action_error")), findsNothing);
-    expect(find.text("OpenCode"), findsOneWidget);
+    expect(find.text("OpenCode"), findsNWidgets(2));
   });
 
   testWidgets("safe setup refresh and restart actions dispatch once", (tester) async {
@@ -1060,6 +1129,7 @@ void main() {
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
 
+    await _showDetail(tester, "opencode");
     await tester.tap(find.byKey(const Key("harness_management_refresh_opencode")));
     await tester.pump();
     verify(
@@ -1091,9 +1161,11 @@ void main() {
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
 
+    await _showDetail(tester, "opencode");
     await tester.tap(find.byKey(const Key("harness_management_refresh_opencode")));
     await tester.pump();
 
+    await _showDetail(tester, "future-harness");
     final restart = find.byKey(const Key("harness_management_restart_future-harness"));
     expect(tester.widget<PregoGroupedRow>(restart).onTap, isNull);
     expect(tester.widget<PregoSwitch>(_switchFor("future-harness")).onChanged, isNull);
@@ -1176,8 +1248,7 @@ void main() {
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
 
-    expect(find.text("No timeout"), findsNWidgets(2));
-    expect(find.text("This harness stays running"), findsOneWidget);
+    expect(find.text("No timeout"), findsOneWidget);
     expect(find.text("0 min"), findsNothing);
 
     await _openRow(tester, "harness_management_default_timeout");
@@ -1239,7 +1310,10 @@ void main() {
       ),
     ).called(1);
 
-    await _openRow(tester, "harness_management_clear_timeout_future-harness");
+    await _openRow(tester, "harness_management_timeout_future-harness");
+    await tester.tap(find.byKey(const Key("harness_management_timeout_use_default")));
+    await tester.tap(find.byKey(const Key("harness_management_timeout_save")));
+    await tester.pumpAndSettle();
     verify(
       () => service.updateIdleTimeout(
         request: const PluginIdleTimeoutUpdateRequest.clearOverride(pluginId: "future-harness"),
@@ -1310,6 +1384,48 @@ void main() {
     await tester.tap(find.byKey(const Key("harness_management_timeout_cancel")));
     await tester.pumpAndSettle();
     expect(find.byType(PregoBottomSheet), findsNothing);
+  });
+
+  testWidgets("safe restart opens named confirmation before one explicit force restart", (tester) async {
+    when(
+      () => service.command(
+        pluginId: "future-harness",
+        request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.safe),
+      ),
+    ).thenAnswer((_) async => const PluginManagementMutationResult.conflict(conflict: _conflict));
+    when(
+      () => service.assessForce(
+        conflict: any(named: "conflict"),
+        action: any(named: "action"),
+      ),
+    ).thenReturn(
+      const PluginManagementForceAssessment.requiresConfirmation(
+        request: PluginLifecycleCommandRequest.restart(mode: PluginStopMode.force),
+      ),
+    );
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    await tester.pumpWidget(_app());
+    await tester.pumpAndSettle();
+    await _openRow(tester, "harness_management_restart_future-harness");
+    expect(find.text("Restart Future Harness?"), findsOneWidget);
+    expect(find.text("Force restart"), findsOneWidget);
+    verifyNever(
+      () => service.command(
+        pluginId: "future-harness",
+        request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.force),
+      ),
+    );
+    final confirm = find.byKey(const Key("harness_management_force_confirm"));
+    final cancel = find.byKey(const Key("harness_management_force_cancel"));
+    expect(tester.getTopLeft(confirm).dy, lessThan(tester.getTopLeft(cancel).dy));
+    await tester.tap(confirm);
+    await tester.pumpAndSettle();
+    verify(
+      () => service.command(
+        pluginId: "future-harness",
+        request: const PluginLifecycleCommandRequest.restart(mode: PluginStopMode.force),
+      ),
+    ).called(1);
   });
 
   testWidgets("force cancel and close send zero force requests, then confirm sends exactly one", (tester) async {
@@ -1417,8 +1533,10 @@ void main() {
 
     // Dispatched on release, and the release must not be a fling: the control
     // waits for the overscroll to spring back to the extent it holds itself.
-    final gesture = await tester.startGesture(tester.getCenter(find.byType(CustomScrollView)));
-    await gesture.moveBy(const Offset(0, 500));
+    final gesture = await tester.startGesture(const Offset(200, 200));
+    await gesture.moveBy(const Offset(0, 30));
+    await tester.pump();
+    await gesture.moveBy(const Offset(0, 300));
     await tester.pump();
     await gesture.moveBy(Offset.zero);
     await tester.pump(const Duration(milliseconds: 200));
@@ -1456,6 +1574,119 @@ void main() {
     expect(find.text("projects-route"), findsNothing);
   });
 
+  for (final openerPath in ["/projects", "/projects/p/sessions/s", "/projects/p/sessions/new"]) {
+    testWidgets("X closes the contiguous settings suffix above $openerPath", (tester) async {
+      snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+      await tester.pumpWidget(
+        _appPushedFromOpener(
+          openerPath: openerPath,
+          throughSettings: true,
+          presentation: HarnessSettingsPresentation.pushed,
+        ),
+      );
+      await tester.pumpAndSettle();
+      final opener = tester.element(find.text("open-harnesses"));
+      await tester.tap(find.text("open-harnesses"));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("settings-open-harnesses"));
+      await tester.pumpAndSettle();
+      await _showDetail(tester, "future-harness");
+      await tester.tap(find.bySemanticsLabel("Close settings"));
+      await tester.pumpAndSettle();
+      expect(tester.element(find.text("open-harnesses")), same(opener));
+      expect(find.text("settings-open-harnesses"), findsNothing);
+      expect(find.byType(HarnessesSettingsView), findsNothing);
+    });
+  }
+
+  testWidgets("closing the flow also removes its authentication sheet without cancelling the operation", (
+    tester,
+  ) async {
+    snapshots.add(
+      PluginManagementLoadResult.supported(
+        response: _response.copyWith(plugins: [_authenticationRequired]),
+        refreshError: null,
+      ),
+    );
+    await tester.pumpWidget(_appPushedFromOpener());
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("open-harnesses"));
+    await tester.pumpAndSettle();
+    await _showDetail(tester, "codex");
+    final detail = tester.widget<HarnessSettingsDetailView>(find.byType(HarnessSettingsDetailView));
+    authenticationChallenges.add({
+      "codex": PluginAuthenticationDeviceCodeChallenge(
+        verificationUri: Uri.parse("https://auth.example/device"),
+        userCode: "ABCD-EFGH",
+      ),
+    });
+    await tester.pump();
+    await tester.tap(find.byKey(const Key("harness_authentication_codex")));
+    await tester.pumpAndSettle();
+    expect(find.byType(PregoBottomSheet), findsOneWidget);
+    detail.onClose();
+    await tester.pumpAndSettle();
+    expect(find.byType(PregoBottomSheet), findsNothing);
+    expect(find.text("open-harnesses"), findsOneWidget);
+    verifyNever(() => service.cancelAuthentication(pluginId: any(named: "pluginId")));
+  });
+
+  testWidgets("direct detail constructs overview ancestry and X removes synthesized Settings", (tester) async {
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    await tester.pumpWidget(_app(initialLocation: "/settings/harnesses/future-harness"));
+    await tester.pumpAndSettle();
+    expect(find.byType(HarnessSettingsDetailView), findsOneWidget);
+    expect(find.byType(HarnessesSettingsView, skipOffstage: false), findsOneWidget);
+    await tester.tap(find.bySemanticsLabel("Back"));
+    await tester.pumpAndSettle();
+    expect(find.byType(HarnessesSettingsView), findsOneWidget);
+    await tester.tap(find.bySemanticsLabel("Close settings"));
+    await tester.pumpAndSettle();
+    expect(find.text("projects-route"), findsOneWidget);
+  });
+
+  testWidgets("production harness shell retains one cubit across detail Back and closes to the opener", (tester) async {
+    snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+    await tester.pumpWidget(_appPushedFromOpener());
+    await tester.pumpAndSettle();
+    await tester.tap(find.text("open-harnesses"));
+    await tester.pumpAndSettle();
+    final overview = tester.element(find.byType(HarnessesSettingsView));
+    final cubit = overview.read<PluginManagementCubit>();
+    unawaited(
+      GoRouter.of(overview).push<void>(
+        const AppRoute.settingsHarnessDetail(
+          pluginId: "future-harness",
+          presentation: HarnessSettingsPresentation.modal,
+        ).buildPath(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.element(find.byType(HarnessSettingsDetailView)).read<PluginManagementCubit>(), same(cubit));
+    expect(find.byType(HarnessesSettingsView, skipOffstage: false), findsOneWidget);
+    expect(find.byType(HarnessSettingsFlowView), findsOneWidget);
+    await tester.tap(find.bySemanticsLabel("Back"));
+    await tester.pumpAndSettle();
+    expect(find.byType(HarnessSettingsDetailView), findsNothing);
+    expect(tester.element(find.byType(HarnessesSettingsView)).read<PluginManagementCubit>(), same(cubit));
+    unawaited(
+      GoRouter.of(overview).push<void>(
+        const AppRoute.settingsHarnessDetail(
+          pluginId: "future-harness",
+          presentation: HarnessSettingsPresentation.modal,
+        ).buildPath(),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.bySemanticsLabel("Close settings"));
+    await tester.pumpAndSettle();
+    expect(find.text("open-harnesses"), findsOneWidget);
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.byType(HarnessesSettingsScreen, skipOffstage: false), findsNothing);
+    expect(snapshots.hasListener, isFalse);
+    expect(authenticationTerminal.hasListener, isFalse);
+  });
+
   testWidgets("raised as a modal, the bar closes with the X and shows no back button", (tester) async {
     snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
     await tester.pumpWidget(_appPushedFromOpener());
@@ -1468,7 +1699,7 @@ void main() {
     expect(find.bySemanticsLabel("Back"), findsNothing);
   });
 
-  testWidgets("pushed onto the settings stack, the bar goes back and shows no close button", (tester) async {
+  testWidgets("pushed onto the settings stack, the bar offers Back and close", (tester) async {
     snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
     await tester.pumpWidget(_appPushedFromOpener(presentation: HarnessSettingsPresentation.pushed));
     await tester.pumpAndSettle();
@@ -1477,7 +1708,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(HarnessesSettingsScreen), findsOneWidget);
-    expect(find.bySemanticsLabel("Close settings"), findsNothing);
+    expect(find.bySemanticsLabel("Close settings"), findsOneWidget);
 
     await tester.tap(find.bySemanticsLabel("Back"));
     await tester.pumpAndSettle();
@@ -1497,6 +1728,7 @@ void main() {
       await tester.pumpWidget(_app());
       snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
       await tester.pumpAndSettle();
+      await _showDetail(tester, "future-harness");
     }
 
     // The keyboard-and-pointer twin of the lists' deep pull. A screen reader
@@ -1531,8 +1763,7 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
-      await tester.tap(row);
-      await tester.pump();
+      expect(tester.widget<PregoGroupedRow>(row).onTap, isNull);
 
       expect(rescan.startedPluginIds, isEmpty);
       expect(
@@ -1551,6 +1782,7 @@ void main() {
 
       final loc = await AppLocalizations.delegate.load(const Locale("en"));
       expect(scanRowText("future-harness", loc.harnessManagementScanNotReady), findsOneWidget);
+      await _showDetail(tester, "opencode");
       expect(
         scanRowText("opencode", loc.harnessManagementScanDescription),
         findsOneWidget,

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -970,8 +970,8 @@ void main() {
     await _showDetail(tester, "future-harness");
     expect(find.text("Version"), findsOneWidget);
     expect(find.text("9.8.7"), findsOneWidget);
-    expect(find.text("Running"), findsOneWidget);
-    expect(find.text("Idle"), findsOneWidget);
+    expect(find.text("Running"), findsNothing);
+    expect(find.text("Idle"), findsNWidgets(2));
     expect(find.byKey(const Key("harness_management_restart_future-harness")), findsOneWidget);
     expect(find.byKey(const Key("harness_management_timeout_future-harness")), findsOneWidget);
     expect(find.text("20 min"), findsOneWidget);
@@ -997,8 +997,8 @@ void main() {
     expect(find.byKey(const Key("harness_management_restart_opencode")), findsNothing);
     expect(find.byKey(const Key("harness_management_timeout_opencode")), findsNothing);
     expect(find.byKey(const Key("harness_management_default_timeout")), findsNothing);
-    expect(find.text("Running"), findsOneWidget);
-    expect(find.text("Idle"), findsOneWidget);
+    expect(find.text("Running"), findsNothing);
+    expect(find.text("Idle"), findsNWidgets(2));
     expect(find.text("Version"), findsNothing);
 
     snapshots.add(
@@ -1022,7 +1022,7 @@ void main() {
     expect(find.byKey(const Key("harness_management_default_timeout")), findsNothing);
   });
 
-  testWidgets("unknown runtime and work facts are omitted rather than presented as disabled", (tester) async {
+  testWidgets("unknown runtime or work never implies disabled or Running", (tester) async {
     _useTallSurface(tester);
     snapshots.add(
       PluginManagementLoadResult.supported(
@@ -1063,9 +1063,9 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text("Running"), findsOneWidget);
+    expect(find.text("Running"), findsNothing);
     expect(find.text("Work"), findsNothing);
-    expect(find.text("Unknown"), findsNothing);
+    expect(find.text("Unknown"), findsOneWidget);
   });
 
   testWidgets("supported response with no harnesses shows the empty state", (tester) async {

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -1526,7 +1526,7 @@ void main() {
     ).called(1);
   });
 
-  testWidgets("pull refresh delegates to the cubit and close returns to Projects", (tester) async {
+  testWidgets("pull refresh delegates to the cubit and direct modal X returns to Projects", (tester) async {
     snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
     await tester.pumpWidget(_app());
     await tester.pumpAndSettle();
@@ -1560,10 +1560,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(HarnessesSettingsScreen), findsOneWidget);
-    // `/settings/harnesses` is a child route of `/settings`, but an imperative
-    // push adds one page for the location's last route — the Settings list is
-    // not inserted underneath. If a go_router upgrade ever changed that, the
-    // single pop below would land on Settings instead of the opener.
+    // The harness-only shell never synthesizes an unrelated Settings page.
     expect(find.byType(SettingsScreen), findsNothing);
 
     await tester.tap(find.bySemanticsLabel("Close settings"));
@@ -1575,7 +1572,7 @@ void main() {
   });
 
   for (final openerPath in ["/projects", "/projects/p/sessions/s", "/projects/p/sessions/new"]) {
-    testWidgets("X closes the contiguous settings suffix above $openerPath", (tester) async {
+    testWidgets("pushed Back preserves Settings and its original $openerPath opener", (tester) async {
       snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
       await tester.pumpWidget(
         _appPushedFromOpener(
@@ -1588,13 +1585,27 @@ void main() {
       final opener = tester.element(find.text("open-harnesses"));
       await tester.tap(find.text("open-harnesses"));
       await tester.pumpAndSettle();
+      final settings = tester.element(find.text("settings-open-harnesses"));
       await tester.tap(find.text("settings-open-harnesses"));
       await tester.pumpAndSettle();
+      expect(find.bySemanticsLabel("Close settings"), findsNothing);
+      final cubit = tester.element(find.byType(HarnessesSettingsView)).read<PluginManagementCubit>();
       await _showDetail(tester, "future-harness");
-      await tester.tap(find.bySemanticsLabel("Close settings"));
+      expect(find.bySemanticsLabel("Close settings"), findsNothing);
+      await tester.tap(find.bySemanticsLabel("Back"));
+      await tester.pumpAndSettle();
+      expect(tester.element(find.byType(HarnessesSettingsView)).read<PluginManagementCubit>(), same(cubit));
+      await tester.tap(find.bySemanticsLabel("Back"));
+      await tester.pumpAndSettle();
+      expect(tester.element(find.text("settings-open-harnesses")), same(settings));
+      // Stream cancellation completes outside the widget-test clock.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      expect(cubit.isClosed, isTrue);
+      expect(snapshots.hasListener, isFalse);
+      expect(authenticationTerminal.hasListener, isFalse);
+      GoRouter.of(settings).pop();
       await tester.pumpAndSettle();
       expect(tester.element(find.text("open-harnesses")), same(opener));
-      expect(find.text("settings-open-harnesses"), findsNothing);
       expect(find.byType(HarnessesSettingsView), findsNothing);
     });
   }
@@ -1631,16 +1642,17 @@ void main() {
     verifyNever(() => service.cancelAuthentication(pluginId: any(named: "pluginId")));
   });
 
-  testWidgets("direct detail constructs overview ancestry and X removes synthesized Settings", (tester) async {
+  testWidgets("direct pushed detail constructs only overview ancestry and Back falls back to Projects", (tester) async {
     snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
-    await tester.pumpWidget(_app(initialLocation: "/settings/harnesses/future-harness"));
+    await tester.pumpWidget(_app(initialLocation: "/settings/harnesses/future-harness?presentation=pushed"));
     await tester.pumpAndSettle();
     expect(find.byType(HarnessSettingsDetailView), findsOneWidget);
     expect(find.byType(HarnessesSettingsView, skipOffstage: false), findsOneWidget);
     await tester.tap(find.bySemanticsLabel("Back"));
     await tester.pumpAndSettle();
     expect(find.byType(HarnessesSettingsView), findsOneWidget);
-    await tester.tap(find.bySemanticsLabel("Close settings"));
+    expect(find.text("settings-ancestor", skipOffstage: false), findsNothing);
+    await tester.tap(find.bySemanticsLabel("Back"));
     await tester.pumpAndSettle();
     expect(find.text("projects-route"), findsOneWidget);
   });
@@ -1699,7 +1711,7 @@ void main() {
     expect(find.bySemanticsLabel("Back"), findsNothing);
   });
 
-  testWidgets("pushed onto the settings stack, the bar offers Back and close", (tester) async {
+  testWidgets("pushed onto the settings stack, the bar offers Back only", (tester) async {
     snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
     await tester.pumpWidget(_appPushedFromOpener(presentation: HarnessSettingsPresentation.pushed));
     await tester.pumpAndSettle();
@@ -1708,7 +1720,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(HarnessesSettingsScreen), findsOneWidget);
-    expect(find.bySemanticsLabel("Close settings"), findsOneWidget);
+    expect(find.bySemanticsLabel("Close settings"), findsNothing);
 
     await tester.tap(find.bySemanticsLabel("Back"));
     await tester.pumpAndSettle();

--- a/client/desktop/lib/core/routing/desktop_router.dart
+++ b/client/desktop/lib/core/routing/desktop_router.dart
@@ -420,56 +420,21 @@ void _popRoute({required BuildContext context}) {
 @visibleForTesting
 ShellRoute buildDesktopHarnessSettingsRoute() {
   final navigatorKey = GlobalKey<NavigatorState>();
-  late final ShellRoute flow;
   void close({required BuildContext context}) {
-    // ignore: no_slop_linter/avoid_raw_go_router, shell-owned stack boundary
-    final router = GoRouter.of(context);
-    final settingsKeys = <LocalKey>{};
-    void collect({required List<RouteMatchBase> matches}) {
-      for (final match in matches) {
-        if (match is ShellRouteMatch) {
-          if (match.route == flow) settingsKeys.add(match.pageKey);
-          collect(matches: match.matches);
-        } else if (match.matchedLocation == AppRouteDef.settings.path ||
-            match.matchedLocation.startsWith("${AppRouteDef.settings.path}/")) {
-          settingsKeys.add(match.pageKey);
-        }
-      }
-    }
-
-    collect(matches: router.routerDelegate.currentConfiguration.matches);
-    var needsHome = false;
-    // The context of the nested Navigator belongs to the outer navigator.
-    // Popping its shell page removes the entire flow, including owned sheets.
-    final outerNavigator =
-        navigatorKey.currentContext?.findAncestorStateOfType<NavigatorState>() ??
-        (throw StateError("Harness flow is not mounted"));
-    outerNavigator.popUntil((route) {
-      final page = route.settings;
-      if (page is! Page) return false;
-      if (!settingsKeys.contains(page.key)) return true;
-      if (route.isFirst) {
-        needsHome = true;
-        return true;
-      }
-      return false;
-    });
-    if (needsHome) {
-      // ignore: no_slop_linter/avoid_raw_go_router, direct links have no signed-in opener
-      router.go(const AppRoute.projects().buildPath());
-    }
-  }
-
-  void back({required BuildContext context}) {
-    if (context.canPop()) {
-      context.pop();
+    // The nested Navigator's context belongs to the stable outer flow page.
+    final flowContext = navigatorKey.currentContext ?? (throw StateError("Harness flow is not mounted"));
+    final flowRoute = ModalRoute.of(flowContext) ?? (throw StateError("Harness flow has no owning route"));
+    final outerNavigator = flowRoute.navigator ?? (throw StateError("Harness flow has no navigator"));
+    // Remove owned pageless sheets first, without touching the opener.
+    outerNavigator.popUntil((route) => route == flowRoute);
+    if (flowRoute.isFirst) {
+      _goRoute(context: context, route: const AppRoute.projects());
     } else {
-      // ignore: no_slop_linter/avoid_raw_go_router, typed route boundary
-      GoRouter.of(context).go(const AppRoute.settings().buildPath());
+      outerNavigator.pop();
     }
   }
 
-  return flow = ShellRoute(
+  return ShellRoute(
     navigatorKey: navigatorKey,
     pageBuilder: (context, state, child) {
       final presentation = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters).presentation;
@@ -488,27 +453,29 @@ ShellRoute buildDesktopHarnessSettingsRoute() {
             presentation: presentation,
             connectionBanner: null,
             onClose: () => close(context: context),
-            onBack: () => back(context: context),
-            onOpenHarness: ({required pluginId}) {
-              // ignore: no_slop_linter/avoid_raw_go_router, typed route boundary
-              GoRouter.of(
-                context,
-              ).push<void>(AppRoute.settingsHarnessDetail(pluginId: pluginId, presentation: presentation).buildPath());
-            },
+            onBack: () => close(context: context),
+            onOpenHarness: ({required pluginId}) => _pushRoute(
+              context: context,
+              route: AppRoute.settingsHarnessDetail(pluginId: pluginId, presentation: presentation),
+            ),
           );
         },
         routes: [
           GoRoute(
             path: ":$pluginIdPathParam",
-            builder: (context, state) => HarnessSettingsDetailView(
-              pluginId: AppRouteSettingsHarnessDetail.fromParams(
+            builder: (context, state) {
+              final route = AppRouteSettingsHarnessDetail.fromParams(
                 pathParams: state.pathParameters,
                 queryParams: state.uri.queryParameters,
-              ).pluginId,
-              connectionBanner: null,
-              onBack: () => context.pop(),
-              onClose: () => close(context: context),
-            ),
+              );
+              return HarnessSettingsDetailView(
+                pluginId: route.pluginId,
+                presentation: route.presentation,
+                connectionBanner: null,
+                onBack: () => context.pop(),
+                onClose: () => close(context: context),
+              );
+            },
           ),
         ],
       ),

--- a/client/desktop/lib/core/routing/desktop_router.dart
+++ b/client/desktop/lib/core/routing/desktop_router.dart
@@ -287,23 +287,7 @@ List<RouteBase> buildDesktopRoutes() => <RouteBase>[
           onLogoutCompleted: _goDesktopHome,
         ),
       ),
-      GoRoute(
-        path: AppRouteDef.settingsHarnesses.path,
-        builder: (BuildContext context, GoRouterState state) {
-          final route = switch (AppRoute.fromDef(
-            def: AppRouteDef.settingsHarnesses,
-            pathParams: state.pathParameters,
-            queryParams: state.uri.queryParameters,
-          )) {
-            final AppRouteSettingsHarnesses route => route,
-            final route => throw StateError("Route ${route.def.name} is not a harness-settings route"),
-          };
-          return DesktopHarnessesSettingsScreen(
-            presentation: route.presentation,
-            onClose: () => _popRoute(context: context),
-          );
-        },
-      ),
+      buildDesktopHarnessSettingsRoute(),
     ],
   ),
 ];
@@ -430,4 +414,104 @@ void _popRoute({required BuildContext context}) {
     return;
   }
   _goDesktopHome();
+}
+
+/// Harness-only navigator and provider shared by overview and URL detail pages.
+@visibleForTesting
+ShellRoute buildDesktopHarnessSettingsRoute() {
+  final navigatorKey = GlobalKey<NavigatorState>();
+  late final ShellRoute flow;
+  void close({required BuildContext context}) {
+    // ignore: no_slop_linter/avoid_raw_go_router, shell-owned stack boundary
+    final router = GoRouter.of(context);
+    final settingsKeys = <LocalKey>{};
+    void collect({required List<RouteMatchBase> matches}) {
+      for (final match in matches) {
+        if (match is ShellRouteMatch) {
+          if (match.route == flow) settingsKeys.add(match.pageKey);
+          collect(matches: match.matches);
+        } else if (match.matchedLocation == AppRouteDef.settings.path ||
+            match.matchedLocation.startsWith("${AppRouteDef.settings.path}/")) {
+          settingsKeys.add(match.pageKey);
+        }
+      }
+    }
+
+    collect(matches: router.routerDelegate.currentConfiguration.matches);
+    var needsHome = false;
+    // The context of the nested Navigator belongs to the outer navigator.
+    // Popping its shell page removes the entire flow, including owned sheets.
+    final outerNavigator =
+        navigatorKey.currentContext?.findAncestorStateOfType<NavigatorState>() ??
+        (throw StateError("Harness flow is not mounted"));
+    outerNavigator.popUntil((route) {
+      final page = route.settings;
+      if (page is! Page) return false;
+      if (!settingsKeys.contains(page.key)) return true;
+      if (route.isFirst) {
+        needsHome = true;
+        return true;
+      }
+      return false;
+    });
+    if (needsHome) {
+      // ignore: no_slop_linter/avoid_raw_go_router, direct links have no signed-in opener
+      router.go(const AppRoute.projects().buildPath());
+    }
+  }
+
+  void back({required BuildContext context}) {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      // ignore: no_slop_linter/avoid_raw_go_router, typed route boundary
+      GoRouter.of(context).go(const AppRoute.settings().buildPath());
+    }
+  }
+
+  return flow = ShellRoute(
+    navigatorKey: navigatorKey,
+    pageBuilder: (context, state, child) {
+      final presentation = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters).presentation;
+      final content = DesktopHarnessesSettingsScreen(child: child);
+      return presentation == HarnessSettingsPresentation.modal
+          ? MaterialPage<void>(key: state.pageKey, fullscreenDialog: true, child: content)
+          : MaterialPage<void>(key: state.pageKey, child: content);
+    },
+    routes: [
+      GoRoute(
+        path: AppRouteDef.settingsHarnesses.path,
+        builder: (context, state) {
+          final presentation = AppRouteSettingsHarnesses.fromParams(queryParams: state.uri.queryParameters)
+              .presentation;
+          return HarnessesSettingsView(
+            presentation: presentation,
+            connectionBanner: null,
+            onClose: () => close(context: context),
+            onBack: () => back(context: context),
+            onOpenHarness: ({required pluginId}) {
+              // ignore: no_slop_linter/avoid_raw_go_router, typed route boundary
+              GoRouter.of(
+                context,
+              ).push<void>(AppRoute.settingsHarnessDetail(pluginId: pluginId, presentation: presentation).buildPath());
+            },
+          );
+        },
+        routes: [
+          GoRoute(
+            path: ":$pluginIdPathParam",
+            builder: (context, state) => HarnessSettingsDetailView(
+              pluginId: AppRouteSettingsHarnessDetail.fromParams(
+                pathParams: state.pathParameters,
+                queryParams: state.uri.queryParameters,
+              ).pluginId,
+              connectionBanner: null,
+              onBack: () => context.pop(),
+              onClose: () => close(context: context),
+            ),
+          ),
+        ],
+      ),
+    ],
+  );
 }

--- a/client/desktop/lib/features/sessions/desktop_session_detail_screen.dart
+++ b/client/desktop/lib/features/sessions/desktop_session_detail_screen.dart
@@ -141,7 +141,8 @@ class _SessionActivityAnalyticsOwnerState() extends State<_SessionActivityAnalyt
       AppRouteDef.settings ||
       AppRouteDef.settingsNotifications ||
       AppRouteDef.settingsProfile ||
-      AppRouteDef.settingsHarnesses => true,
+      AppRouteDef.settingsHarnesses ||
+      AppRouteDef.settingsHarnessDetail => true,
       null ||
       AppRouteDef.splash ||
       AppRouteDef.login ||

--- a/client/desktop/lib/features/settings/desktop_harnesses_settings_screen.dart
+++ b/client/desktop/lib/features/settings/desktop_harnesses_settings_screen.dart
@@ -5,25 +5,15 @@ import "package:sesori_dart_core/sesori_dart_core.dart";
 
 import "../../core/di/injection.dart";
 
-/// Desktop-shell composition for shared harness management.
-class const DesktopHarnessesSettingsScreen({
-  super.key,
-  required final HarnessSettingsPresentation presentation,
-  required final VoidCallback onClose,
-}) extends StatelessWidget {
+/// The desktop harness-flow lifetime, above its nested navigator.
+class const DesktopHarnessesSettingsScreen({super.key, required final Widget child}) extends StatelessWidget {
   @override
-  Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (_) => PluginManagementCubit(
-        service: getIt<PluginManagementService>(),
-        urlLauncher: getIt<UrlLauncher>(),
-        catalogRescanService: getIt<CatalogRescanService>(),
-      ),
-      child: HarnessesSettingsView(
-        presentation: presentation,
-        connectionBanner: null,
-        onModalClose: onClose,
-      ),
-    );
-  }
+  Widget build(BuildContext context) => BlocProvider(
+    create: (_) => PluginManagementCubit(
+      service: getIt<PluginManagementService>(),
+      urlLauncher: getIt<UrlLauncher>(),
+      catalogRescanService: getIt<CatalogRescanService>(),
+    ),
+    child: HarnessSettingsFlowView(child: child),
+  );
 }

--- a/client/desktop/test/core/routing/desktop_router_test.dart
+++ b/client/desktop/test/core/routing/desktop_router_test.dart
@@ -1,11 +1,11 @@
 import "package:flutter_test/flutter_test.dart";
 import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
+import "package:sesori_app_ui/sesori_app_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop/core/routing/desktop_router.dart";
 import "package:sesori_desktop/features/new_session/desktop_new_session_screen.dart";
 import "package:sesori_desktop/features/session_diffs/desktop_session_diffs_screen.dart";
-import "package:sesori_desktop/features/settings/desktop_harnesses_settings_screen.dart";
 
 void main() {
   test("settings destination matching includes its child routes", () {
@@ -69,8 +69,8 @@ void main() {
       ),
     );
 
-    expect(widget, isA<DesktopHarnessesSettingsScreen>());
-    final screen = widget as DesktopHarnessesSettingsScreen;
+    expect(widget, isA<HarnessesSettingsView>());
+    final screen = widget as HarnessesSettingsView;
     expect(screen.presentation, HarnessSettingsPresentation.modal);
   });
 }

--- a/client/desktop/test/features/new_session/desktop_new_session_screen_test.dart
+++ b/client/desktop/test/features/new_session/desktop_new_session_screen_test.dart
@@ -1,16 +1,27 @@
+import "dart:async";
+
 import "package:bloc_test/bloc_test.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
+import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
 import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
 import "package:sesori_app_ui/sesori_app_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_desktop/core/di/injection.dart";
+import "package:sesori_desktop/core/routing/desktop_router.dart";
 import "package:sesori_desktop/features/new_session/desktop_new_session_screen.dart";
+import "package:sesori_shared/sesori_shared.dart";
 import "package:theme_prego/module_prego.dart";
 
 class _MockNewSessionCubit() extends MockCubit<NewSessionState> implements NewSessionCubit;
 
 class _MockChatInputModeCubit() extends MockCubit<ChatInputMode> implements ChatInputModeCubit;
+
+class _MockPluginManagementService() extends Mock implements PluginManagementService;
+class _MockCatalogRescanService() extends Mock implements CatalogRescanService;
+class _MockUrlLauncher() extends Mock implements UrlLauncher;
 
 const _state = NewSessionState.composing(
   config: NewSessionComposeConfig(
@@ -72,4 +83,117 @@ void main() {
     await tester.pump();
     expect(find.byType(EditableText), findsOneWidget);
   });
+  for (final closeFromDetail in [false, true]) {
+    testWidgets("desktop harness modal X preserves the live composer draft (detail: $closeFromDetail)", (tester) async {
+      await getIt.reset();
+      addTearDown(getIt.reset);
+      registerFallbackValue(ComposerDraft.typed(text: ""));
+      final newSessionCubit = _MockNewSessionCubit();
+      final inputModeCubit = _MockChatInputModeCubit();
+      whenListen(newSessionCubit, const Stream<NewSessionState>.empty(), initialState: _state);
+      when(() => newSessionCubit.needsHarnessDiscovery).thenReturn(false);
+      when(() => newSessionCubit.hasNoHarnesses).thenReturn(false);
+      when(() => newSessionCubit.canCreateSession).thenReturn(true);
+      var draft = ComposerDraft.typed(text: "");
+      when(() => newSessionCubit.composerDraft).thenAnswer((_) => draft);
+      when(() => newSessionCubit.saveComposerDraft(draft: any(named: "draft"))).thenAnswer((invocation) {
+        draft = invocation.namedArguments[#draft]! as ComposerDraft;
+      });
+      whenListen(inputModeCubit, const Stream<ChatInputMode>.empty(), initialState: ChatInputMode.voiceFirst);
+      final service = _MockPluginManagementService();
+      final scans = _MockCatalogRescanService();
+      final snapshots = BehaviorSubject<PluginManagementLoadResult>.seeded(
+        const PluginManagementLoadResult.supported(
+          response: PluginManagementResponse(
+            snapshotToken: "navigation-test",
+            bridgeId: "bridge",
+            defaultPluginId: "test",
+            defaultIdleTimeoutMins: 10,
+            plugins: [],
+          ),
+          refreshError: null,
+        ),
+      );
+      final installs = BehaviorSubject<Map<String, PluginInstallState>>.seeded(const {});
+      addTearDown(snapshots.close);
+      addTearDown(installs.close);
+      when(() => service.snapshots).thenAnswer((_) => snapshots.stream);
+      when(() => service.installStates).thenAnswer((_) => installs.stream);
+      when(() => service.authenticationTerminal)
+          .thenAnswer((_) => const Stream<PluginAuthenticationTerminalUpdate>.empty());
+      when(service.onDispose).thenAnswer((_) async {});
+      final scanStates = BehaviorSubject<CatalogRescanState>.seeded(const CatalogRescanState.idle());
+      addTearDown(scanStates.close);
+      when(() => scans.state).thenAnswer((_) => scanStates.stream);
+      when(scans.onDispose).thenAnswer((_) async {});
+      getIt.registerSingleton<PluginManagementService>(service);
+      getIt.registerSingleton<CatalogRescanService>(scans);
+      getIt.registerSingleton<UrlLauncher>(_MockUrlLauncher());
+      final router = GoRouter(
+        initialLocation: "/projects/p/sessions/new",
+        routes: [
+          GoRoute(
+            path: "/projects/p/sessions/new",
+            builder: (context, _) => DesktopNewSessionView(
+              projectId: "p",
+              projectName: "Project",
+              onBack: () {},
+              onOpenHarnessSettings: () => context.push<void>(
+                const AppRoute.settingsHarnesses(presentation: HarnessSettingsPresentation.modal).buildPath(),
+              ),
+              onSessionCreated: ({required session}) {},
+            ),
+          ),
+          buildDesktopHarnessSettingsRoute(),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(
+        MultiBlocProvider(
+          providers: [
+            BlocProvider<NewSessionCubit>.value(value: newSessionCubit),
+            BlocProvider<ChatInputModeCubit>.value(value: inputModeCubit),
+          ],
+          child: MaterialApp.router(
+            routerConfig: router,
+            theme: buildPregoThemeData(brightness: Brightness.light),
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text("Ask anything..."));
+      await tester.pump();
+      await tester.enterText(find.byType(EditableText), "unfinished desktop idea");
+      await tester.pump();
+      final opener = tester.element(find.byType(DesktopNewSessionView));
+      final composer = tester.element(find.byType(PromptInput));
+      tester.widget<DesktopNewSessionView>(find.byType(DesktopNewSessionView)).onOpenHarnessSettings();
+      await tester.pumpAndSettle();
+      final overview = tester.element(find.byType(HarnessesSettingsView));
+      final harnessCubit = overview.read<PluginManagementCubit>();
+      if (closeFromDetail) {
+        unawaited(
+          GoRouter.of(overview).push<void>(
+            const AppRoute.settingsHarnessDetail(
+              pluginId: "removed",
+              presentation: HarnessSettingsPresentation.modal,
+            ).buildPath(),
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+      await tester.tap(find.bySemanticsLabel("Close settings"));
+      await tester.pumpAndSettle();
+      expect(tester.element(find.byType(DesktopNewSessionView)), same(opener));
+      expect(tester.element(find.byType(PromptInput)), same(composer));
+      expect(composer.read<NewSessionCubit>(), same(newSessionCubit));
+      expect(draft, ComposerDraft.typed(text: "unfinished desktop idea"));
+      expect(find.text("unfinished desktop idea"), findsOneWidget);
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      expect(harnessCubit.isClosed, isTrue);
+      expect(snapshots.hasListener, isFalse);
+    });
+  }
 }

--- a/client/desktop/test/features/settings/desktop_settings_screens_test.dart
+++ b/client/desktop/test/features/settings/desktop_settings_screens_test.dart
@@ -420,7 +420,8 @@ void main() {
 
     expect(find.text("Harnesses"), findsOneWidget);
     expect(find.text("OpenCode"), findsOneWidget);
-    expect(find.text("Running"), findsOneWidget);
+    expect(find.text("Running"), findsNothing);
+    expect(find.text("Idle"), findsNothing);
   });
 }
 

--- a/client/desktop/test/features/settings/desktop_settings_screens_test.dart
+++ b/client/desktop/test/features/settings/desktop_settings_screens_test.dart
@@ -3,6 +3,7 @@ import "dart:async";
 import "package:bloc_test/bloc_test.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_test/flutter_test.dart";
+import "package:go_router/go_router.dart";
 import "package:material_ui/material_ui.dart";
 import "package:mocktail/mocktail.dart";
 import "package:package_info_plus/package_info_plus.dart";
@@ -10,6 +11,7 @@ import "package:rxdart/rxdart.dart";
 import "package:sesori_app_ui/sesori_app_ui.dart";
 import "package:sesori_dart_core/sesori_dart_core.dart";
 import "package:sesori_desktop/core/di/injection.dart";
+import "package:sesori_desktop/core/routing/desktop_router.dart";
 import "package:sesori_desktop/features/settings/desktop_harnesses_settings_screen.dart";
 import "package:sesori_desktop/features/settings/desktop_profile_screen.dart";
 import "package:sesori_desktop/features/settings/desktop_settings_screen.dart";
@@ -104,7 +106,7 @@ void main() {
   late _MockDesktopAttentionService desktopAttentionService;
   late BehaviorSubject<ProductAnalyticsState> analyticsStates;
   late BehaviorSubject<PluginManagementLoadResult> pluginSnapshots;
-  late BehaviorSubject<Map<String, PluginInstallProgress>> installProgress;
+  late BehaviorSubject<Map<String, PluginInstallState>> installStates;
   late BehaviorSubject<Map<String, PluginAuthenticationChallenge>> authenticationChallenges;
   late StreamController<PluginAuthenticationTerminalUpdate> authenticationTerminal;
   late BehaviorSubject<CatalogRescanState> catalogScanStates;
@@ -163,7 +165,7 @@ void main() {
       ),
     );
     pluginSnapshots = BehaviorSubject<PluginManagementLoadResult>();
-    installProgress = BehaviorSubject<Map<String, PluginInstallProgress>>.seeded(const {});
+    installStates = BehaviorSubject<Map<String, PluginInstallState>>.seeded(const {});
     authenticationChallenges = BehaviorSubject<Map<String, PluginAuthenticationChallenge>>.seeded(const {});
     authenticationTerminal = StreamController<PluginAuthenticationTerminalUpdate>.broadcast(sync: true);
     catalogScanStates = BehaviorSubject<CatalogRescanState>.seeded(const CatalogRescanState.idle());
@@ -178,7 +180,7 @@ void main() {
     await connectionStatuses.close();
     await analyticsStates.close();
     await pluginSnapshots.close();
-    await installProgress.close();
+    await installStates.close();
     await authenticationChallenges.close();
     await authenticationTerminal.close();
     await catalogScanStates.close();
@@ -285,13 +287,12 @@ void main() {
     expect(completed, 1);
   });
 
-  testWidgets("desktop harness composition renders a supported bridge snapshot", (tester) async {
-    useTallSurface(tester: tester);
+  void registerHarnessServices() {
     final service = _MockPluginManagementService();
     final catalogRescanService = _MockCatalogRescanService();
     final urlLauncher = _MockUrlLauncher();
     when(() => service.snapshots).thenAnswer((_) => pluginSnapshots.stream);
-    when(() => service.installProgress).thenAnswer((_) => installProgress.stream);
+    when(() => service.installStates).thenAnswer((_) => installStates.stream);
     when(() => service.authenticationChallenges).thenAnswer((_) => authenticationChallenges.stream);
     when(() => service.authenticationTerminal).thenAnswer((_) => authenticationTerminal.stream);
     when(service.onDispose).thenAnswer((_) async {});
@@ -300,12 +301,117 @@ void main() {
     getIt.registerSingleton<PluginManagementService>(service);
     getIt.registerSingleton<CatalogRescanService>(catalogRescanService);
     getIt.registerSingleton<UrlLauncher>(urlLauncher);
+  }
+
+  for (final throughSettings in [false, true]) {
+    testWidgets("desktop harness detail retains its flow and X preserves opener (settings: $throughSettings)", (
+      tester,
+    ) async {
+      registerHarnessServices();
+      final product = buildDesktopRoutes().single as ShellRoute;
+      final harnessRoute = product.routes.whereType<ShellRoute>().singleWhere(
+        (shell) => (shell.routes.first as GoRoute).path == AppRouteDef.settingsHarnesses.path,
+      );
+      final presentation = throughSettings ? HarnessSettingsPresentation.pushed : HarnessSettingsPresentation.modal;
+      final router = GoRouter(
+        initialLocation: "/opener",
+        routes: [
+          ShellRoute(
+            builder: (_, _, child) => child,
+            routes: [
+              GoRoute(
+                path: "/opener",
+                builder: (context, _) => Scaffold(
+                  body: TextButton(
+                    onPressed: () => context.push<void>(
+                      throughSettings
+                          ? const AppRoute.settings().buildPath()
+                          : AppRoute.settingsHarnesses(presentation: presentation).buildPath(),
+                    ),
+                    child: const Text("open"),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: AppRouteDef.settings.path,
+                builder: (context, _) => Scaffold(
+                  body: TextButton(
+                    onPressed: () =>
+                        context.push<void>(AppRoute.settingsHarnesses(presentation: presentation).buildPath()),
+                    child: const Text("harnesses"),
+                  ),
+                ),
+              ),
+              GoRoute(
+                path: AppRouteDef.projects.path,
+                builder: (_, _) => const Scaffold(body: Text("home")),
+              ),
+              harnessRoute,
+            ],
+          ),
+        ],
+      );
+      addTearDown(router.dispose);
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: router,
+          theme: buildPregoThemeData(brightness: Brightness.light),
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+        ),
+      );
+      pluginSnapshots.add(const PluginManagementLoadResult.supported(response: _pluginResponse, refreshError: null));
+      await tester.pumpAndSettle();
+      final opener = tester.element(find.text("open"));
+      await tester.tap(find.text("open"));
+      await tester.pumpAndSettle();
+      if (throughSettings) {
+        await tester.tap(find.text("harnesses"));
+        await tester.pumpAndSettle();
+      }
+      final cubit = tester.element(find.byType(HarnessesSettingsView)).read<PluginManagementCubit>();
+      await tester.tap(find.text("OpenCode"));
+      await tester.pumpAndSettle();
+      expect(tester.element(find.byType(HarnessSettingsDetailView)).read<PluginManagementCubit>(), same(cubit));
+      expect(find.byType(HarnessSettingsFlowView), findsOneWidget);
+      await tester.tap(find.bySemanticsLabel("Back"));
+      await tester.pumpAndSettle();
+      expect(find.byType(HarnessesSettingsView), findsOneWidget);
+      await tester.tap(find.text("OpenCode"));
+      await tester.pumpAndSettle();
+      await tester.tap(find.bySemanticsLabel("Close settings"));
+      await tester.pumpAndSettle();
+      expect(tester.element(find.text("open")), same(opener));
+      expect(pluginSnapshots.hasListener, isFalse);
+      expect(find.text("home"), findsNothing);
+      router.go(
+        const AppRoute.settingsHarnessDetail(
+          pluginId: "opencode",
+          presentation: HarnessSettingsPresentation.modal,
+        ).buildPath(),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(HarnessesSettingsView, skipOffstage: false), findsOneWidget);
+      await tester.tap(find.bySemanticsLabel("Close settings"));
+      await tester.pumpAndSettle();
+      expect(find.text("home"), findsOneWidget);
+    });
+  }
+
+  testWidgets("desktop harness composition renders a supported bridge snapshot", (tester) async {
+    useTallSurface(tester: tester);
+    registerHarnessServices();
 
     await tester.pumpWidget(
       app(
         child: const DesktopHarnessesSettingsScreen(
-          presentation: HarnessSettingsPresentation.pushed,
-          onClose: _noOp,
+          child: HarnessesSettingsView(
+            presentation: HarnessSettingsPresentation.pushed,
+            connectionBanner: null,
+            onClose: _noOp,
+            onBack: _noOp,
+            onOpenHarness: _noOpenHarness,
+          ),
         ),
       ),
     );
@@ -314,8 +420,10 @@ void main() {
 
     expect(find.text("Harnesses"), findsOneWidget);
     expect(find.text("OpenCode"), findsOneWidget);
-    expect(find.text("Managed outside Sesori"), findsOneWidget);
+    expect(find.text("Running"), findsOneWidget);
   });
 }
 
 void _noOp() {}
+
+void _noOpenHarness({required String pluginId}) {}

--- a/client/desktop/test/features/settings/desktop_settings_screens_test.dart
+++ b/client/desktop/test/features/settings/desktop_settings_screens_test.dart
@@ -304,7 +304,7 @@ void main() {
   }
 
   for (final throughSettings in [false, true]) {
-    testWidgets("desktop harness detail retains its flow and X preserves opener (settings: $throughSettings)", (
+    testWidgets("desktop harness Back and modal X preserve their own opener (settings: $throughSettings)", (
       tester,
     ) async {
       registerHarnessServices();
@@ -365,34 +365,102 @@ void main() {
       final opener = tester.element(find.text("open"));
       await tester.tap(find.text("open"));
       await tester.pumpAndSettle();
+      final settings = throughSettings ? tester.element(find.text("harnesses")) : null;
       if (throughSettings) {
         await tester.tap(find.text("harnesses"));
         await tester.pumpAndSettle();
       }
       final cubit = tester.element(find.byType(HarnessesSettingsView)).read<PluginManagementCubit>();
+      expect(find.bySemanticsLabel("Close settings"), throughSettings ? findsNothing : findsOneWidget);
+      expect(find.bySemanticsLabel("Back"), throughSettings ? findsOneWidget : findsNothing);
       await tester.tap(find.text("OpenCode"));
       await tester.pumpAndSettle();
+      expect(find.bySemanticsLabel("Close settings"), throughSettings ? findsNothing : findsOneWidget);
       expect(tester.element(find.byType(HarnessSettingsDetailView)).read<PluginManagementCubit>(), same(cubit));
       expect(find.byType(HarnessSettingsFlowView), findsOneWidget);
       await tester.tap(find.bySemanticsLabel("Back"));
       await tester.pumpAndSettle();
       expect(find.byType(HarnessesSettingsView), findsOneWidget);
-      await tester.tap(find.text("OpenCode"));
-      await tester.pumpAndSettle();
-      await tester.tap(find.bySemanticsLabel("Close settings"));
+      expect(tester.element(find.byType(HarnessesSettingsView)).read<PluginManagementCubit>(), same(cubit));
+      if (throughSettings) {
+        await tester.tap(find.bySemanticsLabel("Back"));
+        await tester.pumpAndSettle();
+        expect(tester.element(find.text("harnesses")), same(settings));
+        GoRouter.of(settings!).pop();
+      } else {
+        await tester.tap(find.text("OpenCode"));
+        await tester.pumpAndSettle();
+        await tester.tap(find.bySemanticsLabel("Close settings"));
+      }
       await tester.pumpAndSettle();
       expect(tester.element(find.text("open")), same(opener));
+      // Stream cancellation completes outside the widget-test clock.
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      expect(cubit.isClosed, isTrue);
       expect(pluginSnapshots.hasListener, isFalse);
+      expect(authenticationTerminal.hasListener, isFalse);
       expect(find.text("home"), findsNothing);
+      if (!throughSettings) {
+        // Overview X has the same outer-flow boundary as detail X.
+        await tester.tap(find.text("open"));
+        await tester.pumpAndSettle();
+        await tester.tap(find.bySemanticsLabel("Close settings"));
+        await tester.pumpAndSettle();
+        expect(tester.element(find.text("open")), same(opener));
+        expect(pluginSnapshots.hasListener, isFalse);
+
+        // Owned pageless authentication UI must leave with the outer flow,
+        // without turning dismissal into an upstream cancellation.
+        final service = getIt<PluginManagementService>();
+        final challenge = PluginAuthenticationDeviceCodeChallenge(
+          verificationUri: Uri.parse("https://auth.example/device"),
+          userCode: "ABCD-EFGH",
+        );
+        when(() => service.startAuthentication(pluginId: "opencode")).thenAnswer(
+          (_) async => PluginAuthenticationStartResult.challenge(challenge: challenge),
+        );
+        authenticationChallenges.add({"opencode": challenge});
+        pluginSnapshots.add(
+          PluginManagementLoadResult.supported(
+            response: _pluginResponse.copyWith(
+              plugins: [
+                _plugin.copyWith(
+                  setup: _plugin.setup.copyWith(state: PluginSetupState.authenticationRequired),
+                  managementCapabilities: {PluginManagementCapability.authentication},
+                ),
+              ],
+            ),
+            refreshError: null,
+          ),
+        );
+        await tester.tap(find.text("open"));
+        await tester.pumpAndSettle();
+        await tester.tap(find.text("OpenCode"));
+        await tester.pumpAndSettle();
+        final detail = tester.widget<HarnessSettingsDetailView>(find.byType(HarnessSettingsDetailView));
+        await tester.tap(find.byKey(const Key("harness_authentication_opencode")));
+        await tester.pumpAndSettle();
+        expect(find.byType(PregoBottomSheet), findsOneWidget);
+        detail.onClose();
+        await tester.pumpAndSettle();
+        expect(find.byType(PregoBottomSheet), findsNothing);
+        expect(tester.element(find.text("open")), same(opener));
+        expect(pluginSnapshots.hasListener, isFalse);
+        verifyNever(() => service.cancelAuthentication(pluginId: "opencode"));
+      }
       router.go(
-        const AppRoute.settingsHarnessDetail(
+        AppRoute.settingsHarnessDetail(
           pluginId: "opencode",
-          presentation: HarnessSettingsPresentation.modal,
+          presentation: presentation,
         ).buildPath(),
       );
       await tester.pumpAndSettle();
       expect(find.byType(HarnessesSettingsView, skipOffstage: false), findsOneWidget);
-      await tester.tap(find.bySemanticsLabel("Close settings"));
+      expect(find.text("harnesses", skipOffstage: false), findsNothing);
+      await tester.tap(find.bySemanticsLabel("Back"));
+      await tester.pumpAndSettle();
+      expect(find.byType(HarnessesSettingsView), findsOneWidget);
+      await tester.tap(find.bySemanticsLabel(throughSettings ? "Back" : "Close settings"));
       await tester.pumpAndSettle();
       expect(find.text("home"), findsOneWidget);
     });

--- a/client/module_app_ui/lib/sesori_app_ui.dart
+++ b/client/module_app_ui/lib/sesori_app_ui.dart
@@ -64,7 +64,7 @@ export "src/features/session_list/session_list_panel.dart";
 export "src/features/session_list/session_list_scaffold.dart";
 export "src/features/session_list/session_row_metrics.dart";
 export "src/features/session_list/session_tile.dart";
-export "src/features/settings/harnesses_settings_view.dart";
+export "src/features/settings/harness_settings_flow_view.dart";
 export "src/features/settings/notification_settings_view.dart";
 export "src/features/settings/profile_view.dart";
 export "src/features/settings/settings_view.dart";

--- a/client/module_app_ui/lib/src/features/settings/harness_settings_detail_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/harness_settings_detail_view.dart
@@ -1,0 +1,389 @@
+part of "harness_settings_flow_view.dart";
+
+/// A URL-selected harness; never substitutes another registered identity.
+class const HarnessSettingsDetailView({
+  super.key,
+  required final String pluginId,
+  required final VoidCallback onBack,
+  required final VoidCallback onClose,
+  required final Widget? connectionBanner,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.watch<PluginManagementCubit>();
+    final state = cubit.state;
+    final plugin = state is PluginManagementReady
+        ? state.response.plugins.where((plugin) => plugin.setup.id == pluginId).firstOrNull
+        : null;
+    return PregoGlassScaffold(
+      title: plugin?.setup.displayName ?? context.loc.settingsHarnessesTitle,
+      titleMode: PregoTopNavigationTitleMode.inline,
+      automaticallyImplyLeading: false,
+      onBack: onBack,
+      onRefresh: cubit.refresh,
+      banner: connectionBanner,
+      actions: [
+        PregoButtonsIconGlass(icon: TablerRegular.x, semanticLabel: context.loc.settingsClose, onPressed: onClose),
+      ],
+      slivers: [
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsetsDirectional.fromSTEB(
+              PregoSpacing.xl,
+              _contentTopPadding,
+              PregoSpacing.xl,
+              PregoSpacing.xl + MediaQuery.paddingOf(context).bottom,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                if (state is PluginManagementReady) _HarnessErrors(state: state),
+                if (plugin != null && state is PluginManagementReady)
+                  _HarnessControlCard(
+                    plugin: plugin,
+                    action: state.action,
+                    authentication: state.authentication,
+                    install: state.installs[pluginId],
+                    scanning: state.scanningPluginIds.contains(pluginId),
+                    scanRejection: state.scanRejections[pluginId],
+                  )
+                else
+                  switch (state) {
+                    PluginManagementLoading() => const _LoadingView(),
+                    PluginManagementUnsupported() => const _UnsupportedView(),
+                    PluginManagementFailure() => const _FailureView(),
+                    PluginManagementReady() => Text(context.loc.harnessManagementNotFound),
+                  },
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class const _HarnessControlCard({
+  required final PluginManagementMetadata plugin,
+  required final PluginManagementActionState action,
+  required final PluginAuthenticationPresentationState authentication,
+
+  /// This harness' in-flight installation or retained failure.
+  required final PluginInstallState? install,
+
+  /// Whether a catalog scan covering this harness is running, started here
+  /// or from a list's pull.
+  required final bool scanning,
+
+  /// Why this harness' last targeted scan was turned down, if it was. Never
+  /// carries an accepted start.
+  required final CatalogRescanStartResult? scanRejection,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+    final pluginId = plugin.setup.id;
+    final capabilities = plugin.managementCapabilities;
+    final supportsLifecycle = capabilities.contains(PluginManagementCapability.lifecycle);
+    final showSetupRefresh =
+        capabilities.contains(PluginManagementCapability.setupRefresh) &&
+        plugin.setup.state != PluginSetupState.runtimeMissing;
+    final supportsIdleTimeout = capabilities.contains(PluginManagementCapability.idleTimeout);
+    final showExternal = !supportsLifecycle && !capabilities.contains(PluginManagementCapability.unknown);
+    final setupReady = plugin.setup.state == PluginSetupState.ready;
+    final runtimeVersion = plugin.setup.runtimeVersion;
+    final enabled = plugin.runtimeState.isEnabled;
+    final showOperational = setupReady && enabled;
+    final showWork = showOperational && plugin.workState != PluginManagementWorkState.unknown;
+    // The advertised capability is authoritative; unavailable does not imply an update.
+    final showInstall = _canInstall(plugin: plugin);
+    final showRestart = showOperational && supportsLifecycle;
+    final showScan = plugin.runtimeState.isRoutable;
+    // A rejection replaces the row's description until the user starts another
+    // scan, so the answer to "why did nothing happen" stays on the card that
+    // was tapped. The bridge's own error text is never among these.
+    final scanRejectionText = switch (scanRejection) {
+      null || CatalogRescanStartAccepted() => null,
+      CatalogRescanStartNotImportable() => loc.harnessManagementScanNotReady,
+      CatalogRescanStartUnsupported() => loc.harnessManagementScanUnsupported,
+      CatalogRescanStartFailed() => loc.harnessManagementScanFailed,
+    };
+    final showTimeout = showOperational && supportsIdleTimeout;
+    final supportsAuthentication = capabilities.contains(PluginManagementCapability.authentication);
+    final showAuthentication = supportsAuthentication && plugin.setup.state == PluginSetupState.authenticationRequired;
+    final authenticationForThisHarness = switch (authentication) {
+      PluginAuthenticationPresentationStarting(pluginId: final targetPluginId) ||
+      PluginAuthenticationPresentationChallenge(pluginId: final targetPluginId) ||
+      PluginAuthenticationPresentationBrowserLaunchFailedState(pluginId: final targetPluginId) ||
+      PluginAuthenticationPresentationCancelling(pluginId: final targetPluginId) ||
+      PluginAuthenticationPresentationCancellingUncertain(pluginId: final targetPluginId) => targetPluginId == pluginId,
+      PluginAuthenticationPresentationIdle() || PluginAuthenticationPresentationFailed() => false,
+    };
+    final authenticationStarting = switch (authentication) {
+      PluginAuthenticationPresentationStarting(pluginId: final targetPluginId) => targetPluginId == pluginId,
+      PluginAuthenticationPresentationIdle() ||
+      PluginAuthenticationPresentationChallenge() ||
+      PluginAuthenticationPresentationBrowserLaunchFailedState() ||
+      PluginAuthenticationPresentationCancelling() ||
+      PluginAuthenticationPresentationCancellingUncertain() ||
+      PluginAuthenticationPresentationFailed() => false,
+    };
+    final authenticationActive = switch (authentication) {
+      PluginAuthenticationPresentationIdle() || PluginAuthenticationPresentationFailed() => false,
+      PluginAuthenticationPresentationStarting() ||
+      PluginAuthenticationPresentationChallenge() ||
+      PluginAuthenticationPresentationBrowserLaunchFailedState() ||
+      PluginAuthenticationPresentationCancelling() ||
+      PluginAuthenticationPresentationCancellingUncertain() => true,
+    };
+    final blocked = _controlsBlocked(action) || install is PluginInstallInProgress;
+    final actionHint = plugin.actionHint ?? plugin.setup.actionHint;
+    // The service reports an install as in-flight from the moment its command
+    // is issued until the bridge's terminal event, so this covers the window
+    // before the first progress event without borrowing the generic action
+    // spinner (which any harness action would trigger).
+
+    return KeyedSubtree(
+      key: Key("harness_management_card_$pluginId"),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          SettingsSection(
+            title: loc.harnessesStatusSetupSection,
+            child: PregoGroupedRows(
+              color: context.prego.colors.bgSurface2,
+              key: Key("harnesses_detail_card_$pluginId"),
+              children: [
+                PregoGroupedRow(
+                  key: Key("harness_management_identity_$pluginId"),
+                  minHeight: 52,
+                  verticalPadding: PregoSpacing.xs,
+                  title: Row(
+                    children: [
+                      PregoBrandLogo(pluginId: pluginId, color: context.prego.colors.textTertiary),
+                      const SizedBox(width: PregoSpacing.md),
+                      Expanded(child: Text(plugin.setup.displayName)),
+                    ],
+                  ),
+                  trailing: _HarnessSwitch(plugin: plugin, action: action, install: install),
+                ),
+                _FactRow(
+                  title: loc.harnessesStatusLabel,
+                  value: _HarnessStatus(plugin: plugin, install: install, overview: false),
+                ),
+                if (runtimeVersion != null) _FactRow(title: loc.harnessesVersionLabel, value: Text(runtimeVersion)),
+                if (showWork)
+                  _FactRow(
+                    title: loc.harnessesActivityLabel,
+                    value: Text(_workStatus(context: context, state: plugin.workState)),
+                  ),
+                if (actionHint != null && !(showInstall && plugin.setup.state == PluginSetupState.runtimeMissing))
+                  PregoGroupedRow(title: Text(actionHint)),
+                if (showExternal)
+                  PregoGroupedRow(
+                    key: Key("harness_management_external_$pluginId"),
+                    icon: TablerRegular.info_circle,
+                    title: Text(loc.harnessManagementExternalTitle),
+                    subtitle: Text(loc.harnessManagementExternalDescription),
+                  ),
+                if (showAuthentication)
+                  PregoGroupedRow(
+                    key: Key("harness_authentication_$pluginId"),
+                    icon: TablerRegular.login,
+                    title: Text(
+                      plugin.authenticationState == PluginAuthenticationState.inProgress || authenticationForThisHarness
+                          ? loc.harnessAuthenticationContinue
+                          : loc.harnessAuthenticationLogIn,
+                    ),
+                    subtitle: Text(loc.harnessAuthenticationDescription),
+                    trailing: authenticationStarting ? const PregoActivityIndicator(color: null) : null,
+                    // Only one authentication flow can exist. Its own row can reopen
+                    // a retained challenge after uncertain cancellation; every other
+                    // row stays disabled until that flow settles.
+                    onTap: blocked || authenticationStarting || (authenticationActive && !authenticationForThisHarness)
+                        ? null
+                        : authenticationForThisHarness
+                        ? () => unawaited(
+                            _showAuthenticationSheet(
+                              context: context,
+                              cubit: context.read<PluginManagementCubit>(),
+                            ),
+                          )
+                        : () => context.read<PluginManagementCubit>().startAuthentication(pluginId: pluginId),
+                  ),
+
+                if (showInstall || install != null)
+                  _HarnessInstallation(plugin: plugin, install: install, blocked: blocked),
+              ],
+            ),
+          ),
+          if (showSetupRefresh || showRestart || showScan) ...[
+            const SizedBox(height: PregoSpacing.xl),
+            SettingsSection(
+              title: loc.harnessesActionsSection,
+              child: PregoGroupedRows(
+                color: context.prego.colors.bgSurface2,
+                children: [
+                  if (showSetupRefresh)
+                    PregoGroupedRow(
+                      key: Key("harness_management_refresh_$pluginId"),
+                      icon: TablerRegular.refresh,
+                      minHeight: 68,
+                      verticalPadding: PregoSpacing.lg,
+                      title: Text(loc.harnessManagementRefreshSetup),
+                      subtitle: Text(loc.harnessManagementRefreshSetupDescription),
+                      onTap: blocked
+                          ? null
+                          : () => context.read<PluginManagementCubit>().refreshSetup(pluginId: pluginId),
+                    ),
+                  if (showRestart)
+                    PregoGroupedRow(
+                      key: Key("harness_management_restart_$pluginId"),
+                      icon: TablerRegular.rotate,
+                      minHeight: 68,
+                      verticalPadding: PregoSpacing.lg,
+                      title: Text(loc.harnessManagementRestart),
+                      subtitle: Text(loc.harnessManagementRestartDescription(plugin.setup.displayName)),
+                      onTap: blocked ? null : () => context.read<PluginManagementCubit>().restart(pluginId: pluginId),
+                    ),
+                  // The keyboard-and-pointer twin of the lists' deep pull, which is
+                  // invisible to a screen reader and awkward with a mouse. Offered only
+                  // for a routable harness: `isEnabled` is also true for blocked and
+                  // failed, which the bridge answers with a 503.
+                  if (showScan)
+                    PregoGroupedRow(
+                      key: Key("harness_management_scan_$pluginId"),
+                      icon: TablerRegular.refresh_dot,
+                      verticalPadding: PregoSpacing.lg,
+                      title: Text(loc.harnessManagementScan),
+                      subtitle: Text(scanRejectionText ?? loc.harnessManagementScanDescription),
+                      trailing: scanning ? const PregoActivityIndicator(color: null) : null,
+                      onTap: blocked || scanning
+                          ? null
+                          : () => context.read<PluginManagementCubit>().startCatalogScanFor(pluginId: pluginId),
+                    ),
+                ],
+              ),
+            ),
+          ],
+          if (showTimeout) ...[
+            const SizedBox(height: PregoSpacing.xl),
+            SettingsSection(
+              title: loc.harnessesAutomationSection,
+              child: PregoGroupedRows(
+                color: context.prego.colors.bgSurface2,
+                children: [
+                  if (showTimeout)
+                    PregoGroupedRow(
+                      key: Key("harness_management_timeout_$pluginId"),
+                      icon: TablerRegular.clock,
+                      verticalPadding: PregoSpacing.lg,
+                      title: Text(loc.harnessManagementIdleTimeout),
+                      subtitle: Text(loc.harnessManagementIdleTimeoutDescription),
+                      trailing: Text(
+                        _timeoutLabel(context: context, minutes: plugin.idleTimeoutMins),
+                        style: context.prego.textTheme.textSm.regular.copyWith(
+                          color: context.prego.colors.textTertiary,
+                        ),
+                      ),
+                      onTap: blocked ? null : () => _editHarnessTimeout(context: context, plugin: plugin),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class const _HarnessInstallation({
+  required final PluginManagementMetadata plugin,
+  required final PluginInstallState? install,
+  required final bool blocked,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+    final install = this.install;
+    return Padding(
+      padding: const EdgeInsets.all(PregoSpacing.xl),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(switch (install) {
+            PluginInstallInProgress() => loc.harnessesInstallingTitle(plugin.setup.displayName),
+            PluginInstallFailed() => loc.harnessesInstallationFailed,
+            null => loc.harnessesInstallTitle(plugin.setup.displayName),
+          }, style: context.prego.textTheme.textMd.medium.copyWith(color: context.prego.colors.textPrimary)),
+          const SizedBox(height: PregoSpacing.md),
+          if (install case PluginInstallInProgress(:final progress)) ...[
+            Text(
+              _installPhase(context: context, progress: progress),
+              style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),
+            ),
+            const SizedBox(height: PregoSpacing.md),
+            LinearProgressIndicator(
+              value: _downloadFraction(progress: progress),
+              minHeight: 6,
+              borderRadius: BorderRadius.circular(3),
+              color: context.prego.colors.fgBrandPrimary,
+              backgroundColor: context.prego.colors.bgSurface1,
+            ),
+          ] else ...[
+            Text(
+              install is PluginInstallFailed
+                  ? loc.harnessesInstallationFailedDescription
+                  : loc.harnessesInstallDescription,
+              style: context.prego.textTheme.textXs.regular.copyWith(color: context.prego.colors.textSecondary),
+            ),
+            if (_canInstall(plugin: plugin)) ...[
+              const SizedBox(height: PregoSpacing.xl),
+              PregoButtonsSolid(
+                key: Key("harness_management_install_${plugin.setup.id}"),
+                label: install is PluginInstallFailed
+                    ? loc.harnessesRestartInstallation
+                    : loc.harnessesStartInstallation,
+                hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
+                size: PregoButtonsSolidSize.lg,
+                fullWidth: true,
+                onPressed: blocked
+                    ? null
+                    : () => context.read<PluginManagementCubit>().install(pluginId: plugin.setup.id),
+              ),
+            ],
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class const _FactRow({required final String title, required final Widget value}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) => LayoutBuilder(
+    builder: (context, constraints) => PregoGroupedRow(
+      minHeight: 52,
+      title: Text(title),
+      trailing: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: constraints.maxWidth * .55),
+        child: DefaultTextStyle(
+          textAlign: TextAlign.end,
+          style: context.prego.textTheme.textMd.regular.copyWith(color: context.prego.colors.textSecondary),
+          child: value,
+        ),
+      ),
+    ),
+  );
+}
+
+bool _supportsOperationalTimeout(PluginManagementMetadata plugin) {
+  return plugin.setup.state == PluginSetupState.ready &&
+      plugin.runtimeState.isEnabled &&
+      plugin.managementCapabilities.contains(PluginManagementCapability.idleTimeout);
+}
+
+bool _controlsBlocked(PluginManagementActionState action) {
+  return action is PluginManagementActionInProgress || action is PluginManagementActionForceConfirmationRequired;
+}

--- a/client/module_app_ui/lib/src/features/settings/harness_settings_detail_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/harness_settings_detail_view.dart
@@ -4,6 +4,7 @@ part of "harness_settings_flow_view.dart";
 class const HarnessSettingsDetailView({
   super.key,
   required final String pluginId,
+  required final HarnessSettingsPresentation presentation,
   required final VoidCallback onBack,
   required final VoidCallback onClose,
   required final Widget? connectionBanner,
@@ -23,7 +24,8 @@ class const HarnessSettingsDetailView({
       onRefresh: cubit.refresh,
       banner: connectionBanner,
       actions: [
-        PregoButtonsIconGlass(icon: TablerRegular.x, semanticLabel: context.loc.settingsClose, onPressed: onClose),
+        if (presentation == HarnessSettingsPresentation.modal)
+          PregoButtonsIconGlass(icon: TablerRegular.x, semanticLabel: context.loc.settingsClose, onPressed: onClose),
       ],
       slivers: [
         SliverToBoxAdapter(

--- a/client/module_app_ui/lib/src/features/settings/harness_settings_flow_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/harness_settings_flow_view.dart
@@ -1,0 +1,127 @@
+import "dart:async";
+
+import "package:flutter/semantics.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:go_router/go_router.dart";
+import "package:material_ui/material_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "../../extensions/build_context_x.dart";
+import "../../utils/copy_text_to_clipboard.dart";
+import "../../widgets/catalog_scan_row.dart";
+import "widgets/settings_section.dart";
+
+part "harness_settings_sheets.dart";
+part "harness_settings_presentation.dart";
+part "harness_settings_detail_view.dart";
+part "harnesses_settings_view.dart";
+
+/// Owns transient presentation once for the entire nested harness navigator.
+class const HarnessSettingsFlowView({super.key, required final Widget child}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final cubit = context.read<PluginManagementCubit>();
+    return _HarnessPresentationScope(
+      presentationContext: context,
+      child: MultiBlocListener(
+        listeners: [
+          BlocListener<PluginManagementCubit, PluginManagementState>(
+            listenWhen: (previous, current) => _forceConfirmation(previous) != _forceConfirmation(current),
+            listener: (context, state) {
+              final confirmation = _forceConfirmation(state);
+              if (confirmation == null || !(ModalRoute.of(context)?.isCurrent ?? false)) return;
+              unawaited(_showForceConfirmation(context: context, cubit: cubit, confirmation: confirmation));
+            },
+          ),
+          // This screen hosts no progress row, so a scan started here would
+          // otherwise end in silence: the spinner stops and the service clears
+          // its result before the user could reach a list to read it.
+          BlocListener<PluginManagementCubit, PluginManagementState>(
+            listenWhen: (previous, current) => _scanOutcome(previous) == null && _scanOutcome(current) != null,
+            listener: (context, state) {
+              final outcome = _scanOutcome(state);
+              if (outcome == null) return;
+              final loc = context.loc;
+              final (title, variant) = switch (outcome) {
+                CatalogRescanOutcomeSucceeded(:final counts) => (
+                  loc.harnessManagementScanFinished(catalogScanCountsLine(loc: loc, counts: counts)),
+                  PregoPopupAlertsNotificationsVariant.success,
+                ),
+                CatalogRescanOutcomePartlyFailed(:final succeededCount, :final failedCount) => (
+                  loc.harnessManagementScanPartlyFailed(failedCount, succeededCount + failedCount),
+                  PregoPopupAlertsNotificationsVariant.error,
+                ),
+                CatalogRescanOutcomeFailed() => (
+                  loc.harnessManagementScanFinishedFailed,
+                  PregoPopupAlertsNotificationsVariant.error,
+                ),
+              };
+              PregoPopupAlertPresenter.of(context).show(title: title, variant: variant);
+              // Announced as well as shown. The popup renders ordinary text into
+              // an overlay, which moves no semantic focus and carries no live
+              // region, so on its own it tells a screen-reader user nothing —
+              // and they are the reason this surface exists, the pull being a
+              // gesture they cannot perform.
+              unawaited(
+                SemanticsService.sendAnnouncement(View.of(context), title, Directionality.of(context)),
+              );
+              cubit.dismissCatalogScanOutcome();
+            },
+          ),
+          BlocListener<PluginManagementCubit, PluginManagementState>(
+            listenWhen: (previous, current) =>
+                _authenticationChallenge(state: previous) == null && _authenticationChallenge(state: current) != null,
+            listener: (context, state) {
+              final challenge = _authenticationChallenge(state: state);
+              if (challenge == null || !(ModalRoute.of(context)?.isCurrent ?? false)) return;
+              unawaited(_showAuthenticationSheet(context: context, cubit: cubit));
+            },
+          ),
+        ],
+        child: child,
+      ),
+    );
+  }
+}
+
+PluginAuthenticationPresentationState? _authenticationChallenge({required PluginManagementState state}) =>
+    switch (state) {
+      PluginManagementReady(authentication: final PluginAuthenticationPresentationChallenge challenge) => challenge,
+      PluginManagementReady(authentication: final PluginAuthenticationPresentationBrowserLaunchFailedState challenge) =>
+        challenge,
+      PluginManagementReady(authentication: final PluginAuthenticationPresentationCancelling challenge) => challenge,
+      PluginManagementReady(authentication: final PluginAuthenticationPresentationCancellingUncertain challenge) =>
+        challenge,
+      PluginManagementReady() ||
+      PluginManagementLoading() ||
+      PluginManagementUnsupported() ||
+      PluginManagementFailure() => null,
+    };
+
+CatalogRescanOutcome? _scanOutcome(PluginManagementState state) => switch (state) {
+  PluginManagementReady(:final scanOutcome) => scanOutcome,
+  PluginManagementLoading() || PluginManagementUnsupported() || PluginManagementFailure() => null,
+};
+
+PluginManagementActionForceConfirmationRequired? _forceConfirmation(PluginManagementState state) => switch (state) {
+  PluginManagementReady(action: final PluginManagementActionForceConfirmationRequired confirmation) => confirmation,
+  PluginManagementReady() ||
+  PluginManagementLoading() ||
+  PluginManagementUnsupported() ||
+  PluginManagementFailure() => null,
+};
+
+// Sheets belong to the stable outer flow page, not an offstage overview or a
+// disposable detail page. Navigator removes them when the flow leaves.
+BuildContext _flowPresentationContext({required BuildContext context}) =>
+    context.getInheritedWidgetOfExactType<_HarnessPresentationScope>()?.presentationContext ??
+    (throw StateError("Harness sheets require a harness flow owner"));
+
+class const _HarnessPresentationScope({required final BuildContext presentationContext, required super.child})
+    extends InheritedWidget {
+  @override
+  bool updateShouldNotify(_HarnessPresentationScope oldWidget) => presentationContext != oldWidget.presentationContext;
+}

--- a/client/module_app_ui/lib/src/features/settings/harness_settings_presentation.dart
+++ b/client/module_app_ui/lib/src/features/settings/harness_settings_presentation.dart
@@ -1,0 +1,139 @@
+part of "harness_settings_flow_view.dart";
+
+enum _HarnessGroup() {
+  needsAttention,
+  enabled,
+  notInstalled,
+  disabled,
+}
+
+_HarnessGroup _group({required PluginManagementMetadata plugin, required PluginInstallState? install}) {
+  if (install is PluginInstallInProgress) return _HarnessGroup.notInstalled;
+  if (plugin.runtimeState == PluginRuntimeState.disabled) return _HarnessGroup.disabled;
+  if (plugin.setup.state == PluginSetupState.runtimeMissing) return _HarnessGroup.notInstalled;
+  if (plugin.setup.state == PluginSetupState.ready &&
+      (plugin.runtimeState == PluginRuntimeState.dormant ||
+          plugin.runtimeState == PluginRuntimeState.starting ||
+          plugin.runtimeState == PluginRuntimeState.active)) {
+    return _HarnessGroup.enabled;
+  }
+  return _HarnessGroup.needsAttention;
+}
+
+String _groupTitle({required BuildContext context, required _HarnessGroup group}) => switch (group) {
+  _HarnessGroup.needsAttention => context.loc.harnessesNeedsAttention,
+  _HarnessGroup.enabled => context.loc.harnessManagementEnabled,
+  _HarnessGroup.notInstalled => context.loc.harnessesNotInstalled,
+  _HarnessGroup.disabled => context.loc.harnessesStatusDisabled,
+};
+
+bool _canInstall({required PluginManagementMetadata plugin}) =>
+    plugin.managementCapabilities.contains(PluginManagementCapability.install) &&
+    (plugin.setup.state == PluginSetupState.runtimeMissing || plugin.setup.state == PluginSetupState.unavailable);
+
+String _status({
+  required BuildContext context,
+  required PluginManagementMetadata plugin,
+  required PluginInstallState? install,
+}) {
+  if (install is PluginInstallInProgress) return context.loc.harnessesInstallingStatus;
+  if (plugin.setup.state == PluginSetupState.runtimeMissing) return context.loc.harnessesNotInstalled;
+  if (plugin.setup.state != PluginSetupState.ready) return _setupStatus(context: context, state: plugin.setup.state);
+  if (plugin.runtimeState == PluginRuntimeState.disabled) return context.loc.harnessesStatusDisabled;
+  return switch (plugin.runtimeState) {
+    PluginRuntimeState.dormant => context.loc.harnessesStatusIdle,
+    PluginRuntimeState.active => context.loc.harnessesStatusRunning,
+    final runtime => _runtimeStatus(context: context, state: runtime),
+  };
+}
+
+class const _HarnessStatus({
+  required final PluginManagementMetadata plugin,
+  required final PluginInstallState? install,
+  required final bool overview,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final group = _group(plugin: plugin, install: install);
+    final color = install is PluginInstallInProgress
+        ? context.prego.colors.fgBrandPrimary
+        : plugin.setup.state == PluginSetupState.runtimeMissing || install is PluginInstallFailed
+        ? context.prego.colors.fgErrorPrimary
+        : group == _HarnessGroup.enabled
+        ? context.prego.colors.fgSuccessPrimary
+        : context.prego.colors.textTertiary;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 6,
+          height: 6,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: PregoSpacing.md),
+        Flexible(
+          child: Text(
+            overview && install is PluginInstallFailed
+                ? context.loc.harnessesInstallationFailed
+                : _status(context: context, plugin: plugin, install: install),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class const _HarnessSwitch({
+  required final PluginManagementMetadata plugin,
+  required final PluginManagementActionState action,
+  required final PluginInstallState? install,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    if (plugin.runtimeState == PluginRuntimeState.unknown ||
+        !plugin.managementCapabilities.contains(PluginManagementCapability.lifecycle)) {
+      return const SizedBox.shrink();
+    }
+    final blocked = _controlsBlocked(action) || install is PluginInstallInProgress;
+    Future<void> setEnabled({required bool enabled}) => enabled
+        ? context.read<PluginManagementCubit>().enable(pluginId: plugin.setup.id)
+        : context.read<PluginManagementCubit>().disable(pluginId: plugin.setup.id);
+
+    return Semantics(
+      label: context.loc.harnessesEnabledLabel(plugin.setup.displayName),
+      child: GestureDetector(
+        key: Key("harness_management_enabled_target_${plugin.setup.id}"),
+        behavior: HitTestBehavior.opaque,
+        excludeFromSemantics: true,
+        onTap: blocked ? null : () => unawaited(setEnabled(enabled: !plugin.runtimeState.isEnabled)),
+        child: SizedBox(
+          height: 44,
+          // Expand the hit target without stretching the 64×28 design-system track.
+          child: Center(
+            widthFactor: 1,
+            child: PregoSwitch(
+              key: Key("harness_management_enabled_${plugin.setup.id}"),
+              value: plugin.runtimeState.isEnabled,
+              onChanged: blocked ? null : (value) => unawaited(setEnabled(enabled: value)),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _installPhase({required BuildContext context, required PluginInstallProgress progress}) => switch (progress) {
+  PluginInstallProgress(phase: PluginInstallPhase.downloading, :final percent?) =>
+    context.loc.harnessManagementInstallDownloadingPercent(percent),
+  PluginInstallProgress(phase: PluginInstallPhase.downloading) => context.loc.harnessManagementInstallDownloading,
+  PluginInstallProgress(phase: PluginInstallPhase.verifying) => context.loc.harnessManagementInstallVerifying,
+  PluginInstallProgress(phase: PluginInstallPhase.extracting) => context.loc.harnessManagementInstallExtracting,
+  PluginInstallProgress(phase: PluginInstallPhase.finalizing) => context.loc.harnessManagementInstallFinishing,
+  PluginInstallProgress() => context.loc.harnessManagementInstallInProgress,
+};
+
+double? _downloadFraction({required PluginInstallProgress progress}) => switch (progress) {
+  PluginInstallProgress(phase: PluginInstallPhase.downloading, :final percent?) => percent / 100,
+  PluginInstallProgress() => null,
+};

--- a/client/module_app_ui/lib/src/features/settings/harness_settings_presentation.dart
+++ b/client/module_app_ui/lib/src/features/settings/harness_settings_presentation.dart
@@ -31,6 +31,13 @@ bool _canInstall({required PluginManagementMetadata plugin}) =>
     plugin.managementCapabilities.contains(PluginManagementCapability.install) &&
     (plugin.setup.state == PluginSetupState.runtimeMissing || plugin.setup.state == PluginSetupState.unavailable);
 
+bool _showOverviewStatus({required PluginManagementMetadata plugin, required PluginInstallState? install}) {
+  if (_group(plugin: plugin, install: install) == _HarnessGroup.disabled) return false;
+  if (install != null || plugin.setup.state != PluginSetupState.ready) return true;
+  return plugin.runtimeState != PluginRuntimeState.dormant &&
+      (plugin.runtimeState != PluginRuntimeState.active || plugin.workState != PluginManagementWorkState.idle);
+}
+
 String _status({
   required BuildContext context,
   required PluginManagementMetadata plugin,
@@ -42,7 +49,11 @@ String _status({
   if (plugin.runtimeState == PluginRuntimeState.disabled) return context.loc.harnessesStatusDisabled;
   return switch (plugin.runtimeState) {
     PluginRuntimeState.dormant => context.loc.harnessesStatusIdle,
-    PluginRuntimeState.active => context.loc.harnessesStatusRunning,
+    PluginRuntimeState.active => switch (plugin.workState) {
+      PluginManagementWorkState.busy => context.loc.harnessesStatusRunning,
+      PluginManagementWorkState.idle => context.loc.harnessesStatusIdle,
+      PluginManagementWorkState.unknown => context.loc.harnessesStatusUnknown,
+    },
     final runtime => _runtimeStatus(context: context, state: runtime),
   };
 }
@@ -59,7 +70,7 @@ class const _HarnessStatus({
         ? context.prego.colors.fgBrandPrimary
         : plugin.setup.state == PluginSetupState.runtimeMissing || install is PluginInstallFailed
         ? context.prego.colors.fgErrorPrimary
-        : group == _HarnessGroup.enabled
+        : group == _HarnessGroup.enabled && plugin.workState == PluginManagementWorkState.busy
         ? context.prego.colors.fgSuccessPrimary
         : context.prego.colors.textTertiary;
     return Row(
@@ -93,6 +104,27 @@ class const _HarnessSwitch({
     if (plugin.runtimeState == PluginRuntimeState.unknown ||
         !plugin.managementCapabilities.contains(PluginManagementCapability.lifecycle)) {
       return const SizedBox.shrink();
+    }
+    if (action
+        case PluginManagementActionInProgress(
+          target: PluginManagementActionTargetHarness(:final pluginId),
+        )
+        when pluginId == plugin.setup.id && install is! PluginInstallInProgress) {
+      return Semantics(
+        label: context.loc.harnessesUpdatingLabel(plugin.setup.displayName),
+        liveRegion: true,
+        child: SizedBox(
+          key: Key("harness_management_enabled_target_${plugin.setup.id}"),
+          width: 64,
+          height: 44,
+          child: Center(
+            child: PregoActivityIndicator(
+              key: Key("harness_management_enabled_progress_${plugin.setup.id}"),
+              color: null,
+            ),
+          ),
+        ),
+      );
     }
     final blocked = _controlsBlocked(action) || install is PluginInstallInProgress;
     Future<void> setEnabled({required bool enabled}) => enabled

--- a/client/module_app_ui/lib/src/features/settings/harness_settings_sheets.dart
+++ b/client/module_app_ui/lib/src/features/settings/harness_settings_sheets.dart
@@ -1,0 +1,560 @@
+part of "harness_settings_flow_view.dart";
+
+Future<void> _editDefaultTimeout({required BuildContext context, required PluginManagementReady state}) async {
+  final cubit = context.read<PluginManagementCubit>();
+  final result = await _showTimeoutSheet(
+    context: context,
+    title: context.loc.harnessManagementDefaultTimeoutDialogTitle,
+    allowUseDefault: false,
+    initialChoice: state.response.defaultIdleTimeoutMins <= 0 ? _TimeoutChoice.noTimeout : _TimeoutChoice.custom,
+    initialMinutes: state.response.defaultIdleTimeoutMins,
+  );
+  switch (result) {
+    case null:
+      return;
+    case _UseDefaultTimeoutResult():
+      throw StateError("The global timeout cannot inherit another timeout");
+    case _ApplyTimeoutResult(:final input):
+      await cubit.applyIdleTimeoutToAll(input: input);
+  }
+}
+
+Future<void> _editHarnessTimeout({required BuildContext context, required PluginManagementMetadata plugin}) async {
+  final cubit = context.read<PluginManagementCubit>();
+  final initialChoice = switch ((plugin.hasIdleTimeoutOverride, plugin.idleTimeoutMins)) {
+    (false, _) => _TimeoutChoice.useDefault,
+    (true, <= 0) => _TimeoutChoice.noTimeout,
+    (true, _) => _TimeoutChoice.custom,
+  };
+  final result = await _showTimeoutSheet(
+    context: context,
+    title: context.loc.harnessManagementTimeoutDialogTitle(plugin.setup.displayName),
+    allowUseDefault: true,
+    initialChoice: initialChoice,
+    initialMinutes: plugin.idleTimeoutMins,
+  );
+  switch (result) {
+    case null:
+      return;
+    case _UseDefaultTimeoutResult():
+      await cubit.clearIdleTimeoutOverride(pluginId: plugin.setup.id);
+    case _ApplyTimeoutResult(:final input):
+      await cubit.setIdleTimeoutOverride(pluginId: plugin.setup.id, input: input);
+  }
+}
+
+Future<_TimeoutResult?> _showTimeoutSheet({
+  required BuildContext context,
+  required String title,
+  required bool allowUseDefault,
+  required _TimeoutChoice initialChoice,
+  required int initialMinutes,
+}) {
+  return showPregoBottomSheet<_TimeoutResult>(
+    context: _flowPresentationContext(context: context),
+    title: title,
+    builder: (_) => _TimeoutSheet(
+      allowUseDefault: allowUseDefault,
+      initialChoice: initialChoice,
+      initialMinutes: initialMinutes,
+    ),
+  );
+}
+
+enum _TimeoutChoice() {
+  useDefault,
+  noTimeout,
+  custom,
+}
+
+sealed class const _TimeoutResult();
+
+final class const _UseDefaultTimeoutResult() extends _TimeoutResult;
+
+final class const _ApplyTimeoutResult({required final PluginManagementIdleTimeoutInput input}) extends _TimeoutResult;
+
+class const _TimeoutSheet({
+  required final bool allowUseDefault,
+  required final _TimeoutChoice initialChoice,
+  required final int initialMinutes,
+}) extends StatefulWidget {
+  @override
+  State<_TimeoutSheet> createState() => _TimeoutSheetState();
+}
+
+class _TimeoutSheetState() extends State<_TimeoutSheet> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _controller = TextEditingController(
+    text: widget.initialMinutes > 0 ? widget.initialMinutes.toString() : "",
+  );
+  late _TimeoutChoice _choice = widget.initialChoice;
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _select(_TimeoutChoice? choice) {
+    if (choice == null || choice == _choice) return;
+    setState(() => _choice = choice);
+  }
+
+  void _submit() {
+    final result = switch (_choice) {
+      _TimeoutChoice.useDefault => const _UseDefaultTimeoutResult(),
+      _TimeoutChoice.noTimeout => const _ApplyTimeoutResult(
+        input: PluginManagementIdleTimeoutInput.noTimeout(),
+      ),
+      _TimeoutChoice.custom => _customResult(),
+    };
+    if (result == null) return;
+    context.pop(result);
+  }
+
+  _TimeoutResult? _customResult() {
+    if (!(_formKey.currentState?.validate() ?? false)) return null;
+    return _ApplyTimeoutResult(
+      input: PluginManagementIdleTimeoutInput.custom(input: _controller.text.trim()),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
+
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          RadioGroup<_TimeoutChoice>(
+            groupValue: _choice,
+            onChanged: _select,
+            child: PregoGroupedRows(
+              children: [
+                if (widget.allowUseDefault)
+                  MergeSemantics(
+                    child: PregoGroupedRow(
+                      key: const Key("harness_management_timeout_use_default"),
+                      title: Text(loc.harnessManagementTimeoutUseDefault),
+                      trailing: Radio<_TimeoutChoice>(
+                        value: _TimeoutChoice.useDefault,
+                        activeColor: context.prego.colors.fgBrandPrimary,
+                      ),
+                      onTap: () => _select(_TimeoutChoice.useDefault),
+                    ),
+                  ),
+                MergeSemantics(
+                  child: PregoGroupedRow(
+                    key: const Key("harness_management_timeout_no_timeout"),
+                    title: Text(loc.harnessManagementTimeoutNoTimeout),
+                    trailing: Radio<_TimeoutChoice>(
+                      value: _TimeoutChoice.noTimeout,
+                      activeColor: context.prego.colors.fgBrandPrimary,
+                    ),
+                    onTap: () => _select(_TimeoutChoice.noTimeout),
+                  ),
+                ),
+                MergeSemantics(
+                  child: PregoGroupedRow(
+                    key: const Key("harness_management_timeout_custom"),
+                    title: Text(loc.harnessManagementTimeoutCustom),
+                    trailing: Radio<_TimeoutChoice>(
+                      value: _TimeoutChoice.custom,
+                      activeColor: context.prego.colors.fgBrandPrimary,
+                    ),
+                    onTap: () => _select(_TimeoutChoice.custom),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (_choice == _TimeoutChoice.custom) ...[
+            const SizedBox(height: PregoSpacing.xl),
+            Form(
+              key: _formKey,
+              child: PregoInputField(
+                key: const Key("harness_management_timeout_input"),
+                controller: _controller,
+                label: loc.harnessManagementTimeoutMinutesLabel,
+                isRequired: true,
+                autofocus: true,
+                autocorrect: false,
+                keyboardType: const TextInputType.numberWithOptions(signed: true),
+                textInputAction: TextInputAction.done,
+                validator: (value) {
+                  final minutes = int.tryParse(value?.trim() ?? "");
+                  return minutes != null && minutes > 0 ? null : loc.harnessManagementInvalidTimeout;
+                },
+                onSubmitted: (_) => _submit(),
+              ),
+            ),
+            const SizedBox(height: PregoSpacing.sm),
+            Text(
+              loc.harnessManagementTimeoutHelp,
+              style: context.prego.textTheme.textXs.regular.copyWith(color: context.prego.colors.textSecondary),
+            ),
+          ],
+          const SizedBox(height: PregoSpacing.x2l),
+          PregoSheetActions(
+            secondary: PregoButtonsSolid(
+              key: const Key("harness_management_timeout_cancel"),
+              label: loc.harnessManagementCancel,
+              hierarchy: PregoButtonsSolidHierarchy.secondary,
+              size: PregoButtonsSolidSize.lg,
+              fullWidth: true,
+              onPressed: () => context.pop(),
+            ),
+            primary: PregoButtonsSolid(
+              key: const Key("harness_management_timeout_save"),
+              label: loc.harnessManagementSave,
+              hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
+              size: PregoButtonsSolidSize.lg,
+              fullWidth: true,
+              onPressed: _submit,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+Future<void> _showForceConfirmation({
+  required BuildContext context,
+  required PluginManagementCubit cubit,
+  required PluginManagementActionForceConfirmationRequired confirmation,
+}) async {
+  final confirmed = await showPregoBottomSheet<bool>(
+    context: _flowPresentationContext(context: context),
+    title: confirmation.action == PluginManagementForceAction.disable
+        ? context.loc.harnessManagementForceDisableTitle
+        : context.loc.harnessesForceRestartTitle(confirmation.conflict.current.setup.displayName),
+    isDismissible: false,
+    builder: (sheetContext) => Padding(
+      padding: const EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            confirmation.action == PluginManagementForceAction.restart
+                ? context.loc.harnessesForceRestartDescription(confirmation.conflict.current.setup.displayName)
+                : context.loc.harnessManagementForceDescription,
+            style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),
+          ),
+          const SizedBox(height: PregoSpacing.x2l),
+          PregoButtonsSolid(
+            key: const Key("harness_management_force_confirm"),
+            label: confirmation.action == PluginManagementForceAction.restart
+                ? context.loc.harnessesForceRestartAction
+                : context.loc.harnessManagementForceAction,
+            hierarchy: PregoButtonsSolidHierarchy.primary,
+            size: PregoButtonsSolidSize.lg,
+            type: PregoButtonsSolidType.destructive,
+            fullWidth: true,
+            onPressed: () => sheetContext.pop(true),
+          ),
+          const SizedBox(height: PregoSpacing.md),
+          PregoButtonsSolid(
+            key: const Key("harness_management_force_cancel"),
+            label: context.loc.harnessManagementCancel,
+            hierarchy: PregoButtonsSolidHierarchy.tertiary,
+            size: PregoButtonsSolidSize.lg,
+            fullWidth: true,
+            onPressed: () => sheetContext.pop(false),
+          ),
+        ],
+      ),
+    ),
+  );
+  if (confirmed ?? false) {
+    await cubit.confirmForce();
+  } else {
+    cubit.dismissForceConfirmation();
+  }
+}
+
+Future<void> _showAuthenticationSheet({
+  required BuildContext context,
+  required PluginManagementCubit cubit,
+}) async {
+  await showPregoBottomSheet<void>(
+    context: _flowPresentationContext(context: context),
+    title: context.loc.harnessAuthenticationSheetTitle,
+    builder: (_) => BlocProvider<PluginManagementCubit>.value(
+      value: cubit,
+      child: const _AuthenticationSheet(),
+    ),
+  );
+  // Dismissing presentation is not cancellation. Retain the cubit's challenge
+  // until terminal progress settles the upstream operation so peer harnesses
+  // remain gated and the owning row can reopen this same sheet.
+}
+
+class const _AuthenticationSheet() extends StatefulWidget {
+  @override
+  State<_AuthenticationSheet> createState() => _AuthenticationSheetState();
+}
+
+class _AuthenticationSheetState() extends State<_AuthenticationSheet> {
+  final _redirectController = TextEditingController();
+
+  @override
+  void dispose() {
+    _redirectController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submitRedirect() => context.read<PluginManagementCubit>().submitAuthenticationRedirect(
+    intent: PluginAuthenticationContinuationIntent.pasted(rawInput: _redirectController.text),
+  );
+
+  Future<void> _copyCode({required BuildContext context, required String code}) async {
+    if (!await copyTextToClipboard(text: code, operation: "authentication code") || !context.mounted) return;
+    PregoPopupAlertPresenter.of(context).show(
+      title: context.loc.harnessAuthenticationCodeCopied,
+      variant: PregoPopupAlertsNotificationsVariant.success,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_authenticationChallenge(state: context.read<PluginManagementCubit>().state) == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (context.mounted && (ModalRoute.of(context)?.isCurrent ?? false)) context.pop();
+      });
+    }
+    return BlocListener<PluginManagementCubit, PluginManagementState>(
+      listenWhen: (previous, current) =>
+          _authenticationChallenge(state: previous) != null && _authenticationChallenge(state: current) == null,
+      listener: (context, _) {
+        if (ModalRoute.of(context)?.isCurrent ?? false) context.pop();
+      },
+      child: _buildContent(context: context),
+    );
+  }
+
+  Widget _buildContent({required BuildContext context}) {
+    final loc = context.loc;
+    final state = context.watch<PluginManagementCubit>().state;
+    final challenge = _authenticationChallenge(state: state);
+    if (challenge == null) {
+      return const Padding(
+        padding: EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
+        child: Center(child: PregoActivityIndicator(color: null)),
+      );
+    }
+
+    final operationChallenge = switch (challenge) {
+      PluginAuthenticationPresentationChallenge(:final challenge) => challenge.challenge,
+      PluginAuthenticationPresentationBrowserLaunchFailedState(:final challenge) ||
+      PluginAuthenticationPresentationCancelling(:final challenge) ||
+      PluginAuthenticationPresentationCancellingUncertain(:final challenge) => challenge,
+      PluginAuthenticationPresentationIdle() ||
+      PluginAuthenticationPresentationStarting() ||
+      PluginAuthenticationPresentationFailed() => throw StateError("Expected an authentication challenge"),
+    };
+    final browserChallenge = operationChallenge is PluginAuthenticationBrowserChallenge ? operationChallenge : null;
+    final securityDescription = switch (operationChallenge) {
+      PluginAuthenticationDeviceCodeChallenge() => loc.harnessAuthenticationSecurityDescription,
+      PluginAuthenticationBrowserChallenge() => loc.harnessAuthenticationBrowserInstructions,
+      PluginAuthenticationUnsupportedChallenge() => loc.harnessAuthenticationUpdateRequired,
+    };
+    final redirectPresentation = challenge is PluginAuthenticationPresentationChallenge ? challenge.challenge : null;
+    final canSubmitRedirect =
+        browserChallenge != null &&
+        redirectPresentation is! PluginAuthenticationRedirectSubmittingPresentation &&
+        redirectPresentation is! PluginAuthenticationRedirectSubmittedPresentation &&
+        challenge is! PluginAuthenticationPresentationCancelling &&
+        challenge is! PluginAuthenticationPresentationCancellingUncertain;
+    return Padding(
+      padding: const EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Semantics(
+            label: operationChallenge is PluginAuthenticationDeviceCodeChallenge
+                ? loc.harnessAuthenticationSecuritySemantics
+                : securityDescription,
+            child: Text(
+              securityDescription,
+              style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),
+            ),
+          ),
+          const SizedBox(height: PregoSpacing.xl),
+          if (operationChallenge case PluginAuthenticationDeviceCodeChallenge(:final userCode))
+            PregoGroupedRows(
+              children: [
+                PregoGroupedRow(
+                  key: const Key("harness_authentication_code"),
+                  icon: TablerRegular.key,
+                  title: Text(loc.harnessAuthenticationCodeLabel),
+                  subtitle: SelectableText(userCode),
+                  trailing: IconButton(
+                    key: const Key("harness_authentication_copy"),
+                    tooltip: loc.harnessAuthenticationCopyCode,
+                    onPressed: () => _copyCode(context: context, code: userCode),
+                    icon: const Icon(TablerRegular.copy),
+                  ),
+                ),
+              ],
+            )
+          else if (browserChallenge != null)
+            PregoInputField(
+              key: const Key("harness_authentication_redirect_input"),
+              controller: _redirectController,
+              label: loc.harnessAuthenticationRedirectLabel,
+              isRequired: true,
+              autofocus: false,
+              autocorrect: false,
+              keyboardType: TextInputType.url,
+              textInputAction: TextInputAction.done,
+              onSubmitted: canSubmitRedirect ? (_) => unawaited(_submitRedirect()) : null,
+            ),
+          const SizedBox(height: PregoSpacing.xl),
+          if (challenge is PluginAuthenticationPresentationBrowserLaunchFailedState ||
+              redirectPresentation is PluginAuthenticationInvalidRedirectPresentation) ...[
+            Text(
+              challenge is PluginAuthenticationPresentationBrowserLaunchFailedState
+                  ? loc.harnessAuthenticationBrowserFailed
+                  : loc.harnessAuthenticationInvalidRedirect,
+              textAlign: TextAlign.center,
+              style: context.prego.textTheme.textSm.medium.copyWith(color: context.prego.colors.textErrorPrimary),
+            ),
+            const SizedBox(height: PregoSpacing.md),
+          ],
+          Text(
+            switch (challenge) {
+              PluginAuthenticationPresentationCancellingUncertain() => loc.harnessAuthenticationCancellingUncertain,
+              PluginAuthenticationPresentationCancelling() => loc.harnessAuthenticationCancelling,
+              PluginAuthenticationPresentationChallenge() ||
+              PluginAuthenticationPresentationBrowserLaunchFailedState() => loc.harnessAuthenticationWaiting,
+              PluginAuthenticationPresentationIdle() ||
+              PluginAuthenticationPresentationStarting() ||
+              PluginAuthenticationPresentationFailed() => throw StateError("Expected an authentication challenge"),
+            },
+            textAlign: TextAlign.center,
+            style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),
+          ),
+          const SizedBox(height: PregoSpacing.x2l),
+          PregoButtonsSolid(
+            key: const Key("harness_authentication_open_browser"),
+            label: loc.harnessAuthenticationOpenBrowser,
+            hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
+            size: PregoButtonsSolidSize.lg,
+            fullWidth: true,
+            onPressed: switch (challenge) {
+              PluginAuthenticationPresentationCancelling() ||
+              PluginAuthenticationPresentationCancellingUncertain() => null,
+              PluginAuthenticationPresentationChallenge() ||
+              PluginAuthenticationPresentationBrowserLaunchFailedState() =>
+                operationChallenge is PluginAuthenticationUnsupportedChallenge
+                    ? null
+                    : context.read<PluginManagementCubit>().launchAuthenticationBrowser,
+              PluginAuthenticationPresentationIdle() ||
+              PluginAuthenticationPresentationStarting() ||
+              PluginAuthenticationPresentationFailed() => throw StateError("Expected an authentication challenge"),
+            },
+          ),
+          if (browserChallenge != null) ...[
+            const SizedBox(height: PregoSpacing.md),
+            PregoButtonsSolid(
+              key: const Key("harness_authentication_submit_redirect"),
+              label: loc.harnessAuthenticationContinue,
+              hierarchy: PregoButtonsSolidHierarchy.primary,
+              size: PregoButtonsSolidSize.lg,
+              fullWidth: true,
+              isLoading: redirectPresentation is PluginAuthenticationRedirectSubmittingPresentation,
+              onPressed: canSubmitRedirect ? _submitRedirect : null,
+            ),
+          ],
+          const SizedBox(height: PregoSpacing.md),
+          PregoButtonsSolid(
+            key: const Key("harness_authentication_cancel"),
+            label: switch (challenge) {
+              PluginAuthenticationPresentationCancelling() => loc.harnessAuthenticationCancelling,
+              PluginAuthenticationPresentationChallenge() ||
+              PluginAuthenticationPresentationBrowserLaunchFailedState() ||
+              PluginAuthenticationPresentationCancellingUncertain() => loc.harnessAuthenticationCancel,
+              PluginAuthenticationPresentationIdle() ||
+              PluginAuthenticationPresentationStarting() ||
+              PluginAuthenticationPresentationFailed() => throw StateError("Expected an authentication challenge"),
+            },
+            hierarchy: PregoButtonsSolidHierarchy.secondary,
+            size: PregoButtonsSolidSize.lg,
+            type: PregoButtonsSolidType.destructive,
+            fullWidth: true,
+            isLoading: challenge is PluginAuthenticationPresentationCancelling,
+            onPressed: switch (challenge) {
+              PluginAuthenticationPresentationCancelling() => null,
+              PluginAuthenticationPresentationChallenge() ||
+              PluginAuthenticationPresentationBrowserLaunchFailedState() ||
+              PluginAuthenticationPresentationCancellingUncertain() =>
+                context.read<PluginManagementCubit>().cancelAuthentication,
+              PluginAuthenticationPresentationIdle() ||
+              PluginAuthenticationPresentationStarting() ||
+              PluginAuthenticationPresentationFailed() => throw StateError("Expected an authentication challenge"),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _authenticationErrorDescription({
+  required BuildContext context,
+  required PluginAuthenticationPresentationError error,
+}) => switch (error) {
+  PluginAuthenticationPresentationNotFound() => context.loc.harnessAuthenticationNotFound,
+  PluginAuthenticationPresentationUnsupported() => context.loc.harnessAuthenticationUnsupported,
+  PluginAuthenticationPresentationConflict() => context.loc.harnessAuthenticationConflict,
+  PluginAuthenticationPresentationUncertain() => context.loc.harnessAuthenticationUncertain,
+  PluginAuthenticationPresentationInvalidChallenge() => context.loc.harnessAuthenticationInvalidChallenge,
+  PluginAuthenticationPresentationRemoteError(:final message) => message,
+  PluginAuthenticationPresentationRequestError() => context.loc.harnessAuthenticationRequestFailed,
+};
+
+String _actionErrorDescription({required BuildContext context, required PluginManagementActionError error}) =>
+    switch (error) {
+      PluginManagementInvalidIdleTimeout() => context.loc.harnessManagementInvalidTimeout,
+      PluginManagementActionNotFound() => context.loc.harnessManagementNotFound,
+      PluginManagementActionConflict() => context.loc.harnessManagementConflict,
+      PluginManagementActionUncertain() => context.loc.harnessManagementUncertain,
+      PluginManagementActionRequestError() => context.loc.harnessManagementRequestFailed,
+    };
+
+String _timeoutLabel({required BuildContext context, required int minutes}) {
+  return minutes <= 0 ? context.loc.harnessesNoIdleTimeout : context.loc.harnessesIdleTimeoutMinutes(minutes);
+}
+
+String _setupStatus({required BuildContext context, required PluginSetupState state}) => switch (state) {
+  PluginSetupState.notInspected => context.loc.harnessesSetupNotInspected,
+  PluginSetupState.ready => context.loc.harnessesSetupReady,
+  PluginSetupState.runtimeMissing => context.loc.harnessesSetupRuntimeMissing,
+  PluginSetupState.authenticationRequired => context.loc.harnessesSetupAuthenticationRequired,
+  PluginSetupState.unavailable => context.loc.harnessesSetupUnavailable,
+  PluginSetupState.unknown => context.loc.harnessesStatusUnknown,
+};
+
+String _runtimeStatus({required BuildContext context, required PluginRuntimeState state}) => switch (state) {
+  PluginRuntimeState.disabled => context.loc.harnessesStatusDisabled,
+  PluginRuntimeState.blocked => context.loc.harnessesStatusBlocked,
+  PluginRuntimeState.dormant => context.loc.harnessesStatusDormant,
+  PluginRuntimeState.starting => context.loc.harnessesStatusStarting,
+  PluginRuntimeState.active => context.loc.harnessesStatusActive,
+  PluginRuntimeState.degraded => context.loc.harnessesStatusDegraded,
+  PluginRuntimeState.stopping => context.loc.harnessesStatusStopping,
+  PluginRuntimeState.failed => context.loc.harnessesStatusFailed,
+  PluginRuntimeState.unknown => context.loc.harnessesStatusUnknown,
+};
+
+String _workStatus({required BuildContext context, required PluginManagementWorkState state}) => switch (state) {
+  PluginManagementWorkState.idle => context.loc.harnessesWorkIdle,
+  PluginManagementWorkState.busy => context.loc.harnessesWorkBusy,
+  PluginManagementWorkState.unknown => context.loc.harnessesStatusUnknown,
+};

--- a/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
@@ -1,25 +1,7 @@
-import "dart:async";
+part of "harness_settings_flow_view.dart";
 
-import "package:flutter/semantics.dart";
-import "package:flutter_bloc/flutter_bloc.dart";
-import "package:go_router/go_router.dart";
-import "package:material_ui/material_ui.dart";
-import "package:sesori_dart_core/sesori_dart_core.dart";
-import "package:sesori_shared/sesori_shared.dart";
-import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
-import "package:theme_prego/module_prego.dart";
+const double _contentTopPadding = 10;
 
-import "../../extensions/build_context_x.dart";
-import "../../utils/copy_text_to_clipboard.dart";
-import "../../widgets/catalog_scan_row.dart";
-import "widgets/settings_section.dart";
-
-const double _contentTopPadding = 10.0;
-
-/// Shared harness-management view.
-///
-/// The product shell constructs [PluginManagementCubit] and supplies modal
-/// dismissal, keeping DI and route ownership outside this package.
 class const HarnessesSettingsView({
   super.key,
 
@@ -27,7 +9,9 @@ class const HarnessesSettingsView({
   /// page goes back, a modal one closes.
   required final HarnessSettingsPresentation presentation,
   required final Widget? connectionBanner,
-  required final VoidCallback onModalClose,
+  required final VoidCallback onClose,
+  required final VoidCallback? onBack,
+  required final void Function({required String pluginId}) onOpenHarness,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -39,132 +23,45 @@ class const HarnessesSettingsView({
     final cubit = context.read<PluginManagementCubit>();
     final state = context.watch<PluginManagementCubit>().state;
 
-    return MultiBlocListener(
-      listeners: [
-        BlocListener<PluginManagementCubit, PluginManagementState>(
-          listenWhen: (previous, current) => _forceConfirmation(previous) != _forceConfirmation(current),
-          listener: (context, state) {
-            final confirmation = _forceConfirmation(state);
-            if (confirmation == null) return;
-            unawaited(_showForceConfirmation(context: context, cubit: cubit, confirmation: confirmation));
-          },
-        ),
-        // This screen hosts no progress row, so a scan started here would
-        // otherwise end in silence: the spinner stops and the service clears
-        // its result before the user could reach a list to read it.
-        BlocListener<PluginManagementCubit, PluginManagementState>(
-          listenWhen: (previous, current) => _scanOutcome(previous) == null && _scanOutcome(current) != null,
-          listener: (context, state) {
-            final outcome = _scanOutcome(state);
-            if (outcome == null) return;
-            final loc = context.loc;
-            final (title, variant) = switch (outcome) {
-              CatalogRescanOutcomeSucceeded(:final counts) => (
-                loc.harnessManagementScanFinished(catalogScanCountsLine(loc: loc, counts: counts)),
-                PregoPopupAlertsNotificationsVariant.success,
-              ),
-              CatalogRescanOutcomePartlyFailed(:final succeededCount, :final failedCount) => (
-                loc.harnessManagementScanPartlyFailed(failedCount, succeededCount + failedCount),
-                PregoPopupAlertsNotificationsVariant.error,
-              ),
-              CatalogRescanOutcomeFailed() => (
-                loc.harnessManagementScanFinishedFailed,
-                PregoPopupAlertsNotificationsVariant.error,
-              ),
-            };
-            PregoPopupAlertPresenter.of(context).show(title: title, variant: variant);
-            // Announced as well as shown. The popup renders ordinary text into
-            // an overlay, which moves no semantic focus and carries no live
-            // region, so on its own it tells a screen-reader user nothing —
-            // and they are the reason this surface exists, the pull being a
-            // gesture they cannot perform.
-            unawaited(
-              SemanticsService.sendAnnouncement(View.of(context), title, Directionality.of(context)),
-            );
-            cubit.dismissCatalogScanOutcome();
-          },
-        ),
-        BlocListener<PluginManagementCubit, PluginManagementState>(
-          listenWhen: (previous, current) =>
-              _authenticationChallenge(state: previous) == null && _authenticationChallenge(state: current) != null,
-          listener: (context, state) {
-            final challenge = _authenticationChallenge(state: state);
-            if (challenge == null) return;
-            unawaited(_showAuthenticationSheet(context: context, cubit: cubit));
-          },
+    return PregoGlassScaffold(
+      title: loc.settingsHarnessesTitle,
+      titleMode: PregoTopNavigationTitleMode.inline,
+      banner: connectionBanner,
+      // Back leaves one level; X closes all settings in either presentation.
+      automaticallyImplyLeading: false,
+      onBack: isModal ? null : onBack,
+      actions: [
+        PregoButtonsIconGlass(
+          icon: TablerRegular.x,
+          semanticLabel: loc.settingsClose,
+          // The shell decides whether this pops the opener or falls back
+          // to its signed-in home route.
+          onPressed: onClose,
         ),
       ],
-      child: PregoGlassScaffold(
-        title: loc.settingsHarnessesTitle,
-        titleMode: PregoTopNavigationTitleMode.inline,
-        banner: connectionBanner,
-        // A modal has no page below it to go back to, so the close button is
-        // its only way out and an implied back chevron would be a second,
-        // redundant dismissal in the same bar. A pushed page is the other way
-        // round: the settings list sits underneath and the back chevron is the
-        // way back to it.
-        automaticallyImplyLeading: !isModal,
-        actions: [
-          if (isModal)
-            PregoButtonsIconGlass(
-              icon: TablerRegular.x,
-              semanticLabel: loc.settingsClose,
-              // The shell decides whether this pops the opener or falls back
-              // to its signed-in home route.
-              onPressed: onModalClose,
+      onRefresh: cubit.refresh,
+      slivers: [
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: PregoSpacing.xl,
+              vertical: _contentTopPadding,
             ),
-        ],
-        onRefresh: cubit.refresh,
-        slivers: [
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: PregoSpacing.xl,
-                vertical: _contentTopPadding,
-              ),
-              child: switch (state) {
-                PluginManagementLoading() => const _LoadingView(),
-                PluginManagementUnsupported() => const _UnsupportedView(),
-                PluginManagementFailure() => const _FailureView(),
-                PluginManagementReady() => _ReadyView(state: state),
-              },
-            ),
+            child: switch (state) {
+              PluginManagementLoading() => const _LoadingView(),
+              PluginManagementUnsupported() => const _UnsupportedView(),
+              PluginManagementFailure() => const _FailureView(),
+              PluginManagementReady() => _ReadyView(state: state, onOpenHarness: onOpenHarness),
+            },
           ),
-          SliverToBoxAdapter(
-            child: SizedBox(height: MediaQuery.paddingOf(context).bottom + PregoSpacing.xl),
-          ),
-        ],
-      ),
+        ),
+        SliverToBoxAdapter(
+          child: SizedBox(height: MediaQuery.paddingOf(context).bottom + PregoSpacing.xl),
+        ),
+      ],
     );
   }
 }
-
-PluginAuthenticationPresentationState? _authenticationChallenge({required PluginManagementState state}) =>
-    switch (state) {
-      PluginManagementReady(authentication: final PluginAuthenticationPresentationChallenge challenge) => challenge,
-      PluginManagementReady(authentication: final PluginAuthenticationPresentationBrowserLaunchFailedState challenge) =>
-        challenge,
-      PluginManagementReady(authentication: final PluginAuthenticationPresentationCancelling challenge) => challenge,
-      PluginManagementReady(authentication: final PluginAuthenticationPresentationCancellingUncertain challenge) =>
-        challenge,
-      PluginManagementReady() ||
-      PluginManagementLoading() ||
-      PluginManagementUnsupported() ||
-      PluginManagementFailure() => null,
-    };
-
-CatalogRescanOutcome? _scanOutcome(PluginManagementState state) => switch (state) {
-  PluginManagementReady(:final scanOutcome) => scanOutcome,
-  PluginManagementLoading() || PluginManagementUnsupported() || PluginManagementFailure() => null,
-};
-
-PluginManagementActionForceConfirmationRequired? _forceConfirmation(PluginManagementState state) => switch (state) {
-  PluginManagementReady(action: final PluginManagementActionForceConfirmationRequired confirmation) => confirmation,
-  PluginManagementReady() ||
-  PluginManagementLoading() ||
-  PluginManagementUnsupported() ||
-  PluginManagementFailure() => null,
-};
 
 class const _LoadingView() extends StatelessWidget {
   @override
@@ -211,20 +108,139 @@ class const _FailureView() extends StatelessWidget {
   }
 }
 
-class const _ReadyView({required final PluginManagementReady state}) extends StatelessWidget {
+class const _ReadyView({
+  required final PluginManagementReady state,
+  required final void Function({required String pluginId}) onOpenHarness,
+}) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final loc = context.loc;
     final response = state.response;
-    final showDefaultTimeout = response.plugins.any(_supportsOperationalTimeout);
-    final defaultTimeoutActionInProgress = switch (state.action) {
-      PluginManagementActionInProgress(target: PluginManagementActionTargetAllHarnesses()) => true,
-      PluginManagementActionIdle() ||
-      PluginManagementActionInProgress() ||
-      PluginManagementActionFailed() ||
-      PluginManagementActionForceConfirmationRequired() => false,
-    };
+    final timeoutBusy = state.action is PluginManagementActionInProgress;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _HarnessErrors(state: state),
+        if (response.plugins.isEmpty)
+          PregoGroupedNoticeRow(
+            icon: TablerRegular.info_circle,
+            title: Text(loc.harnessesEmptyTitle),
+            subtitle: Text(loc.harnessesEmptyDescription),
+          ),
+        for (final group in _HarnessGroup.values)
+          if (response.plugins.any(
+            (plugin) => _group(plugin: plugin, install: state.installs[plugin.setup.id]) == group,
+          )) ...[
+            SettingsSection(
+              title: _groupTitle(context: context, group: group),
+              child: PregoGroupedRows(
+                color: context.prego.colors.bgSurface2,
+                showDividers: false,
+                children: [
+                  for (final plugin in response.plugins)
+                    if (_group(plugin: plugin, install: state.installs[plugin.setup.id]) == group)
+                      _HarnessOverviewRow(
+                        plugin: plugin,
+                        state: state,
+                        onOpen: () => onOpenHarness(pluginId: plugin.setup.id),
+                      ),
+                ],
+              ),
+            ),
+            const SizedBox(height: PregoSpacing.xl),
+          ],
+        if (response.plugins.any(_supportsOperationalTimeout))
+          SettingsSection(
+            title: loc.harnessManagementDefaultsSection,
+            child: PregoGroupedRows(
+              color: context.prego.colors.bgSurface2,
+              children: [
+                PregoGroupedRow(
+                  key: const Key("harness_management_default_timeout"),
+                  icon: TablerRegular.clock,
+                  title: Text(loc.harnessManagementDefaultTimeout),
+                  subtitle: Text(loc.harnessManagementDefaultTimeoutDescription),
+                  trailing: timeoutBusy
+                      ? const PregoActivityIndicator(color: null)
+                      : Text(
+                          _timeoutLabel(context: context, minutes: response.defaultIdleTimeoutMins),
+                          style: context.prego.textTheme.textSm.regular.copyWith(
+                            color: context.prego.colors.textTertiary,
+                          ),
+                        ),
+                  onTap: _controlsBlocked(state.action)
+                      ? null
+                      : () => _editDefaultTimeout(context: context, state: state),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+}
 
+class const _HarnessOverviewRow({
+  required final PluginManagementMetadata plugin,
+  required final PluginManagementReady state,
+  required final VoidCallback onOpen,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final install = state.installs[plugin.setup.id];
+    return PregoGroupedRow(
+      key: Key("harnesses_card_${plugin.setup.id}"),
+      minHeight: 68,
+      leading: PregoBrandLogo(pluginId: plugin.setup.id, color: context.prego.colors.textTertiary),
+      title: Text(plugin.setup.displayName),
+      subtitle: _group(plugin: plugin, install: install) == _HarnessGroup.disabled
+          ? null
+          : _HarnessStatus(plugin: plugin, install: install, overview: true),
+      onTap: onOpen,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _HarnessSwitch(plugin: plugin, action: state.action, install: install),
+          if (install case PluginInstallInProgress(:final progress))
+            SizedBox(
+              width: 44,
+              height: 44,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: _downloadFraction(progress: progress) == null
+                    ? PregoActivityIndicator(color: context.prego.colors.fgBrandPrimary)
+                    :
+                      // ignore: no_slop_linter/avoid_flutter_spinners, determinate download progress is not a busy spinner
+                      CircularProgressIndicator(
+                        value: _downloadFraction(progress: progress),
+                        color: context.prego.colors.fgBrandPrimary,
+                        strokeWidth: 10,
+                        semanticsLabel: _installPhase(context: context, progress: progress),
+                      ),
+              ),
+            )
+          else if (_canInstall(plugin: plugin))
+            IconButton(
+              key: Key("harness_management_install_${plugin.setup.id}"),
+              constraints: const BoxConstraints(minWidth: 44, minHeight: 44),
+              tooltip: context.loc.harnessesInstallTitle(plugin.setup.displayName),
+              icon: const Icon(TablerRegular.download),
+              onPressed: _controlsBlocked(state.action)
+                  ? null
+                  : () => context.read<PluginManagementCubit>().install(pluginId: plugin.setup.id),
+            )
+          else
+            const SizedBox(width: 44, height: 44, child: Icon(TablerRegular.chevron_right)),
+        ],
+      ),
+    );
+  }
+}
+
+class const _HarnessErrors({required final PluginManagementReady state}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.loc;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -264,59 +280,6 @@ class const _ReadyView({required final PluginManagementReady state}) extends Sta
           ),
           const SizedBox(height: PregoSpacing.xl),
         ],
-        Text(
-          loc.harnessManagementDescription,
-          style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),
-        ),
-        const SizedBox(height: PregoSpacing.xl),
-        if (showDefaultTimeout) ...[
-          SettingsSection(
-            title: loc.harnessManagementDefaultsSection,
-            child: PregoGroupedRows(
-              children: [
-                PregoGroupedRow(
-                  key: const Key("harness_management_default_timeout"),
-                  icon: TablerRegular.clock,
-                  title: Text(loc.harnessManagementDefaultTimeout),
-                  subtitle: Text(loc.harnessManagementDefaultTimeoutDescription),
-                  trailing: defaultTimeoutActionInProgress
-                      ? const PregoActivityIndicator(color: null)
-                      : Text(_timeoutLabel(context: context, minutes: response.defaultIdleTimeoutMins)),
-                  onTap: _controlsBlocked(state.action)
-                      ? null
-                      : () => _editDefaultTimeout(context: context, state: state),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: PregoSpacing.xl),
-        ],
-        SettingsSection(
-          title: loc.harnessesRegisteredSection,
-          child: response.plugins.isEmpty
-              ? PregoGroupedNoticeRow(
-                  icon: TablerRegular.info_circle,
-                  title: Text(loc.harnessesEmptyTitle),
-                  subtitle: Text(loc.harnessesEmptyDescription),
-                )
-              : Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    for (var index = 0; index < response.plugins.length; index++) ...[
-                      _HarnessControlCard(
-                        plugin: response.plugins[index],
-                        isDefault: response.plugins[index].setup.id == response.defaultPluginId,
-                        action: state.action,
-                        authentication: state.authentication,
-                        install: state.installs[response.plugins[index].setup.id],
-                        scanning: state.scanningPluginIds.contains(response.plugins[index].setup.id),
-                        scanRejection: state.scanRejections[response.plugins[index].setup.id],
-                      ),
-                      if (index != response.plugins.length - 1) const SizedBox(height: PregoSpacing.md),
-                    ],
-                  ],
-                ),
-        ),
       ],
     );
   }
@@ -347,856 +310,3 @@ class const _MessageRow({
     );
   }
 }
-
-class const _HarnessControlCard({
-  required final PluginManagementMetadata plugin,
-  required final bool isDefault,
-  required final PluginManagementActionState action,
-  required final PluginAuthenticationPresentationState authentication,
-
-  /// This harness' in-flight managed runtime install, when one is running.
-  required final PluginInstallProgress? install,
-
-  /// Whether a catalog scan covering this harness is running, started here
-  /// or from a list's pull.
-  required final bool scanning,
-
-  /// Why this harness' last targeted scan was turned down, if it was. Never
-  /// carries an accepted start.
-  required final CatalogRescanStartResult? scanRejection,
-}) extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    final loc = context.loc;
-    final pluginId = plugin.setup.id;
-    final capabilities = plugin.managementCapabilities;
-    final supportsLifecycle = capabilities.contains(PluginManagementCapability.lifecycle);
-    final showSetupRefresh = capabilities.contains(PluginManagementCapability.setupRefresh);
-    final supportsIdleTimeout = capabilities.contains(PluginManagementCapability.idleTimeout);
-    final showExternal = !supportsLifecycle && !capabilities.contains(PluginManagementCapability.unknown);
-    final setupReady = plugin.setup.state == PluginSetupState.ready;
-    final runtimeVersion = plugin.setup.runtimeVersion;
-    final runtimeKnown = plugin.runtimeState != PluginRuntimeState.unknown;
-    final enabled = plugin.runtimeState.isEnabled;
-    final showOperational = setupReady && enabled;
-    final showRuntime = showOperational;
-    final showWork = showOperational && plugin.workState != PluginManagementWorkState.unknown;
-    final showLifecycle = supportsLifecycle && runtimeKnown;
-    // Install is offered only while the bridge advertises it and the runtime
-    // is genuinely missing or too old — the two states a managed install fixes.
-    final showInstall =
-        capabilities.contains(PluginManagementCapability.install) &&
-        (plugin.setup.state == PluginSetupState.runtimeMissing || plugin.setup.state == PluginSetupState.unavailable);
-    final showRestart = showOperational && supportsLifecycle;
-    final showScan = plugin.runtimeState.isRoutable;
-    // A rejection replaces the row's description until the user starts another
-    // scan, so the answer to "why did nothing happen" stays on the card that
-    // was tapped. The bridge's own error text is never among these.
-    final scanRejectionText = switch (scanRejection) {
-      null || CatalogRescanStartAccepted() => null,
-      CatalogRescanStartNotImportable() => loc.harnessManagementScanNotReady,
-      CatalogRescanStartUnsupported() => loc.harnessManagementScanUnsupported,
-      CatalogRescanStartFailed() => loc.harnessManagementScanFailed,
-    };
-    final showTimeout = showOperational && supportsIdleTimeout;
-    final showClearTimeout = showTimeout && plugin.hasIdleTimeoutOverride;
-    final supportsAuthentication = capabilities.contains(PluginManagementCapability.authentication);
-    final showAuthentication = supportsAuthentication && plugin.setup.state == PluginSetupState.authenticationRequired;
-    final authenticationForThisHarness = switch (authentication) {
-      PluginAuthenticationPresentationStarting(pluginId: final targetPluginId) ||
-      PluginAuthenticationPresentationChallenge(pluginId: final targetPluginId) ||
-      PluginAuthenticationPresentationBrowserLaunchFailedState(pluginId: final targetPluginId) ||
-      PluginAuthenticationPresentationCancelling(pluginId: final targetPluginId) ||
-      PluginAuthenticationPresentationCancellingUncertain(pluginId: final targetPluginId) => targetPluginId == pluginId,
-      PluginAuthenticationPresentationIdle() || PluginAuthenticationPresentationFailed() => false,
-    };
-    final authenticationStarting = switch (authentication) {
-      PluginAuthenticationPresentationStarting(pluginId: final targetPluginId) => targetPluginId == pluginId,
-      PluginAuthenticationPresentationIdle() ||
-      PluginAuthenticationPresentationChallenge() ||
-      PluginAuthenticationPresentationBrowserLaunchFailedState() ||
-      PluginAuthenticationPresentationCancelling() ||
-      PluginAuthenticationPresentationCancellingUncertain() ||
-      PluginAuthenticationPresentationFailed() => false,
-    };
-    final authenticationActive = switch (authentication) {
-      PluginAuthenticationPresentationIdle() || PluginAuthenticationPresentationFailed() => false,
-      PluginAuthenticationPresentationStarting() ||
-      PluginAuthenticationPresentationChallenge() ||
-      PluginAuthenticationPresentationBrowserLaunchFailedState() ||
-      PluginAuthenticationPresentationCancelling() ||
-      PluginAuthenticationPresentationCancellingUncertain() => true,
-    };
-    final blocked = _controlsBlocked(action);
-    final actionForThisHarness = switch (action) {
-      PluginManagementActionInProgress(
-        target: PluginManagementActionTargetHarness(pluginId: final targetPluginId),
-      ) =>
-        targetPluginId == pluginId,
-      PluginManagementActionIdle() ||
-      PluginManagementActionInProgress(target: PluginManagementActionTargetAllHarnesses()) ||
-      PluginManagementActionFailed() ||
-      PluginManagementActionForceConfirmationRequired() => false,
-    };
-    final actionHint = plugin.actionHint ?? plugin.setup.actionHint;
-    // The service reports an install as in-flight from the moment its command
-    // is issued until the bridge's terminal event, so this covers the window
-    // before the first progress event without borrowing the generic action
-    // spinner (which any harness action would trigger).
-    final installing = install != null;
-
-    return KeyedSubtree(
-      key: Key("harness_management_card_$pluginId"),
-      child: PregoGroupedRows(
-        key: Key("harnesses_card_$pluginId"),
-        children: [
-          PregoGroupedRow(
-            leading: PregoBrandLogo(pluginId: pluginId, color: context.prego.colors.textTertiary),
-            title: Row(
-              children: [
-                Flexible(child: Text(plugin.setup.displayName)),
-                if (isDefault) ...[
-                  const SizedBox(width: PregoSpacing.md),
-                  PregoTag(label: loc.harnessesDefaultBadge),
-                ],
-              ],
-            ),
-            subtitle: actionHint == null ? null : Text(actionHint),
-            trailing: actionForThisHarness ? const PregoActivityIndicator(color: null) : null,
-          ),
-          _FactRow(
-            title: loc.harnessesSetupStatus,
-            value: _setupStatus(context: context, state: plugin.setup.state),
-          ),
-          if (runtimeVersion != null)
-            _FactRow(
-              title: loc.harnessesRuntimeVersion,
-              value: runtimeVersion,
-            ),
-          if (showAuthentication)
-            PregoGroupedRow(
-              key: Key("harness_authentication_$pluginId"),
-              icon: TablerRegular.login,
-              title: Text(
-                plugin.authenticationState == PluginAuthenticationState.inProgress || authenticationForThisHarness
-                    ? loc.harnessAuthenticationContinue
-                    : loc.harnessAuthenticationLogIn,
-              ),
-              subtitle: Text(loc.harnessAuthenticationDescription),
-              trailing: authenticationStarting ? const PregoActivityIndicator(color: null) : null,
-              // Only one authentication flow can exist. Its own row can reopen
-              // a retained challenge after uncertain cancellation; every other
-              // row stays disabled until that flow settles.
-              onTap: blocked || authenticationStarting || (authenticationActive && !authenticationForThisHarness)
-                  ? null
-                  : authenticationForThisHarness
-                  ? () => unawaited(
-                      _showAuthenticationSheet(
-                        context: context,
-                        cubit: context.read<PluginManagementCubit>(),
-                      ),
-                    )
-                  : () => context.read<PluginManagementCubit>().startAuthentication(pluginId: pluginId),
-            ),
-          if (showRuntime)
-            _FactRow(
-              title: loc.harnessesRuntimeStatus,
-              value: _runtimeStatus(context: context, state: plugin.runtimeState),
-            ),
-          if (showWork)
-            _FactRow(
-              title: loc.harnessesWorkStatus,
-              value: _workStatus(context: context, state: plugin.workState),
-            ),
-          if (showExternal)
-            PregoGroupedRow(
-              key: Key("harness_management_external_$pluginId"),
-              icon: TablerRegular.info_circle,
-              title: Text(loc.harnessManagementExternalTitle),
-              subtitle: Text(loc.harnessManagementExternalDescription),
-            ),
-          if (showInstall)
-            PregoGroupedRow(
-              key: Key("harness_management_install_$pluginId"),
-              icon: TablerRegular.download,
-              title: Text(loc.harnessManagementInstall),
-              subtitle: Text(
-                switch (install) {
-                  null => loc.harnessManagementInstallDescription,
-                  PluginInstallProgress(phase: PluginInstallPhase.downloading, :final percent?) =>
-                    loc.harnessManagementInstallDownloadingPercent(percent),
-                  PluginInstallProgress(phase: PluginInstallPhase.downloading) =>
-                    loc.harnessManagementInstallDownloading,
-                  PluginInstallProgress(phase: PluginInstallPhase.verifying) => loc.harnessManagementInstallVerifying,
-                  PluginInstallProgress(phase: PluginInstallPhase.extracting) => loc.harnessManagementInstallExtracting,
-                  PluginInstallProgress(phase: PluginInstallPhase.finalizing) => loc.harnessManagementInstallFinishing,
-                  // A phase only a newer bridge names: report work without
-                  // claiming which step it is.
-                  PluginInstallProgress() => loc.harnessManagementInstallInProgress,
-                },
-              ),
-              trailing: installing ? const PregoActivityIndicator(color: null) : null,
-              // Also blocked between the tap and the first progress event: the
-              // command returns as soon as the bridge accepts it, long before
-              // any phase arrives.
-              onTap: blocked || installing
-                  ? null
-                  : () => context.read<PluginManagementCubit>().install(pluginId: pluginId),
-            ),
-          if (showLifecycle)
-            MergeSemantics(
-              child: PregoGroupedRow(
-                key: Key("harness_management_enabled_$pluginId"),
-                title: Text(loc.harnessManagementEnabled),
-                trailing: PregoSwitch(
-                  value: enabled,
-                  onChanged: blocked
-                      ? null
-                      : (value) => value
-                            ? context.read<PluginManagementCubit>().enable(pluginId: pluginId)
-                            : context.read<PluginManagementCubit>().disable(pluginId: pluginId),
-                ),
-                onTap: blocked
-                    ? null
-                    : () => enabled
-                          ? context.read<PluginManagementCubit>().disable(pluginId: pluginId)
-                          : context.read<PluginManagementCubit>().enable(pluginId: pluginId),
-              ),
-            ),
-          if (showSetupRefresh)
-            PregoGroupedRow(
-              key: Key("harness_management_refresh_$pluginId"),
-              icon: TablerRegular.refresh,
-              title: Text(loc.harnessManagementRefreshSetup),
-              onTap: blocked ? null : () => context.read<PluginManagementCubit>().refreshSetup(pluginId: pluginId),
-            ),
-          if (showRestart)
-            PregoGroupedRow(
-              key: Key("harness_management_restart_$pluginId"),
-              icon: TablerRegular.rotate_clockwise,
-              title: Text(loc.harnessManagementRestart),
-              onTap: blocked ? null : () => context.read<PluginManagementCubit>().restart(pluginId: pluginId),
-            ),
-          // The keyboard-and-pointer twin of the lists' deep pull, which is
-          // invisible to a screen reader and awkward with a mouse. Offered only
-          // for a routable harness: `isEnabled` is also true for blocked and
-          // failed, which the bridge answers with a 503.
-          if (showScan)
-            PregoGroupedRow(
-              key: Key("harness_management_scan_$pluginId"),
-              icon: TablerRegular.refresh_dot,
-              title: Text(loc.harnessManagementScan),
-              subtitle: Text(scanRejectionText ?? loc.harnessManagementScanDescription),
-              trailing: scanning ? const PregoActivityIndicator(color: null) : null,
-              onTap: blocked || scanning
-                  ? null
-                  : () => context.read<PluginManagementCubit>().startCatalogScanFor(pluginId: pluginId),
-            ),
-          if (showTimeout)
-            PregoGroupedRow(
-              key: Key("harness_management_timeout_$pluginId"),
-              icon: TablerRegular.clock,
-              title: Text(loc.harnessManagementIdleTimeout),
-              subtitle: Text(
-                plugin.idleTimeoutMins <= 0
-                    ? loc.harnessesNoIdleTimeoutDescription
-                    : plugin.hasIdleTimeoutOverride
-                    ? loc.harnessesCustomIdleTimeout
-                    : loc.harnessesUsesDefaultIdleTimeout,
-              ),
-              trailing: Text(_timeoutLabel(context: context, minutes: plugin.idleTimeoutMins)),
-              onTap: blocked ? null : () => _editHarnessTimeout(context: context, plugin: plugin),
-            ),
-          if (showClearTimeout)
-            PregoGroupedRow(
-              key: Key("harness_management_clear_timeout_$pluginId"),
-              icon: TablerRegular.x,
-              title: Text(loc.harnessManagementClearOverride),
-              onTap: blocked
-                  ? null
-                  : () => context.read<PluginManagementCubit>().clearIdleTimeoutOverride(pluginId: pluginId),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-class const _FactRow({required final String title, required final String value}) extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return PregoGroupedRow(
-      title: Text(title),
-      trailing: Text(
-        value,
-        textAlign: TextAlign.end,
-        style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),
-      ),
-    );
-  }
-}
-
-bool _supportsOperationalTimeout(PluginManagementMetadata plugin) {
-  return plugin.setup.state == PluginSetupState.ready &&
-      plugin.runtimeState.isEnabled &&
-      plugin.managementCapabilities.contains(PluginManagementCapability.idleTimeout);
-}
-
-bool _controlsBlocked(PluginManagementActionState action) {
-  return action is PluginManagementActionInProgress || action is PluginManagementActionForceConfirmationRequired;
-}
-
-Future<void> _editDefaultTimeout({required BuildContext context, required PluginManagementReady state}) async {
-  final cubit = context.read<PluginManagementCubit>();
-  final result = await _showTimeoutSheet(
-    context: context,
-    title: context.loc.harnessManagementDefaultTimeoutDialogTitle,
-    allowUseDefault: false,
-    initialChoice: state.response.defaultIdleTimeoutMins <= 0 ? _TimeoutChoice.noTimeout : _TimeoutChoice.custom,
-    initialMinutes: state.response.defaultIdleTimeoutMins,
-  );
-  switch (result) {
-    case null:
-      return;
-    case _UseDefaultTimeoutResult():
-      throw StateError("The global timeout cannot inherit another timeout");
-    case _ApplyTimeoutResult(:final input):
-      await cubit.applyIdleTimeoutToAll(input: input);
-  }
-}
-
-Future<void> _editHarnessTimeout({required BuildContext context, required PluginManagementMetadata plugin}) async {
-  final cubit = context.read<PluginManagementCubit>();
-  final initialChoice = switch ((plugin.hasIdleTimeoutOverride, plugin.idleTimeoutMins)) {
-    (false, _) => _TimeoutChoice.useDefault,
-    (true, <= 0) => _TimeoutChoice.noTimeout,
-    (true, _) => _TimeoutChoice.custom,
-  };
-  final result = await _showTimeoutSheet(
-    context: context,
-    title: context.loc.harnessManagementTimeoutDialogTitle(plugin.setup.displayName),
-    allowUseDefault: true,
-    initialChoice: initialChoice,
-    initialMinutes: plugin.idleTimeoutMins,
-  );
-  switch (result) {
-    case null:
-      return;
-    case _UseDefaultTimeoutResult():
-      await cubit.clearIdleTimeoutOverride(pluginId: plugin.setup.id);
-    case _ApplyTimeoutResult(:final input):
-      await cubit.setIdleTimeoutOverride(pluginId: plugin.setup.id, input: input);
-  }
-}
-
-Future<_TimeoutResult?> _showTimeoutSheet({
-  required BuildContext context,
-  required String title,
-  required bool allowUseDefault,
-  required _TimeoutChoice initialChoice,
-  required int initialMinutes,
-}) {
-  return showPregoBottomSheet<_TimeoutResult>(
-    context: context,
-    title: title,
-    builder: (_) => _TimeoutSheet(
-      allowUseDefault: allowUseDefault,
-      initialChoice: initialChoice,
-      initialMinutes: initialMinutes,
-    ),
-  );
-}
-
-enum _TimeoutChoice() {
-  useDefault,
-  noTimeout,
-  custom,
-}
-
-sealed class const _TimeoutResult();
-
-final class const _UseDefaultTimeoutResult() extends _TimeoutResult;
-
-final class const _ApplyTimeoutResult({required final PluginManagementIdleTimeoutInput input}) extends _TimeoutResult;
-
-class const _TimeoutSheet({
-  required final bool allowUseDefault,
-  required final _TimeoutChoice initialChoice,
-  required final int initialMinutes,
-}) extends StatefulWidget {
-  @override
-  State<_TimeoutSheet> createState() => _TimeoutSheetState();
-}
-
-class _TimeoutSheetState() extends State<_TimeoutSheet> {
-  final _formKey = GlobalKey<FormState>();
-  late final TextEditingController _controller = TextEditingController(
-    text: widget.initialMinutes > 0 ? widget.initialMinutes.toString() : "",
-  );
-  late _TimeoutChoice _choice = widget.initialChoice;
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _select(_TimeoutChoice? choice) {
-    if (choice == null || choice == _choice) return;
-    setState(() => _choice = choice);
-  }
-
-  void _submit() {
-    final result = switch (_choice) {
-      _TimeoutChoice.useDefault => const _UseDefaultTimeoutResult(),
-      _TimeoutChoice.noTimeout => const _ApplyTimeoutResult(
-        input: PluginManagementIdleTimeoutInput.noTimeout(),
-      ),
-      _TimeoutChoice.custom => _customResult(),
-    };
-    if (result == null) return;
-    context.pop(result);
-  }
-
-  _TimeoutResult? _customResult() {
-    if (!(_formKey.currentState?.validate() ?? false)) return null;
-    return _ApplyTimeoutResult(
-      input: PluginManagementIdleTimeoutInput.custom(input: _controller.text.trim()),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final loc = context.loc;
-
-    return Padding(
-      padding: const EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          RadioGroup<_TimeoutChoice>(
-            groupValue: _choice,
-            onChanged: _select,
-            child: PregoGroupedRows(
-              children: [
-                if (widget.allowUseDefault)
-                  MergeSemantics(
-                    child: PregoGroupedRow(
-                      key: const Key("harness_management_timeout_use_default"),
-                      title: Text(loc.harnessManagementTimeoutUseDefault),
-                      trailing: Radio<_TimeoutChoice>(
-                        value: _TimeoutChoice.useDefault,
-                        activeColor: context.prego.colors.fgBrandPrimary,
-                      ),
-                      onTap: () => _select(_TimeoutChoice.useDefault),
-                    ),
-                  ),
-                MergeSemantics(
-                  child: PregoGroupedRow(
-                    key: const Key("harness_management_timeout_no_timeout"),
-                    title: Text(loc.harnessManagementTimeoutNoTimeout),
-                    trailing: Radio<_TimeoutChoice>(
-                      value: _TimeoutChoice.noTimeout,
-                      activeColor: context.prego.colors.fgBrandPrimary,
-                    ),
-                    onTap: () => _select(_TimeoutChoice.noTimeout),
-                  ),
-                ),
-                MergeSemantics(
-                  child: PregoGroupedRow(
-                    key: const Key("harness_management_timeout_custom"),
-                    title: Text(loc.harnessManagementTimeoutCustom),
-                    trailing: Radio<_TimeoutChoice>(
-                      value: _TimeoutChoice.custom,
-                      activeColor: context.prego.colors.fgBrandPrimary,
-                    ),
-                    onTap: () => _select(_TimeoutChoice.custom),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          if (_choice == _TimeoutChoice.custom) ...[
-            const SizedBox(height: PregoSpacing.xl),
-            Form(
-              key: _formKey,
-              child: PregoInputField(
-                key: const Key("harness_management_timeout_input"),
-                controller: _controller,
-                label: loc.harnessManagementTimeoutMinutesLabel,
-                isRequired: true,
-                autofocus: true,
-                autocorrect: false,
-                keyboardType: const TextInputType.numberWithOptions(signed: true),
-                textInputAction: TextInputAction.done,
-                validator: (value) {
-                  final minutes = int.tryParse(value?.trim() ?? "");
-                  return minutes != null && minutes > 0 ? null : loc.harnessManagementInvalidTimeout;
-                },
-                onSubmitted: (_) => _submit(),
-              ),
-            ),
-            const SizedBox(height: PregoSpacing.sm),
-            Text(
-              loc.harnessManagementTimeoutHelp,
-              style: context.prego.textTheme.textXs.regular.copyWith(color: context.prego.colors.textSecondary),
-            ),
-          ],
-          const SizedBox(height: PregoSpacing.x2l),
-          PregoSheetActions(
-            secondary: PregoButtonsSolid(
-              key: const Key("harness_management_timeout_cancel"),
-              label: loc.harnessManagementCancel,
-              hierarchy: PregoButtonsSolidHierarchy.secondary,
-              size: PregoButtonsSolidSize.lg,
-              fullWidth: true,
-              onPressed: () => context.pop(),
-            ),
-            primary: PregoButtonsSolid(
-              key: const Key("harness_management_timeout_save"),
-              label: loc.harnessManagementSave,
-              hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
-              size: PregoButtonsSolidSize.lg,
-              fullWidth: true,
-              onPressed: _submit,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-Future<void> _showForceConfirmation({
-  required BuildContext context,
-  required PluginManagementCubit cubit,
-  required PluginManagementActionForceConfirmationRequired confirmation,
-}) async {
-  final confirmed = await showPregoBottomSheet<bool>(
-    context: context,
-    title: confirmation.action == PluginManagementForceAction.disable
-        ? context.loc.harnessManagementForceDisableTitle
-        : context.loc.harnessManagementForceRestartTitle,
-    isDismissible: false,
-    builder: (sheetContext) => Padding(
-      padding: const EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Text(
-            context.loc.harnessManagementForceDescription,
-            style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),
-          ),
-          const SizedBox(height: PregoSpacing.x2l),
-          PregoSheetActions(
-            secondary: PregoButtonsSolid(
-              key: const Key("harness_management_force_cancel"),
-              label: context.loc.harnessManagementCancel,
-              hierarchy: PregoButtonsSolidHierarchy.secondary,
-              size: PregoButtonsSolidSize.lg,
-              fullWidth: true,
-              onPressed: () => sheetContext.pop(false),
-            ),
-            primary: PregoButtonsSolid(
-              key: const Key("harness_management_force_confirm"),
-              label: context.loc.harnessManagementForceAction,
-              hierarchy: PregoButtonsSolidHierarchy.primary,
-              size: PregoButtonsSolidSize.lg,
-              type: PregoButtonsSolidType.destructive,
-              fullWidth: true,
-              onPressed: () => sheetContext.pop(true),
-            ),
-          ),
-        ],
-      ),
-    ),
-  );
-  if (confirmed ?? false) {
-    await cubit.confirmForce();
-  } else {
-    cubit.dismissForceConfirmation();
-  }
-}
-
-Future<void> _showAuthenticationSheet({
-  required BuildContext context,
-  required PluginManagementCubit cubit,
-}) async {
-  await showPregoBottomSheet<void>(
-    context: context,
-    title: context.loc.harnessAuthenticationSheetTitle,
-    builder: (_) => BlocProvider<PluginManagementCubit>.value(
-      value: cubit,
-      child: const _AuthenticationSheet(),
-    ),
-  );
-  // Dismissing presentation is not cancellation. Retain the cubit's challenge
-  // until terminal progress settles the upstream operation so peer harnesses
-  // remain gated and the owning row can reopen this same sheet.
-}
-
-class const _AuthenticationSheet() extends StatefulWidget {
-  @override
-  State<_AuthenticationSheet> createState() => _AuthenticationSheetState();
-}
-
-class _AuthenticationSheetState() extends State<_AuthenticationSheet> {
-  final _redirectController = TextEditingController();
-
-  @override
-  void dispose() {
-    _redirectController.dispose();
-    super.dispose();
-  }
-
-  Future<void> _submitRedirect() => context.read<PluginManagementCubit>().submitAuthenticationRedirect(
-    intent: PluginAuthenticationContinuationIntent.pasted(rawInput: _redirectController.text),
-  );
-
-  Future<void> _copyCode({required BuildContext context, required String code}) async {
-    if (!await copyTextToClipboard(text: code, operation: "authentication code") || !context.mounted) return;
-    PregoPopupAlertPresenter.of(context).show(
-      title: context.loc.harnessAuthenticationCodeCopied,
-      variant: PregoPopupAlertsNotificationsVariant.success,
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (_authenticationChallenge(state: context.read<PluginManagementCubit>().state) == null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (context.mounted && (ModalRoute.of(context)?.isCurrent ?? false)) context.pop();
-      });
-    }
-    return BlocListener<PluginManagementCubit, PluginManagementState>(
-      listenWhen: (previous, current) =>
-          _authenticationChallenge(state: previous) != null && _authenticationChallenge(state: current) == null,
-      listener: (context, _) {
-        if (ModalRoute.of(context)?.isCurrent ?? false) context.pop();
-      },
-      child: _buildContent(context: context),
-    );
-  }
-
-  Widget _buildContent({required BuildContext context}) {
-    final loc = context.loc;
-    final state = context.watch<PluginManagementCubit>().state;
-    final challenge = _authenticationChallenge(state: state);
-    if (challenge == null) {
-      return const Padding(
-        padding: EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
-        child: Center(child: PregoActivityIndicator(color: null)),
-      );
-    }
-
-    final operationChallenge = switch (challenge) {
-      PluginAuthenticationPresentationChallenge(:final challenge) => challenge.challenge,
-      PluginAuthenticationPresentationBrowserLaunchFailedState(:final challenge) ||
-      PluginAuthenticationPresentationCancelling(:final challenge) ||
-      PluginAuthenticationPresentationCancellingUncertain(:final challenge) => challenge,
-      PluginAuthenticationPresentationIdle() ||
-      PluginAuthenticationPresentationStarting() ||
-      PluginAuthenticationPresentationFailed() => throw StateError("Expected an authentication challenge"),
-    };
-    final browserChallenge = operationChallenge is PluginAuthenticationBrowserChallenge ? operationChallenge : null;
-    final securityDescription = switch (operationChallenge) {
-      PluginAuthenticationDeviceCodeChallenge() => loc.harnessAuthenticationSecurityDescription,
-      PluginAuthenticationBrowserChallenge() => loc.harnessAuthenticationBrowserInstructions,
-      PluginAuthenticationUnsupportedChallenge() => loc.harnessAuthenticationUpdateRequired,
-    };
-    final redirectPresentation = challenge is PluginAuthenticationPresentationChallenge ? challenge.challenge : null;
-    final canSubmitRedirect = browserChallenge != null &&
-        redirectPresentation is! PluginAuthenticationRedirectSubmittingPresentation &&
-        redirectPresentation is! PluginAuthenticationRedirectSubmittedPresentation &&
-        challenge is! PluginAuthenticationPresentationCancelling &&
-        challenge is! PluginAuthenticationPresentationCancellingUncertain;
-    return Padding(
-      padding: const EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Semantics(
-            label: operationChallenge is PluginAuthenticationDeviceCodeChallenge
-                ? loc.harnessAuthenticationSecuritySemantics
-                : securityDescription,
-            child: Text(
-              securityDescription,
-              style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),
-            ),
-          ),
-          const SizedBox(height: PregoSpacing.xl),
-          if (operationChallenge case PluginAuthenticationDeviceCodeChallenge(:final userCode))
-            PregoGroupedRows(
-              children: [
-                PregoGroupedRow(
-                  key: const Key("harness_authentication_code"),
-                  icon: TablerRegular.key,
-                  title: Text(loc.harnessAuthenticationCodeLabel),
-                  subtitle: SelectableText(userCode),
-                  trailing: IconButton(
-                    key: const Key("harness_authentication_copy"),
-                    tooltip: loc.harnessAuthenticationCopyCode,
-                    onPressed: () => _copyCode(context: context, code: userCode),
-                    icon: const Icon(TablerRegular.copy),
-                  ),
-                ),
-              ],
-            )
-          else if (browserChallenge != null)
-            PregoInputField(
-              key: const Key("harness_authentication_redirect_input"),
-              controller: _redirectController,
-              label: loc.harnessAuthenticationRedirectLabel,
-              isRequired: true,
-              autofocus: false,
-              autocorrect: false,
-              keyboardType: TextInputType.url,
-              textInputAction: TextInputAction.done,
-              onSubmitted: canSubmitRedirect ? (_) => unawaited(_submitRedirect()) : null,
-            ),
-          const SizedBox(height: PregoSpacing.xl),
-          if (challenge is PluginAuthenticationPresentationBrowserLaunchFailedState ||
-              redirectPresentation is PluginAuthenticationInvalidRedirectPresentation) ...[
-            Text(
-              challenge is PluginAuthenticationPresentationBrowserLaunchFailedState
-                  ? loc.harnessAuthenticationBrowserFailed
-                  : loc.harnessAuthenticationInvalidRedirect,
-              textAlign: TextAlign.center,
-              style: context.prego.textTheme.textSm.medium.copyWith(color: context.prego.colors.textErrorPrimary),
-            ),
-            const SizedBox(height: PregoSpacing.md),
-          ],
-          Text(
-            switch (challenge) {
-              PluginAuthenticationPresentationCancellingUncertain() => loc.harnessAuthenticationCancellingUncertain,
-              PluginAuthenticationPresentationCancelling() => loc.harnessAuthenticationCancelling,
-              PluginAuthenticationPresentationChallenge() ||
-              PluginAuthenticationPresentationBrowserLaunchFailedState() => loc.harnessAuthenticationWaiting,
-              PluginAuthenticationPresentationIdle() ||
-              PluginAuthenticationPresentationStarting() ||
-              PluginAuthenticationPresentationFailed() => throw StateError("Expected an authentication challenge"),
-            },
-            textAlign: TextAlign.center,
-            style: context.prego.textTheme.textSm.regular.copyWith(color: context.prego.colors.textSecondary),
-          ),
-          const SizedBox(height: PregoSpacing.x2l),
-          PregoButtonsSolid(
-            key: const Key("harness_authentication_open_browser"),
-            label: loc.harnessAuthenticationOpenBrowser,
-            hierarchy: PregoButtonsSolidHierarchy.primaryAlt,
-            size: PregoButtonsSolidSize.lg,
-            fullWidth: true,
-            onPressed: switch (challenge) {
-              PluginAuthenticationPresentationCancelling() ||
-              PluginAuthenticationPresentationCancellingUncertain() => null,
-              PluginAuthenticationPresentationChallenge() ||
-              PluginAuthenticationPresentationBrowserLaunchFailedState() =>
-                operationChallenge is PluginAuthenticationUnsupportedChallenge
-                    ? null
-                    : context.read<PluginManagementCubit>().launchAuthenticationBrowser,
-              PluginAuthenticationPresentationIdle() ||
-              PluginAuthenticationPresentationStarting() ||
-              PluginAuthenticationPresentationFailed() => throw StateError("Expected an authentication challenge"),
-            },
-          ),
-          if (browserChallenge != null) ...[
-            const SizedBox(height: PregoSpacing.md),
-            PregoButtonsSolid(
-              key: const Key("harness_authentication_submit_redirect"),
-              label: loc.harnessAuthenticationContinue,
-              hierarchy: PregoButtonsSolidHierarchy.primary,
-              size: PregoButtonsSolidSize.lg,
-              fullWidth: true,
-              isLoading: redirectPresentation is PluginAuthenticationRedirectSubmittingPresentation,
-              onPressed: canSubmitRedirect ? _submitRedirect : null,
-            ),
-          ],
-          const SizedBox(height: PregoSpacing.md),
-          PregoButtonsSolid(
-            key: const Key("harness_authentication_cancel"),
-            label: switch (challenge) {
-              PluginAuthenticationPresentationCancelling() => loc.harnessAuthenticationCancelling,
-              PluginAuthenticationPresentationChallenge() ||
-              PluginAuthenticationPresentationBrowserLaunchFailedState() ||
-              PluginAuthenticationPresentationCancellingUncertain() => loc.harnessAuthenticationCancel,
-              PluginAuthenticationPresentationIdle() ||
-              PluginAuthenticationPresentationStarting() ||
-              PluginAuthenticationPresentationFailed() => throw StateError("Expected an authentication challenge"),
-            },
-            hierarchy: PregoButtonsSolidHierarchy.secondary,
-            size: PregoButtonsSolidSize.lg,
-            type: PregoButtonsSolidType.destructive,
-            fullWidth: true,
-            isLoading: challenge is PluginAuthenticationPresentationCancelling,
-            onPressed: switch (challenge) {
-              PluginAuthenticationPresentationCancelling() => null,
-              PluginAuthenticationPresentationChallenge() ||
-              PluginAuthenticationPresentationBrowserLaunchFailedState() ||
-              PluginAuthenticationPresentationCancellingUncertain() =>
-                context.read<PluginManagementCubit>().cancelAuthentication,
-              PluginAuthenticationPresentationIdle() ||
-              PluginAuthenticationPresentationStarting() ||
-              PluginAuthenticationPresentationFailed() => throw StateError("Expected an authentication challenge"),
-            },
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-String _authenticationErrorDescription({
-  required BuildContext context,
-  required PluginAuthenticationPresentationError error,
-}) => switch (error) {
-  PluginAuthenticationPresentationNotFound() => context.loc.harnessAuthenticationNotFound,
-  PluginAuthenticationPresentationUnsupported() => context.loc.harnessAuthenticationUnsupported,
-  PluginAuthenticationPresentationConflict() => context.loc.harnessAuthenticationConflict,
-  PluginAuthenticationPresentationUncertain() => context.loc.harnessAuthenticationUncertain,
-  PluginAuthenticationPresentationInvalidChallenge() => context.loc.harnessAuthenticationInvalidChallenge,
-  PluginAuthenticationPresentationRemoteError(:final message) => message,
-  PluginAuthenticationPresentationRequestError() => context.loc.harnessAuthenticationRequestFailed,
-};
-
-String _actionErrorDescription({required BuildContext context, required PluginManagementActionError error}) =>
-    switch (error) {
-      PluginManagementInvalidIdleTimeout() => context.loc.harnessManagementInvalidTimeout,
-      PluginManagementActionNotFound() => context.loc.harnessManagementNotFound,
-      PluginManagementActionConflict() => context.loc.harnessManagementConflict,
-      PluginManagementActionUncertain() => context.loc.harnessManagementUncertain,
-      PluginManagementActionRequestError() => context.loc.harnessManagementRequestFailed,
-    };
-
-String _timeoutLabel({required BuildContext context, required int minutes}) {
-  return minutes <= 0 ? context.loc.harnessesNoIdleTimeout : context.loc.harnessesIdleTimeoutMinutes(minutes);
-}
-
-String _setupStatus({required BuildContext context, required PluginSetupState state}) => switch (state) {
-  PluginSetupState.notInspected => context.loc.harnessesSetupNotInspected,
-  PluginSetupState.ready => context.loc.harnessesSetupReady,
-  PluginSetupState.runtimeMissing => context.loc.harnessesSetupRuntimeMissing,
-  PluginSetupState.authenticationRequired => context.loc.harnessesSetupAuthenticationRequired,
-  PluginSetupState.unavailable => context.loc.harnessesSetupUnavailable,
-  PluginSetupState.unknown => context.loc.harnessesStatusUnknown,
-};
-
-String _runtimeStatus({required BuildContext context, required PluginRuntimeState state}) => switch (state) {
-  PluginRuntimeState.disabled => context.loc.harnessesStatusDisabled,
-  PluginRuntimeState.blocked => context.loc.harnessesStatusBlocked,
-  PluginRuntimeState.dormant => context.loc.harnessesStatusDormant,
-  PluginRuntimeState.starting => context.loc.harnessesStatusStarting,
-  PluginRuntimeState.active => context.loc.harnessesStatusActive,
-  PluginRuntimeState.degraded => context.loc.harnessesStatusDegraded,
-  PluginRuntimeState.stopping => context.loc.harnessesStatusStopping,
-  PluginRuntimeState.failed => context.loc.harnessesStatusFailed,
-  PluginRuntimeState.unknown => context.loc.harnessesStatusUnknown,
-};
-
-String _workStatus({required BuildContext context, required PluginManagementWorkState state}) => switch (state) {
-  PluginManagementWorkState.idle => context.loc.harnessesWorkIdle,
-  PluginManagementWorkState.busy => context.loc.harnessesWorkBusy,
-  PluginManagementWorkState.unknown => context.loc.harnessesStatusUnknown,
-};

--- a/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
@@ -116,7 +116,13 @@ class const _ReadyView({
   Widget build(BuildContext context) {
     final loc = context.loc;
     final response = state.response;
-    final timeoutBusy = state.action is PluginManagementActionInProgress;
+    final timeoutBusy = switch (state.action) {
+      PluginManagementActionInProgress(target: PluginManagementActionTargetAllHarnesses()) => true,
+      PluginManagementActionIdle() ||
+      PluginManagementActionInProgress() ||
+      PluginManagementActionFailed() ||
+      PluginManagementActionForceConfirmationRequired() => false,
+    };
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [

--- a/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
@@ -199,9 +199,9 @@ class const _HarnessOverviewRow({
       minHeight: 68,
       leading: PregoBrandLogo(pluginId: plugin.setup.id, color: context.prego.colors.textTertiary),
       title: Text(plugin.setup.displayName),
-      subtitle: _group(plugin: plugin, install: install) == _HarnessGroup.disabled
-          ? null
-          : _HarnessStatus(plugin: plugin, install: install, overview: true),
+      subtitle: _showOverviewStatus(plugin: plugin, install: install)
+          ? _HarnessStatus(plugin: plugin, install: install, overview: true)
+          : null,
       onTap: onOpen,
       trailing: Row(
         mainAxisSize: MainAxisSize.min,

--- a/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
@@ -27,17 +27,18 @@ class const HarnessesSettingsView({
       title: loc.settingsHarnessesTitle,
       titleMode: PregoTopNavigationTitleMode.inline,
       banner: connectionBanner,
-      // Back leaves one level; X closes all settings in either presentation.
+      // Pushed pages go back to Settings; only modal flows offer dismissal.
       automaticallyImplyLeading: false,
       onBack: isModal ? null : onBack,
       actions: [
-        PregoButtonsIconGlass(
-          icon: TablerRegular.x,
-          semanticLabel: loc.settingsClose,
-          // The shell decides whether this pops the opener or falls back
-          // to its signed-in home route.
-          onPressed: onClose,
-        ),
+        if (isModal)
+          PregoButtonsIconGlass(
+            icon: TablerRegular.x,
+            semanticLabel: loc.settingsClose,
+            // The shell decides whether this pops the opener or falls back
+            // to its signed-in home route.
+            onPressed: onClose,
+          ),
       ],
       onRefresh: cubit.refresh,
       slivers: [

--- a/client/module_app_ui/lib/src/l10n/app_en.arb
+++ b/client/module_app_ui/lib/src/l10n/app_en.arb
@@ -221,11 +221,11 @@
     }
   },
   "harnessManagementDescription": "Control the harnesses that support management through Sesori.",
-  "harnessManagementDefaultsSection": "Bridge Default",
+  "harnessManagementDefaultsSection": "Global harness settings",
   "harnessManagementDefaultTimeout": "Default idle timeout",
-  "harnessManagementDefaultTimeoutDescription": "Apply this timeout to every harness that supports idle-timeout control.",
+  "harnessManagementDefaultTimeoutDescription": "Apply to all harnesses and replace individual overrides.",
   "harnessManagementEnabled": "Enabled",
-  "harnessManagementRefreshSetup": "Refresh setup",
+  "harnessManagementRefreshSetup": "Check setup",
   "harnessManagementInstall": "Install runtime",
   "harnessManagementInstallDescription": "Download this harness for Sesori only. Your system stays untouched.",
   "harnessManagementInstallDownloading": "Downloading…",
@@ -241,7 +241,7 @@
   "harnessManagementInstallExtracting": "Extracting…",
   "harnessManagementInstallFinishing": "Finishing up…",
   "harnessManagementInstallInProgress": "Installing…",
-  "harnessManagementRestart": "Restart",
+  "harnessManagementRestart": "Restart harness",
   "harnessManagementIdleTimeout": "Idle timeout",
   "harnessManagementClearOverride": "Use bridge default",
   "harnessManagementExternalTitle": "Managed outside Sesori",
@@ -1265,7 +1265,7 @@
   "@harnessManagementScan": {
     "description": "Settings action on a harness card that re-imports that one harness's catalog, the pointer-and-keyboard equivalent of the lists' deep pull."
   },
-  "harnessManagementScanDescription": "Import projects and sessions this harness has on disk",
+  "harnessManagementScanDescription": "Find sessions created or moved outside Sesori and reload their latest messages.",
   "@harnessManagementScanDescription": {
     "description": "Supporting line under the per-harness scan action, saying what scanning does."
   },
@@ -1284,5 +1284,36 @@
   "catalogScanDismiss": "Dismiss",
   "@catalogScanDismiss": {
     "description": "Action on a finished scan row that clears it once the user has read the result."
-  }
+  },
+  "harnessManagementRefreshSetupDescription": "Recheck installation, sign-in and runtime status.",
+  "harnessManagementRestartDescription": "Restart {name}. Active sessions need your confirmation.",
+  "@harnessManagementRestartDescription": {"placeholders": {"name": {"type": "String"}}},
+  "harnessManagementIdleTimeoutDescription": "Stop this harness after the selected time without an active session.",
+  "harnessesNeedsAttention": "Needs attention",
+  "harnessesNotInstalled": "Not installed",
+  "harnessesStatusSetupSection": "Status & setup",
+  "harnessesActionsSection": "Actions",
+  "harnessesAutomationSection": "Automation",
+  "harnessesStatusLabel": "Status",
+  "harnessesVersionLabel": "Version",
+  "harnessesActivityLabel": "Activity",
+  "harnessesInstallingStatus": "Installing",
+  "harnessesInstallTitle": "Install {name}",
+  "@harnessesInstallTitle": {"placeholders": {"name": {"type": "String"}}},
+  "harnessesInstallingTitle": "Installing {name}",
+  "@harnessesInstallingTitle": {"placeholders": {"name": {"type": "String"}}},
+  "harnessesInstallDescription": "Install this harness on your connected computer to use it in Sesori.",
+  "harnessesStartInstallation": "Start installation",
+  "harnessesRestartInstallation": "Restart installation",
+  "harnessesInstallationFailed": "Installation failed",
+  "harnessesInstallationFailedDescription": "Start the installation again when you’re ready.",
+  "harnessesEnabledLabel": "{name} enabled",
+  "@harnessesEnabledLabel": {"placeholders": {"name": {"type": "String"}}},
+  "harnessesForceRestartTitle": "Restart {name}?",
+  "@harnessesForceRestartTitle": {"placeholders": {"name": {"type": "String"}}},
+  "harnessesForceRestartDescription": "{name} may be active in a session. Force restarting can interrupt active work.",
+  "@harnessesForceRestartDescription": {"placeholders": {"name": {"type": "String"}}},
+  "harnessesForceRestartAction": "Force restart",
+  "harnessesStatusIdle": "Idle",
+  "harnessesStatusRunning": "Running"
 }

--- a/client/module_app_ui/lib/src/l10n/app_en.arb
+++ b/client/module_app_ui/lib/src/l10n/app_en.arb
@@ -1309,6 +1309,8 @@
   "harnessesInstallationFailedDescription": "Start the installation again when you’re ready.",
   "harnessesEnabledLabel": "{name} enabled",
   "@harnessesEnabledLabel": {"placeholders": {"name": {"type": "String"}}},
+  "harnessesUpdatingLabel": "Updating {name}",
+  "@harnessesUpdatingLabel": {"placeholders": {"name": {"type": "String"}}},
   "harnessesForceRestartTitle": "Restart {name}?",
   "@harnessesForceRestartTitle": {"placeholders": {"name": {"type": "String"}}},
   "harnessesForceRestartDescription": "{name} may be active in a session. Force restarting can interrupt active work.",

--- a/client/module_app_ui/lib/src/l10n/app_localizations.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations.dart
@@ -3733,6 +3733,12 @@ abstract class AppLocalizations {
   /// **'{name} enabled'**
   String harnessesEnabledLabel(String name);
 
+  /// No description provided for @harnessesUpdatingLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Updating {name}'**
+  String harnessesUpdatingLabel(String name);
+
   /// No description provided for @harnessesForceRestartTitle.
   ///
   /// In en, this message translates to:

--- a/client/module_app_ui/lib/src/l10n/app_localizations.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations.dart
@@ -658,7 +658,7 @@ abstract class AppLocalizations {
   /// No description provided for @harnessManagementDefaultsSection.
   ///
   /// In en, this message translates to:
-  /// **'Bridge Default'**
+  /// **'Global harness settings'**
   String get harnessManagementDefaultsSection;
 
   /// No description provided for @harnessManagementDefaultTimeout.
@@ -670,7 +670,7 @@ abstract class AppLocalizations {
   /// No description provided for @harnessManagementDefaultTimeoutDescription.
   ///
   /// In en, this message translates to:
-  /// **'Apply this timeout to every harness that supports idle-timeout control.'**
+  /// **'Apply to all harnesses and replace individual overrides.'**
   String get harnessManagementDefaultTimeoutDescription;
 
   /// No description provided for @harnessManagementEnabled.
@@ -682,7 +682,7 @@ abstract class AppLocalizations {
   /// No description provided for @harnessManagementRefreshSetup.
   ///
   /// In en, this message translates to:
-  /// **'Refresh setup'**
+  /// **'Check setup'**
   String get harnessManagementRefreshSetup;
 
   /// No description provided for @harnessManagementInstall.
@@ -736,7 +736,7 @@ abstract class AppLocalizations {
   /// No description provided for @harnessManagementRestart.
   ///
   /// In en, this message translates to:
-  /// **'Restart'**
+  /// **'Restart harness'**
   String get harnessManagementRestart;
 
   /// No description provided for @harnessManagementIdleTimeout.
@@ -3586,7 +3586,7 @@ abstract class AppLocalizations {
   /// Supporting line under the per-harness scan action, saying what scanning does.
   ///
   /// In en, this message translates to:
-  /// **'Import projects and sessions this harness has on disk'**
+  /// **'Find sessions created or moved outside Sesori and reload their latest messages.'**
   String get harnessManagementScanDescription;
 
   /// Replaces the scan action's description when the bridge refused to import from this harness, usually because it is not running or its setup is incomplete.
@@ -3612,6 +3612,156 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Dismiss'**
   String get catalogScanDismiss;
+
+  /// No description provided for @harnessManagementRefreshSetupDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Recheck installation, sign-in and runtime status.'**
+  String get harnessManagementRefreshSetupDescription;
+
+  /// No description provided for @harnessManagementRestartDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Restart {name}. Active sessions need your confirmation.'**
+  String harnessManagementRestartDescription(String name);
+
+  /// No description provided for @harnessManagementIdleTimeoutDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop this harness after the selected time without an active session.'**
+  String get harnessManagementIdleTimeoutDescription;
+
+  /// No description provided for @harnessesNeedsAttention.
+  ///
+  /// In en, this message translates to:
+  /// **'Needs attention'**
+  String get harnessesNeedsAttention;
+
+  /// No description provided for @harnessesNotInstalled.
+  ///
+  /// In en, this message translates to:
+  /// **'Not installed'**
+  String get harnessesNotInstalled;
+
+  /// No description provided for @harnessesStatusSetupSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Status & setup'**
+  String get harnessesStatusSetupSection;
+
+  /// No description provided for @harnessesActionsSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Actions'**
+  String get harnessesActionsSection;
+
+  /// No description provided for @harnessesAutomationSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Automation'**
+  String get harnessesAutomationSection;
+
+  /// No description provided for @harnessesStatusLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Status'**
+  String get harnessesStatusLabel;
+
+  /// No description provided for @harnessesVersionLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Version'**
+  String get harnessesVersionLabel;
+
+  /// No description provided for @harnessesActivityLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Activity'**
+  String get harnessesActivityLabel;
+
+  /// No description provided for @harnessesInstallingStatus.
+  ///
+  /// In en, this message translates to:
+  /// **'Installing'**
+  String get harnessesInstallingStatus;
+
+  /// No description provided for @harnessesInstallTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Install {name}'**
+  String harnessesInstallTitle(String name);
+
+  /// No description provided for @harnessesInstallingTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Installing {name}'**
+  String harnessesInstallingTitle(String name);
+
+  /// No description provided for @harnessesInstallDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Install this harness on your connected computer to use it in Sesori.'**
+  String get harnessesInstallDescription;
+
+  /// No description provided for @harnessesStartInstallation.
+  ///
+  /// In en, this message translates to:
+  /// **'Start installation'**
+  String get harnessesStartInstallation;
+
+  /// No description provided for @harnessesRestartInstallation.
+  ///
+  /// In en, this message translates to:
+  /// **'Restart installation'**
+  String get harnessesRestartInstallation;
+
+  /// No description provided for @harnessesInstallationFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Installation failed'**
+  String get harnessesInstallationFailed;
+
+  /// No description provided for @harnessesInstallationFailedDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Start the installation again when you’re ready.'**
+  String get harnessesInstallationFailedDescription;
+
+  /// No description provided for @harnessesEnabledLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} enabled'**
+  String harnessesEnabledLabel(String name);
+
+  /// No description provided for @harnessesForceRestartTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Restart {name}?'**
+  String harnessesForceRestartTitle(String name);
+
+  /// No description provided for @harnessesForceRestartDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'{name} may be active in a session. Force restarting can interrupt active work.'**
+  String harnessesForceRestartDescription(String name);
+
+  /// No description provided for @harnessesForceRestartAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Force restart'**
+  String get harnessesForceRestartAction;
+
+  /// No description provided for @harnessesStatusIdle.
+  ///
+  /// In en, this message translates to:
+  /// **'Idle'**
+  String get harnessesStatusIdle;
+
+  /// No description provided for @harnessesStatusRunning.
+  ///
+  /// In en, this message translates to:
+  /// **'Running'**
+  String get harnessesStatusRunning;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
@@ -2068,6 +2068,11 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
+  String harnessesUpdatingLabel(String name) {
+    return 'Updating $name';
+  }
+
+  @override
   String harnessesForceRestartTitle(String name) {
     return 'Restart $name?';
   }

--- a/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
@@ -324,20 +324,19 @@ class AppLocalizationsEn extends AppLocalizations {
   String get harnessManagementDescription => 'Control the harnesses that support management through Sesori.';
 
   @override
-  String get harnessManagementDefaultsSection => 'Bridge Default';
+  String get harnessManagementDefaultsSection => 'Global harness settings';
 
   @override
   String get harnessManagementDefaultTimeout => 'Default idle timeout';
 
   @override
-  String get harnessManagementDefaultTimeoutDescription =>
-      'Apply this timeout to every harness that supports idle-timeout control.';
+  String get harnessManagementDefaultTimeoutDescription => 'Apply to all harnesses and replace individual overrides.';
 
   @override
   String get harnessManagementEnabled => 'Enabled';
 
   @override
-  String get harnessManagementRefreshSetup => 'Refresh setup';
+  String get harnessManagementRefreshSetup => 'Check setup';
 
   @override
   String get harnessManagementInstall => 'Install runtime';
@@ -367,7 +366,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get harnessManagementInstallInProgress => 'Installing…';
 
   @override
-  String get harnessManagementRestart => 'Restart';
+  String get harnessManagementRestart => 'Restart harness';
 
   @override
   String get harnessManagementIdleTimeout => 'Idle timeout';
@@ -1984,7 +1983,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get harnessManagementScan => 'Scan for sessions';
 
   @override
-  String get harnessManagementScanDescription => 'Import projects and sessions this harness has on disk';
+  String get harnessManagementScanDescription =>
+      'Find sessions created or moved outside Sesori and reload their latest messages.';
 
   @override
   String get harnessManagementScanNotReady => 'This harness cannot be scanned right now';
@@ -1997,4 +1997,92 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get catalogScanDismiss => 'Dismiss';
+
+  @override
+  String get harnessManagementRefreshSetupDescription => 'Recheck installation, sign-in and runtime status.';
+
+  @override
+  String harnessManagementRestartDescription(String name) {
+    return 'Restart $name. Active sessions need your confirmation.';
+  }
+
+  @override
+  String get harnessManagementIdleTimeoutDescription =>
+      'Stop this harness after the selected time without an active session.';
+
+  @override
+  String get harnessesNeedsAttention => 'Needs attention';
+
+  @override
+  String get harnessesNotInstalled => 'Not installed';
+
+  @override
+  String get harnessesStatusSetupSection => 'Status & setup';
+
+  @override
+  String get harnessesActionsSection => 'Actions';
+
+  @override
+  String get harnessesAutomationSection => 'Automation';
+
+  @override
+  String get harnessesStatusLabel => 'Status';
+
+  @override
+  String get harnessesVersionLabel => 'Version';
+
+  @override
+  String get harnessesActivityLabel => 'Activity';
+
+  @override
+  String get harnessesInstallingStatus => 'Installing';
+
+  @override
+  String harnessesInstallTitle(String name) {
+    return 'Install $name';
+  }
+
+  @override
+  String harnessesInstallingTitle(String name) {
+    return 'Installing $name';
+  }
+
+  @override
+  String get harnessesInstallDescription => 'Install this harness on your connected computer to use it in Sesori.';
+
+  @override
+  String get harnessesStartInstallation => 'Start installation';
+
+  @override
+  String get harnessesRestartInstallation => 'Restart installation';
+
+  @override
+  String get harnessesInstallationFailed => 'Installation failed';
+
+  @override
+  String get harnessesInstallationFailedDescription => 'Start the installation again when you’re ready.';
+
+  @override
+  String harnessesEnabledLabel(String name) {
+    return '$name enabled';
+  }
+
+  @override
+  String harnessesForceRestartTitle(String name) {
+    return 'Restart $name?';
+  }
+
+  @override
+  String harnessesForceRestartDescription(String name) {
+    return '$name may be active in a session. Force restarting can interrupt active work.';
+  }
+
+  @override
+  String get harnessesForceRestartAction => 'Force restart';
+
+  @override
+  String get harnessesStatusIdle => 'Idle';
+
+  @override
+  String get harnessesStatusRunning => 'Running';
 }

--- a/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
+++ b/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
@@ -1,0 +1,341 @@
+import "dart:async";
+
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_app_ui/sesori_app_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_dart_core/testing.dart";
+import "package:sesori_shared/sesori_shared.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
+import "package:theme_prego/module_prego.dart";
+
+class _Service() extends Mock implements PluginManagementService;
+class _Launcher() extends Mock implements UrlLauncher;
+
+const _ready = PluginManagementMetadata(
+  setup: PluginSetupMetadata(
+    id: "ready",
+    displayName: "Ready harness",
+    state: PluginSetupState.ready,
+    runtimeVersion: "1.2.3",
+    actionHint: null,
+  ),
+  runtimeState: PluginRuntimeState.active,
+  workState: PluginManagementWorkState.idle,
+  idleTimeoutMins: 10,
+  hasIdleTimeoutOverride: false,
+  managementCapabilities: {
+    PluginManagementCapability.lifecycle,
+    PluginManagementCapability.install,
+    PluginManagementCapability.setupRefresh,
+    PluginManagementCapability.idleTimeout,
+  },
+  actionHint: null,
+);
+
+PluginManagementMetadata _plugin({
+  required String id,
+  required PluginRuntimeState runtime,
+  required PluginSetupState setup,
+}) => _ready.copyWith(
+  setup: _ready.setup.copyWith(id: id, displayName: id, state: setup),
+  runtimeState: runtime,
+);
+
+void main() {
+  late _Service service;
+  late BehaviorSubject<PluginManagementLoadResult> snapshots;
+  late BehaviorSubject<Map<String, PluginInstallState>> installs;
+  late StreamController<PluginAuthenticationTerminalUpdate> terminal;
+  late PluginManagementCubit cubit;
+  late FakeCatalogRescanService scan;
+  final opened = <String>[];
+
+  setUpAll(() => registerFallbackValue(const PluginLifecycleCommandRequest.enable()));
+  setUp(() {
+    service = _Service();
+    snapshots = BehaviorSubject(sync: true);
+    installs = BehaviorSubject.seeded(const {}, sync: true);
+    terminal = StreamController.broadcast();
+    scan = FakeCatalogRescanService();
+    when(() => service.snapshots).thenAnswer((_) => snapshots.stream);
+    when(() => service.installStates).thenAnswer((_) => installs.stream);
+    when(() => service.authenticationTerminal).thenAnswer((_) => terminal.stream);
+    when(
+      () => service.command(
+        pluginId: any(named: "pluginId"),
+        request: any(named: "request"),
+      ),
+    ).thenAnswer((_) async => const PluginManagementMutationResult.uncertain());
+    cubit = PluginManagementCubit(service: service, urlLauncher: _Launcher(), catalogRescanService: scan);
+    opened.clear();
+  });
+  tearDown(() async {
+    await cubit.close();
+    await snapshots.close();
+    await installs.close();
+    await terminal.close();
+    await scan.onDispose();
+  });
+
+  void publish({required List<PluginManagementMetadata> plugins}) => snapshots.add(
+    PluginManagementLoadResult.supported(
+      response: PluginManagementResponse(
+        snapshotToken: "test",
+        bridgeId: "bridge",
+        defaultPluginId: "ready",
+        defaultIdleTimeoutMins: 10,
+        plugins: plugins,
+      ),
+      refreshError: null,
+    ),
+  );
+
+  Widget app({String? detailId, double scale = 1}) => BlocProvider.value(
+    value: cubit,
+    child: MaterialApp(
+      theme: buildPregoThemeData(brightness: Brightness.light),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      builder: (context, child) => MediaQuery(
+        data: MediaQuery.of(context).copyWith(textScaler: TextScaler.linear(scale)),
+        child: child!,
+      ),
+      home: HarnessSettingsFlowView(
+        child: detailId == null
+            ? HarnessesSettingsView(
+                presentation: HarnessSettingsPresentation.modal,
+                connectionBanner: null,
+                onClose: () {},
+                onBack: null,
+                onOpenHarness: ({required pluginId}) => opened.add(pluginId),
+              )
+            : HarnessSettingsDetailView(pluginId: detailId, connectionBanner: null, onBack: () {}, onClose: () {}),
+      ),
+    ),
+  );
+
+  void phone({required WidgetTester tester}) {
+    tester.view.physicalSize = const Size(393, 852);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+  }
+
+  testWidgets("overview groups honest states in design order and preserves registry order", (tester) async {
+    phone(tester: tester);
+    publish(
+      plugins: [
+        _plugin(id: "disabled", runtime: PluginRuntimeState.disabled, setup: PluginSetupState.authenticationRequired),
+        _ready,
+        _plugin(id: "missing", runtime: PluginRuntimeState.blocked, setup: PluginSetupState.runtimeMissing),
+        _plugin(id: "degraded", runtime: PluginRuntimeState.degraded, setup: PluginSetupState.ready),
+        _plugin(id: "unknown", runtime: PluginRuntimeState.unknown, setup: PluginSetupState.ready),
+        _plugin(id: "starting", runtime: PluginRuntimeState.starting, setup: PluginSetupState.ready),
+      ],
+    );
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+    final ids = tester
+        .widgetList<PregoGroupedRow>(find.byType(PregoGroupedRow))
+        .map((row) => row.key)
+        .whereType<Key>()
+        .toList();
+    expect(ids, [
+      const Key("harnesses_card_degraded"),
+      const Key("harnesses_card_unknown"),
+      const Key("harnesses_card_ready"),
+      const Key("harnesses_card_starting"),
+      const Key("harnesses_card_missing"),
+      const Key("harnesses_card_disabled"),
+      const Key("harness_management_default_timeout"),
+    ]);
+    final disabled = tester.widget<PregoGroupedRow>(find.byKey(const Key("harnesses_card_disabled")));
+    expect(disabled.subtitle, isNull);
+    expect(disabled.minHeight, 68);
+    expect(find.byKey(const Key("harness_management_enabled_unknown")), findsNothing);
+    expect(find.text("Default"), findsNothing);
+    expect(find.text("Automatic updates"), findsNothing);
+    expect(find.text("Unknown"), findsOneWidget);
+    for (final card in tester.widgetList<PregoGroupedRows>(find.byType(PregoGroupedRows)).take(4)) {
+      expect(card.showDividers, isFalse);
+      expect(card.color, PregoDesignSystem.light.colors.bgSurface2);
+    }
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets("name, actual enabled switch and immediate install icon are independent targets", (tester) async {
+    phone(tester: tester);
+    publish(
+      plugins: [_plugin(id: "missing", runtime: PluginRuntimeState.blocked, setup: PluginSetupState.runtimeMissing)],
+    );
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+    final toggle = find.byKey(const Key("harness_management_enabled_missing"));
+    final toggleTarget = find.byKey(const Key("harness_management_enabled_target_missing"));
+    expect(tester.widget<PregoSwitch>(toggle).value, isTrue);
+    expect(tester.getSize(toggle), const Size(64, 28));
+    expect(tester.getSize(toggleTarget), const Size(64, 44));
+    final enabledSemantics = find.bySemanticsLabel("missing enabled");
+    expect(enabledSemantics, findsOneWidget);
+    expect(tester.getSemantics(enabledSemantics).rect.height, 44);
+    // The padding belongs to the switch, not the navigable harness row.
+    await tester.tapAt(tester.getTopLeft(toggleTarget) + const Offset(32, 2));
+    await tester.pumpAndSettle();
+    verify(
+      () => service.command(
+        pluginId: "missing",
+        request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+      ),
+    ).called(1);
+    expect(opened, isEmpty);
+    final install = find.byKey(const Key("harness_management_install_missing"));
+    expect(tester.getSize(install).shortestSide, greaterThanOrEqualTo(44));
+    await tester.tap(install);
+    await tester.pumpAndSettle();
+    verify(() => service.command(pluginId: "missing", request: const PluginLifecycleCommandRequest.install()))
+        .called(1);
+    expect(opened, isEmpty);
+    await tester.tap(find.text("missing"));
+    expect(opened, ["missing"]);
+  });
+
+  testWidgets("detail identity keeps its 52px row and a labeled 44px switch target", (tester) async {
+    phone(tester: tester);
+    publish(plugins: [_ready]);
+    await tester.pumpWidget(app(detailId: "ready"));
+    await tester.pumpAndSettle();
+    // The row includes a one-pixel divider below its 52px content.
+    expect(tester.getSize(find.byKey(const Key("harness_management_identity_ready"))).height, 53);
+    expect(tester.getSize(find.byKey(const Key("harness_management_enabled_ready"))), const Size(64, 28));
+    expect(tester.getSemantics(find.bySemanticsLabel("Ready harness enabled")).rect.height, 44);
+  });
+
+  testWidgets("failed detail retains truthful unavailable status and offers a functional retry", (tester) async {
+    phone(tester: tester);
+    publish(
+      plugins: [_plugin(id: "unavailable", runtime: PluginRuntimeState.blocked, setup: PluginSetupState.unavailable)],
+    );
+    installs.add(const {"unavailable": PluginInstallState.failed()});
+    await tester.pumpWidget(app(detailId: "unavailable"));
+    await tester.pumpAndSettle();
+    expect(find.text("Unavailable"), findsOneWidget);
+    expect(find.text("Not installed"), findsNothing);
+    expect(find.text("Installation failed"), findsOneWidget);
+    final retry = find.byKey(const Key("harness_management_install_unavailable"));
+    await tester.ensureVisible(retry);
+    await tester.tap(retry);
+    await tester.pumpAndSettle();
+    verify(() => service.command(pluginId: "unavailable", request: const PluginLifecycleCommandRequest.install()))
+        .called(1);
+    expect(find.byType(PregoBottomSheet), findsNothing);
+  });
+
+  testWidgets("install card replaces redundant missing-runtime instructions but preserves manual setup help", (
+    tester,
+  ) async {
+    phone(tester: tester);
+    const hint = "Install the harness locally or use Sesori installation.";
+    final missing = _plugin(
+      id: "missing",
+      runtime: PluginRuntimeState.blocked,
+      setup: PluginSetupState.runtimeMissing,
+    ).copyWith(actionHint: hint);
+    publish(plugins: [missing]);
+    await tester.pumpWidget(app(detailId: "missing"));
+    await tester.pumpAndSettle();
+    expect(find.text(hint), findsNothing);
+    expect(find.text("Start installation"), findsOneWidget);
+
+    publish(
+      plugins: [
+        missing.copyWith(managementCapabilities: {PluginManagementCapability.lifecycle}),
+      ],
+    );
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pumpAndSettle();
+    expect(find.text(hint), findsOneWidget);
+    expect(find.text("Start installation"), findsNothing);
+  });
+
+  testWidgets("disabled missing runtime keeps a false switch and truthful failed-install status", (tester) async {
+    phone(tester: tester);
+    publish(
+      plugins: [_plugin(id: "missing", runtime: PluginRuntimeState.disabled, setup: PluginSetupState.runtimeMissing)],
+    );
+    installs.add(const {"missing": PluginInstallState.failed()});
+    await tester.pumpWidget(app(detailId: "missing"));
+    await tester.pumpAndSettle();
+    expect(find.text("Not installed"), findsOneWidget);
+    expect(find.text("Installation failed"), findsOneWidget);
+    expect(tester.widget<PregoSwitch>(find.byKey(const Key("harness_management_enabled_missing"))).value, isFalse);
+    expect(find.byKey(const Key("harness_management_restart_missing")), findsNothing);
+    expect(find.byKey(const Key("harness_management_refresh_missing")), findsNothing);
+  });
+
+  testWidgets("only download percentage is determinate and conflicting switches stay honest", (tester) async {
+    phone(tester: tester);
+    publish(
+      plugins: [_plugin(id: "missing", runtime: PluginRuntimeState.blocked, setup: PluginSetupState.runtimeMissing)],
+    );
+    installs.add(const {
+      "missing": PluginInstallState.inProgress(
+        progress: PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 40),
+      ),
+    });
+    await tester.pumpWidget(app(detailId: "missing"));
+    await tester.pump();
+    expect(tester.widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator)).value, .4);
+    final toggle = tester.widget<PregoSwitch>(find.byKey(const Key("harness_management_enabled_missing")));
+    expect(toggle.value, isTrue);
+    expect(toggle.onChanged, isNull);
+    expect(find.byType(PregoButtonsSolid), findsNothing);
+    installs.add(const {
+      "missing": PluginInstallState.inProgress(
+        progress: PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: 40),
+      ),
+    });
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+    expect(tester.widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator)).value, isNull);
+    expect(find.text("Extracting…"), findsOneWidget);
+    expect(find.textContaining("40%"), findsNothing);
+  });
+
+  testWidgets("detail selection never substitutes an unknown identity", (tester) async {
+    publish(plugins: [_ready]);
+    await tester.pumpWidget(app(detailId: "removed"));
+    await tester.pumpAndSettle();
+    expect(find.text("The harness is no longer registered on this bridge."), findsOneWidget);
+    expect(find.text("Ready harness"), findsNothing);
+    expect(find.bySemanticsLabel("Back"), findsOneWidget);
+    expect(find.bySemanticsLabel("Close settings"), findsOneWidget);
+  });
+
+  for (final detail in [false, true]) {
+    testWidgets("${detail ? 'detail' : 'overview'} grows at phone width and larger text", (tester) async {
+      phone(tester: tester);
+      publish(
+        plugins: [
+          _ready.copyWith(
+            setup: _ready.setup.copyWith(state: PluginSetupState.authenticationRequired),
+            runtimeState: PluginRuntimeState.blocked,
+          ),
+        ],
+      );
+      await tester.pumpWidget(app(detailId: detail ? "ready" : null, scale: 2));
+      await tester.pumpAndSettle();
+      expect(tester.takeException(), isNull);
+      if (detail) {
+        publish(plugins: [_ready]);
+        await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+        await tester.pumpAndSettle();
+        await tester.ensureVisible(find.byKey(const Key("harness_management_timeout_ready")));
+        await tester.pumpAndSettle();
+        expect(tester.takeException(), isNull);
+      }
+    });
+  }
+}

--- a/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
+++ b/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
@@ -94,7 +94,11 @@ void main() {
     ),
   );
 
-  Widget app({String? detailId, double scale = 1}) => BlocProvider.value(
+  Widget app({
+    String? detailId,
+    double scale = 1,
+    HarnessSettingsPresentation presentation = HarnessSettingsPresentation.modal,
+  }) => BlocProvider.value(
     value: cubit,
     child: MaterialApp(
       theme: buildPregoThemeData(brightness: Brightness.light),
@@ -107,13 +111,19 @@ void main() {
       home: HarnessSettingsFlowView(
         child: detailId == null
             ? HarnessesSettingsView(
-                presentation: HarnessSettingsPresentation.modal,
+                presentation: presentation,
                 connectionBanner: null,
                 onClose: () {},
-                onBack: null,
+                onBack: () {},
                 onOpenHarness: ({required pluginId}) => opened.add(pluginId),
               )
-            : HarnessSettingsDetailView(pluginId: detailId, connectionBanner: null, onBack: () {}, onClose: () {}),
+            : HarnessSettingsDetailView(
+                presentation: presentation,
+                pluginId: detailId,
+                connectionBanner: null,
+                onBack: () {},
+                onClose: () {},
+              ),
       ),
     ),
   );
@@ -122,6 +132,27 @@ void main() {
     tester.view.physicalSize = const Size(393, 852);
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
+  }
+
+  for (final presentation in HarnessSettingsPresentation.values) {
+    for (final detail in [false, true]) {
+      testWidgets("$presentation ${detail ? 'detail' : 'overview'} header offers only its navigation actions", (
+        tester,
+      ) async {
+        publish(plugins: [_ready]);
+        await tester.pumpWidget(app(detailId: detail ? "ready" : null, presentation: presentation));
+        await tester.pumpAndSettle();
+        final hasBack = detail || presentation == HarnessSettingsPresentation.pushed;
+        final hasClose = presentation == HarnessSettingsPresentation.modal;
+        final back = find.bySemanticsLabel("Back");
+        final close = find.bySemanticsLabel("Close settings");
+        expect(back, hasBack ? findsOneWidget : findsNothing);
+        expect(close, hasClose ? findsOneWidget : findsNothing);
+        final center = tester.getCenter(find.byType(PregoGlassScaffold)).dx;
+        if (hasBack) expect(tester.getCenter(back).dx, lessThan(center));
+        if (hasClose) expect(tester.getCenter(close).dx, greaterThan(center));
+      });
+    }
   }
 
   testWidgets("overview groups honest states in design order and preserves registry order", (tester) async {

--- a/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
+++ b/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
@@ -202,6 +202,120 @@ void main() {
     expect(opened, ["missing"]);
   });
 
+  testWidgets("overview shows Running for busy work and omits idle or stopped subtitles", (tester) async {
+    phone(tester: tester);
+    publish(
+      plugins: [
+        _plugin(
+          id: "busy",
+          runtime: PluginRuntimeState.active,
+          setup: PluginSetupState.ready,
+        ).copyWith(workState: PluginManagementWorkState.busy),
+        _plugin(id: "idle", runtime: PluginRuntimeState.active, setup: PluginSetupState.ready),
+        _plugin(
+          id: "stopped",
+          runtime: PluginRuntimeState.dormant,
+          setup: PluginSetupState.ready,
+        ).copyWith(workState: PluginManagementWorkState.unknown),
+        _plugin(id: "disabled", runtime: PluginRuntimeState.disabled, setup: PluginSetupState.ready),
+        _plugin(
+          id: "unknown-work",
+          runtime: PluginRuntimeState.active,
+          setup: PluginSetupState.ready,
+        ).copyWith(workState: PluginManagementWorkState.unknown),
+      ],
+    );
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+    expect(find.text("Running"), findsOneWidget);
+    expect(find.text("Unknown"), findsOneWidget);
+    expect(find.text("Idle"), findsNothing);
+    for (final id in ["idle", "stopped", "disabled"]) {
+      final row = tester.widget<PregoGroupedRow>(find.byKey(Key("harnesses_card_$id")));
+      expect(row.subtitle, isNull, reason: "$id must not reserve a subtitle section.");
+    }
+  });
+
+  testWidgets("detail does not equate a started runtime with active session work", (tester) async {
+    phone(tester: tester);
+    publish(plugins: [_ready]);
+    await tester.pumpWidget(app(detailId: "ready"));
+    await tester.pumpAndSettle();
+    for (final (workState, label) in [
+      (PluginManagementWorkState.busy, "Running"),
+      (PluginManagementWorkState.idle, "Idle"),
+      (PluginManagementWorkState.unknown, "Unknown"),
+    ]) {
+      publish(plugins: [_ready.copyWith(workState: workState)]);
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pumpAndSettle();
+      final statusRow = find.widgetWithText(PregoGroupedRow, "Status");
+      expect(find.descendant(of: statusRow, matching: find.text(label)), findsOneWidget);
+      if (workState != PluginManagementWorkState.busy) expect(find.text("Running"), findsNothing);
+    }
+  });
+
+  for (final detail in [false, true]) {
+    testWidgets("${detail ? 'detail enable' : 'overview disable'} keeps loading inside the affected switch slot", (
+      tester,
+    ) async {
+      phone(tester: tester);
+      final target = _ready.copyWith(
+        runtimeState: detail ? PluginRuntimeState.disabled : PluginRuntimeState.active,
+      );
+      final peer = _plugin(id: "peer", runtime: PluginRuntimeState.active, setup: PluginSetupState.ready);
+      publish(plugins: [target, peer]);
+      final request = detail
+          ? const PluginLifecycleCommandRequest.enable()
+          : const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe);
+      final result = Completer<PluginManagementMutationResult>();
+      when(() => service.command(pluginId: "ready", request: request)).thenAnswer((_) => result.future);
+      await tester.pumpWidget(app(detailId: detail ? "ready" : null));
+      await tester.pumpAndSettle();
+      final flow = tester.element(find.byType(HarnessSettingsFlowView));
+      final slot = find.byKey(const Key("harness_management_enabled_target_ready"));
+      final slotRect = tester.getRect(slot);
+
+      await tester.tap(find.byKey(const Key("harness_management_enabled_ready")));
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+      expect(find.bySemanticsLabel("Loading harnesses"), findsNothing);
+      expect(tester.element(find.byType(HarnessSettingsFlowView)), same(flow));
+      expect(find.byKey(const Key("harness_management_enabled_ready")), findsNothing);
+      expect(find.byKey(const Key("harness_management_enabled_progress_ready")), findsOneWidget);
+      expect(find.bySemanticsLabel(RegExp("Updating Ready harness")), findsOneWidget);
+      expect(tester.getRect(slot), slotRect);
+      expect(find.byType(PregoActivityIndicator), findsOneWidget);
+      if (!detail) {
+        final peerSwitch = tester.widget<PregoSwitch>(find.byKey(const Key("harness_management_enabled_peer")));
+        expect(peerSwitch.value, isTrue);
+        expect(peerSwitch.onChanged, isNull);
+        expect(find.text("peer"), findsOneWidget);
+      }
+
+      publish(
+        plugins: [
+          target.copyWith(runtimeState: detail ? PluginRuntimeState.active : PluginRuntimeState.disabled),
+          peer,
+        ],
+      );
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pump();
+      expect(find.bySemanticsLabel("Loading harnesses"), findsNothing);
+      expect(find.byKey(const Key("harness_management_enabled_progress_ready")), findsOneWidget);
+      result.complete(
+        PluginManagementMutationResult.success(
+          response: (snapshots.value as PluginManagementLoadResultSupported).response,
+        ),
+      );
+      await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key("harness_management_enabled_progress_ready")), findsNothing);
+      expect(tester.widget<PregoSwitch>(find.byKey(const Key("harness_management_enabled_ready"))).value, detail);
+      verify(() => service.command(pluginId: "ready", request: request)).called(1);
+    });
+  }
+
   testWidgets("global timeout shows progress only for its own all-harness update", (tester) async {
     phone(tester: tester);
     publish(plugins: [_ready]);

--- a/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
+++ b/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
@@ -202,6 +202,47 @@ void main() {
     expect(opened, ["missing"]);
   });
 
+  testWidgets("global timeout shows progress only for its own all-harness update", (tester) async {
+    phone(tester: tester);
+    publish(plugins: [_ready]);
+    final response = (snapshots.value as PluginManagementLoadResultSupported).response;
+    final harnessResult = Completer<PluginManagementMutationResult>();
+    when(
+      () => service.command(
+        pluginId: "ready",
+        request: const PluginLifecycleCommandRequest.disable(mode: PluginStopMode.safe),
+      ),
+    ).thenAnswer((_) => harnessResult.future);
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+
+    final harnessAction = cubit.disable(pluginId: "ready");
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+    final timeoutRow = find.byKey(const Key("harness_management_default_timeout"));
+    final busyPeerRow = tester.widget<PregoGroupedRow>(timeoutRow);
+    expect(busyPeerRow.onTap, isNull);
+    expect(busyPeerRow.trailing, isA<Text>().having((text) => text.data, "value", "10 min"));
+    harnessResult.complete(PluginManagementMutationResult.success(response: response));
+    await harnessAction;
+    await tester.pumpAndSettle();
+
+    const input = PluginManagementIdleTimeoutInput.noTimeout();
+    const request = PluginIdleTimeoutUpdateRequest.applyAll(idleTimeoutMins: 0);
+    final timeoutResult = Completer<PluginManagementMutationResult>();
+    when(() => service.planApplyAllIdleTimeout(input: input)).thenReturn(
+      const PluginManagementCommandPlan.request(request: request),
+    );
+    when(() => service.updateIdleTimeout(request: request)).thenAnswer((_) => timeoutResult.future);
+    final timeoutAction = cubit.applyIdleTimeoutToAll(input: input);
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+    expect(tester.widget<PregoGroupedRow>(timeoutRow).trailing, isA<PregoActivityIndicator>());
+    timeoutResult.complete(PluginManagementMutationResult.success(response: response));
+    await timeoutAction;
+    await tester.pumpAndSettle();
+  });
+
   testWidgets("detail identity keeps its 52px row and a labeled 44px switch target", (tester) async {
     phone(tester: tester);
     publish(plugins: [_ready]);

--- a/client/module_app_ui/test/platform/go_router_route_source_test.dart
+++ b/client/module_app_ui/test/platform/go_router_route_source_test.dart
@@ -155,6 +155,7 @@ void main() {
       AppRouteDef.settings: "/settings",
       AppRouteDef.settingsNotifications: "/settings/notifications",
       AppRouteDef.settingsHarnesses: "/settings/harnesses",
+      AppRouteDef.settingsHarnessDetail: "/settings/harnesses/codex",
       AppRouteDef.settingsProfile: "/settings/profile",
       AppRouteDef.sessions: "/projects/p1/sessions",
       AppRouteDef.newSession: "/projects/p1/sessions/new",

--- a/client/module_core/lib/sesori_dart_core.dart
+++ b/client/module_core/lib/sesori_dart_core.dart
@@ -183,6 +183,7 @@ export "src/services/models/catalog_rescan_state.dart";
 export "src/services/models/new_session_backend_scope.dart";
 export "src/services/models/new_session_options_source.dart";
 export "src/services/models/new_session_selection_intent.dart";
+export "src/services/models/plugin_install_state.dart";
 export "src/services/models/product_analytics_state.dart";
 export "src/services/models/session_activity_info.dart";
 export "src/services/new_session_options_service.dart";

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -9,6 +9,7 @@ import "../../platform/url_launcher.dart";
 import "../../repositories/models/plugin_management_result.dart";
 import "../../services/catalog_rescan_service.dart";
 import "../../services/models/catalog_rescan_state.dart";
+import "../../services/models/plugin_install_state.dart";
 import "../../services/plugin_management_service.dart";
 import "plugin_management_state.dart";
 
@@ -20,7 +21,7 @@ class PluginManagementCubit({
   this : super(const PluginManagementState.loading()) {
     _subscriptions
       ..add(_service.snapshots.listen((snapshot) => _onSnapshot(snapshot: snapshot)))
-      ..add(_service.installProgress.listen((installs) => _onInstallProgress(installs: installs)))
+      ..add(_service.installStates.listen((installs) => _onInstallStates(installs: installs)))
       ..add(_service.authenticationTerminal.listen(_onAuthenticationTerminal))
       ..add(_catalogRescanService.state.listen(_onCatalogScan));
   }
@@ -70,8 +71,9 @@ class PluginManagementCubit({
         final presentation = switch (challenge) {
           final PluginAuthenticationDeviceCodeChallenge challenge =>
             PluginAuthenticationChallengePresentation.deviceCode(challenge: challenge),
-          final PluginAuthenticationBrowserChallenge challenge =>
-            PluginAuthenticationChallengePresentation.browser(challenge: challenge),
+          final PluginAuthenticationBrowserChallenge challenge => PluginAuthenticationChallengePresentation.browser(
+            challenge: challenge,
+          ),
           final PluginAuthenticationUnsupportedChallenge challenge =>
             PluginAuthenticationChallengePresentation.updateRequired(challenge: challenge),
           null => null,
@@ -163,8 +165,7 @@ class PluginManagementCubit({
       PluginManagementReady(:final authentication) => authentication,
       PluginManagementLoading() || PluginManagementUnsupported() || PluginManagementFailure() => null,
     };
-    if (authentication is! PluginAuthenticationPresentationChallenge ||
-        authentication.pluginId != challenge.pluginId) {
+    if (authentication is! PluginAuthenticationPresentationChallenge || authentication.pluginId != challenge.pluginId) {
       return;
     }
     final presentation = authentication.challenge;
@@ -588,7 +589,7 @@ class PluginManagementCubit({
         // this cubit is recreated (the screen builds a new one per visit), so
         // seeding from an empty map would hide a live install until its next
         // progress event.
-        final installs = _service.installProgress.valueOrNull ?? const <String, PluginInstallProgress>{};
+        final installs = _service.installStates.valueOrNull ?? const <String, PluginInstallState>{};
         emit(
           PluginManagementState.ready(
             response: response,
@@ -741,13 +742,13 @@ class PluginManagementCubit({
     CatalogRescanNoHarness() => null,
   };
 
-  void _onInstallProgress({required Map<String, PluginInstallProgress> installs}) {
+  void _onInstallStates({required Map<String, PluginInstallState> installs}) {
     if (isClosed) return;
     final current = state;
     // A non-ready state has no card to update; the next ready snapshot reads
     // the service's current progress, so nothing is lost by ignoring it here.
     if (current is! PluginManagementReady) return;
-    if (const MapEquality<String, PluginInstallProgress>().equals(current.installs, installs)) return;
+    if (const MapEquality<String, PluginInstallState>().equals(current.installs, installs)) return;
     emit(current.copyWith(installs: installs));
   }
 
@@ -761,12 +762,16 @@ class PluginManagementCubit({
 ({String pluginId, PluginAuthenticationChallenge challenge})? _authenticationChallengeData(
   PluginAuthenticationPresentationState state,
 ) => switch (state) {
-  PluginAuthenticationPresentationChallenge(:final pluginId, :final challenge) =>
-    (pluginId: pluginId, challenge: challenge.challenge),
+  PluginAuthenticationPresentationChallenge(:final pluginId, :final challenge) => (
+    pluginId: pluginId,
+    challenge: challenge.challenge,
+  ),
   PluginAuthenticationPresentationBrowserLaunchFailedState(:final pluginId, :final challenge) ||
   PluginAuthenticationPresentationCancelling(:final pluginId, :final challenge) ||
-  PluginAuthenticationPresentationCancellingUncertain(:final pluginId, :final challenge) =>
-    (pluginId: pluginId, challenge: challenge),
+  PluginAuthenticationPresentationCancellingUncertain(
+    :final pluginId,
+    :final challenge,
+  ) => (pluginId: pluginId, challenge: challenge),
   PluginAuthenticationPresentationIdle() ||
   PluginAuthenticationPresentationStarting() ||
   PluginAuthenticationPresentationFailed() => null,

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.dart
@@ -4,6 +4,7 @@ import "package:sesori_shared/sesori_shared.dart";
 
 import "../../repositories/models/plugin_management_result.dart";
 import "../../services/models/catalog_rescan_state.dart";
+import "../../services/models/plugin_install_state.dart";
 import "../../services/plugin_management_service.dart";
 
 part "plugin_management_state.freezed.dart";
@@ -170,8 +171,8 @@ sealed class PluginManagementState with _$PluginManagementState {
     required PluginManagementActionState action,
     required PluginAuthenticationPresentationState authentication,
 
-    /// In-flight managed runtime installs, keyed by plugin id.
-    required Map<String, PluginInstallProgress> installs,
+    /// In-progress installs and retained terminal failures, keyed by plugin id.
+    required Map<String, PluginInstallState> installs,
 
     /// Harnesses with a catalog scan in flight, whether this screen started it
     /// or the lists did. Their scan action is not offered again while it runs.

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_state.freezed.dart
@@ -2085,17 +2085,17 @@ $ApiErrorCopyWith<$Res> get error {
 
 
 class PluginManagementReady implements PluginManagementState {
-  const PluginManagementReady({required this.response, required this.refresh, required this.action, required this.authentication, required  Map<String, PluginInstallProgress> installs, required  Set<String> scanningPluginIds, required  Map<String, CatalogRescanStartResult> scanRejections, required this.scanOutcome}): _installs = installs,_scanningPluginIds = scanningPluginIds,_scanRejections = scanRejections;
+  const PluginManagementReady({required this.response, required this.refresh, required this.action, required this.authentication, required  Map<String, PluginInstallState> installs, required  Set<String> scanningPluginIds, required  Map<String, CatalogRescanStartResult> scanRejections, required this.scanOutcome}): _installs = installs,_scanningPluginIds = scanningPluginIds,_scanRejections = scanRejections;
   
 
  final  PluginManagementResponse response;
  final  PluginManagementRefreshState refresh;
  final  PluginManagementActionState action;
  final  PluginAuthenticationPresentationState authentication;
-/// In-flight managed runtime installs, keyed by plugin id.
- final  Map<String, PluginInstallProgress> _installs;
-/// In-flight managed runtime installs, keyed by plugin id.
- Map<String, PluginInstallProgress> get installs {
+/// In-progress installs and retained terminal failures, keyed by plugin id.
+ final  Map<String, PluginInstallState> _installs;
+/// In-progress installs and retained terminal failures, keyed by plugin id.
+ Map<String, PluginInstallState> get installs {
   if (_installs is EqualUnmodifiableMapView) return _installs;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableMapView(_installs);
@@ -2163,7 +2163,7 @@ abstract mixin class $PluginManagementReadyCopyWith<$Res> implements $PluginMana
   factory $PluginManagementReadyCopyWith(PluginManagementReady value, $Res Function(PluginManagementReady) _then) = _$PluginManagementReadyCopyWithImpl;
 @useResult
 $Res call({
- PluginManagementResponse response, PluginManagementRefreshState refresh, PluginManagementActionState action, PluginAuthenticationPresentationState authentication, Map<String, PluginInstallProgress> installs, Set<String> scanningPluginIds, Map<String, CatalogRescanStartResult> scanRejections, CatalogRescanOutcome? scanOutcome
+ PluginManagementResponse response, PluginManagementRefreshState refresh, PluginManagementActionState action, PluginAuthenticationPresentationState authentication, Map<String, PluginInstallState> installs, Set<String> scanningPluginIds, Map<String, CatalogRescanStartResult> scanRejections, CatalogRescanOutcome? scanOutcome
 });
 
 
@@ -2187,7 +2187,7 @@ as PluginManagementResponse,refresh: null == refresh ? _self.refresh : refresh /
 as PluginManagementRefreshState,action: null == action ? _self.action : action // ignore: cast_nullable_to_non_nullable
 as PluginManagementActionState,authentication: null == authentication ? _self.authentication : authentication // ignore: cast_nullable_to_non_nullable
 as PluginAuthenticationPresentationState,installs: null == installs ? _self._installs : installs // ignore: cast_nullable_to_non_nullable
-as Map<String, PluginInstallProgress>,scanningPluginIds: null == scanningPluginIds ? _self._scanningPluginIds : scanningPluginIds // ignore: cast_nullable_to_non_nullable
+as Map<String, PluginInstallState>,scanningPluginIds: null == scanningPluginIds ? _self._scanningPluginIds : scanningPluginIds // ignore: cast_nullable_to_non_nullable
 as Set<String>,scanRejections: null == scanRejections ? _self._scanRejections : scanRejections // ignore: cast_nullable_to_non_nullable
 as Map<String, CatalogRescanStartResult>,scanOutcome: freezed == scanOutcome ? _self.scanOutcome : scanOutcome // ignore: cast_nullable_to_non_nullable
 as CatalogRescanOutcome?,

--- a/client/module_core/lib/src/routing/analytics_route_listener.dart
+++ b/client/module_core/lib/src/routing/analytics_route_listener.dart
@@ -114,7 +114,9 @@ class AnalyticsRouteListener {
     AppRouteDef.splash => throw StateError("Splash is a readiness route, not an analytics screen"),
     AppRouteDef.login => AnalyticsScreen.login,
     AppRouteDef.projects => AnalyticsScreen.projects,
-    AppRouteDef.settings || AppRouteDef.settingsHarnesses => AnalyticsScreen.settings,
+    AppRouteDef.settings ||
+    AppRouteDef.settingsHarnesses ||
+    AppRouteDef.settingsHarnessDetail => AnalyticsScreen.settings,
     AppRouteDef.settingsNotifications => AnalyticsScreen.settingsNotifications,
     AppRouteDef.settingsProfile => AnalyticsScreen.settingsProfile,
     AppRouteDef.sessions => AnalyticsScreen.sessions,

--- a/client/module_core/lib/src/routing/app_routes.dart
+++ b/client/module_core/lib/src/routing/app_routes.dart
@@ -3,6 +3,7 @@ const redirectUri = "$bundleId://auth/callback";
 const projectNameQueryParam = "name";
 const projectIdPathParam = "projectId";
 const sessionIdPathParam = "sessionId";
+const pluginIdPathParam = "pluginId";
 const harnessSettingsPresentationQueryParam = "presentation";
 
 /// How the harness settings page was raised, which decides both its page
@@ -42,12 +43,12 @@ enum AppRouteDef(final String path) {
   settings("/settings"),
   settingsNotifications("/settings/notifications"),
   settingsHarnesses("/settings/harnesses"),
+  settingsHarnessDetail("/settings/harnesses/:$pluginIdPathParam"),
   settingsProfile("/settings/profile"),
   sessions("/projects/:$projectIdPathParam/sessions"),
   newSession("/projects/:$projectIdPathParam/sessions/new"),
   sessionDetail("/projects/:$projectIdPathParam/sessions/:$sessionIdPathParam"),
   sessionDiffs("/projects/:$projectIdPathParam/sessions/:$sessionIdPathParam/diffs"),
-  ;
 }
 
 /// Type-safe route definitions for navigation.
@@ -83,6 +84,8 @@ sealed class const AppRoute() {
   const factory settingsHarnesses({
     required HarnessSettingsPresentation presentation,
   }) = AppRouteSettingsHarnesses;
+  const factory settingsHarnessDetail({required String pluginId, required HarnessSettingsPresentation presentation}) =
+      AppRouteSettingsHarnessDetail;
   const factory settingsProfile() = AppRouteSettingsProfile;
   const factory sessions({
     required String projectId,
@@ -121,6 +124,10 @@ sealed class const AppRoute() {
       AppRouteDef.settings => const AppRoute.settings(),
       AppRouteDef.settingsNotifications => const AppRoute.settingsNotifications(),
       AppRouteDef.settingsHarnesses => AppRouteSettingsHarnesses.fromParams(queryParams: queryParams),
+      AppRouteDef.settingsHarnessDetail => AppRouteSettingsHarnessDetail.fromParams(
+        pathParams: pathParams,
+        queryParams: queryParams,
+      ),
       AppRouteDef.settingsProfile => const AppRoute.settingsProfile(),
       AppRouteDef.sessions => AppRouteSessions.fromParams(pathParams: pathParams, queryParams: queryParams),
       AppRouteDef.newSession => AppRouteNewSession.fromParams(pathParams: pathParams, queryParams: queryParams),
@@ -201,6 +208,28 @@ class const AppRouteSettingsHarnesses({required final HarnessSettingsPresentatio
       queryParameters: {_presentationQueryParam: presentation.name},
     );
   }
+}
+
+class const AppRouteSettingsHarnessDetail({
+  required final String pluginId,
+  required final HarnessSettingsPresentation presentation,
+}) extends AppRoute {
+  factory fromParams({required Map<String, String> pathParams, required Map<String, String> queryParams}) =>
+      AppRouteSettingsHarnessDetail(
+        pluginId: pathParams[pluginIdPathParam] ?? (throw ArgumentError("Missing harness identity")),
+        presentation:
+            HarnessSettingsPresentation.tryParse(queryParams[harnessSettingsPresentationQueryParam]) ??
+            HarnessSettingsPresentation.modal,
+      );
+
+  @override
+  AppRouteDef get def => AppRouteDef.settingsHarnessDetail;
+
+  @override
+  String buildPath() => _appendQuery(
+    path: "/settings/harnesses/${Uri.encodeComponent(pluginId)}",
+    queryParameters: {harnessSettingsPresentationQueryParam: presentation.name},
+  );
 }
 
 class const AppRouteSettingsProfile() extends AppRoute {

--- a/client/module_core/lib/src/services/models/plugin_install_state.dart
+++ b/client/module_core/lib/src/services/models/plugin_install_state.dart
@@ -26,7 +26,7 @@ final class const PluginInstallFailed() extends PluginInstallState {
 
 /// The last reported phase, not a percentage of the entire installation.
 @immutable
-class const PluginInstallProgress({
+final class const PluginInstallProgress({
   required final PluginInstallPhase phase,
 
   /// Download completion, only present while downloading with a known total.

--- a/client/module_core/lib/src/services/models/plugin_install_state.dart
+++ b/client/module_core/lib/src/services/models/plugin_install_state.dart
@@ -1,0 +1,40 @@
+import "package:meta/meta.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+/// Connection-scoped managed installation. Absence means no retained operation.
+@immutable
+sealed class const PluginInstallState() {
+  const factory inProgress({required PluginInstallProgress progress}) = PluginInstallInProgress;
+  const factory failed() = PluginInstallFailed;
+}
+
+final class const PluginInstallInProgress({required final PluginInstallProgress progress}) extends PluginInstallState {
+  @override
+  bool operator ==(Object other) => other is PluginInstallInProgress && other.progress == progress;
+
+  @override
+  int get hashCode => progress.hashCode;
+}
+
+final class const PluginInstallFailed() extends PluginInstallState {
+  @override
+  bool operator ==(Object other) => other is PluginInstallFailed;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+}
+
+/// The last reported phase, not a percentage of the entire installation.
+@immutable
+class const PluginInstallProgress({
+  required final PluginInstallPhase phase,
+
+  /// Download completion, only present while downloading with a known total.
+  required final int? percent,
+}) {
+  @override
+  bool operator ==(Object other) => other is PluginInstallProgress && other.phase == phase && other.percent == percent;
+
+  @override
+  int get hashCode => Object.hash(phase, percent);
+}

--- a/client/module_core/lib/src/services/plugin_management_service.dart
+++ b/client/module_core/lib/src/services/plugin_management_service.dart
@@ -3,7 +3,6 @@ import "dart:math";
 
 import "package:get_it/get_it.dart";
 import "package:injectable/injectable.dart";
-import "package:meta/meta.dart";
 import "package:rxdart/rxdart.dart";
 import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -16,6 +15,7 @@ import "../logging/logging.dart";
 import "../repositories/models/analytics_delivery_result.dart";
 import "../repositories/models/plugin_management_result.dart";
 import "../repositories/plugin_repository.dart";
+import "models/plugin_install_state.dart";
 import "product_analytics_service.dart";
 
 typedef _ManagementRequestFence = ({
@@ -35,13 +35,13 @@ typedef PluginAuthenticationTerminalUpdate = ({String pluginId, PluginAuthentica
 sealed class const PluginManagementIdleTimeoutInput() {
   const factory noTimeout() = PluginManagementIdleTimeoutInputNoTimeout;
 
-  const factory custom({required String input}) =
-      PluginManagementIdleTimeoutInputCustom;
+  const factory custom({required String input}) = PluginManagementIdleTimeoutInputCustom;
 }
 
 final class const PluginManagementIdleTimeoutInputNoTimeout() extends PluginManagementIdleTimeoutInput;
 
-final class const PluginManagementIdleTimeoutInputCustom({required final String input}) extends PluginManagementIdleTimeoutInput;
+final class const PluginManagementIdleTimeoutInputCustom({required final String input})
+    extends PluginManagementIdleTimeoutInput;
 
 sealed class const PluginAuthenticationContinuationIntent() {
   const factory pasted({required String rawInput}) = PluginAuthenticationPastedContinuationIntent;
@@ -52,10 +52,10 @@ final class const PluginAuthenticationPastedContinuationIntent({required final S
 
 @lazySingleton
 class PluginManagementService({
-    required final PluginRepository _pluginRepository,
-    required final ConnectionService _connectionService,
-    required final ProductAnalyticsService _productAnalyticsService,
-  }) with Disposable {
+  required final PluginRepository _pluginRepository,
+  required final ConnectionService _connectionService,
+  required final ProductAnalyticsService _productAnalyticsService,
+}) with Disposable {
   this {
     _subscriptions
       ..add(_connectionService.status.listen(_onConnectionStatus))
@@ -64,7 +64,7 @@ class PluginManagementService({
   }
 
   final BehaviorSubject<PluginManagementLoadResult> _snapshots = BehaviorSubject();
-  final BehaviorSubject<Map<String, PluginInstallProgress>> _installProgress = BehaviorSubject.seeded(const {});
+  final BehaviorSubject<Map<String, PluginInstallState>> _installStates = BehaviorSubject.seeded(const {});
   final BehaviorSubject<Map<String, PluginAuthenticationChallenge>> _authenticationChallenges = BehaviorSubject.seeded(
     const {},
   );
@@ -107,9 +107,8 @@ class PluginManagementService({
 
   ValueStream<PluginManagementLoadResult> get snapshots => _snapshots.stream;
 
-  /// In-flight managed runtime installs, keyed by plugin id. An entry appears
-  /// when the bridge reports progress and disappears when the install settles.
-  ValueStream<Map<String, PluginInstallProgress>> get installProgress => _installProgress.stream;
+  /// Replayed in-progress installs and failures, scoped to this connection.
+  ValueStream<Map<String, PluginInstallState>> get installStates => _installStates.stream;
 
   ValueStream<Map<String, PluginAuthenticationChallenge>> get authenticationChallenges =>
       _authenticationChallenges.stream;
@@ -133,7 +132,7 @@ class PluginManagementService({
     if (isInstall) {
       _selfStartedInstalls.add(pluginId);
       _installRequestsInFlight.add(pluginId);
-      _publishInstallProgress(_installProgress.value);
+      _publishInstallStates(Map<String, PluginInstallState>.from(_installStates.value)..remove(pluginId));
     }
     final result = await _runMutation(
       request: () => _pluginRepository.command(pluginId: pluginId, request: request),
@@ -182,7 +181,9 @@ class PluginManagementService({
 
   Future<PluginAuthenticationStartResult> startAuthentication({required String pluginId}) async {
     if (_disposed || !_connected || !_activeBridgeIdentityKnown) {
-      return PluginAuthenticationStartResult.failed(failure: PluginAuthenticationFailure.request(error: ApiError.generic()));
+      return PluginAuthenticationStartResult.failed(
+        failure: PluginAuthenticationFailure.request(error: ApiError.generic()),
+      );
     }
     final captured = _captureRequest(staleGeneration: _staleGeneration);
     _selfStartedAuthentications.add(pluginId);
@@ -258,7 +259,9 @@ class PluginManagementService({
 
     _authenticationRedirectClaims[pluginId] = fence;
     final result = await _pluginRepository.submitAuthenticationRedirect(pluginId: pluginId, redirectUri: redirectUri);
-    if (!_isConnectionFenceCurrent(fence) || !_activeBridgeIdentityKnown || _activeBridgeId != fence.bridgeId ||
+    if (!_isConnectionFenceCurrent(fence) ||
+        !_activeBridgeIdentityKnown ||
+        _activeBridgeId != fence.bridgeId ||
         _authenticationFences[pluginId] != null && _authenticationFences[pluginId] != fence) {
       return const PluginAuthenticationContinuationResult.uncertain();
     }
@@ -274,7 +277,9 @@ class PluginManagementService({
 
   Future<PluginAuthenticationCancelResult> cancelAuthentication({required String pluginId}) async {
     if (_disposed || !_connected || !_isAuthenticationFenceCurrent(pluginId: pluginId)) {
-      return PluginAuthenticationCancelResult.failed(failure: PluginAuthenticationFailure.request(error: ApiError.generic()));
+      return PluginAuthenticationCancelResult.failed(
+        failure: PluginAuthenticationFailure.request(error: ApiError.generic()),
+      );
     }
     _authenticationRequestsInFlight.add(pluginId);
     final result = await _pluginRepository.cancelAuthentication(pluginId: pluginId);
@@ -459,14 +464,15 @@ class PluginManagementService({
     required PluginInstallPhase phase,
     required int? percent,
   }) {
-    if (_disposed || _installProgress.isClosed) return;
-    final next = Map<String, PluginInstallProgress>.from(_installProgress.value);
+    if (_disposed || _installStates.isClosed) return;
+    final next = Map<String, PluginInstallState>.from(_installStates.value);
     switch (phase) {
       case PluginInstallPhase.completed || PluginInstallPhase.failed:
-        // The terminal outcome is carried by the refreshed snapshot (and, on
-        // failure, the harness' unchanged setup state), so the transient
-        // progress entry is dropped here.
-        next.remove(pluginId);
+        if (phase == PluginInstallPhase.failed) {
+          next[pluginId] = const PluginInstallState.failed();
+        } else {
+          next.remove(pluginId);
+        }
         // The bridge's terminal event is the authoritative outcome, so report
         // it here rather than at the tap — but only for an install this app
         // started, since every connected surface sees the same event. While
@@ -481,38 +487,43 @@ class PluginManagementService({
           PluginInstallPhase.verifying ||
           PluginInstallPhase.extracting ||
           PluginInstallPhase.finalizing:
-        next[pluginId] = PluginInstallProgress(phase: phase, percent: percent);
+        next[pluginId] = PluginInstallState.inProgress(
+          progress: PluginInstallProgress(phase: phase, percent: percent),
+        );
       case PluginInstallPhase.unknown:
         // A newer bridge phase: keep the row in an in-progress state without
         // claiming a phase this app can name.
-        next[pluginId] = const PluginInstallProgress(phase: PluginInstallPhase.unknown, percent: null);
+        next[pluginId] = const PluginInstallState.inProgress(
+          progress: PluginInstallProgress(phase: PluginInstallPhase.unknown, percent: null),
+        );
     }
-    _publishInstallProgress(next);
+    _publishInstallStates(next);
   }
 
   /// Drops [pluginId]'s progress entry so its Install row is tappable again.
   /// Only meaningful once authorship has been released, since
-  /// [_publishInstallProgress] re-adds a synthetic entry for tracked installs.
+  /// [_publishInstallStates] re-adds a synthetic entry for tracked installs.
   void _releaseInstallRow({required String pluginId}) {
-    _publishInstallProgress(
-      Map<String, PluginInstallProgress>.from(_installProgress.value)..remove(pluginId),
-    );
+    if (_installStates.value[pluginId] is! PluginInstallInProgress) return;
+    _publishInstallStates(Map<String, PluginInstallState>.from(_installStates.value)..remove(pluginId));
   }
 
   /// Publishes [progress] plus a synthetic entry for every install this app
   /// started that the bridge has not reported on yet, so the row stays busy for
   /// the whole window between the tap and the first progress event — which
   /// spans the command's own round trip and the gap after it.
-  void _publishInstallProgress(Map<String, PluginInstallProgress> progress) {
-    if (_disposed || _installProgress.isClosed) return;
-    final next = Map<String, PluginInstallProgress>.from(progress);
+  void _publishInstallStates(Map<String, PluginInstallState> progress) {
+    if (_disposed || _installStates.isClosed) return;
+    final next = Map<String, PluginInstallState>.from(progress);
     for (final pluginId in _selfStartedInstalls) {
       next.putIfAbsent(
         pluginId,
-        () => const PluginInstallProgress(phase: PluginInstallPhase.unknown, percent: null),
+        () => const PluginInstallState.inProgress(
+          progress: PluginInstallProgress(phase: PluginInstallPhase.unknown, percent: null),
+        ),
       );
     }
-    _installProgress.add(Map<String, PluginInstallProgress>.unmodifiable(next));
+    _installStates.add(Map<String, PluginInstallState>.unmodifiable(next));
   }
 
   void _reportInstallOutcome({required PluginInstallPhase phase}) {
@@ -539,7 +550,7 @@ class PluginManagementService({
     );
   }
 
-  void _clearInstallProgress() {
+  void _clearInstallStates() {
     // A new connection or bridge identity makes any pending outcome
     // unattributable, so authorship is forgotten with the progress itself. The
     // in-flight set goes too, otherwise a command still awaiting its response
@@ -547,8 +558,8 @@ class PluginManagementService({
     _selfStartedInstalls.clear();
     _pendingInstallOutcomes.clear();
     _installRequestsInFlight.clear();
-    if (_disposed || _installProgress.isClosed || _installProgress.value.isEmpty) return;
-    _installProgress.add(const {});
+    if (_disposed || _installStates.isClosed || _installStates.value.isEmpty) return;
+    _installStates.add(const {});
   }
 
   void _markStale() {
@@ -699,6 +710,13 @@ class PluginManagementService({
         }
         _activeBridgeIdentityKnown = true;
         _activeBridgeId = response.bridgeId;
+        final installs = Map<String, PluginInstallState>.from(_installStates.value);
+        for (final plugin in response.plugins) {
+          if (plugin.setup.state == PluginSetupState.ready && installs[plugin.setup.id] is PluginInstallFailed) {
+            installs.remove(plugin.setup.id);
+          }
+        }
+        _publishInstallStates(installs);
       case PluginManagementLoadResultUnsupported():
         _forgetActiveBridgeIdentity();
       case PluginManagementLoadResultFailure(:final error):
@@ -751,7 +769,7 @@ class PluginManagementService({
     _publicationGeneration++;
     // Progress belongs to the bridge connection that reported it; a new
     // connection or bridge identity re-reports whatever is still running.
-    _clearInstallProgress();
+    _clearInstallStates();
     _clearAuthentications();
     _snapshots.add(const PluginManagementLoadResult.loading());
   }
@@ -764,7 +782,7 @@ class PluginManagementService({
     await _subscriptions.dispose();
     await _refreshTail;
     await _snapshots.close();
-    await _installProgress.close();
+    await _installStates.close();
     await _authenticationChallenges.close();
     await _authenticationTerminalController.close();
   }
@@ -780,20 +798,6 @@ int? _parseIdleTimeoutMins({required PluginManagementIdleTimeoutInput input}) {
   };
 }
 
-/// One harness' in-flight managed runtime install, as last reported.
-@immutable
-class const PluginInstallProgress({
-  required final PluginInstallPhase phase,
-  /// Download completion, only present while downloading with a known total.
-  required final int? percent,
-}) {
-  @override
-  bool operator ==(Object other) => other is PluginInstallProgress && other.phase == phase && other.percent == percent;
-
-  @override
-  int get hashCode => Object.hash(phase, percent);
-}
-
 bool _isLoopbackHost(String host) {
   final normalized = host.toLowerCase();
   if (normalized == "localhost" || normalized == "::1") return true;
@@ -805,9 +809,19 @@ bool _isLoopbackHost(String host) {
   });
 }
 
-enum _RefreshOutcome() { applied, failed, superseded, fenced }
+enum _RefreshOutcome() {
+  applied,
+  failed,
+  superseded,
+  fenced,
+}
 
-enum _PublicationOutcome() { applied, fenced, superseded, identitySuperseded }
+enum _PublicationOutcome() {
+  applied,
+  fenced,
+  superseded,
+  identitySuperseded,
+}
 
 sealed class const PluginManagementCommandPlan() {
   const factory request({
@@ -817,11 +831,15 @@ sealed class const PluginManagementCommandPlan() {
   const factory invalidInput() = PluginManagementCommandPlanInvalidInput;
 }
 
-final class const PluginManagementCommandPlanRequest({required final PluginIdleTimeoutUpdateRequest request}) extends PluginManagementCommandPlan;
+final class const PluginManagementCommandPlanRequest({required final PluginIdleTimeoutUpdateRequest request})
+    extends PluginManagementCommandPlan;
 
 final class const PluginManagementCommandPlanInvalidInput() extends PluginManagementCommandPlan;
 
-enum PluginManagementForceAction() { disable, restart }
+enum PluginManagementForceAction() {
+  disable,
+  restart,
+}
 
 sealed class const PluginManagementForceAssessment() {
   const factory requiresConfirmation({
@@ -831,7 +849,9 @@ sealed class const PluginManagementForceAssessment() {
   const factory notForceable() = PluginManagementForceAssessmentNotForceable;
 }
 
-final class const PluginManagementForceAssessmentRequiresConfirmation({required final PluginLifecycleCommandRequest request}) extends PluginManagementForceAssessment;
+final class const PluginManagementForceAssessmentRequiresConfirmation({
+  required final PluginLifecycleCommandRequest request,
+}) extends PluginManagementForceAssessment;
 
 final class const PluginManagementForceAssessmentNotForceable() extends PluginManagementForceAssessment;
 

--- a/client/module_core/lib/src/services/plugin_management_service.dart
+++ b/client/module_core/lib/src/services/plugin_management_service.dart
@@ -716,7 +716,9 @@ class PluginManagementService({
             installs.remove(plugin.setup.id);
           }
         }
-        _publishInstallStates(installs);
+        if (installs.length != _installStates.value.length) {
+          _publishInstallStates(installs);
+        }
       case PluginManagementLoadResultUnsupported():
         _forgetActiveBridgeIdentity();
       case PluginManagementLoadResultFailure(:final error):

--- a/client/module_core/lib/src/services/project_viewing_service.dart
+++ b/client/module_core/lib/src/services/project_viewing_service.dart
@@ -272,6 +272,7 @@ class ProjectViewingService({
       AppRouteDef.settings ||
       AppRouteDef.settingsNotifications ||
       AppRouteDef.settingsHarnesses ||
+      AppRouteDef.settingsHarnessDetail ||
       AppRouteDef.settingsProfile ||
       null => null,
     };

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -27,7 +27,7 @@ Future<void> _settle() async {
 void main() {
   late _MockPluginManagementService service;
   late BehaviorSubject<PluginManagementLoadResult> snapshots;
-  late BehaviorSubject<Map<String, PluginInstallProgress>> installProgress;
+  late BehaviorSubject<Map<String, PluginInstallState>> installStates;
   late StreamController<PluginAuthenticationTerminalUpdate> authenticationTerminal;
   late BehaviorSubject<Map<String, PluginAuthenticationChallenge>> authenticationChallenges;
   late PluginManagementCubit cubit;
@@ -46,11 +46,11 @@ void main() {
     service = _MockPluginManagementService();
     urlLauncher = _MockUrlLauncher();
     snapshots = BehaviorSubject();
-    installProgress = BehaviorSubject.seeded(const {});
+    installStates = BehaviorSubject.seeded(const {});
     authenticationTerminal = StreamController.broadcast(sync: true);
     authenticationChallenges = BehaviorSubject.seeded(const {});
     when(() => service.snapshots).thenAnswer((_) => snapshots.stream);
-    when(() => service.installProgress).thenAnswer((_) => installProgress.stream);
+    when(() => service.installStates).thenAnswer((_) => installStates.stream);
     when(() => service.authenticationTerminal).thenAnswer((_) => authenticationTerminal.stream);
     when(() => service.authenticationChallenges).thenAnswer((_) => authenticationChallenges.stream);
     when(() => service.refresh()).thenAnswer((_) async {});
@@ -93,7 +93,7 @@ void main() {
     await cubit.close();
     await rescan.onDispose();
     await snapshots.close();
-    await installProgress.close();
+    await installStates.close();
     await authenticationTerminal.close();
     await authenticationChallenges.close();
   });
@@ -160,8 +160,10 @@ void main() {
     ).thenAnswer((_) async => const PluginAuthenticationContinuationResult.invalidRedirect());
     await cubit.submitAuthenticationRedirect(intent: invalidIntent);
     final invalidState = (cubit.state as PluginManagementReady).authentication;
-    expect((invalidState as PluginAuthenticationPresentationChallenge).challenge,
-        isA<PluginAuthenticationInvalidRedirectPresentation>());
+    expect(
+      (invalidState as PluginAuthenticationPresentationChallenge).challenge,
+      isA<PluginAuthenticationInvalidRedirectPresentation>(),
+    );
     const intent = PluginAuthenticationContinuationIntent.pasted(
       rawInput: "http://127.0.0.1/callback?code=opaque",
     );
@@ -459,23 +461,31 @@ void main() {
         ),
       ).called(1);
 
-      installProgress.add(const {
-        "one": PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 42),
+      installStates.add(const {
+        "one": PluginInstallState.inProgress(
+          progress: PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 42),
+        ),
       });
       await _settle();
       expect(
         (cubit.state as PluginManagementReady).installs,
-        const {"one": PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 42)},
+        const {
+          "one": PluginInstallState.inProgress(
+            progress: PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 42),
+          ),
+        },
       );
 
-      installProgress.add(const {});
+      installStates.add(const {});
       await _settle();
       expect((cubit.state as PluginManagementReady).installs, isEmpty);
     });
 
     test("a cubit created mid-install seeds progress from the service", () async {
-      installProgress.add(const {
-        "one": PluginInstallProgress(phase: PluginInstallPhase.verifying, percent: null),
+      installStates.add(const {
+        "one": PluginInstallState.inProgress(
+          progress: PluginInstallProgress(phase: PluginInstallPhase.verifying, percent: null),
+        ),
       });
       await _settle();
 
@@ -488,13 +498,32 @@ void main() {
 
       expect(
         (reopened.state as PluginManagementReady).installs,
-        const {"one": PluginInstallProgress(phase: PluginInstallPhase.verifying, percent: null)},
+        const {
+          "one": PluginInstallState.inProgress(
+            progress: PluginInstallProgress(phase: PluginInstallPhase.verifying, percent: null),
+          ),
+        },
       );
     });
 
+    test("retained install failure replays into a recreated flow cubit", () async {
+      installStates.add(const {"one": PluginInstallState.failed()});
+      snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+      await _settle();
+      final reopened = PluginManagementCubit(service: service, urlLauncher: urlLauncher, catalogRescanService: rescan);
+      addTearDown(reopened.close);
+      await _settle();
+      expect((reopened.state as PluginManagementReady).installs["one"], const PluginInstallState.failed());
+      snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
+      await _settle();
+      expect((reopened.state as PluginManagementReady).installs["one"], const PluginInstallState.failed());
+    });
+
     test("a loading transition mid-install restores progress with the next snapshot", () async {
-      installProgress.add(const {
-        "one": PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 10),
+      installStates.add(const {
+        "one": PluginInstallState.inProgress(
+          progress: PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 10),
+        ),
       });
       await _settle();
 
@@ -507,21 +536,29 @@ void main() {
 
       expect(
         (cubit.state as PluginManagementReady).installs,
-        const {"one": PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 10)},
+        const {
+          "one": PluginInstallState.inProgress(
+            progress: PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 10),
+          ),
+        },
       );
     });
 
     test("an equivalent progress map does not emit a new state", () async {
-      installProgress.add(const {
-        "one": PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null),
+      installStates.add(const {
+        "one": PluginInstallState.inProgress(
+          progress: PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null),
+        ),
       });
       await _settle();
       final emitted = <PluginManagementState>[];
       final subscription = cubit.stream.listen(emitted.add);
       addTearDown(subscription.cancel);
 
-      installProgress.add(const {
-        "one": PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null),
+      installStates.add(const {
+        "one": PluginInstallState.inProgress(
+          progress: PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null),
+        ),
       });
       await _settle();
 
@@ -529,8 +566,10 @@ void main() {
     });
 
     test("install progress survives a refreshed snapshot", () async {
-      installProgress.add(const {
-        "one": PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null),
+      installStates.add(const {
+        "one": PluginInstallState.inProgress(
+          progress: PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null),
+        ),
       });
       await _settle();
 
@@ -539,7 +578,11 @@ void main() {
 
       expect(
         (cubit.state as PluginManagementReady).installs,
-        const {"one": PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null)},
+        const {
+          "one": PluginInstallState.inProgress(
+            progress: PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null),
+          ),
+        },
       );
     });
 
@@ -1132,7 +1175,6 @@ void main() {
       expect((reopened.state as PluginManagementReady).scanningPluginIds, {"codex"});
     });
   });
-
 }
 
 PluginLifecycleConflict _conflict(List<PluginLifecycleConflictReason> reasons) {

--- a/client/module_core/test/routing/analytics_route_listener_test.dart
+++ b/client/module_core/test/routing/analytics_route_listener_test.dart
@@ -105,6 +105,7 @@ void main() {
       AppRouteDef.settings,
       AppRouteDef.settingsNotifications,
       AppRouteDef.settingsHarnesses,
+      AppRouteDef.settingsHarnessDetail,
       AppRouteDef.settingsProfile,
       AppRouteDef.sessions,
       AppRouteDef.newSession,

--- a/client/module_core/test/routing/app_routes_test.dart
+++ b/client/module_core/test/routing/app_routes_test.dart
@@ -43,6 +43,27 @@ void main() {
       }
     });
 
+    test("harness detail encodes identity once and defaults presentation at the boundary", () {
+      const id = "harness/with ? & symbols";
+      for (final presentation in HarnessSettingsPresentation.values) {
+        final uri = Uri.parse(AppRoute.settingsHarnessDetail(pluginId: id, presentation: presentation).buildPath());
+        final decoded = AppRoute.fromDef(
+          def: AppRouteDef.settingsHarnessDetail,
+          pathParams: {pluginIdPathParam: uri.pathSegments.last},
+          queryParams: uri.queryParameters,
+        ) as AppRouteSettingsHarnessDetail;
+        expect(decoded.pluginId, id);
+        expect(decoded.presentation, presentation);
+      }
+      expect(
+        AppRouteSettingsHarnessDetail.fromParams(
+          pathParams: const {pluginIdPathParam: id},
+          queryParams: const {},
+        ).presentation,
+        HarnessSettingsPresentation.modal,
+      );
+    });
+
     test("settings Harness management route is removed", () {
       expect(AppRouteDef.values.map((def) => def.name), isNot(contains("settingsHarnessManagement")));
       expect(AppRouteDef.values.map((def) => def.path), isNot(contains("/settings/harnesses/manage")));

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -12,6 +12,7 @@ import "package:sesori_dart_core/src/foundation/models/product_analytics/product
 import "package:sesori_dart_core/src/repositories/models/analytics_delivery_result.dart";
 import "package:sesori_dart_core/src/repositories/models/plugin_management_result.dart";
 import "package:sesori_dart_core/src/repositories/plugin_repository.dart";
+import "package:sesori_dart_core/src/services/models/plugin_install_state.dart";
 import "package:sesori_dart_core/src/services/plugin_management_service.dart";
 import "package:sesori_dart_core/src/services/product_analytics_service.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -83,8 +84,10 @@ void main() {
         intent: const PluginAuthenticationContinuationIntent.pasted(rawInput: redirect),
       );
       final first = submit();
-      expect((await submit() as PluginAuthenticationContinuationRejected).reason,
-          PluginAuthenticationContinuationRejection.alreadySubmitted);
+      expect(
+        (await submit() as PluginAuthenticationContinuationRejected).reason,
+        PluginAuthenticationContinuationRejection.alreadySubmitted,
+      );
       final terminals = <PluginAuthenticationTerminalUpdate>[];
       service.authenticationTerminal.listen(terminals.add);
       connection.emitAuthenticationProgress(
@@ -907,20 +910,28 @@ void main() {
       connection.emitInstallProgress(pluginId: "codex", phase: PluginInstallPhase.downloading, percent: 30);
       await _pump();
       expect(
-        service.installProgress.value,
-        const {"codex": PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 30)},
+        service.installStates.value,
+        const {
+          "codex": PluginInstallState.inProgress(
+            progress: PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 30),
+          ),
+        },
       );
 
       connection.emitInstallProgress(pluginId: "codex", phase: PluginInstallPhase.extracting);
       await _pump();
       expect(
-        service.installProgress.value,
-        const {"codex": PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null)},
+        service.installStates.value,
+        const {
+          "codex": PluginInstallState.inProgress(
+            progress: PluginInstallProgress(phase: PluginInstallPhase.extracting, percent: null),
+          ),
+        },
       );
 
       connection.emitInstallProgress(pluginId: "codex", phase: PluginInstallPhase.completed);
       await _pump();
-      expect(service.installProgress.value, isEmpty);
+      expect(service.installStates.value, isEmpty);
       // The terminal outcome does not itself refresh; the bridge's snapshot
       // invalidation does, exactly as for any other management change.
       expect(repository.loadCalls, 1);
@@ -928,6 +939,94 @@ void main() {
       // report — otherwise the metric would count surfaces, not installs.
       expect(reportedEvents, isEmpty);
     });
+
+    test("failed installs replay, survive missing snapshots, recover, and reset on disconnect", () async {
+      final missing = _conflict([]).current
+          .copyWith(setup: _conflict([]).current.setup.copyWith(state: PluginSetupState.runtimeMissing));
+      final ready = missing.copyWith(setup: missing.setup.copyWith(state: PluginSetupState.ready));
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "one").copyWith(plugins: [missing])))
+        ..queueLoad(_supported(_response(token: "two").copyWith(plugins: [missing])))
+        ..queueLoad(_supported(_response(token: "three").copyWith(plugins: [ready])));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(
+        pluginRepository: repository,
+        connectionService: connection,
+        productAnalyticsService: analytics,
+      );
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+      connection.emitInstallProgress(pluginId: "one", phase: PluginInstallPhase.failed);
+      await _pump();
+      expect((await service.installStates.first)["one"], const PluginInstallState.failed());
+      await service.refresh();
+      expect(service.installStates.value["one"], const PluginInstallState.failed());
+      await service.refresh();
+      expect(service.installStates.value, isEmpty);
+      connection.emitInstallProgress(pluginId: "one", phase: PluginInstallPhase.failed);
+      await _pump();
+      connection.emitInstallProgress(pluginId: "one", phase: PluginInstallPhase.downloading, percent: 10);
+      await _pump();
+      expect(service.installStates.value["one"], isA<PluginInstallInProgress>());
+      connection.emitInstallProgress(pluginId: "one", phase: PluginInstallPhase.failed);
+      await _pump();
+      connection.emitStatus(const ConnectionStatus.disconnected());
+      await _pump();
+      expect(service.installStates.value, isEmpty);
+      expect(reportedEvents, isEmpty);
+    });
+
+    for (final response in [
+      _success(_response(token: "accepted")),
+      const PluginManagementMutationResult.uncertain(),
+      PluginManagementMutationResult.failure(error: ApiError.generic()),
+    ]) {
+      for (final terminal in [PluginInstallPhase.failed, PluginInstallPhase.completed]) {
+        test("early $terminal survives ${response.runtimeType} and retry clears failure", () async {
+          final mutation = Completer<PluginManagementMutationResult>();
+          final repository = _FakePluginRepository()
+            ..queueLoad(_supported(_response(token: "one")))
+            ..queueMutation(mutation.future)
+            ..queueMutation(const PluginManagementMutationResult.uncertain())
+            ..queueLoad(_supported(_response(token: "two")))
+            ..queueLoad(_supported(_response(token: "three")));
+          final connection = _FakeConnectionService(initialStatus: _connected);
+          final service = PluginManagementService(
+            pluginRepository: repository,
+            connectionService: connection,
+            productAnalyticsService: analytics,
+          );
+          addTearDown(() async {
+            await service.onDispose();
+            await connection.dispose();
+          });
+          await _waitFor(() => service.snapshots.hasValue);
+          final command = service.command(pluginId: "codex", request: const PluginLifecycleCommandRequest.install());
+          connection.emitInstallProgress(pluginId: "codex", phase: terminal);
+          await _pump();
+          if (terminal == PluginInstallPhase.failed) {
+            expect(service.installStates.value["codex"], const PluginInstallState.failed());
+          }
+          mutation.complete(response);
+          await command;
+          await _pump();
+          expect(
+            service.installStates.value["codex"],
+            terminal == PluginInstallPhase.failed ? const PluginInstallState.failed() : null,
+          );
+          expect(reportedEvents.single.parameters, {"outcome": terminal.name});
+          if (terminal == PluginInstallPhase.failed) {
+            final retry = service.command(pluginId: "codex", request: const PluginLifecycleCommandRequest.install());
+            expect(service.installStates.value["codex"], isA<PluginInstallInProgress>());
+            await retry;
+            expect(reportedEvents, hasLength(1));
+          }
+        });
+      }
+    }
 
     test("reports the outcome only for an install this app started", () async {
       final repository = _FakePluginRepository()
@@ -990,7 +1089,7 @@ void main() {
       );
       // The row is busy from the tap, before any progress event arrives.
       await _pump();
-      expect(service.installProgress.value.containsKey("codex"), isTrue);
+      expect(service.installStates.value.containsKey("codex"), isTrue);
 
       // A cached install can finish inside the request round trip.
       connection.emitInstallProgress(pluginId: "codex", phase: PluginInstallPhase.completed);
@@ -1002,7 +1101,7 @@ void main() {
       await _pump();
 
       expect(reportedEvents.single.parameters, {"outcome": "completed"});
-      expect(service.installProgress.value, isEmpty);
+      expect(service.installStates.value, isEmpty);
     });
 
     test("the row stays busy from acceptance until the first progress event", () async {
@@ -1029,18 +1128,20 @@ void main() {
 
       // Accepted, but the bridge has not reported a phase yet: the harness must
       // still read as installing so the row cannot be tapped again.
-      expect(service.installProgress.value.containsKey("codex"), isTrue);
+      expect(service.installStates.value.containsKey("codex"), isTrue);
 
       connection.emitInstallProgress(pluginId: "codex", phase: PluginInstallPhase.downloading, percent: 5);
       await _pump();
       expect(
-        service.installProgress.value["codex"],
-        const PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 5),
+        service.installStates.value["codex"],
+        const PluginInstallState.inProgress(
+          progress: PluginInstallProgress(phase: PluginInstallPhase.downloading, percent: 5),
+        ),
       );
 
       connection.emitInstallProgress(pluginId: "codex", phase: PluginInstallPhase.completed);
       await _pump();
-      expect(service.installProgress.value, isEmpty);
+      expect(service.installStates.value, isEmpty);
     });
 
     test("a reconnect during an unresolved install command leaves no busy row", () async {
@@ -1066,18 +1167,18 @@ void main() {
         request: const PluginLifecycleCommandRequest.install(),
       );
       await _pump();
-      expect(service.installProgress.value.containsKey("codex"), isTrue);
+      expect(service.installStates.value.containsKey("codex"), isTrue);
 
       connection.emitStatus(const ConnectionStatus.disconnected());
       await _pump();
-      expect(service.installProgress.value, isEmpty);
+      expect(service.installStates.value, isEmpty);
 
       // The orphaned command resolving later must not resurrect the row.
       mutation.complete(_success(_response(token: "one")));
       await command;
       await _pump();
 
-      expect(service.installProgress.value, isEmpty);
+      expect(service.installStates.value, isEmpty);
       expect(reportedEvents, isEmpty);
     });
 
@@ -1106,12 +1207,12 @@ void main() {
 
       // The command may still have reached the bridge, so Install must not
       // become tappable and start a second download.
-      expect(service.installProgress.value.containsKey("codex"), isTrue);
+      expect(service.installStates.value.containsKey("codex"), isTrue);
 
       connection.emitInstallProgress(pluginId: "codex", phase: PluginInstallPhase.completed);
       await _pump();
 
-      expect(service.installProgress.value, isEmpty);
+      expect(service.installStates.value, isEmpty);
       expect(reportedEvents.single.parameters, {"outcome": "completed"});
     });
 
@@ -1146,7 +1247,7 @@ void main() {
       await command;
       await _pump();
 
-      expect(service.installProgress.value, isEmpty);
+      expect(service.installStates.value, isEmpty);
       expect(reportedEvents.single.parameters, {"outcome": "completed"});
     });
 
@@ -1174,7 +1275,7 @@ void main() {
 
       // A rejected command must also release the busy row, or Install could
       // never be retried.
-      expect(service.installProgress.value, isEmpty);
+      expect(service.installStates.value, isEmpty);
 
       // The bridge never accepted it, so a later install of the same harness
       // (started elsewhere) is not this app's outcome.
@@ -1203,12 +1304,12 @@ void main() {
       await _waitFor(() => service.snapshots.hasValue);
       connection.emitInstallProgress(pluginId: "codex", phase: PluginInstallPhase.downloading, percent: 10);
       await _pump();
-      expect(service.installProgress.value, isNotEmpty);
+      expect(service.installStates.value, isNotEmpty);
 
       connection.emitStatus(const ConnectionStatus.disconnected());
       await _pump();
 
-      expect(service.installProgress.value, isEmpty);
+      expect(service.installStates.value, isEmpty);
     });
   });
 }

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -962,10 +962,20 @@ void main() {
       connection.emitInstallProgress(pluginId: "one", phase: PluginInstallPhase.failed);
       await _pump();
       expect((await service.installStates.first)["one"], const PluginInstallState.failed());
+      final emittedStates = <Map<String, PluginInstallState>>[];
+      final subscription = service.installStates.listen(emittedStates.add);
+      addTearDown(subscription.cancel);
+      await _pump();
+      emittedStates.clear();
+
       await service.refresh();
+      await _pump();
       expect(service.installStates.value["one"], const PluginInstallState.failed());
+      expect(emittedStates, isEmpty, reason: "An unchanged snapshot is not an install-state update.");
       await service.refresh();
+      await _pump();
       expect(service.installStates.value, isEmpty);
+      expect(emittedStates, [<String, PluginInstallState>{}], reason: "Ready recovery publishes the cleared failure.");
       connection.emitInstallProgress(pluginId: "one", phase: PluginInstallPhase.failed);
       await _pump();
       connection.emitInstallProgress(pluginId: "one", phase: PluginInstallPhase.downloading, percent: 10);

--- a/client/module_core/test/services/project_viewing_service_test.dart
+++ b/client/module_core/test/services/project_viewing_service_test.dart
@@ -310,6 +310,17 @@ void main() {
       expect(sent, ["project-1", "project-2"]);
     });
 
+    test("harness detail covers project viewing without destroying the underlying claim", () async {
+      readyList("project-1");
+      await drain();
+      routeSource.routes.add(AppRouteDef.settingsHarnessDetail);
+      await drain();
+      expect(sent.last, isNull);
+      routeSource.routes.add(AppRouteDef.sessions);
+      await drain();
+      expect(sent.last, "project-1");
+    });
+
     test("disposal rejects new claims while subscription cancellation is pending", () async {
       await service.onDispose();
       await lifecycleSource.states.close();

--- a/client/module_prego/lib/components/surfaces/prego_grouped_rows.dart
+++ b/client/module_prego/lib/components/surfaces/prego_grouped_rows.dart
@@ -27,11 +27,13 @@ class const PregoGroupedRows({
 
   /// Rows rendered with dividers between children.
   required final List<Widget> children,
+  final Color? color,
+  final bool showDividers = true,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: context.prego.colors.bgSurface3,
+      color: color ?? context.prego.colors.bgSurface3,
       clipBehavior: Clip.antiAlias,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(PregoRadius.x5l)),
       child: Column(
@@ -44,7 +46,7 @@ class const PregoGroupedRows({
                 final key? => ValueKey<Key>(key),
                 null => null,
               },
-              isLast: index == children.length - 1,
+              isLast: !showDividers || index == children.length - 1,
               child: children[index],
             ),
         ],
@@ -78,6 +80,10 @@ class const PregoGroupedRow({
   /// Trailing slot. Icon descendants default to 20px in the tertiary colour.
   final Widget? trailing,
   final VoidCallback? onTap,
+  final double? minHeight,
+
+  /// Vertical content inset, independently of the minimum row height.
+  final double verticalPadding = PregoSpacing.md,
 }) extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -128,10 +134,10 @@ class const PregoGroupedRow({
     );
 
     Widget tile = Container(
-      constraints: BoxConstraints(minHeight: subtitle != null ? _tallRowMinHeight : _rowMinHeight),
-      padding: const EdgeInsets.symmetric(
+      constraints: BoxConstraints(minHeight: minHeight ?? (subtitle != null ? _tallRowMinHeight : _rowMinHeight)),
+      padding: EdgeInsets.symmetric(
         horizontal: PregoSpacing.xl,
-        vertical: PregoSpacing.md,
+        vertical: verticalPadding,
       ),
       alignment: AlignmentDirectional.centerStart,
       child: row,

--- a/client/module_prego/test/components/prego_grouped_rows_test.dart
+++ b/client/module_prego/test/components/prego_grouped_rows_test.dart
@@ -80,6 +80,33 @@ void main() {
     expect(hairlines, hasLength(1));
   });
 
+  testWidgets("card tone, divider omission and minimum height are opt-in", (tester) async {
+    await tester.pumpWidget(
+      _harness(
+        PregoGroupedRows(
+          color: PregoDesignSystem.light.colors.bgSurface2,
+          showDividers: false,
+          children: const [
+            PregoGroupedRow(title: Text("Alpha"), minHeight: 68),
+            PregoGroupedRow(title: Text("Beta"), minHeight: 68),
+          ],
+        ),
+      ),
+    );
+    expect(
+      tester.widget<Material>(find.ancestor(of: find.text("Alpha"), matching: find.byType(Material)).first).color,
+      PregoDesignSystem.light.colors.bgSurface2,
+    );
+    expect(
+      tester
+          .widgetList<ColoredBox>(find.byType(ColoredBox))
+          .where((box) => box.color == PregoDesignSystem.light.colors.borderSecondary),
+      isEmpty,
+    );
+    expect(tester.getSize(find.widgetWithText(Container, "Alpha")).height, 68);
+    expect(tester.getSize(find.widgetWithText(Container, "Beta")).height, 68);
+  });
+
   testWidgets("keyed rows retain state when reordered", (tester) async {
     const alphaKey = ValueKey("alpha");
     const betaKey = ValueKey("beta");

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -34,6 +34,21 @@ The upgrade only replaces a runtime Sesori already manages. A machine with no
 managed version directory keeps the explicit Install action; it never downloads
 a runtime the user has not asked for.
 
+### Harness settings contract limitations (verified 2026-09-07)
+
+These gaps apply to every registered harness through the current management wire seam
+(`shared/sesori_shared/lib/src/models/sesori/plugin_management.dart` and install-progress SSE).
+They do not claim that a harness's native CLI could never implement an equivalent feature.
+
+| Capability through the current management seam | Status |
+|---|---|
+| Client-controlled automatic-update preference | 🚫 Not supported: no preference or command; existing bridge-start managed upgrades are unchanged. |
+| Pause/stop/cancel a managed installation | 🚫 Not supported: no command or stopped outcome; these UI controls remain hidden. |
+| Distinct update-required setup status | 🚫 Not supported: unavailable is broader and cannot truthfully be relabelled update-required. |
+| Enabled preference when runtime is unknown | 🚫 Not supported: unknown does not prove disabled; clients omit the switch. |
+| Overall installation percentage or active-session count | 🚫 Not supported: only optional download percentage and idle/busy/unknown work state are reported. |
+| Replay a failed installation observed by this client within the connection | ✅ Implemented for every harness advertising installation; memory only, not cross-device history. |
+
 ## Option pickers
 
 | Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |

--- a/docs/regression/plugin-runtime-installation.md
+++ b/docs/regression/plugin-runtime-installation.md
@@ -65,6 +65,9 @@ bridge start when Sesori already manages an older version.
   first progress event. Only reported download percentage is determinate; verification,
   extraction, finalization and unknown phases remain indeterminate rather than claiming
   total-install completion. No install pause/stop menu or stopped outcome is invented.
+- Harness detail Back returns to overview without recreating its flow-owned cubit. Settings-opened
+  pages offer Back only; New Session modal X dismisses the entire harness modal from either
+  page while retaining the composer and draft.
 - Failed terminal SSE is retained in connection-scoped client memory and replayed across
   overview/detail navigation and cubit recreation. Retry starts immediately and clears it;
   observed progress from another surface replaces it. An unchanged missing/unavailable

--- a/docs/regression/plugin-runtime-installation.md
+++ b/docs/regression/plugin-runtime-installation.md
@@ -10,8 +10,10 @@ bridge start when Sesori already manages an older version.
 
 - Install is offered only where the bridge advertises the capability for that harness in
   its configuration and platform; a binary override or a platform with no pinned asset
-  removes the offer. The app offers it only for a missing or too-old runtime, never for
-  ready, authentication-required, or unknown states.
+  removes the offer. The app offers it only for runtimeMissing or unavailable setup with advertised install support, never for
+  ready, authentication-required, or unknown states. Install-ready missing runtimes use
+  the dedicated installation content; manual setup hints remain for externally installed
+  harnesses and other setup failures.
 - Artifact installation writes the pinned version into the harness's own managed state
   area; placement preserves a published bare executable, an archived executable, or its
   required package directory, never installs system-wide, touches files elsewhere, or starts the backend.
@@ -29,8 +31,8 @@ bridge start when Sesori already manages an older version.
   six arm64/x64 macOS, Linux, and Windows archives for the pinned release.
   Artifacts are checksum-verified, and no partial binary or package is adopted.
 - The command is accepted immediately because an install can outlast a request budget;
-  progress reports phases with a percentage, and the terminal outcome also lands in the
-  management snapshot.
+  progress reports phases with an optional download percentage. Completion re-inspects setup;
+  a setup snapshot alone is not evidence of a historical installation failure.
 - Success then implies enable: the harness is persisted enabled, setup is re-inspected,
   and the post-install enable phase starts it when ready. A still-blocked setup is
   reported honestly, and failure text sent to the client is sanitized while paths and
@@ -59,6 +61,24 @@ bridge start when Sesori already manages an older version.
   and a harness whose only managed runtime was below the minimum stays runtime-missing
   with its install hint. Failure detail stays in the bridge log.
 
+- The client marks a requested installation busy immediately, before its command response or
+  first progress event. Only reported download percentage is determinate; verification,
+  extraction, finalization and unknown phases remain indeterminate rather than claiming
+  total-install completion. No install pause/stop menu or stopped outcome is invented.
+- Failed terminal SSE is retained in connection-scoped client memory and replayed across
+  overview/detail navigation and cubit recreation. Retry starts immediately and clears it;
+  observed progress from another surface replaces it. An unchanged missing/unavailable
+  snapshot preserves failure; a newly applied ready snapshot or completed SSE clears it.
+  Connection/bridge invalidation clears all retained installation state.
+- Failure detail offers Restart installation where install remains eligible. Status still
+  follows actual setup: a missing runtime is Not installed, unavailable remains Unavailable,
+  and a recovered runtime is never relabelled missing. A definite command rejection is an
+  action error, not evidence that an installation ran and failed. Uncertain acceptance stays busy.
+- Terminal events racing accepted, uncertain or rejected command responses settle correctly:
+  retained failure is not replaced by synthetic progress or removed on response settlement.
+  Analytics reports each locally authored outcome once; merely observing another surface's
+  installation or navigating its detail never reports another outcome.
+
 ## Regression Levels
 
 | Level | Additional coverage |
@@ -79,6 +99,11 @@ an upgrade completes; whether another harness is busy; and the interruption poin
 download, verification, or placement. Use a disposable data directory.
 
 ## Failure Signals
+
+- Losing a failed terminal event on navigation or unchanged setup refresh, treating command
+  rejection as failed installation, retry leaving stale failure, or attributing remote installs locally.
+- Displaying download percentage as total progress or enabling conflicting controls between
+  acceptance and the first progress event.
 
 - Install offered where it cannot apply, or hidden where it genuinely can.
 - Anything written outside the managed state area, a system-wide install, or an
@@ -106,6 +131,10 @@ download, verification, or placement. Use a disposable data directory.
   its failure detail reaching the client instead of the log.
 
 ## Known Limitations
+
+- Retained client failure is not persisted or historical: a new surface cannot reconstruct an
+  earlier failure from runtimeMissing alone. Automatic bridge-start upgrades remain independent
+  of the unsupported client automatic-update preference.
 
 - Only harnesses declaring the capability with a pinned per-platform asset can install; a
   registered harness without one is correctly not installable.

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -246,9 +246,12 @@ idle suspension, the management snapshot, and lifecycle commands.
   externally managed capabilities remain honest. Individual timeout inheritance, custom
   minutes and no-timeout are all available through the timeout editor.
 - One flow-owned cubit and transient-presentation owner survives overview/detail navigation.
-  Back returns detail to overview; X removes the harness flow and the contiguous settings
-  suffix, preserving the first unrelated opener, including a live new-session composer.
-  Direct detail links construct overview ancestry, and links without an opener fall back to
+  Opened from Settings, overview and detail show only left Back: detail returns to overview,
+  then overview returns to the same Settings page. Opened modally from New Session,
+  overview shows only right X and detail shows left Back plus right X. Detail Back retains
+  the overview flow; X from either page dismisses only the harness modal, preserving the
+  same New Session page and draft. Direct detail links construct overview ancestry without
+  creating an unrelated Settings page, and links without an opener fall back to
   signed-in Projects on both shells. Removed IDs show an unavailable detail, not another harness.
   Authentication and force sheets belong to this flow and leave with it; sheet dismissal
   remains distinct from cancelling authentication. Safe lifecycle conflicts still authorize
@@ -287,7 +290,8 @@ owned-process exit; and restart.
 ## Failure Signals
 
 - Detail navigation recreating operation state, duplicate force/auth sheets or scan announcements,
-  X exposing Settings instead of the original opener, or a missing ID displaying another harness.
+  pushed Back skipping Settings, modal X losing the New Session page or draft, incorrect
+  Back/X header controls, or a missing ID displaying another harness.
 - A setup-blocked switch falsely shown off, unknown preference represented as disabled,
   degraded grouped as healthy, or controls overflowing at phone width with larger text.
 

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -224,13 +224,42 @@ idle suspension, the management snapshot, and lifecycle commands.
   the bridge refused outright, which the harness card already reports; a run that ends without
   a terminal outcome announces nothing at all.
 
+- Mobile and desktop share a grouped overview (Needs attention, Enabled, Not installed,
+  Disabled) and URL-addressable `/settings/harnesses/:pluginId` details. Registry order is
+  retained within groups; empty groups disappear. Installing entries belong to Not installed;
+  genuinely disabled entries belong to Disabled; only ready dormant/starting/active entries
+  are Enabled. Degraded remains attention even though its separate scan capability is routable.
+- Harness names open details, switches send actual enable/disable intent, and the separate
+  download target immediately starts an advertised install. Switches retain the bridge's
+  known enabled preference while blocked by setup or another operation; unknown runtime
+  has no inferred switch. Other overview rows always show their status, including Idle;
+  disabled overview rows have no subtitle. Global timeout is last.
+- Detail reports only known version and idle/busy activity, never a fabricated session count.
+  Missing runtime has setup/install content rather than operational actions. Unknown and
+  externally managed capabilities remain honest. Individual timeout inheritance, custom
+  minutes and no-timeout are all available through the timeout editor.
+- One flow-owned cubit and transient-presentation owner survives overview/detail navigation.
+  Back returns detail to overview; X removes the harness flow and the contiguous settings
+  suffix, preserving the first unrelated opener, including a live new-session composer.
+  Direct detail links construct overview ancestry, and links without an opener fall back to
+  signed-in Projects on both shells. Removed IDs show an unavailable detail, not another harness.
+  Authentication and force sheets belong to this flow and leave with it; sheet dismissal
+  remains distinct from cancelling authentication. Safe lifecycle conflicts still authorize
+  force confirmation, never an install retry.
+- Shared cards use surface2, 26px radius, 16px page/section gaps, 68px minimum overview/action
+  rows and 52px minimum detail facts, growing at larger text sizes. Switches keep their
+  64×28 visual track inside an independently tappable, labeled 64×44 target; padding taps
+  toggle rather than navigate. Overview groups omit dividers and default badges.
+  Unsupported automatic-update and install pause/stop controls
+  are hidden rather than simulated.
+
 ## Regression Levels
 
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | A started bridge inspects every registered harness and publishes coherent setup and management snapshots. A ready fixture has a selectable default; a fixture with no usable harness has zero selectable entries and no default without failing startup. Headless bridge; all registered harnesses listed. |
 | L2 Routine | Demand-driven start of a ready harness, non-blocking session-open warm-up plus immediate app-setting enable/disable, clean lifecycle-owned bridge shutdown, Codex keepalive traffic remaining local and stopping on disposal, Codex root work remaining busy until its last child settles, setup refresh, and the disable list surviving restart with eligibility and ordering intact. Package automation covers DeepSeek explicit/PATH/managed selection, immutable six-platform archive metadata, readiness, extension refusal, crash/reconnect, and idempotent shutdown. Copilot package automation covers branded version parsing, explicit/PATH/managed precedence, exact six-archive metadata, provisioning-authoritative startup, and local-login-required failure. Grok package automation covers explicit/PATH authority, bounded branded version parsing, read-only inspection, local-login-required startup, crash/reconnect, and owned shutdown. Automated runtime coverage proves the bounded cold start reports connected on success, degraded on failure, and degraded on budget exhaustion while absorbing the late failure. Headless bridge; representative managed harness for start and shutdown, every registered harness for listing and ordering. |
-| L3 Release | The shared mobile and desktop management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, default badge, enable/disable, restart, idle-timeout default plus override persisted across a bridge restart, and the per-harness catalog scan on a routable harness including its in-place progress and the announcement of what it found. Copilot renders the exact `GitHub Copilot` name and Primer interface icon in both themes. Grok renders as `Grok Build` with the official contrasting mark, selected version, local setup guidance, and no managed-install control. Client end to end on both product surfaces; every harness declaring the relevant capability must pass. |
+| L3 Release | The shared mobile and desktop management surface as rendered: per-harness selected runtime version when reported, setup, runtime and work state, capability-appropriate controls, built-in name and light/dark artwork, grouped overview and per-harness detail navigation, enable/disable, restart, idle-timeout default plus override persisted across a bridge restart, and the per-harness catalog scan on a routable harness including its in-place progress and the announcement of what it found. Copilot renders the exact `GitHub Copilot` name and Primer interface icon in both themes. Grok renders as `Grok Build` with the official contrasting mark, selected version, local setup guidance, and no managed-install control. Client end to end on both product surfaces; every harness declaring the relevant capability must pass. |
 | L4 Extended | Busy conflict with force confirmation and cancellation, authentication start/join/cancel plus shutdown cleanup, peer harness login rows disabled throughout a retained authentication operation, an owning row reopening a dismissed or `cancellingUncertain` challenge, idle suspension elapsing then returning on demand, harnesses blocked by missing runtime or authentication with no catalog-scan action offered on them, a targeted scan rejected by the bridge reporting on its own card, a terminally failed harness leaving others usable, a bridge with no usable harness, an externally managed configuration, two harnesses active at once, second mobile platform. Copilot live coverage includes an unexpected owned-process exit followed by demand reconnect and a deliberate clean shutdown that is not reported as a crash. Grok live coverage includes the same failure isolation and demand reconnect with a supported user-installed release. Live plugin where a real backend must start or be interrupted, client end to end where card state is claimed. |
 | L5 Full | Every registered production harness through inspect, enable, disable, restart, refresh, and idle behavior on a supported platform, plus forward-compatible presentation of an unknown harness or capability and the reported state of a session interrupted by a forced disable. Compatibility pairs prove an older client treats `copilot` and `grok` as unknown raw-id/generic-icon harnesses without decode failure, while an older bridge simply supplies no corresponding entry to a newer client. Live plugin and client end to end as each entry requires. |
 
@@ -249,6 +278,11 @@ headless and interactive-only authentication; catalog refresh; enable/disable;
 owned-process exit; and restart.
 
 ## Failure Signals
+
+- Detail navigation recreating operation state, duplicate force/auth sheets or scan announcements,
+  X exposing Settings instead of the original opener, or a missing ID displaying another harness.
+- A setup-blocked switch falsely shown off, unknown preference represented as disabled,
+  degraded grouped as healthy, or controls overflowing at phone width with larger text.
 
 - An isolated child receiving ambient variables, an inert JSON child selection creating
   directories, repeated child scopes losing concurrent updates, consumed ACP output appearing

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -233,7 +233,8 @@ idle suspension, the management snapshot, and lifecycle commands.
   download target immediately starts an advertised install. Switches retain the bridge's
   known enabled preference while blocked by setup or another operation; unknown runtime
   has no inferred switch. Other overview rows always show their status, including Idle;
-  disabled overview rows have no subtitle. Global timeout is last.
+  disabled overview rows have no subtitle. Global timeout is last; its value remains visible
+  but not editable during per-harness commands, and only its own all-harness update shows progress.
 - Detail reports only known version and idle/busy activity, never a fabricated session count.
   Missing runtime has setup/install content rather than operational actions. Unknown and
   externally managed capabilities remain honest. Individual timeout inheritance, custom

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -232,9 +232,15 @@ idle suspension, the management snapshot, and lifecycle commands.
 - Harness names open details, switches send actual enable/disable intent, and the separate
   download target immediately starts an advertised install. Switches retain the bridge's
   known enabled preference while blocked by setup or another operation; unknown runtime
-  has no inferred switch. Other overview rows always show their status, including Idle;
-  disabled overview rows have no subtitle. Global timeout is last; its value remains visible
-  but not editable during per-harness commands, and only its own all-harness update shows progress.
+  has no inferred switch. A pending toggle replaces only that harness's switch with an
+  in-place indicator in the same 64×44 slot; the list stays visible and other mutations
+  remain temporarily gated. Independent per-harness toggles are follow-up #1358.
+- Running means reported busy session work, not merely an active runtime. Idle or stopped
+  overview entries have no subtitle section, even when the process is alive; disabled
+  entries also omit it. Installation/setup problems remain visible on eligible entries,
+  and unknown activity is not labelled Running. Global timeout is last; its value remains
+  visible but not editable during per-harness commands, and only its own all-harness update
+  shows progress.
 - Detail reports only known version and idle/busy activity, never a fabricated session count.
   Missing runtime has setup/install content rather than operational actions. Unknown and
   externally managed capabilities remain honest. Individual timeout inheritance, custom


### PR DESCRIPTION
## Complexity

⚙️ Moderate: shared mobile/desktop navigation, flow-owned state and sheets, retained installation outcomes, and design-system presentation.

## What

- Implement the [Figma harness overview and detail designs](https://www.figma.com/design/NILKXLD9cwuWHhLnGqPqeJ/Sesori?node-id=5296-14830), including installation progress, retained failure/retry and named destructive restart confirmation.
- Group actual harness states, keep enabled preferences truthful, and separate row navigation, switches and immediate-install targets. Running requires reported busy session work; idle/stopped entries have no subtitle even when their process is alive.
- Show pending toggle progress in place of only the affected switch, keeping the same 64×44 slot and the existing one-request-at-a-time safety gate. Keep the list visible.
- Share URL-addressable details and one cubit/sheet owner across both shells. Settings-opened overview/detail show Back only. New Session modal overview shows X only; detail shows Back + X. X dismisses only the harness modal and preserves the existing composer/draft.
- Remove GoRouter match-tree traversal and settings-stack unwinding. Both shells dismiss their owned flow page and reuse typed navigation helpers; the eight added navigation lint suppressions are removed.
- Preserve authentication, safe/force safeguards, scans, timeout editing, connection errors and once-per-install analytics.
- Update regression documentation and the harness capability matrix.

## Why

Replace the dense inline management screen with the annotated design while exposing only functionality the current bridge supports. Unsupported controls are hidden, not simulated.

## Risk and test focus

- User-visible mobile and desktop UI/navigation changes. **No database or wire-contract changes.** No backend/plugin implementation expansion.
- Focus on opener and cubit lifetime, independent touch targets, truthful unknown/disabled states, terminal-event/command-response races, authentication/force-sheet ownership, and 393px layouts at 2× text.
- Installation failure replay is connection-scoped client memory, not persisted or cross-device history.

## Expected result

Users can scan harness status, open dedicated details, install from either supported entry point, follow real progress, retry observed failures, and use existing supported actions without losing their settings/composer context.

## Verification

- Architecture plan and implementation reviews approved, including the revised navigation ownership.
- Latest navigation refinement: **158 focused tests passed** (19 shared UI, 93 mobile harness/New Session, 38 mobile typed-route, 5 desktop settings, 3 desktop New Session); all three owning-module analyzers passed.
- Earlier core service/cubit/route and downstream coverage remains passing: 98 initial cases, 92 service/cubit follow-up cases, 6 exhaustive route-source cases, and 11 Prego grouped-row cases. The timeout-spinner and duplicate-install-publication assertions failed before their fixes and pass afterward.
- Latest iOS simulator build passed. On the existing signed-in iPhone 17 Pro, verified the exact four-cell Back/X header matrix, pushed Back to the same Settings screen, modal detail Back to overview, and X from both modal pages preserving the actual unsent New Session draft. The QA-only draft was discarded without sending. No harness mutation was performed during this navigation check; appearance stayed light.
- Earlier light/dark design QA, timeout cancellation and owner-authorized DeepSeek 0.1.3 installation/disable/regroup/enable checks remain recorded. Real download progress was observed and the enabled preference restored. No active session was interrupted or force command issued.
- Failed-install and force-confirmation states are covered deterministically; failures were not induced on the user's bridge. Native Android/macOS navigation smoke was not run for this refinement.

## Remaining functionality and live follow-up

- Independent per-harness toggles are explicitly deferred to [#1358](https://github.com/sesori-ai/sesori_apps_monorepo/issues/1358). The current UI localizes loading feedback while keeping the existing single-mutation gate.
- Current management contracts cannot expose an automatic-update preference; install pause/cancel/stop/restart-in-flight; a distinct stopped-install or update-required outcome; an exact active-session count or overall-install percentage; or the enabled preference when runtime is unknown. These controls/data remain hidden or honest. Existing bridge-start managed upgrades are unchanged.
- Earlier live restart and enable exercised the existing “connection changed before the result could be confirmed” warning while refreshed metadata showed an active, idle runtime. The mutation freshness/fencing path is unchanged; its precise live cause was not diagnosed in this UI task. Clean live restart/enable acknowledgment is **not** claimed and remains a separate business-logic follow-up.
