### PR TITLE
⚙️ Match thread activity animations to Figma

### DIFF
--- a/client/app/test/playbook/thread_state_motion_playbook.dart
+++ b/client/app/test/playbook/thread_state_motion_playbook.dart
@@ -1,0 +1,219 @@
+import "dart:ui";
+
+import "package:material_ui/material_ui.dart";
+import "package:sesori_app_ui/sesori_app_ui.dart";
+import "package:sesori_dart_core/testing.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
+import "package:theme_prego/module_prego.dart";
+
+/// Direct simulator entrypoint using the production indicator and thread row.
+void main() => runApp(const ThreadStateMotionPlaybook());
+
+class const ThreadStateMotionPlaybook({super.key}) extends StatefulWidget {
+  @override
+  State<ThreadStateMotionPlaybook> createState() => _ThreadStateMotionPlaybookState();
+}
+
+class _ThreadStateMotionPlaybookState() extends State<ThreadStateMotionPlaybook> {
+  bool _dark = true;
+  bool _reducedMotion = false;
+  bool _working = true;
+  bool _showThreads = true;
+
+  @override
+  Widget build(BuildContext context) => MaterialApp(
+    debugShowCheckedModeBanner: false,
+    theme: buildPregoThemeData(brightness: Brightness.light),
+    darkTheme: buildPregoThemeData(brightness: Brightness.dark),
+    themeMode: _dark ? ThemeMode.dark : ThemeMode.light,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    builder: (context, child) => MediaQuery(
+      data: MediaQuery.of(context).copyWith(disableAnimations: _reducedMotion),
+      child: child!,
+    ),
+    home: Builder(builder: _buildScene),
+  );
+
+  Widget _buildScene(BuildContext context) {
+    final prego = context.prego;
+    return Scaffold(
+      extendBodyBehindAppBar: true,
+      appBar: AppBar(
+        title: Text("Thread activity", style: prego.textTheme.textLg.medium),
+        backgroundColor: prego.colors.bgSurface1.withValues(alpha: 0.8),
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        flexibleSpace: ClipRect(
+          child: BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
+            child: const SizedBox.expand(),
+          ),
+        ),
+      ),
+      body: ListView(
+        key: const ValueKey("thread-motion-scroll"),
+        padding: EdgeInsets.fromLTRB(16, MediaQuery.paddingOf(context).top + kToolbarHeight + 12, 16, 40),
+        children: [
+          _setting(
+            context: context,
+            label: "Dark appearance",
+            value: _dark,
+            onChanged: (value) => setState(() => _dark = value),
+          ),
+          _setting(
+            context: context,
+            label: "Reduce motion",
+            value: _reducedMotion,
+            onChanged: (value) => setState(() => _reducedMotion = value),
+          ),
+          const SizedBox(height: 20),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: 12,
+            children: [
+              Expanded(
+                child: _sample(context: context, title: "Idle", detail: "Unopened updates", working: false),
+              ),
+              Expanded(
+                child: _sample(context: context, title: "Loading", detail: "Thinking / working", working: true),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Text("Loading → idle", style: prego.textTheme.textMd.medium),
+          const SizedBox(height: 4),
+          Text("Finish a turn, then start again at any point.", style: prego.textTheme.textSm.regular),
+          const SizedBox(height: 20),
+          Center(
+            child: PregoAiLoader(
+              key: const ValueKey("replay-detail"),
+              size: 80,
+              animate: _working,
+            ),
+          ),
+          const SizedBox(height: 12),
+          _thread(id: "replay-thread", title: "Polish the thread experience", working: _working),
+          const SizedBox(height: 16),
+          Row(
+            spacing: 12,
+            children: [
+              Expanded(
+                child: PregoButtonsSolid(
+                  label: "Start working",
+                  size: .md,
+                  hierarchy: .secondary,
+                  onPressed: () => setState(() => _working = true),
+                ),
+              ),
+              Expanded(
+                child: PregoButtonsSolid(
+                  label: "Finish",
+                  size: .md,
+                  hierarchy: .primary,
+                  onPressed: () => setState(() => _working = false),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          _setting(
+            context: context,
+            label: "Show thread list",
+            value: _showThreads,
+            onChanged: (value) => setState(() => _showThreads = value),
+          ),
+          Text(
+            "Scroll the threads beneath the glass header.",
+            style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textTertiary),
+          ),
+          const SizedBox(height: 12),
+          if (_showThreads)
+            for (var index = 0; index < 18; index++)
+              _thread(
+                id: "list-thread-$index",
+                title: switch (index % 3) {
+                  0 => "Review the latest changes",
+                  1 => "Explore the next idea",
+                  _ => "Refine the details",
+                },
+                working: index.isEven,
+              ),
+        ],
+      ),
+    );
+  }
+
+  Widget _sample({
+    required BuildContext context,
+    required String title,
+    required String detail,
+    required bool working,
+  }) {
+    final prego = context.prego;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: prego.colors.bgSurface2,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              spacing: 8,
+              children: [
+                PregoAiLoader(size: 20, animate: working),
+                Text(title, style: prego.textTheme.textSm.medium),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(detail, style: prego.textTheme.textXs.regular.copyWith(color: prego.colors.textTertiary)),
+            const SizedBox(height: 20),
+            Center(child: PregoAiLoader(size: 80, animate: working)),
+            const SizedBox(height: 12),
+            Center(
+              child: Text(
+                "20 px · 4× detail",
+                style: prego.textTheme.textXs.regular.copyWith(color: prego.colors.textTertiary),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _setting({
+    required BuildContext context,
+    required String label,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+  }) => Padding(
+    padding: const EdgeInsets.symmetric(vertical: 8),
+    child: Row(
+      children: [
+        Expanded(child: Text(label, style: context.prego.textTheme.textSm.medium)),
+        Semantics(
+          label: label,
+          child: PregoSwitch(value: value, onChanged: onChanged),
+        ),
+      ],
+    ),
+  );
+
+  Widget _thread({required String id, required String title, required bool working}) => SessionTile(
+    key: ValueKey(id),
+    session: testSession(id: id, title: title, branchName: "main", pluginId: "codex"),
+    isArchived: false,
+    isActive: working,
+    unseen: true,
+    onTap: null,
+    menuEntries: () => const [],
+    onArchive: () {},
+    onDelete: () {},
+    onToggleUnread: () {},
+  );
+}

--- a/client/app/test/playbook/thread_state_motion_playbook_test.dart
+++ b/client/app/test/playbook/thread_state_motion_playbook_test.dart
@@ -1,0 +1,31 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:sesori_app_ui/sesori_app_ui.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "thread_state_motion_playbook.dart";
+
+void main() {
+  testWidgets("replays completion on the same row and can interrupt it", (tester) async {
+    await tester.binding.setSurfaceSize(const Size(430, 1200));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(const ThreadStateMotionPlaybook());
+
+    final detail = find.byKey(const ValueKey("replay-detail"));
+    final row = find.byKey(const ValueKey("replay-thread"));
+    final initialState = tester.state(detail);
+
+    await tester.tap(find.text("Finish"));
+    await tester.pump(const Duration(milliseconds: 150));
+    expect(tester.widget<SessionTile>(row).isActive, isFalse);
+    expect(tester.widget<PregoAiLoader>(detail).animate, isFalse);
+    expect(tester.state(detail), same(initialState));
+
+    await tester.tap(find.text("Start working"));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(tester.widget<SessionTile>(row).isActive, isTrue);
+    expect(tester.widget<PregoAiLoader>(detail).animate, isTrue);
+    expect(tester.state(detail), same(initialState));
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/client/module_app_ui/lib/src/features/session_list/session_tile.dart
+++ b/client/module_app_ui/lib/src/features/session_list/session_tile.dart
@@ -24,7 +24,7 @@ typedef SessionOpenedCallback = void Function({required Session session});
 /// The title line's two ends answer different questions. The leading slot says
 /// which backend owns the session, so a list mixing harnesses stays readable
 /// at a glance. The trailing slot carries the liveness the old status line
-/// spelled out: the sparkle twinkles while an agent works and rests solid —
+/// spelled out: the sparkle rotates while an agent works and rests solid —
 /// the same "new activity" mark the project list uses — when the session has
 /// activity the user hasn't opened, and gives way to when the session last
 /// changed once there is neither. Only states that need words keep them, as
@@ -303,7 +303,7 @@ class const SessionTile({
     );
   }
 
-  /// The session's state, told by the sparkle: twinkling while an agent works,
+  /// The session's state, told by the sparkle: rotating while an agent works,
   /// resting solid when there is activity the user hasn't opened, absent for a
   /// quiet session. A live turn is the more informative of the two, so it wins;
   /// unseen still shows through the title's weight.
@@ -359,7 +359,7 @@ class const SessionTile({
 
   /// The states that still need words after the sparkle has said "working":
   /// input wanted, a retry loop, tasks running behind the turn. A plain
-  /// running session carries no label — the twinkle is the signal.
+  /// running session carries no label — the rotation is the signal.
   Widget? _statusLabel({required BuildContext context}) {
     final loc = context.loc;
     final prego = context.prego;
@@ -422,4 +422,4 @@ const double _titleLineHeight = 24;
 const double _footerLineHeight = 20;
 
 const double _brandLogoSize = 12;
-const double _stateIconSize = 16;
+const double _stateIconSize = 20;

--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -16,7 +16,15 @@ public final class ThemePregoPlugin: NSObject, FlutterPlugin {
       withId: NativeActivityIndicatorPlatformViewFactory.viewType
     )
     registrar.register(
-      NativeAiLoaderPlatformViewFactory(),
+      NativeAiLoaderPlatformViewFactory(
+        messenger: {
+          #if os(iOS)
+            registrar.messenger()
+          #else
+            registrar.messenger
+          #endif
+        }()
+      ),
       withId: NativeAiLoaderPlatformViewFactory.viewType
     )
   }
@@ -62,95 +70,106 @@ private struct ActivityIndicatorCreationParams {
   }
 }
 
-/// The three keyframe colours and phase offset the Dart sparkle sends when
-/// it creates a native twinkle view.
+/// Theme colours, initial state, and phase supplied by the Flutter decoration.
 private struct AiLoaderCreationParams {
   let solid: CGColor
   let outline: CGColor
-  let faded: CGColor
   let phase: Double
+  let loading: Bool
 
   init?(from args: Any?) {
     guard
       let dictionary = args as? [String: Any],
       let solid = dictionary["solid"] as? NSNumber,
       let outline = dictionary["outline"] as? NSNumber,
-      let faded = dictionary["faded"] as? NSNumber,
-      let phase = dictionary["phase"] as? NSNumber
+      let phase = dictionary["phase"] as? NSNumber,
+      let loading = dictionary["loading"] as? Bool
     else { return nil }
     self.solid = ColorComponents(fromARGB: solid.int64Value).cgColor
     self.outline = ColorComponents(fromARGB: outline.int64Value).cgColor
-    self.faded = ColorComponents(fromARGB: faded.int64Value).cgColor
     self.phase = phase.doubleValue
+    self.loading = loading
   }
 }
 
-/// The AI sparkle's geometry and twinkle, mirroring `PregoAiLoader`'s
-/// painter.
-///
-/// The keyframes — solid brand, hollow outline at 0.4, faded solid at 0.7,
-/// back to solid — and the 1.4s period must stay in step with the Dart
-/// fallback painter. The path is the painter's Tabler `sparkle-2` outline
-/// with its arcs pre-converted to cubic Béziers (CGPath has no SVG-style
-/// endpoint-parameterised arc).
+/// Mirrors the Flutter painter: a 14px Tabler sparkle inside Figma's 20px
+/// frame. Core Animation owns every animation frame on Apple platforms.
 private enum AiLoaderSparkle {
-  static let viewBox: CGFloat = 24
-  static let period: CFTimeInterval = 1.4
+  static let viewBox: CGFloat = 20
+  static let period: CFTimeInterval = 2
+  static let completionDuration: CFTimeInterval = 0.7
+  static let clear = ColorComponents(fromARGB: 0x00b2d1ff).cgColor
+  static let completionHighlight = ColorComponents(fromARGB: 0xffb2d1ff).cgColor
+  static let colourTiming = CAMediaTimingFunction(controlPoints: 0.5, 0, 0.5, 1)
 
   static func makeShapeLayer(params: AiLoaderCreationParams) -> CAShapeLayer {
     let layer = CAShapeLayer()
     layer.bounds = CGRect(x: 0, y: 0, width: viewBox, height: viewBox)
     layer.path = path()
-    layer.lineWidth = 2
+    layer.lineWidth = 7.0 / 6.0
     layer.lineJoin = .round
     layer.lineCap = .round
-    // The base (non-animated) values are the resting solid keyframe: the
-    // same frame the Dart painter shows when the loop is off. The running
-    // twinkle overrides them in the presentation layer only.
-    layer.fillColor = params.solid
-    layer.strokeColor = params.solid
+    layer.fillColor = params.loading ? clear : params.solid
+    layer.strokeColor = params.loading ? params.outline : params.solid
+    if params.loading {
+      layer.setValue(params.phase * .pi * 2, forKeyPath: "transform.rotation.z")
+    }
     return layer
   }
 
-  /// The infinitely repeating twinkle, animated entirely by the render
-  /// server: once added, the app process schedules no frames for it.
-  static func twinkle(params: AiLoaderCreationParams) -> CAAnimationGroup {
-    let keyTimes: [NSNumber] = [0, 0.4, 0.7, 1]
+  /// Capture the displayed angle and colours before replacing animations, so
+  /// finishing and a rapid restart never jump to a different visual frame.
+  static func animate(layer: CAShapeLayer, params: AiLoaderCreationParams, loading: Bool) {
+    let displayed = layer.presentation() ?? layer
+    let angle = (displayed.value(forKeyPath: "transform.rotation.z") as? NSNumber)?.doubleValue ?? 0
+    let fill = displayed.fillColor ?? clear
+    let stroke = displayed.strokeColor ?? params.outline
+    let quarterTurn = Double.pi / 2
+    let target = loading ? angle : ceil((angle + 0.593) / quarterTurn) * quarterTurn
 
-    let fill = CAKeyframeAnimation(keyPath: "fillColor")
-    // The fill hollows out towards the outline keyframe and refills towards
-    // the faded one; encoding the opacity into the colour's alpha lets one
-    // linear colour interpolation carry both.
-    fill.values = [
-      params.solid,
-      params.outline.copy(alpha: 0) ?? params.outline,
-      params.faded,
-      params.solid,
-    ]
-    fill.keyTimes = keyTimes
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    layer.removeAllAnimations()
+    layer.setValue(target, forKeyPath: "transform.rotation.z")
+    layer.fillColor = loading ? clear : params.solid
+    layer.strokeColor = loading ? params.outline : params.solid
 
-    let stroke = CAKeyframeAnimation(keyPath: "strokeColor")
-    stroke.values = [params.solid, params.outline, params.faded, params.solid]
-    stroke.keyTimes = keyTimes
-
-    let scale = CAKeyframeAnimation(keyPath: "transform.scale")
-    scale.values = [1, 0.86, 0.92, 1]
-    scale.keyTimes = keyTimes
-
-    let group = CAAnimationGroup()
-    group.animations = [fill, stroke, scale]
-    // A group's duration does NOT propagate to its children; an unset child
-    // duration falls back to the 0.25s CATransaction default, which would end
-    // each keyframe pass almost immediately and leave the sparkle solid for
-    // the rest of every repeat.
-    for animation in group.animations ?? [] {
-      animation.duration = period
+    let rotation = CABasicAnimation(keyPath: "transform.rotation.z")
+    rotation.fromValue = angle
+    rotation.toValue = loading ? angle + .pi * 2 : target
+    rotation.duration = loading ? period : completionDuration
+    rotation.timingFunction = loading
+      ? CAMediaTimingFunction(name: .linear)
+      : CAMediaTimingFunction(controlPoints: 0.45, 1.45, 0.833, 1.368)
+    if loading {
+      rotation.repeatCount = .infinity
     }
-    group.duration = period
-    group.repeatCount = .infinity
-    // Staggers list rows apart, matching the Dart painter's phase offset.
-    group.timeOffset = params.phase * period
-    return group
+    layer.add(rotation, forKey: loading ? "loading" : "completion")
+
+    let fillAnimation = CAKeyframeAnimation(keyPath: "fillColor")
+    fillAnimation.values = loading ? [fill, clear] : [fill, completionHighlight, params.solid]
+    fillAnimation.keyTimes = loading ? [0, 1] : [0, 0.5, 1]
+    fillAnimation.timingFunctions = loading ? [colourTiming] : [colourTiming, colourTiming]
+    fillAnimation.duration = loading ? 0.15 : completionDuration
+    layer.add(fillAnimation, forKey: "fill")
+
+    let strokeAnimation = CABasicAnimation(keyPath: "strokeColor")
+    strokeAnimation.fromValue = stroke
+    strokeAnimation.toValue = loading ? params.outline : params.solid
+    strokeAnimation.duration = loading ? 0.15 : completionDuration
+    strokeAnimation.timingFunction = colourTiming
+    layer.add(strokeAnimation, forKey: "stroke")
+    CATransaction.commit()
+  }
+
+  static func showStatic(layer: CAShapeLayer, params: AiLoaderCreationParams, loading: Bool) {
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    layer.removeAllAnimations()
+    layer.transform = CATransform3DIdentity
+    layer.fillColor = loading ? clear : params.solid
+    layer.strokeColor = loading ? params.outline : params.solid
+    CATransaction.commit()
   }
 
   private static func path() -> CGPath {
@@ -201,7 +220,8 @@ private enum AiLoaderSparkle {
       to: CGPoint(x: 12, y: 3),
       control1: CGPoint(x: 11.289, y: 3.232), control2: CGPoint(x: 11.625, y: 3.001))
     path.closeSubpath()
-    return path
+    var transform = CGAffineTransform(a: 7.0 / 12.0, b: 0, c: 0, d: 7.0 / 12.0, tx: 3, ty: 3.4)
+    return path.copy(using: &transform)!
   }
 }
 
@@ -308,6 +328,12 @@ private enum AiLoaderSparkle {
 
   private final class NativeAiLoaderPlatformViewFactory: NSObject, FlutterPlatformViewFactory {
     static let viewType = "sesori/native-ai-loader"
+    private let messenger: FlutterBinaryMessenger
+
+    init(messenger: FlutterBinaryMessenger) {
+      self.messenger = messenger
+      super.init()
+    }
 
     func createArgsCodec() -> FlutterMessageCodec & NSObjectProtocol {
       FlutterStandardMessageCodec.sharedInstance()
@@ -321,7 +347,7 @@ private enum AiLoaderSparkle {
       guard let params = AiLoaderCreationParams(from: args) else {
         preconditionFailure("Invalid native AI loader creation arguments")
       }
-      return NativeAiLoaderPlatformView(frame: frame, params: params)
+      return NativeAiLoaderPlatformView(frame: frame, params: params, messenger: messenger, viewId: viewId)
     }
   }
 
@@ -329,9 +355,13 @@ private enum AiLoaderSparkle {
     private let params: AiLoaderCreationParams
     private let fitLayer = CALayer()
     private let sparkleLayer: CAShapeLayer
+    private let channel: FlutterMethodChannel
+    private var loading: Bool
 
-    init(frame: CGRect, params: AiLoaderCreationParams) {
+    init(frame: CGRect, params: AiLoaderCreationParams, messenger: FlutterBinaryMessenger, viewId: Int64) {
       self.params = params
+      loading = params.loading
+      channel = FlutterMethodChannel(name: "sesori/native-ai-loader/\(viewId)", binaryMessenger: messenger)
       sparkleLayer = AiLoaderSparkle.makeShapeLayer(params: params)
       super.init(frame: frame)
 
@@ -341,27 +371,51 @@ private enum AiLoaderSparkle {
       accessibilityElementsHidden = true
       fitLayer.bounds = CGRect(
         x: 0, y: 0, width: AiLoaderSparkle.viewBox, height: AiLoaderSparkle.viewBox)
-      sparkleLayer.position = CGPoint(
-        x: AiLoaderSparkle.viewBox / 2, y: AiLoaderSparkle.viewBox / 2)
+      // Keep Figma's baseline offset outside rotation so every quarter-turn
+      // rests on the same footprint as an initially idle sparkle.
+      sparkleLayer.anchorPoint = CGPoint(x: 0.5, y: 0.52)
+      sparkleLayer.position = CGPoint(x: 10, y: 10.4)
       fitLayer.addSublayer(sparkleLayer)
       layer.addSublayer(fitLayer)
+
+      channel.setMethodCallHandler { [weak self] call, result in
+        guard call.method == "setLoading" else {
+          result(FlutterMethodNotImplemented)
+          return
+        }
+        guard let loading = call.arguments as? Bool else {
+          result(FlutterError(
+            code: "invalid_arguments",
+            message: "Expected a Boolean loading argument for native AI loader view \(viewId)",
+            details: call.arguments
+          ))
+          return
+        }
+        self?.setLoading(loading: loading)
+        result(nil)
+      }
 
       let notificationCenter = NotificationCenter.default
       notificationCenter.addObserver(
         self,
-        selector: #selector(twinkleConditionsDidChange),
+        selector: #selector(animationConditionsDidChange),
         name: UIAccessibility.reduceMotionStatusDidChangeNotification,
         object: nil
       )
-      // UIKit strips CAAnimations when the app backgrounds; the repeating
-      // twinkle has to be re-added on return.
+      // UIKit strips animations on backgrounding. Resume only loading when
+      // the app returns; idle must never replay its completion transition.
       notificationCenter.addObserver(
         self,
-        selector: #selector(twinkleConditionsDidChange),
+        selector: #selector(animationConditionsDidChange),
         name: UIApplication.didBecomeActiveNotification,
         object: nil
       )
-      updateAnimationState()
+      notificationCenter.addObserver(
+        self,
+        selector: #selector(animationConditionsDidChange),
+        name: UIApplication.didEnterBackgroundNotification,
+        object: nil
+      )
     }
 
     required init?(coder: NSCoder) {
@@ -369,6 +423,7 @@ private enum AiLoaderSparkle {
     }
 
     deinit {
+      channel.setMethodCallHandler(nil)
       NotificationCenter.default.removeObserver(self)
     }
 
@@ -396,19 +451,30 @@ private enum AiLoaderSparkle {
       updateAnimationState()
     }
 
-    @objc private func twinkleConditionsDidChange() {
+    @objc private func animationConditionsDidChange() {
       updateAnimationState()
     }
 
-    private func updateAnimationState() {
-      if window != nil && !UIAccessibility.isReduceMotionEnabled {
-        if sparkleLayer.animation(forKey: "twinkle") == nil {
-          sparkleLayer.add(AiLoaderSparkle.twinkle(params: params), forKey: "twinkle")
-        }
+    private var canAnimate: Bool {
+      window != nil && UIApplication.shared.applicationState == .active
+        && !UIAccessibility.isReduceMotionEnabled
+    }
+
+    private func setLoading(loading: Bool) {
+      guard self.loading != loading else { return }
+      self.loading = loading
+      if canAnimate {
+        AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: loading)
       } else {
-        // The base layer values are the resting solid keyframe, so removing
-        // the animation is itself the static reduced-motion frame.
-        sparkleLayer.removeAnimation(forKey: "twinkle")
+        AiLoaderSparkle.showStatic(layer: sparkleLayer, params: params, loading: loading)
+      }
+    }
+
+    private func updateAnimationState() {
+      if !canAnimate {
+        AiLoaderSparkle.showStatic(layer: sparkleLayer, params: params, loading: loading)
+      } else if loading && sparkleLayer.animation(forKey: "loading") == nil {
+        AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: true)
       }
     }
   }
@@ -531,6 +597,12 @@ private enum AiLoaderSparkle {
 
   private final class NativeAiLoaderPlatformViewFactory: NSObject, FlutterPlatformViewFactory {
     static let viewType = "sesori/native-ai-loader"
+    private let messenger: FlutterBinaryMessenger
+
+    init(messenger: FlutterBinaryMessenger) {
+      self.messenger = messenger
+      super.init()
+    }
 
     func createArgsCodec() -> (FlutterMessageCodec & NSObjectProtocol)? {
       FlutterStandardMessageCodec.sharedInstance()
@@ -540,7 +612,7 @@ private enum AiLoaderSparkle {
       guard let params = AiLoaderCreationParams(from: args) else {
         preconditionFailure("Invalid native AI loader creation arguments")
       }
-      return NativeAiLoaderView(params: params)
+      return NativeAiLoaderView(params: params, messenger: messenger, viewId: viewId)
     }
   }
 
@@ -548,9 +620,15 @@ private enum AiLoaderSparkle {
     private let params: AiLoaderCreationParams
     private let fitLayer = CALayer()
     private let sparkleLayer: CAShapeLayer
+    private let channel: FlutterMethodChannel
+    private var loading: Bool
 
-    init(params: AiLoaderCreationParams) {
+    override var isFlipped: Bool { true }
+
+    init(params: AiLoaderCreationParams, messenger: FlutterBinaryMessenger, viewId: Int64) {
       self.params = params
+      loading = params.loading
+      channel = FlutterMethodChannel(name: "sesori/native-ai-loader/\(viewId)", binaryMessenger: messenger)
       sparkleLayer = AiLoaderSparkle.makeShapeLayer(params: params)
       super.init(frame: .zero)
 
@@ -560,10 +638,29 @@ private enum AiLoaderSparkle {
       wantsLayer = true
       fitLayer.bounds = CGRect(
         x: 0, y: 0, width: AiLoaderSparkle.viewBox, height: AiLoaderSparkle.viewBox)
-      sparkleLayer.position = CGPoint(
-        x: AiLoaderSparkle.viewBox / 2, y: AiLoaderSparkle.viewBox / 2)
+      // Keep Figma's baseline offset outside rotation so every quarter-turn
+      // rests on the same footprint as an initially idle sparkle.
+      sparkleLayer.anchorPoint = CGPoint(x: 0.5, y: 0.52)
+      sparkleLayer.position = CGPoint(x: 10, y: 10.4)
       fitLayer.addSublayer(sparkleLayer)
       layer?.addSublayer(fitLayer)
+
+      channel.setMethodCallHandler { [weak self] call, result in
+        guard call.method == "setLoading" else {
+          result(FlutterMethodNotImplemented)
+          return
+        }
+        guard let loading = call.arguments as? Bool else {
+          result(FlutterError(
+            code: "invalid_arguments",
+            message: "Expected a Boolean loading argument for native AI loader view \(viewId)",
+            details: call.arguments
+          ))
+          return
+        }
+        self?.setLoading(loading: loading)
+        result(nil)
+      }
 
       NSWorkspace.shared.notificationCenter.addObserver(
         self,
@@ -571,7 +668,6 @@ private enum AiLoaderSparkle {
         name: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
         object: nil
       )
-      updateAnimationState()
     }
 
     required init?(coder: NSCoder) {
@@ -579,6 +675,7 @@ private enum AiLoaderSparkle {
     }
 
     deinit {
+      channel.setMethodCallHandler(nil)
       NSWorkspace.shared.notificationCenter.removeObserver(
         self,
         name: NSWorkspace.accessibilityDisplayOptionsDidChangeNotification,
@@ -610,15 +707,25 @@ private enum AiLoaderSparkle {
       updateAnimationState()
     }
 
-    private func updateAnimationState() {
-      if window != nil && !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
-        if sparkleLayer.animation(forKey: "twinkle") == nil {
-          sparkleLayer.add(AiLoaderSparkle.twinkle(params: params), forKey: "twinkle")
-        }
+    private var canAnimate: Bool {
+      window != nil && !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
+
+    private func setLoading(loading: Bool) {
+      guard self.loading != loading else { return }
+      self.loading = loading
+      if canAnimate {
+        AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: loading)
       } else {
-        // The base layer values are the resting solid keyframe, so removing
-        // the animation is itself the static reduced-motion frame.
-        sparkleLayer.removeAnimation(forKey: "twinkle")
+        AiLoaderSparkle.showStatic(layer: sparkleLayer, params: params, loading: loading)
+      }
+    }
+
+    private func updateAnimationState() {
+      if !canAnimate {
+        AiLoaderSparkle.showStatic(layer: sparkleLayer, params: params, loading: loading)
+      } else if loading && sparkleLayer.animation(forKey: "loading") == nil {
+        AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: true)
       }
     }
   }

--- a/client/module_prego/lib/components/loaders/prego_ai_loader.dart
+++ b/client/module_prego/lib/components/loaders/prego_ai_loader.dart
@@ -1,5 +1,8 @@
-/// The AI activity indicator: a sparkle that twinkles while an agent works.
+/// The thread activity sparkle: rotating outline → settled unread fill.
 library;
+
+import "dart:async";
+import "dart:math" as math;
 
 import "package:flutter/foundation.dart";
 import "package:flutter/rendering.dart";
@@ -12,69 +15,36 @@ import "../../utils/lerp_utils.dart";
 
 /// How the sparkle's interior is painted.
 enum PregoAiLoaderFillMode() {
-  /// Follow the designed solid → outline → faded-solid twinkle keyframes.
+  /// Hollow while working; fills once when work finishes.
   keyframed,
 
-  /// Keep the exact Tabler `sparkle-2` path hollow at every frame.
+  /// A hollow mark, including when a parent owns its animation.
   outline,
 }
 
-/// A sparkle marking AI activity, twinkling while [animate] is set.
+/// Figma's `Icon AI Loader` (2506:20093): a 14px glyph in a 20px slot.
 ///
-/// The loop runs through three designed keyframes — solid brand, hollow
-/// outline, faded solid — shrinking slightly as it hollows out, so it reads as
-/// a pulse rather than a spinner. With [animate] false it rests on the first of
-/// them, a solid brand sparkle: the same still frame the platform's
-/// reduced-motion preference forces, so a caller can use it as a static "has
-/// activity" mark without a second widget.
+/// [animate] means the agent is working: a hollow sparkle turns once every
+/// two seconds. Changing it to false eases the current rotation into place
+/// and fills the sparkle blue, once. Mounting an already-unread row renders
+/// the solid mark immediately. A new turn interrupts the settle in place.
 ///
-/// On iOS and macOS the twinkle is a native platform view animated by the
-/// render server, so a screen of working sessions schedules no Flutter frames.
-/// Android deliberately keeps the Flutter painter: hybrid-composition platform
-/// views in scrolling list rows wreck Android scroll performance (measured
-/// on-device, 2026-08-31) even though they improve idle battery. Every static
-/// state uses the painter too.
-///
-/// The sparkle is decorative — it always accompanies a label that carries the
-/// meaning, so it is excluded from semantics.
+/// Apple platforms keep the loop and settle in Core Animation; other platforms
+/// repaint only this isolated primitive. Reduced motion preserves the hollow
+/// working / solid unread distinction without rotation. The containing row
+/// supplies the status semantics; this mark is decorative.
 class const PregoAiLoader({
   super.key,
-
-  /// Side of the square the sparkle is painted into. Defaults to the 16px the
-  /// design uses inline with a text-sm label.
-  final double size = 16,
-
-  /// Whether the sparkle twinkles. When false it rests on the solid keyframe.
+  final double size = 20,
   final bool animate = true,
-
-  /// Whether the sparkle follows its fill keyframes or stays outlined.
-  ///
-  /// The outline mode is useful when a parent owns the motion, such as a
-  /// spinner that rotates the Figma icon without changing its drawing style.
   final PregoAiLoaderFillMode fillMode = .keyframed,
 
-  /// Overrides the sparkle colour for every keyframe.
-  ///
-  /// The default follows the designed brand/outline/disabled colour sequence.
-  /// Components that choreograph the sparkle themselves can instead pass one
-  /// semantic colour and set [animate] to false, then transform the static
-  /// mark from their own shared timeline.
+  /// Overrides both states, for a caller-owned timeline such as Deep Scan.
   final Color? color,
 
-  /// Fraction of the loop [0, 1) this sparkle starts at.
-  ///
-  /// Several sparkles built in the same frame would otherwise twinkle in
-  /// lockstep — a list of running projects reads as one flickering block
-  /// rather than several independently working agents. Callers pass a value
-  /// derived from something stable about the row, so a given row's phase
-  /// survives a rebuild. Ignored while the sparkle is at rest, which always
-  /// shows the solid keyframe.
+  /// Initial fraction of a rotation, stable per row across rebuilds.
   final double phase = 0,
 }) extends StatefulWidget {
-  /// A [phase] derived from [seed], for staggering a list of sparkles.
-  ///
-  /// Rows pass something stable about themselves (their id), so each row keeps
-  /// its offset across rebuilds while different rows twinkle out of step.
   static double phaseFor(String seed) => (seed.hashCode % 100) / 100;
 
   @override
@@ -83,174 +53,193 @@ class const PregoAiLoader({
 
 class _PregoAiLoaderState()
     extends State<PregoAiLoader>
-    with SingleTickerProviderStateMixin, WidgetsBindingObserver, PregoReducedMotionStateMixin {
+    with TickerProviderStateMixin, WidgetsBindingObserver, PregoReducedMotionStateMixin {
   static const _nativeViewType = "sesori/native-ai-loader";
+  static const _period = Duration(seconds: 2);
 
-  /// One full twinkle. Slow enough to read as breathing rather than blinking.
-  /// The native renderer hardcodes the same period.
-  static const Duration _period = Duration(milliseconds: 1400);
+  // The Figma example contains several seconds of loading and a long idle
+  // hold. Only the finish is a UI transition: preserve its fill and rotational
+  // overshoot in 700ms, without delaying the actual thread state or input.
+  // Keep these values in step with AiLoaderSparkle in the Darwin renderer.
+  static const _settleDuration = Duration(milliseconds: 700);
+  static const _resumeDuration = Duration(milliseconds: 150);
+  static const _settleCurve = Cubic(0.45, 1.45, 0.833, 1.368);
 
-  /// Whether this platform has a native twinkle renderer registered by the
-  /// theme_prego plugin. iOS and macOS: on Android the sparkle sits in
-  /// scrolling list rows, where per-row platform views cost far more in scroll
-  /// jank than they save in idle battery.
-  static bool get _nativeTwinkleSupported {
-    if (kIsWeb) return false;
-    return switch (defaultTargetPlatform) {
-      TargetPlatform.iOS || TargetPlatform.macOS => true,
-      TargetPlatform.android || TargetPlatform.fuchsia || TargetPlatform.linux || TargetPlatform.windows => false,
-    };
-  }
+  late final _rotation = AnimationController.unbounded(
+    vsync: this,
+    value: widget.animate ? widget.phase * 2 * math.pi : 0,
+  );
+  late final _fill = AnimationController(vsync: this, value: 1);
+  late ({Color fill, Color stroke}) _fillOrigin = (
+    fill: const Color(0x00B2D1FF),
+    stroke: context.prego.colors.textPrimary,
+  );
+  MethodChannel? _nativeChannel;
 
-  bool get _usesNativeTwinkle => _nativeTwinkleSupported && widget.fillMode == .keyframed && widget.color == null;
+  bool get _usesNativeRenderer =>
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.iOS || defaultTargetPlatform == TargetPlatform.macOS) &&
+      widget.fillMode == .keyframed &&
+      widget.color == null;
 
-  /// Constructed unstarted: whether it may run depends on [MediaQuery], which
-  /// cannot be read until `didChangeDependencies`.
-  late final AnimationController _loop = AnimationController(vsync: this, duration: _period);
-
-  /// The Flutter loop only ever animates where no native renderer exists: on
-  /// native platforms every animated frame is the platform view's, and the
-  /// painter is only built for static states — a repeating controller there
-  /// would schedule the very frames the native view exists to avoid.
   @override
-  bool get motionEnabled => widget.animate && !_usesNativeTwinkle;
+  bool get motionEnabled => !_usesNativeRenderer && TickerMode.valuesOf(context).enabled;
 
   @override
   void startMotion() {
-    if (!_loop.isAnimating) _loop.repeat();
+    if (widget.animate) {
+      if (!_rotation.isAnimating) {
+        _rotation.repeat(min: _rotation.value, max: _rotation.value + 2 * math.pi, period: _period);
+      }
+    } else if (_fill.value < 1 && !_rotation.isAnimating) {
+      const quarterTurn = math.pi / 2;
+      final target = ((_rotation.value + 0.593) / quarterTurn).ceil() * quarterTurn;
+      _rotation.animateTo(target, duration: _settleDuration, curve: _settleCurve);
+    }
+    if (_fill.value < 1 && !_fill.isAnimating) {
+      _fill.animateTo(1, duration: widget.animate ? _resumeDuration : _settleDuration);
+    }
   }
 
   @override
   void stopMotion() {
-    if (_loop.isAnimating) _loop.stop();
-    // Rest on the solid keyframe rather than wherever the loop was cut.
-    _loop.value = 0;
+    _rotation.stop();
+    _rotation.value = 0;
+    _fill.stop();
+    _fill.value = 1;
   }
 
   @override
   void didUpdateWidget(PregoAiLoader oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.animate != widget.animate ||
-        oldWidget.fillMode != widget.fillMode ||
-        oldWidget.color != widget.color) {
+    if (oldWidget.animate != widget.animate) {
+      // Capture colours as well as rotation. Reversing the finishing timeline
+      // would flash the pale-blue highlight again when a new turn starts.
+      final colors = context.prego.colors;
+      _fillOrigin = _AiLoaderPainter.colorsAt(
+        progress: _fill.value,
+        loading: oldWidget.animate,
+        origin: _fillOrigin,
+        solid: widget.color ?? colors.textPrimaryOnBrand,
+        outline: widget.color ?? colors.textPrimary,
+        bloom: widget.color ?? const Color(0xFFB2D1FF),
+      );
+      _rotation.stop();
+      _fill.stop();
+      _fill.value = 0;
       syncMotion();
+      if (_usesNativeRenderer && !prefersReducedMotion(context) && TickerMode.valuesOf(context).enabled) {
+        unawaited(_updateNativeLoading());
+      }
+    } else if (oldWidget.fillMode != widget.fillMode || oldWidget.color != widget.color) {
+      stopMotion();
+      syncMotion();
+    }
+  }
+
+  // ignore: no_slop_linter/prefer_required_named_parameters, platform-view callback signature
+  void _nativeViewCreated(int id) {
+    _nativeChannel = MethodChannel("$_nativeViewType/$id");
+    // The row may have finished while the platform was creating its view.
+    unawaited(_updateNativeLoading());
+  }
+
+  Future<void> _updateNativeLoading() async {
+    try {
+      await _nativeChannel?.invokeMethod<void>("setLoading", widget.animate);
+    } on Object catch (error, stackTrace) {
+      FlutterError.reportError(
+        FlutterErrorDetails(
+          exception: error,
+          stack: stackTrace,
+          library: "theme_prego",
+          context: ErrorDescription("updating native AI loader state"),
+        ),
+      );
     }
   }
 
   @override
   void dispose() {
-    _loop.dispose();
+    _rotation.dispose();
+    _fill.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final colors = context.prego.colors;
+    final native = _usesNativeRenderer && !prefersReducedMotion(context) && TickerMode.valuesOf(context).enabled;
     return ExcludeSemantics(
-      // The loop repaints this sparkle every frame; without a boundary of its
-      // own it would repaint whatever layer it was composited into — the whole
-      // list row. CustomPaint adds no boundary itself.
       child: RepaintBoundary(
-        child: _twinkle(context: context, colors: colors),
+        child: native
+            ? _nativeSparkle(colors: colors)
+            : CustomPaint(
+                size: Size.square(widget.size),
+                painter: _AiLoaderPainter(
+                  rotation: _rotation,
+                  fill: _fill,
+                  loading: widget.animate,
+                  origin: _fillOrigin,
+                  fillMode: widget.fillMode,
+                  solid: widget.color ?? colors.textPrimaryOnBrand,
+                  outline: widget.color ?? colors.textPrimary,
+                  bloom: widget.color ?? const Color(0xFFB2D1FF),
+                ),
+              ),
       ),
     );
   }
 
-  Widget _twinkle({required BuildContext context, required PregoColors colors}) {
-    final twinkling = widget.animate && !prefersReducedMotion(context) && TickerMode.valuesOf(context).enabled;
-    if (twinkling && _usesNativeTwinkle) {
-      final nativeView = _nativeTwinkle(colors: colors);
-      if (nativeView != null) {
-        return SizedBox.square(dimension: widget.size, child: nativeView);
-      }
-    }
-
-    return CustomPaint(
-      size: Size.square(widget.size),
-      painter: _AiLoaderPainter(
-        repaint: _loop,
-        // A resting sparkle always shows the solid keyframe, so the phase
-        // offset only applies while the loop runs.
-        phase: motionAllowed ? widget.phase : 0,
-        fillMode: widget.fillMode,
-        solid: widget.color ?? colors.textPrimaryOnBrand,
-        outline: widget.color ?? colors.textPrimary,
-        faded: widget.color ?? colors.textDisabled,
-      ),
-    );
-  }
-
-  Widget? _nativeTwinkle({required PregoColors colors}) {
-    if (!_nativeTwinkleSupported) return null;
-
-    final params = <String, num>{
+  Widget _nativeSparkle({required PregoColors colors}) {
+    final params = <String, Object>{
       "solid": colors.textPrimaryOnBrand.toARGB32(),
       "outline": colors.textPrimary.toARGB32(),
-      "faded": colors.textDisabled.toARGB32(),
       "phase": widget.phase,
+      "loading": widget.animate,
     };
     final nativeView = defaultTargetPlatform == TargetPlatform.iOS
         ? UiKitView(
             viewType: _nativeViewType,
             creationParams: params,
             creationParamsCodec: const StandardMessageCodec(),
+            onPlatformViewCreated: _nativeViewCreated,
             hitTestBehavior: PlatformViewHitTestBehavior.transparent,
           )
         : AppKitView(
             viewType: _nativeViewType,
             creationParams: params,
             creationParamsCodec: const StandardMessageCodec(),
+            onPlatformViewCreated: _nativeViewCreated,
             hitTestBehavior: PlatformViewHitTestBehavior.transparent,
           );
-    // Native views consume creationParams only at creation, so a keyframe
-    // colour change (a theme switch while a sparkle is visible) must recreate
-    // the view. The phase participates for the same reason.
-    return KeyedSubtree(
-      key: ValueKey(Object.hash(params["solid"], params["outline"], params["faded"], widget.phase)),
-      child: nativeView,
+    return SizedBox.square(
+      dimension: widget.size,
+      // State and phase must not replace the renderer at completion. Colours
+      // are creation-time data, so a theme change does create the new palette.
+      child: KeyedSubtree(
+        key: ValueKey(Object.hash(params["solid"], params["outline"])),
+        child: nativeView,
+      ),
     );
   }
 }
 
-/// Paints the sparkle at the keyframe [repaint] currently sits on.
-///
-/// Driven by `repaint:` rather than an [AnimatedBuilder]: the render object
-/// listens to the animation and repaints, without rebuilding an element sixty
-/// times a second. The cost is that [shouldRepaint] is only consulted when the
-/// widget rebuilds, so it must compare everything *except* the animation.
+/// Paint-only animation: neither the row nor this widget rebuilds per frame.
 class _AiLoaderPainter({
-  required Animation<double> repaint,
-  required final double phase,
+  required final Animation<double> rotation,
+  required final Animation<double> fill,
+  required final bool loading,
+  required final ({Color fill, Color stroke}) origin,
   required final PregoAiLoaderFillMode fillMode,
-
-  /// The three designed keyframes: a solid brand sparkle, a hollow outline, and
-  /// a faded solid one.
   required final Color solid,
   required final Color outline,
-  required final Color faded,
+  required final Color bloom,
 }) extends CustomPainter {
-  this : super(repaint: repaint);
+  this : super(repaint: Listenable.merge([rotation, fill]));
 
-  final Animation<double> _progress = repaint;
-
-  /// The sparkle's coordinate space, from the source icon.
-  static const double _viewBox = 24;
-
-  /// Stroke width in [_viewBox] units. The canvas is scaled rather than the
-  /// path, so this scales down with the geometry (1.33px at a 16px sparkle).
-  static const double _strokeWidth = 2;
-
-  /// Tabler's `sparkle-2` outline (MIT), a single path in a 24x24 box.
-  ///
-  /// It is a stroke *centreline*, so filling it alone yields a silhouette inset
-  /// by half a stroke. The solid keyframes therefore paint the fill *and* the
-  /// stroke in one colour — the stroke outsets the fill back to the true solid
-  /// shape — and the outline keyframe just drops the fill away. Interpolating
-  /// the fill's alpha instead of switching paint styles keeps the sparkle the
-  /// same size across the whole loop.
-  ///
-  /// The native iOS/macOS renderer embeds this same geometry with the arcs
-  /// pre-converted to cubics; a change here must be mirrored there.
+  // The existing Tabler sparkle-2 centreline matches the Figma font glyph.
+  // Fill + stroke preserves the same outer silhouette in both states.
   static final Path _sparkle = Path()
     ..moveTo(12, 3)
     ..cubicTo(12.375, 3, 12.711, 3.231, 12.846, 3.581)
@@ -272,82 +261,73 @@ class _AiLoaderPainter({
     ..arcToPoint(const Offset(12, 3), radius: const Radius.circular(0.91))
     ..close();
 
-  /// Where each keyframe sits in the loop. The solid brand sparkle holds for
-  /// the back third, so the twinkle has a rest rather than reading as a strobe.
-  static const double _outlineAt = 0.4;
-  static const double _fadedAt = 0.7;
+  static ({Color fill, Color stroke}) colorsAt({
+    required double progress,
+    required bool loading,
+    required ({Color fill, Color stroke}) origin,
+    required Color solid,
+    required Color outline,
+    required Color bloom,
+  }) {
+    const ease = Cubic(0.5, 0, 0.5, 1);
+    final t = ease.transform(progress);
+    if (loading) {
+      return (
+        fill: lerpColorNonNull(origin.fill, bloom.withValues(alpha: 0), t),
+        stroke: lerpColorNonNull(origin.stroke, outline, t),
+      );
+    }
+    return (
+      fill: progress < 0.5
+          ? lerpColorNonNull(origin.fill, bloom, ease.transform(progress * 2))
+          : lerpColorNonNull(bloom, solid, ease.transform((progress - 0.5) * 2)),
+      stroke: lerpColorNonNull(origin.stroke, solid, t),
+    );
+  }
 
   @override
   void paint(Canvas canvas, Size size) {
-    final t = (_progress.value + phase) % 1.0;
-    final (color, keyframedFillOpacity, scale) = _keyframe(t);
-    final fillOpacity = fillMode == .outline ? 0.0 : keyframedFillOpacity;
+    final colors = fillMode == .outline
+        ? (fill: outline.withValues(alpha: 0), stroke: outline)
+        : colorsAt(
+            progress: fill.value,
+            loading: loading,
+            origin: origin,
+            solid: solid,
+            outline: outline,
+            bloom: bloom,
+          );
 
     canvas.save();
-    // Pulse about the sparkle's centre, then map the source box onto the paint
-    // area. Scaling the canvas (not the path) carries the stroke width with it
-    // and keeps the path allocation-free.
-    final centre = Offset(size.width / 2, size.height / 2);
-    canvas.translate(centre.dx, centre.dy);
-    canvas.scale(scale);
-    canvas.translate(-centre.dx, -centre.dy);
-    canvas.scale(size.shortestSide / _viewBox);
-
-    canvas.drawPath(
-      _sparkle,
-      Paint()
-        ..style = PaintingStyle.fill
-        ..color = color.withValues(alpha: color.a * fillOpacity),
-    );
+    canvas.scale(size.shortestSide / 20);
+    canvas.translate(10, 10.4);
+    canvas.rotate(rotation.value);
+    canvas.translate(-10, -10.4);
+    // Figma uses a 14px Tabler font in a 20px line box. The exported glyph's
+    // baseline puts its centre at (10, 10.4), rather than (10, 10).
+    canvas.translate(3, 3.4);
+    canvas.scale(14 / 24);
+    canvas.drawPath(_sparkle, Paint()..color = colors.fill);
     canvas.drawPath(
       _sparkle,
       Paint()
         ..style = PaintingStyle.stroke
-        ..strokeWidth = _strokeWidth
+        ..strokeWidth = 2
         ..strokeJoin = StrokeJoin.round
         ..strokeCap = StrokeCap.round
-        ..color = color,
+        ..color = colors.stroke,
     );
     canvas.restore();
   }
 
-  /// The colour, fill opacity and scale of the sparkle at [t] in the loop:
-  /// solid brand at full size, hollowing out and shrinking to the outline, then
-  /// filling back in as a faded sparkle before returning to brand.
-  ///
-  /// The native iOS/macOS renderer implements these same keyframes; a change
-  /// here must be mirrored there.
-  (Color, double, double) _keyframe(double t) {
-    if (t < _outlineAt) {
-      final p = t / _outlineAt;
-      return (
-        lerpColorNonNull(solid, outline, p),
-        1 - p,
-        lerpDoubleNonNull(1.0, 0.86, p),
-      );
-    }
-    if (t < _fadedAt) {
-      final p = (t - _outlineAt) / (_fadedAt - _outlineAt);
-      return (
-        lerpColorNonNull(outline, faded, p),
-        p,
-        lerpDoubleNonNull(0.86, 0.92, p),
-      );
-    }
-    final p = (t - _fadedAt) / (1 - _fadedAt);
-    return (
-      lerpColorNonNull(faded, solid, p),
-      1,
-      lerpDoubleNonNull(0.92, 1.0, p),
-    );
-  }
-
   @override
-  bool shouldRepaint(_AiLoaderPainter oldDelegate) {
-    return oldDelegate.phase != phase ||
-        oldDelegate.fillMode != fillMode ||
-        oldDelegate.solid != solid ||
-        oldDelegate.outline != outline ||
-        oldDelegate.faded != faded;
-  }
+  bool shouldRepaint(_AiLoaderPainter oldDelegate) =>
+      oldDelegate.rotation != rotation ||
+      oldDelegate.fill != fill ||
+      oldDelegate.loading != loading ||
+      oldDelegate.origin != origin ||
+      oldDelegate.fillMode != fillMode ||
+      oldDelegate.solid != solid ||
+      oldDelegate.outline != outline ||
+      oldDelegate.bloom != bloom;
 }

--- a/client/module_prego/lib/components/loaders/prego_ai_loader.dart
+++ b/client/module_prego/lib/components/loaders/prego_ai_loader.dart
@@ -192,6 +192,8 @@ class _PregoAiLoaderState()
   }
 
   Widget _nativeSparkle({required PregoColors colors}) {
+    // StandardMessageCodec carries ARGB integers, a double phase, and a bool.
+    // ignore: no_slop_linter/prefer_specific_type, heterogeneous native codec payload
     final params = <String, Object>{
       "solid": colors.textPrimaryOnBrand.toARGB32(),
       "outline": colors.textPrimary.toARGB32(),

--- a/client/module_prego/test/components/prego_ai_loader_test.dart
+++ b/client/module_prego/test/components/prego_ai_loader_test.dart
@@ -1,18 +1,19 @@
 import "dart:ui" as ui;
 
 import "package:flutter/rendering.dart";
+import "package:flutter/services.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
 import "package:theme_prego/module_prego.dart";
 
 /// Behavioural guards for the AI activity sparkle.
 ///
-/// The twinkle is an infinite repeating animation, so these tests pump fixed
+/// The rotation is an infinite repeating animation, so these tests pump fixed
 /// durations and never `pumpAndSettle` — it would pump to its timeout and throw.
 ///
-/// The painter tests pin a platform without a native twinkle renderer (Linux):
+/// The painter tests pin a platform without a native rotation renderer (Linux):
 /// on iOS and macOS the animated sparkle is a platform view, which cannot
-/// paint pixels in a widget test. The `native twinkle` group covers those
+/// paint pixels in a widget test. The `native rotation` group covers those
 /// branches and the deliberate Android fallback explicitly.
 void main() {
   Widget harness(Widget child, {bool disableAnimations = false}) {
@@ -28,9 +29,9 @@ void main() {
 
   /// The colour actually painted at the middle of the sparkle.
   ///
-  /// The keyframes differ in the fill, not just the tint: a solid sparkle has
-  /// an opaque brand-coloured body, while the hollow outline keyframe leaves
-  /// the middle transparent. Reading the pixel therefore says which keyframe is
+  /// The states differ in fill, not just tint: an unread sparkle has
+  /// an opaque brand-coloured body, while the working outline leaves
+  /// the middle transparent. Reading the pixel therefore says which state is
   /// on screen — asserting the widget merely "renders" would not.
   Future<Color> sparkleCentre(WidgetTester tester) async {
     final boundary = tester.renderObject<RenderRepaintBoundary>(
@@ -65,8 +66,8 @@ void main() {
     return visiblePixels;
   }
 
-  /// Where in the loop the sparkle is at its hollowest.
-  const outlineKeyframe = Duration(milliseconds: 560);
+  /// A non-cardinal rotation, so a jump to the resting angle is visible.
+  const loadingSample = Duration(milliseconds: 250);
 
   group("phaseFor", () {
     test("derives a stable phase in [0, 1) from a seed", () {
@@ -84,7 +85,7 @@ void main() {
     });
   });
 
-  testWidgets("twinkles by default", (tester) async {
+  testWidgets("rotates by default", (tester) async {
     await tester.pumpWidget(harness(const PregoAiLoader()));
     await tester.pump(const Duration(milliseconds: 200));
 
@@ -123,35 +124,43 @@ void main() {
     expect(await sparkleVisiblePixels(tester), greaterThan(0));
   });
 
-  testWidgets("hollows out mid-twinkle", (tester) async {
+  testWidgets("keeps the working sparkle hollow through the loop", (tester) async {
     await tester.pumpWidget(harness(const PregoAiLoader()));
-    await tester.pump(outlineKeyframe);
+    await tester.pump(loadingSample);
 
     expect((await sparkleCentre(tester)).a, 0);
   }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
   testWidgets("settles back on the solid keyframe when the loop is switched off", (tester) async {
     await tester.pumpWidget(harness(const PregoAiLoader()));
-    await tester.pump(outlineKeyframe);
+    await tester.pump(loadingSample);
 
     await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
     await tester.pump();
 
+    expect(tester.hasRunningAnimations, isTrue);
+    expect((await sparkleCentre(tester)).a, 0);
+    await tester.pump(const Duration(milliseconds: 175));
+    final filling = await sparkleCentre(tester);
+    expect(filling.a, greaterThan(0));
+    expect(filling.a, lessThan(1));
+    await tester.pump(const Duration(milliseconds: 526));
     expect(tester.hasRunningAnimations, isFalse);
-    // Stopping a controller leaves it wherever it was — a sparkle frozen
-    // half-faded would read as a rendering bug.
     expect(await sparkleCentre(tester), PregoColorsLight.textPrimaryOnBrand);
+    await tester.pump(const Duration(seconds: 3));
+    expect(tester.hasRunningAnimations, isFalse);
   }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
   testWidgets("a phase offset moves it through the loop, but never off its resting frame", (tester) async {
     await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.4)));
     await tester.pump();
 
-    // Phase 0.4 starts where an unoffset sparkle would be at its hollowest.
+    // Loading is hollow at every phase, including the first visible frame.
     expect((await sparkleCentre(tester)).a, 0);
 
-    await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.4, animate: false)));
+    await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
     await tester.pump();
+    await tester.pump(const Duration(milliseconds: 700));
 
     expect(await sparkleCentre(tester), PregoColorsLight.textPrimaryOnBrand);
   }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
@@ -161,6 +170,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
 
     expect(tester.hasRunningAnimations, isFalse);
+    expect((await sparkleCentre(tester)).a, 0);
+    await tester.pumpWidget(harness(const PregoAiLoader(animate: false), disableAnimations: true));
     expect(await sparkleCentre(tester), PregoColorsLight.textPrimaryOnBrand);
   }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
@@ -206,12 +217,87 @@ void main() {
     expect(tester.getSize(find.byType(PregoAiLoader)), const Size(24, 24));
   }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
-  group("native twinkle", () {
+  testWidgets("a new turn interrupts the completion without flashing the fill", (tester) async {
+    await tester.pumpWidget(harness(const PregoAiLoader()));
+    await tester.pump(loadingSample);
+    await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 175));
+    final beforeRestart = await sparkleCentre(tester);
+
+    await tester.pumpWidget(harness(const PregoAiLoader()));
+    expect(await sparkleCentre(tester), beforeRestart);
+    await tester.pump(const Duration(milliseconds: 75));
+    final clearing = await sparkleCentre(tester);
+    expect(clearing.a, greaterThan(0));
+    expect(clearing.a, lessThan(beforeRestart.a));
+    // Finishing again mid-clear must preserve this exact displayed colour.
+    await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
+    expect(await sparkleCentre(tester), clearing);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 701));
+    expect(await sparkleCentre(tester), PregoColorsLight.textPrimaryOnBrand);
+    expect(tester.hasRunningAnimations, isFalse);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+
+  testWidgets("starting a new turn clears idle without replaying the completion highlight", (tester) async {
+    await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
+    await tester.pumpWidget(harness(const PregoAiLoader()));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 75));
+    final clearing = await sparkleCentre(tester);
+    expect(clearing.a, greaterThan(0));
+    expect(clearing.a, lessThan(1));
+    await tester.pump(const Duration(milliseconds: 76));
+    expect((await sparkleCentre(tester)).a, 0);
+    expect(tester.hasRunningAnimations, isTrue);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+
+  testWidgets("changing Reduce Motion during completion settles without replay", (tester) async {
+    await tester.pumpWidget(harness(const PregoAiLoader()));
+    await tester.pump(loadingSample);
+    await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 175));
+    await tester.pumpWidget(harness(const PregoAiLoader(animate: false), disableAnimations: true));
+    expect(tester.hasRunningAnimations, isFalse);
+    expect(await sparkleCentre(tester), PregoColorsLight.textPrimaryOnBrand);
+
+    await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
+    await tester.pump(const Duration(seconds: 1));
+    expect(tester.hasRunningAnimations, isFalse);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+
+  testWidgets("sends completion and restart to the same native view without Flutter ticks", (tester) async {
+    const channel = MethodChannel("sesori/native-ai-loader/99");
+    final calls = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+    addTearDown(() => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null));
+
+    await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.4)));
+    final original = tester.state(find.byType(AppKitView));
+    tester.widget<AppKitView>(find.byType(AppKitView)).onPlatformViewCreated!(99);
+    await tester.pump();
+    await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
+    await tester.pump();
+    await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.4)));
+    await tester.pump();
+
+    expect(tester.state(find.byType(AppKitView)), same(original));
+    expect(calls.map((call) => call.method), everyElement("setLoading"));
+    expect(calls.map((call) => call.arguments), [true, false, true]);
+    expect(tester.hasRunningAnimations, isFalse);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
+
+  group("native rotation", () {
     final expectedParams = <String, Object>{
       "solid": PregoColorsLight.textPrimaryOnBrand.toARGB32(),
       "outline": PregoColorsLight.textPrimary.toARGB32(),
-      "faded": PregoColorsLight.textDisabled.toARGB32(),
       "phase": 0.25,
+      "loading": true,
     };
 
     Finder painter() => find.descendant(of: find.byType(PregoAiLoader), matching: find.byType(CustomPaint));
@@ -240,7 +326,7 @@ void main() {
 
     testWidgets("Android keeps the animated Flutter painter in list rows", (tester) async {
       // Deliberate: a platform view per visible session row wrecks Android
-      // scroll performance (measured on-device), so Android twinkles in Flutter.
+      // scroll performance (measured on-device), so Android rotations in Flutter.
       await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.25)));
       await tester.pump(const Duration(milliseconds: 200));
 
@@ -257,16 +343,16 @@ void main() {
       expect(find.byType(AppKitView), findsNothing);
       expect(painter(), findsOneWidget);
       expect(tester.hasRunningAnimations, isFalse);
-      expect(await sparkleCentre(tester), PregoColorsLight.textPrimaryOnBrand);
+      expect((await sparkleCentre(tester)).a, 0);
     }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
 
-    testWidgets("a resting sparkle never creates a platform view", (tester) async {
+    testWidgets("an initially unread sparkle uses a static native view", (tester) async {
       await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
 
-      expect(find.byType(AppKitView), findsNothing);
-      expect(painter(), findsOneWidget);
+      final view = tester.widget<AppKitView>(find.byType(AppKitView));
+      expect((view.creationParams! as Map)["loading"], isFalse);
+      expect(painter(), findsNothing);
       expect(tester.hasRunningAnimations, isFalse);
-      expect(await sparkleCentre(tester), PregoColorsLight.textPrimaryOnBrand);
     }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
 
     testWidgets("disabled TickerMode keeps the static painter", (tester) async {
@@ -280,7 +366,7 @@ void main() {
       expect(tester.hasRunningAnimations, isFalse);
     }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
 
-    testWidgets("recreates the native view when the phase changes", (tester) async {
+    testWidgets("retains the native view when the unread caller drops its phase", (tester) async {
       await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.25)));
       final firstKey = tester
           .widget<KeyedSubtree>(
@@ -288,14 +374,14 @@ void main() {
           )
           .key;
 
-      await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.5)));
+      await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
       final secondKey = tester
           .widget<KeyedSubtree>(
             find.ancestor(of: find.byType(AppKitView), matching: find.byType(KeyedSubtree)).first,
           )
           .key;
 
-      expect(secondKey, isNot(firstKey));
+      expect(secondKey, firstKey);
     }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
   });
 }

--- a/docs/regression/native-activity-indicators.md
+++ b/docs/regression/native-activity-indicators.md
@@ -3,7 +3,7 @@
 ## Capability
 
 `PregoActivityIndicator` renders the shared busy spinner and `PregoAiLoader`
-the twinkling AI-activity sparkle shown on active session and project rows.
+the AI-activity sparkle shown on active and unread session and project rows.
 On iOS and macOS both render through `theme_prego` platform views animated by
 Core Animation outside Flutter's frame pipeline, so an otherwise-static screen
 schedules no Flutter frames. Android is deliberately all-Flutter for both
@@ -18,12 +18,23 @@ steps, and stops its timer while the app is not visible (paused, hidden, or
 detached; an unfocused but visible window keeps spinning). The sparkle
 keeps its animated Flutter fallback there. Reduced motion and disabled tickers
 replace the native views with static Flutter frames (the spinner rests on one
-stepped frame; the sparkle rests on its solid keyframe, matching its
-`animate: false` still), the spinner owns loading-spinner semantics on every
+stepped frame; the sparkle is a hollow working mark or a solid unread mark), the spinner owns loading-spinner semantics on every
 platform, and the sparkle stays decorative.
-The sparkle's native renderer duplicates the Dart painter's geometry,
-keyframes, and 1.4s period, including the per-row phase stagger passed at
-creation.
+The sparkle matches Figma `2506:20093`: a 14px Tabler glyph in a 20px slot,
+including its font baseline offset. Working stays hollow and turns clockwise
+once every two seconds. An observed working → unread change fills through pale
+blue into brand blue and eases the rotation into place in 700ms, with Figma's
+small overshoot. It finishes once; initially unread rows are already solid.
+A new turn interrupts the finish from the displayed angle and fill. Opening a
+read thread removes the status mark through the existing row state rules.
+
+Apple views retain their renderer through working/unread changes and receive
+`setLoading` on a per-view channel; both the loop and completion use Core
+Animation, without continuous Flutter frames. Native and Flutter renderers
+share the same geometry, colours, timing, and per-row initial phase. Theme
+changes rebuild the native palette. Reduced motion and disabled TickerMode
+settle immediately, retaining the hollow/solid state distinction. Caller-owned
+outline mode and explicit colours remain available for Deep Scan.
 
 ## Regression Levels
 
@@ -59,9 +70,11 @@ request no brand tint, so every spinner shows its platform's natural colour
 for the app's resolved brightness (native views receive that brightness and
 surfaces that invert the page ask for the opposite natural grey) while the
 tint capability stays available;
-sparkles in a list twinkling in lockstep despite distinct phases; the native
-sparkle keyframes visibly diverging from the Flutter fallback; reduce motion
-still animating.
+sparkles in a list rotating in lockstep despite distinct phases; the native
+sparkle motion visibly diverging from the Flutter fallback; completion
+restarting on rebuild or looping after work ends; a visible angle/fill jump
+when another turn starts during completion; a stale native loading state after
+a row update; reduce motion still animating or making working look unread.
 
 ## Sources
 
@@ -70,3 +83,18 @@ still animating.
 - `client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift`
 - `client/module_prego/test/components/prego_activity_indicator_test.dart`
 - `client/module_prego/test/components/prego_ai_loader_test.dart`
+
+## Simulator Review
+
+Run from `client/app`:
+
+```sh
+flutter run -d <simulator-id> -t test/playbook/thread_state_motion_playbook.dart
+```
+
+The preview uses production indicators at 20px and 4× detail, plus actual
+`SessionTile` rows. Inspect light and dark appearance; finish a turn and restart
+during its settle; toggle reduced motion while working and finishing. Scroll
+the list beneath the blurred header and toggle the list repeatedly to exercise
+native clipping, insertion, disposal, and reattachment. Verify the regular loop
+still produces no continuous Flutter frames on iOS/macOS.


### PR DESCRIPTION
## Complexity
⚙️ Moderate: coordinated Flutter and Core Animation state transitions in the existing shared indicator.

## What
Replace the pulsing thread indicator with Figma's three states: a solid blue unread sparkle, a hollow loading sparkle rotating once every two seconds, and a one-time 700ms loading-to-unread finish. Match the 20px slot, 14px glyph, and font baseline. Keep the glyph centered through its finishing overshoot.

Native Apple views now receive state changes without being replaced. Both renderers capture the current rotation and fill when interrupted. Add a simulator playbook with real thread rows, enlarged detail, replay controls, appearance/reduced-motion toggles, and scrolling/native-view lifecycle checks.

## Why
Working and unopened updates previously shared a pulsing fill animation, and finishing snapped directly to the unread mark. The new behavior follows Figma node 2506:20093, including its running/unread annotations and finishing motion, adapted from the demonstration timeline into a responsive one-time transition.

## Risk and test focus
User-visible change on shared project/thread indicators. Focus on fill/rotation continuity, native view identity, scrolling and glass composition, and accessibility. Initially unread rows remain still; reduced motion retains hollow working versus solid unread states. Existing Deep Scan caller-owned outline mode remains supported. No database, transport, harness capability, or business-state impact.

## Expected result
Working threads rotate a hollow sparkle; when work finishes with unopened updates, it fills blue and settles once. Starting another turn interrupts the finish smoothly. Read inactive threads continue showing their timestamp instead of an indicator.

## Verification
- CI follow-up: documented the heterogeneous native codec payload; `dart analyze --fatal-infos` passes in module_prego and all 25 indicator tests pass. The platform callback signature and codec payload are the two narrowly justified lint exceptions. No runtime behavior changed.
- 99 focused Flutter tests passed: indicator (25), session/Deep Scan (61), project rows (12), preview state wiring (1).
- Analyzer passed in module_prego, module_app_ui, and app.
- Native Swift typechecks passed for iOS simulator and macOS; both native applications built and ran.
- Rendered iOS/macOS checks: loading/idle/completion, rapid restart, light/dark, reduced motion, list removal/restoration, scrolling and clipping beneath a blurred header.
- Native idle samples recorded zero new Flutter frame events over five seconds on each Apple target, excluding historical event replay.
- Figma timeline played and inspected, including scoped comment #139 and state annotations. Local simulator video inspected frame by frame.

Simulator entrypoint from client/app: `flutter run -d <simulator-id> -t test/playbook/thread_state_motion_playbook.dart`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the pulsing thread indicator with Figma's motion states: a hollow sparkle rotates while the agent works, then fills solid blue once when work finishes.

- The 700ms finish eases the current rotation into place and captures the displayed angle and fill, so starting another turn mid-settle interrupts smoothly without a jump.
- Native Apple views keep their identity across state changes and receive updates over a per-view method channel instead of being recreated.
- The sparkle moves from a 16px to a 20px slot with Figma's 14px glyph and baseline offset.
- Reduced motion keeps the hollow working vs. solid unread distinction without animation.
- Adds a simulator playbook with real thread rows, replay controls, and appearance and reduced-motion toggles.
- Existing Deep Scan caller-owned outline mode and explicit color overrides remain supported.

<sup>Written for commit a26f6c3a9ed14fa8aacb699f591226f7f797392d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

