### PR TITLE
🌱 Apply selected star bounce timing and dip

### DIFF
--- a/client/app/test/playbook/feedback_motion_spec.dart
+++ b/client/app/test/playbook/feedback_motion_spec.dart
@@ -38,7 +38,7 @@ const feedbackStarDuration = MotionDuration(
   id: "feedback.stars.duration",
   label: "Bounce duration",
   source: "$_source · _Stars / _FeedbackSheet",
-  initialValue: Duration(milliseconds: 280),
+  initialValue: Duration(milliseconds: 470),
   min: Duration.zero,
   max: Duration(milliseconds: 2000),
 );
@@ -134,7 +134,7 @@ const feedbackStarDip = MotionNumber(
   id: "feedback.stars.dip",
   label: "Dip scale",
   source: "$_source · _tapScale",
-  initialValue: 0.88,
+  initialValue: 0.99,
   min: 0.7,
   max: 1,
   step: 0.01,

--- a/client/app/test/playbook/feedback_motion_test.dart
+++ b/client/app/test/playbook/feedback_motion_test.dart
@@ -55,7 +55,7 @@ void main() {
       final sheet = tester.element(find.byType(BottomSheet));
       await tester.tap(find.byKey(const ValueKey("rating-2")));
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 280));
+      await tester.pump(const Duration(milliseconds: 470));
       await tester.pump(const Duration(milliseconds: 50));
 
       expect(find.text("How’s Sesori working for you?"), findsOneWidget);
@@ -290,7 +290,7 @@ Future<void> _openPrivate({required WidgetTester tester}) async {
 Future<void> _rate({required WidgetTester tester}) async {
   await tester.tap(find.byKey(const ValueKey("rating-2")));
   await tester.pump();
-  await tester.pump(const Duration(milliseconds: 300));
+  await tester.pump(const Duration(milliseconds: 490));
   await tester.pumpAndSettle();
 }
 

--- a/client/app/test/playbook/feedback_star_animation_test.dart
+++ b/client/app/test/playbook/feedback_star_animation_test.dart
@@ -18,8 +18,8 @@ void main() {
 
     await tester.tap(star);
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 40));
-    expect(_scale(tester: tester, rating: 3), lessThan(0.95));
+    await tester.pump(const Duration(milliseconds: 75));
+    expect(_scale(tester: tester, rating: 3), closeTo(0.99, 0.001));
     for (var rating = 1; rating <= 5; rating++) {
       expect(
         _starAsset(tester: tester, rating: rating),
@@ -32,16 +32,16 @@ void main() {
 
     // A second tap during the bounce must not change the accepted rating.
     await tester.tap(find.byKey(const ValueKey("rating-5")));
-    await tester.pump(const Duration(milliseconds: 100));
-    expect(_scale(tester: tester, rating: 3), greaterThan(1.15));
+    await tester.pump(const Duration(milliseconds: 160));
+    expect(_scale(tester: tester, rating: 3), closeTo(1.18, 0.001));
     expect(_scale(tester: tester, rating: 5), 1);
     expect(find.text("What should we improve?"), findsNothing);
 
-    await tester.pump(const Duration(milliseconds: 120));
+    await tester.pump(const Duration(milliseconds: 205));
     expect(_scale(tester: tester, rating: 3), closeTo(1, 0.02));
     expect(find.text("How’s Sesori working for you?"), findsOneWidget);
 
-    await tester.pump(const Duration(milliseconds: 40));
+    await tester.pump(const Duration(milliseconds: 50));
     await tester.pumpAndSettle();
     expect(find.text("What should we improve?"), findsOneWidget);
     expect(tester.takeException(), isNull);

--- a/docs/regression/motion-tuning.md
+++ b/docs/regression/motion-tuning.md
@@ -13,6 +13,10 @@ choice. Typed controls edit a draft snapshot. Replay captures one immutable
 snapshot for the animation and its related timing. Original comparison and
 target reset leave unrelated draft values intact.
 
+The feedback star bounce defaults to 470 ms, with a subtle 0.99 dip and a 1.18
+peak before settling. Only the chosen star scales; the selected range fills
+immediately, and reduced-motion settings preserve the fill without scaling.
+
 The feedback result target replays the shared top toast with its standard
 motion and automatic dismissal. It is labeled replay only and exposes no
 target-specific tuning controls. Whole-flow replay uses that same presenter;


### PR DESCRIPTION
## Complexity

🌱 Trivial. Two animation defaults and their timing expectations.

## What

Set the feedback preview star bounce to 470 ms with a 0.99 dip scale. Keep the existing 1.18 peak, settling scale, and easing. Update the existing star and flow timing tests and regression notes.

## Why

Apply the designer-selected Motion settings: a subtler press dip and a longer bounce that leaves room for the pop and settle.

## Risk and test focus

The feedback step must wait for the longer bounce, and only the tapped star should scale. Selected stars still fill immediately; reduced-motion settings suppress scaling. No database impact. No user-visible production impact: these changes apply to the development feedback preview.

This PR is stacked on `codex/feedback` (#1361), which contains the preview and its Motion toolkit.

## Expected result

The normal feedback preview and Motion's Original/Reset values use a 470 ms bounce, 0.99 dip, and 1.18 peak.

## Verification

- All 40 feedback flow, motion, tuning, and star animation tests passed.
- Full app analysis passed; pinned Dart formatting and `git diff --check` passed.
- Tests sample the 0.99 dip and 1.18 peak, retain single-star movement, and verify advancement after the longer bounce and reduced-motion behavior.
- iOS simulator build passed. Verified the default fields show 470 ms / 0.99 / 1.18, replayed the star-only scene, and left the rating simulator open at Normal speed.
