### PR TITLE
⚙️ Complete feedback preview voice recovery and cancellation

### DIFF
--- a/client/app/android/app/src/main/kotlin/com/sesori/app/MainActivity.kt
+++ b/client/app/android/app/src/main/kotlin/com/sesori/app/MainActivity.kt
@@ -1,6 +1,11 @@
 package com.sesori.app
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
 import android.graphics.Color
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
@@ -17,6 +22,7 @@ import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
     private var recorderPrewarmService: RecorderPrewarmService? = null
+    private var previewMicrophoneResult: MethodChannel.Result? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -26,6 +32,42 @@ class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
                 RecorderPrewarmService.channelName,
             ),
         )
+        // Local feedback playbook only; unavailable in profile and release builds.
+        if (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) {
+            MethodChannel(
+                flutterEngine.dartExecutor.binaryMessenger,
+                "com.sesori.app/feedback_preview",
+            ).setMethodCallHandler { call, result ->
+                if (call.method != "requestMicrophoneAccess") {
+                    result.notImplemented()
+                } else if (checkSelfPermission(Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
+                    result.success(true)
+                } else if (previewMicrophoneResult != null) {
+                    result.error("permission_request_pending", "A microphone permission request is already open.", null)
+                } else {
+                    previewMicrophoneResult = result
+                    requestPermissions(arrayOf(Manifest.permission.RECORD_AUDIO), previewMicrophoneRequestCode)
+                }
+            }
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray,
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode != previewMicrophoneRequestCode) return
+        val result = previewMicrophoneResult ?: return
+        previewMicrophoneResult = null
+        val granted = grantResults.firstOrNull() == PackageManager.PERMISSION_GRANTED
+        if (!granted && grantResults.isNotEmpty()) {
+            startActivity(
+                Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse("package:$packageName")),
+            )
+        }
+        result.success(granted)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -97,5 +139,9 @@ class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
             return false
         }
         return getNavigationMode() == 2
+    }
+
+    private companion object {
+        const val previewMicrophoneRequestCode = 43019
     }
 }

--- a/client/app/android/app/src/main/kotlin/com/sesori/app/MainActivity.kt
+++ b/client/app/android/app/src/main/kotlin/com/sesori/app/MainActivity.kt
@@ -41,12 +41,13 @@ class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
                 if (call.method != "requestMicrophoneAccess") {
                     result.notImplemented()
                 } else if (checkSelfPermission(Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
+                    // True means permission was already granted before this gesture.
                     result.success(true)
                 } else if (previewMicrophoneResult != null) {
                     result.error("permission_request_pending", "A microphone permission request is already open.", null)
                 } else {
                     previewMicrophoneResult = result
-                    requestPermissions(arrayOf(Manifest.permission.RECORD_AUDIO), previewMicrophoneRequestCode)
+                    requestPermissions(arrayOf(Manifest.permission.RECORD_AUDIO), PREVIEW_MICROPHONE_REQUEST_CODE)
                 }
             }
         }
@@ -58,7 +59,7 @@ class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
         grantResults: IntArray,
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode != previewMicrophoneRequestCode) return
+        if (requestCode != PREVIEW_MICROPHONE_REQUEST_CODE) return
         val result = previewMicrophoneResult ?: return
         previewMicrophoneResult = null
         val granted = grantResults.firstOrNull() == PackageManager.PERMISSION_GRANTED
@@ -67,7 +68,8 @@ class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
                 Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse("package:$packageName")),
             )
         }
-        result.success(granted)
+        // Native UI interrupted the gesture; check permission on a fresh gesture.
+        result.success(false)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -142,6 +144,6 @@ class MainActivity : FlutterActivity(), FlutterUiDisplayListener {
     }
 
     private companion object {
-        const val previewMicrophoneRequestCode = 43019
+        const val PREVIEW_MICROPHONE_REQUEST_CODE = 43019
     }
 }

--- a/client/app/ios/Runner/AppDelegate.swift
+++ b/client/app/ios/Runner/AppDelegate.swift
@@ -1,6 +1,7 @@
 import Flutter
 import UIKit
 #if DEBUG
+import AVFoundation
 import StoreKit
 #endif
 
@@ -29,6 +30,23 @@ import StoreKit
       name: "com.sesori.app/feedback_preview",
       binaryMessenger: engineBridge.applicationRegistrar.messenger()
     ).setMethodCallHandler { call, result in
+      if call.method == "requestMicrophoneAccess" {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized:
+          result(true)
+        case .notDetermined:
+          AVCaptureDevice.requestAccess(for: .audio) { granted in
+            DispatchQueue.main.async { result(granted) }
+          }
+        case .denied, .restricted:
+          UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!) { _ in
+            result(false)
+          }
+        @unknown default:
+          result(false)
+        }
+        return
+      }
       guard call.method == "requestReview" else {
         result(FlutterMethodNotImplemented)
         return

--- a/client/app/ios/Runner/AppDelegate.swift
+++ b/client/app/ios/Runner/AppDelegate.swift
@@ -31,17 +31,20 @@ import StoreKit
       binaryMessenger: engineBridge.applicationRegistrar.messenger()
     ).setMethodCallHandler { call, result in
       if call.method == "requestMicrophoneAccess" {
+        // True means already authorized; native UI requires a fresh gesture.
         switch AVCaptureDevice.authorizationStatus(for: .audio) {
         case .authorized:
           result(true)
         case .notDetermined:
-          AVCaptureDevice.requestAccess(for: .audio) { granted in
-            DispatchQueue.main.async { result(granted) }
+          AVCaptureDevice.requestAccess(for: .audio) { _ in
+            DispatchQueue.main.async { result(false) }
           }
-        case .denied, .restricted:
+        case .denied:
           UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!) { _ in
             result(false)
           }
+        case .restricted:
+          result(false)
         @unknown default:
           result(false)
         }

--- a/client/app/test/playbook/feedback_flow_playbook.dart
+++ b/client/app/test/playbook/feedback_flow_playbook.dart
@@ -1,8 +1,10 @@
 // Local feedback prototype. Voice and submission are simulated; 4–5 stars
 // requests Apple's native rating UI through an iOS debug-only channel.
+// The microphone-permission scenario opens real iOS/Android permissions/settings.
 import "dart:async";
 import "dart:math" as math;
 
+import "package:flutter/foundation.dart";
 import "package:flutter/services.dart";
 import "package:flutter_svg/flutter_svg.dart";
 import "package:material_ui/material_ui.dart";
@@ -19,7 +21,7 @@ void main() => runApp(const FeedbackFlowPlaybook(openOnLaunch: true));
 enum FeedbackPreviewScenario({required final String label}) {
   success(label: "Successful feedback"),
   submissionRetry(label: "Submission fails once"),
-  microphoneDenied(label: "Microphone permission denied"),
+  microphoneDenied(label: "Microphone permission / settings"),
   transcriptionRetry(label: "Transcription fails once"),
 }
 
@@ -35,10 +37,10 @@ enum _InputMode() {
 
 enum _VoiceStage() {
   idle,
+  requestingPermission,
   recording,
+  cancelling,
   transcribing,
-  denied,
-  failed,
 }
 
 enum _SubmissionStage() {
@@ -234,6 +236,11 @@ class _PreviewLauncherState()
                 FeedbackMotionScope.maybeOf(context: context) != null
                     ? "Voice and feedback submission are simulated. Native rating is skipped while tuning motion."
                     : "Voice and feedback submission are simulated. 4–5 stars opens Apple’s native rating prompt in iOS debug builds.",
+                style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                "The microphone permission scenario opens real iOS or Android permission/settings screens.",
                 style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textSecondary),
               ),
               const SizedBox(height: 24),
@@ -744,16 +751,23 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
   final _focus = FocusNode();
   final _issues = <String>{};
   final _issuePressKey = GlobalKey<_FeedbackPressState>();
+  final _cancelRecordingKey = GlobalKey();
+  final _cancelProgress = ValueNotifier<double>(0);
   _InputMode _mode = _InputMode.voice;
   _VoiceStage _voice = _VoiceStage.idle;
   _SubmissionStage _submission = _SubmissionStage.editing;
   bool _submissionFailedOnce = false;
   bool _transcriptionFailedOnce = false;
+  bool _microphoneReady = false;
 
   bool get _canSend =>
       _submission != _SubmissionStage.submitting &&
+      _voice != _VoiceStage.requestingPermission &&
       _voice != _VoiceStage.recording &&
+      _voice != _VoiceStage.cancelling &&
       _voice != _VoiceStage.transcribing;
+
+  bool get _recording => _voice == _VoiceStage.recording || _voice == _VoiceStage.cancelling;
 
   @override
   void initState() {
@@ -788,7 +802,8 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
   }
 
   Future<void> _replayVoice() async {
-    _startRecording();
+    // Replay stays local even when the permission-denied scenario is selected.
+    setState(() => _voice = _VoiceStage.recording);
     await Future<void>.delayed(
       FeedbackMotionScope.valuesOf(context: context).duration(parameter: feedbackControlDuration),
     );
@@ -819,6 +834,7 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
     _focus.removeListener(_refresh);
     _text.dispose();
     _focus.dispose();
+    _cancelProgress.dispose();
     super.dispose();
   }
 
@@ -830,25 +846,75 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
     _focus.requestFocus();
   }
 
-  void _startRecording() {
-    if (_submission == _SubmissionStage.submitting || _voice == _VoiceStage.transcribing) return;
+  Future<void> _startRecording() async {
+    if (!_canSend) return;
     _focus.unfocus();
+    if (widget.scenario == FeedbackPreviewScenario.microphoneDenied && !_microphoneReady) {
+      setState(() => _voice = _VoiceStage.requestingPermission);
+      try {
+        _microphoneReady =
+            await const MethodChannel("com.sesori.app/feedback_preview")
+                .invokeMethod<bool>("requestMicrophoneAccess") ??
+            false;
+      } on MissingPluginException {
+        if (mounted) {
+          _showVoiceError(message: "Microphone settings are available in the iOS and Android debug preview.");
+        }
+      } on PlatformException {
+        if (mounted) _showVoiceError(message: "Couldn’t open microphone settings. Please try again.");
+      }
+      // The original hold has ended while the OS prompt was open. A fresh
+      // gesture starts the simulated recording after permission is granted.
+      if (mounted) setState(() => _voice = _VoiceStage.idle);
+      return;
+    }
+    _cancelProgress.value = 0;
     setState(() {
       _mode = _InputMode.voice;
-      _voice = widget.scenario == FeedbackPreviewScenario.microphoneDenied ? _VoiceStage.denied : _VoiceStage.recording;
+      _voice = _VoiceStage.recording;
     });
   }
 
+  void _cancelRecording() {
+    _cancelProgress.value = 0;
+    setState(() => _voice = _VoiceStage.idle);
+  }
+
+  void _dragRecording({required Offset position}) {
+    if (!_recording) return;
+    final target = _cancelRecordingKey.currentContext?.findRenderObject();
+    if (target is! RenderBox) return;
+    final distance = (position - target.localToGlobal(target.size.center(Offset.zero))).distance;
+    _cancelProgress.value = (1 - (distance - 44) / (170 - 44)).clamp(0.0, 1.0);
+    final next = _cancelProgress.value == 1 ? _VoiceStage.cancelling : _VoiceStage.recording;
+    if (_voice != next) setState(() => _voice = next);
+  }
+
+  void _finishRecording() {
+    if (_voice == _VoiceStage.cancelling) {
+      _cancelRecording();
+    } else {
+      unawaited(_transcribe());
+    }
+  }
+
+  void _showVoiceError({required String message}) => PregoPopupAlertPresenter.of(context).show(
+    title: message,
+    variant: PregoPopupAlertsNotificationsVariant.error,
+  );
+
   Future<void> _transcribe() async {
-    if (_voice != _VoiceStage.recording && _voice != _VoiceStage.failed) return;
+    if (_voice != _VoiceStage.recording) return;
+    _cancelProgress.value = 0;
     setState(() => _voice = _VoiceStage.transcribing);
     await Future<void>.delayed(const Duration(milliseconds: 900));
     if (!mounted || _voice != _VoiceStage.transcribing) return;
     if (widget.scenario == FeedbackPreviewScenario.transcriptionRetry && !_transcriptionFailedOnce) {
       setState(() {
         _transcriptionFailedOnce = true;
-        _voice = _VoiceStage.failed;
+        _voice = _VoiceStage.idle;
       });
+      _showVoiceError(message: "Couldn’t transcribe that. Please try again.");
       return;
     }
     setState(() => _voice = _VoiceStage.idle);
@@ -906,32 +972,28 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
           ),
         ),
         const SizedBox(height: 18),
+        _FeedbackContentTransition(
+          child: _recording
+              ? Padding(
+                  padding: const EdgeInsets.only(bottom: PregoSpacing.x3l),
+                  child: Text(
+                    _voice == _VoiceStage.cancelling ? "Release to cancel" : "Release to transcribe",
+                    textAlign: TextAlign.center,
+                    style: prego.textTheme.textMd.regular.copyWith(
+                      color: _voice == _VoiceStage.cancelling
+                          ? prego.colors.textErrorPrimary
+                          : prego.colors.textPrimary,
+                    ),
+                  ),
+                )
+              : const SizedBox.shrink(),
+        ),
         _buildComposer(context: context),
         _FeedbackContentTransition(
           child: Column(
-            key: ValueKey((
-              _voice == _VoiceStage.denied,
-              _voice == _VoiceStage.failed,
-              _submission == _SubmissionStage.failed,
-            )),
+            key: ValueKey(_submission == _SubmissionStage.failed),
             mainAxisSize: MainAxisSize.min,
             children: [
-              if (_voice == _VoiceStage.denied) ...[
-                const SizedBox(height: 12),
-                _InlineMessage(
-                  message: "Microphone access is off. You can type your feedback instead.",
-                  action: "Use keyboard",
-                  onAction: _typeFeedback,
-                ),
-              ],
-              if (_voice == _VoiceStage.failed) ...[
-                const SizedBox(height: 12),
-                _InlineMessage(
-                  message: "Couldn’t transcribe that. Try again or use the keyboard.",
-                  action: "Retry transcription",
-                  onAction: _transcribe,
-                ),
-              ],
               if (_submission == _SubmissionStage.failed) ...[
                 const SizedBox(height: 12),
                 _InlineMessage(
@@ -1043,7 +1105,31 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
                       style: PregoComposerSurfaceStyle.subtle,
                       borderRadius: BorderRadius.circular(PregoRadius.full),
                     ).copyWith(boxShadow: const []),
-                    child: Padding(padding: const EdgeInsets.all(PregoSpacing.sm), child: controls),
+                    child: Stack(
+                      children: [
+                        Positioned.fill(
+                          child: IgnorePointer(
+                            child: ValueListenableBuilder<double>(
+                              valueListenable: _cancelProgress,
+                              builder: (context, progress, child) => Opacity(opacity: progress, child: child),
+                              child: DecoratedBox(
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(PregoRadius.full),
+                                  gradient: LinearGradient(
+                                    colors: [
+                                      prego.colors.bgDestructivePressedAlt.withValues(alpha: 0.5),
+                                      prego.colors.bgDestructivePressedAlt.withValues(alpha: 0),
+                                    ],
+                                    stops: const [0, 0.28],
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                        Padding(padding: const EdgeInsets.all(PregoSpacing.sm), child: controls),
+                      ],
+                    ),
                   ),
               ],
             ),
@@ -1059,27 +1145,47 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
     final hasText = _text.text.isNotEmpty;
     final keyboardMode = _mode == _InputMode.keyboard;
     final busy = _submission == _SubmissionStage.submitting;
-    final voiceBusy = _voice == _VoiceStage.recording || _voice == _VoiceStage.transcribing;
-    final transcriptReady = hasText && !keyboardMode;
+    final voiceBusy = _recording || _voice == _VoiceStage.transcribing || _voice == _VoiceStage.requestingPermission;
+    final transcriptReady = hasText && !keyboardMode && !_recording;
     return Row(
       children: [
+        _FeedbackActionTransition(
+          child: _recording
+              ? Padding(
+                  padding: const EdgeInsetsDirectional.only(end: PregoSpacing.md),
+                  child: Semantics(
+                    label: "Cancel recording",
+                    button: true,
+                    child: PregoButtonsSolid.iconOnly(
+                      key: _cancelRecordingKey,
+                      leadingIcon: TablerRegular.x,
+                      hierarchy: PregoButtonsSolidHierarchy.primary,
+                      size: PregoButtonsSolidSize.lg,
+                      type: PregoButtonsSolidType.destructive,
+                      onPressed: _cancelRecording,
+                    ),
+                  ),
+                )
+              : const SizedBox.shrink(),
+        ),
         if (!keyboardMode)
           Expanded(
             child: Semantics(
               button: true,
-              label: _voice == _VoiceStage.recording
+              label: _recording
                   ? "Finish recording"
                   : hasText
                   ? "Hold to talk more"
                   : "Hold to talk to give feedback",
               excludeSemantics: true,
-              onTap: busy ? null : () => _voice == _VoiceStage.recording ? _transcribe() : _startRecording(),
+              onTap: busy ? null : () => _recording ? _finishRecording() : _startRecording(),
               child: GestureDetector(
                 key: const ValueKey("feedback-voice"),
                 behavior: HitTestBehavior.opaque,
-                onTap: busy ? null : () => _voice == _VoiceStage.recording ? _transcribe() : _startRecording(),
+                onTap: busy ? null : () => _recording ? _finishRecording() : _startRecording(),
                 onLongPressStart: busy ? null : (_) => _startRecording(),
-                onLongPressEnd: busy ? null : (_) => _transcribe(),
+                onLongPressMoveUpdate: busy ? null : (details) => _dragRecording(position: details.globalPosition),
+                onLongPressEnd: busy ? null : (_) => _finishRecording(),
                 child: _FeedbackPress(
                   enabled: !busy && _voice != _VoiceStage.transcribing,
                   child: SizedBox(
@@ -1087,9 +1193,14 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
                     child: Center(
                       child: _FeedbackContentTransition(
                         child: KeyedSubtree(
-                          key: ValueKey((_voice, hasText)),
+                          key: ValueKey((_recording ? _VoiceStage.recording : _voice, hasText)),
                           child: switch (_voice) {
-                            _VoiceStage.recording => const _RecordingPreview(),
+                            _VoiceStage.recording ||
+                            _VoiceStage.cancelling => _RecordingPreview(flattenProgress: _cancelProgress),
+                            _VoiceStage.requestingPermission => Text(
+                              "Microphone access…",
+                              style: prego.textTheme.textMd.regular,
+                            ),
                             _VoiceStage.transcribing => Text("Transcribing…", style: voiceLabelStyle),
                             _ => Padding(
                               // Balance the trailing 44px Send action, as in Figma.
@@ -1145,7 +1256,7 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
               : const SizedBox.shrink(),
         ),
         _FeedbackActionTransition(
-          child: !transcriptReady
+          child: !transcriptReady && !_recording
               ? Padding(
                   padding: const EdgeInsetsDirectional.only(start: PregoSpacing.sm),
                   child: _ComposerButton(
@@ -1314,7 +1425,7 @@ class const _InlineMessage({
   );
 }
 
-class const _RecordingPreview() extends StatefulWidget {
+class const _RecordingPreview({required final ValueListenable<double> flattenProgress}) extends StatefulWidget {
   @override
   State<_RecordingPreview> createState() => _RecordingPreviewState();
 }
@@ -1327,7 +1438,7 @@ class _RecordingPreviewState() extends State<_RecordingPreview> {
 
   @override
   Widget build(BuildContext context) => Padding(
-    padding: const EdgeInsets.symmetric(horizontal: 12),
+    padding: const EdgeInsetsDirectional.only(end: PregoSpacing.sm),
     child: ShaderMask(
       blendMode: BlendMode.dstIn,
       shaderCallback: (bounds) => const LinearGradient(
@@ -1337,7 +1448,8 @@ class _RecordingPreviewState() extends State<_RecordingPreview> {
       child: PregoVoiceWaveform(
         amplitudeStream: _samples,
         barColor: context.prego.colors.textPrimary,
-        dotColor: context.prego.colors.textQuaternary,
+        dotColor: context.prego.colors.fgQuaternary,
+        flattenProgress: widget.flattenProgress,
       ),
     ),
   );

--- a/client/app/test/playbook/feedback_flow_playbook.dart
+++ b/client/app/test/playbook/feedback_flow_playbook.dart
@@ -1328,10 +1328,17 @@ class _RecordingPreviewState() extends State<_RecordingPreview> {
   @override
   Widget build(BuildContext context) => Padding(
     padding: const EdgeInsets.symmetric(horizontal: 12),
-    child: PregoVoiceWaveform(
-      amplitudeStream: _samples,
-      barColor: context.prego.colors.textPrimary,
-      dotColor: context.prego.colors.textQuaternary,
+    child: ShaderMask(
+      blendMode: BlendMode.dstIn,
+      shaderCallback: (bounds) => const LinearGradient(
+        colors: [Colors.transparent, Colors.white, Colors.white, Colors.transparent],
+        stops: [0, 0.08, 0.92, 1],
+      ).createShader(bounds),
+      child: PregoVoiceWaveform(
+        amplitudeStream: _samples,
+        barColor: context.prego.colors.textPrimary,
+        dotColor: context.prego.colors.textQuaternary,
+      ),
     ),
   );
 }

--- a/client/app/test/playbook/feedback_flow_playbook.dart
+++ b/client/app/test/playbook/feedback_flow_playbook.dart
@@ -38,6 +38,7 @@ enum _InputMode() {
 enum _VoiceStage() {
   idle,
   requestingPermission,
+  awaitingPermissionAfterRelease,
   recording,
   cancelling,
   transcribing,
@@ -758,11 +759,11 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
   _SubmissionStage _submission = _SubmissionStage.editing;
   bool _submissionFailedOnce = false;
   bool _transcriptionFailedOnce = false;
-  bool _microphoneReady = false;
 
   bool get _canSend =>
       _submission != _SubmissionStage.submitting &&
       _voice != _VoiceStage.requestingPermission &&
+      _voice != _VoiceStage.awaitingPermissionAfterRelease &&
       _voice != _VoiceStage.recording &&
       _voice != _VoiceStage.cancelling &&
       _voice != _VoiceStage.transcribing;
@@ -849,24 +850,33 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
   Future<void> _startRecording() async {
     if (!_canSend) return;
     _focus.unfocus();
-    if (widget.scenario == FeedbackPreviewScenario.microphoneDenied && !_microphoneReady) {
+    if (widget.scenario == FeedbackPreviewScenario.microphoneDenied) {
       setState(() => _voice = _VoiceStage.requestingPermission);
       try {
-        _microphoneReady =
+        // True means access was already authorized, so no OS UI interrupted
+        // this gesture. Any permission/settings round trip returns false.
+        final canContinue =
             await const MethodChannel("com.sesori.app/feedback_preview")
                 .invokeMethod<bool>("requestMicrophoneAccess") ??
             false;
+        if (!mounted) return;
+        if (!canContinue || _voice == _VoiceStage.awaitingPermissionAfterRelease) {
+          setState(() => _voice = _VoiceStage.idle);
+          return;
+        }
       } on MissingPluginException {
         if (mounted) {
           _showVoiceError(message: "Microphone settings are available in the iOS and Android debug preview.");
+          setState(() => _voice = _VoiceStage.idle);
         }
+        return;
       } on PlatformException {
-        if (mounted) _showVoiceError(message: "Couldn’t open microphone settings. Please try again.");
+        if (mounted) {
+          _showVoiceError(message: "Couldn’t open microphone settings. Please try again.");
+          setState(() => _voice = _VoiceStage.idle);
+        }
+        return;
       }
-      // The original hold has ended while the OS prompt was open. A fresh
-      // gesture starts the simulated recording after permission is granted.
-      if (mounted) setState(() => _voice = _VoiceStage.idle);
-      return;
     }
     _cancelProgress.value = 0;
     setState(() {
@@ -891,7 +901,9 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
   }
 
   void _finishRecording() {
-    if (_voice == _VoiceStage.cancelling) {
+    if (_voice == _VoiceStage.requestingPermission) {
+      setState(() => _voice = _VoiceStage.awaitingPermissionAfterRelease);
+    } else if (_voice == _VoiceStage.cancelling) {
       _cancelRecording();
     } else {
       unawaited(_transcribe());
@@ -1145,7 +1157,11 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
     final hasText = _text.text.isNotEmpty;
     final keyboardMode = _mode == _InputMode.keyboard;
     final busy = _submission == _SubmissionStage.submitting;
-    final voiceBusy = _recording || _voice == _VoiceStage.transcribing || _voice == _VoiceStage.requestingPermission;
+    final voiceBusy =
+        _recording ||
+        _voice == _VoiceStage.transcribing ||
+        _voice == _VoiceStage.requestingPermission ||
+        _voice == _VoiceStage.awaitingPermissionAfterRelease;
     final transcriptReady = hasText && !keyboardMode && !_recording;
     return Row(
       children: [
@@ -1197,7 +1213,7 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
                           child: switch (_voice) {
                             _VoiceStage.recording ||
                             _VoiceStage.cancelling => _RecordingPreview(flattenProgress: _cancelProgress),
-                            _VoiceStage.requestingPermission => Text(
+                            _VoiceStage.requestingPermission || _VoiceStage.awaitingPermissionAfterRelease => Text(
                               "Microphone access…",
                               style: prego.textTheme.textMd.regular,
                             ),

--- a/client/app/test/playbook/feedback_flow_playbook.dart
+++ b/client/app/test/playbook/feedback_flow_playbook.dart
@@ -1055,6 +1055,7 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
 
   Widget _buildComposerControls({required BuildContext context}) {
     final prego = context.prego;
+    final voiceLabelStyle = prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary);
     final hasText = _text.text.isNotEmpty;
     final keyboardMode = _mode == _InputMode.keyboard;
     final busy = _submission == _SubmissionStage.submitting;
@@ -1089,7 +1090,7 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
                           key: ValueKey((_voice, hasText)),
                           child: switch (_voice) {
                             _VoiceStage.recording => const _RecordingPreview(),
-                            _VoiceStage.transcribing => Text("Transcribing…", style: prego.textTheme.textSm.regular),
+                            _VoiceStage.transcribing => Text("Transcribing…", style: voiceLabelStyle),
                             _ => Padding(
                               // Balance the trailing 44px Send action, as in Figma.
                               padding: EdgeInsetsDirectional.only(start: transcriptReady ? 44 : 0),
@@ -1097,7 +1098,7 @@ class _PrivateFeedbackStepState() extends State<_PrivateFeedbackStep> {
                                 hasText ? "Hold to talk more" : "Hold to talk to give feedback",
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
-                                style: prego.textTheme.textMd.regular.copyWith(color: prego.colors.textSecondary),
+                                style: voiceLabelStyle,
                               ),
                             ),
                           },

--- a/client/app/test/playbook/feedback_flow_playbook_test.dart
+++ b/client/app/test/playbook/feedback_flow_playbook_test.dart
@@ -238,7 +238,9 @@ void main() {
       await tester.ensureVisible(voice);
       final hold = await tester.startGesture(tester.getCenter(voice));
       await tester.pump(const Duration(milliseconds: 600));
-      expect(tester.widget<Semantics>(_control(label: "Send feedback")).properties.enabled, isFalse);
+      await tester.pump(const Duration(milliseconds: 400));
+      expect(_control(label: "Send feedback"), findsNothing);
+      expect(_control(label: "Cancel recording"), findsOneWidget);
       await hold.up();
       await tester.pump();
       expect(find.text("Transcribing…"), findsOneWidget);

--- a/client/app/test/playbook/feedback_motion_test.dart
+++ b/client/app/test/playbook/feedback_motion_test.dart
@@ -1,4 +1,5 @@
 import "package:flutter/rendering.dart";
+import "package:flutter/services.dart";
 import "package:flutter_test/flutter_test.dart";
 import "package:material_ui/material_ui.dart";
 import "package:theme_prego/module_prego.dart";
@@ -232,15 +233,23 @@ void main() {
 
   testWidgets(
     variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    "microphone denial reveals the keyboard alternative and keeps selected issues",
+    "microphone denial requests native settings and keeps selected issues",
     (tester) async {
+      const channel = MethodChannel("com.sesori.app/feedback_preview");
+      final requests = <String>[];
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+        requests.add(call.method);
+        return false;
+      });
+      addTearDown(() => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null));
       await _openScenario(tester: tester, scenario: FeedbackPreviewScenario.microphoneDenied);
       await tester.tap(find.text("Connection drops"));
       await tester.pumpAndSettle();
       await tester.tap(_control(label: "Hold to talk to give feedback"));
       await tester.pumpAndSettle();
-      expect(find.text("Microphone access is off. You can type your feedback instead."), findsOneWidget);
-      await tester.tap(find.text("Use keyboard"));
+      expect(requests, ["requestMicrophoneAccess"]);
+      expect(find.textContaining("Microphone access is off"), findsNothing);
+      await tester.tap(_control(label: "Use keyboard"));
       await tester.pumpAndSettle();
       expect(find.byKey(const ValueKey("feedback-text")), findsOneWidget);
       expect(tester.widget<Semantics>(_control(label: "Connection drops")).properties.checked, isTrue);
@@ -250,7 +259,7 @@ void main() {
 
   testWidgets(
     variant: TargetPlatformVariant.only(TargetPlatform.iOS),
-    "transcription failure retires into an editable draft on retry",
+    "transcription failure shows an auto-dismissed top toast and accepts a fresh recording",
     (tester) async {
       await _openScenario(tester: tester, scenario: FeedbackPreviewScenario.transcriptionRetry);
       await tester.tap(_control(label: "Hold to talk to give feedback"));
@@ -260,12 +269,21 @@ void main() {
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 950));
       await tester.pumpAndSettle();
-      expect(find.text("Couldn’t transcribe that. Try again or use the keyboard."), findsOneWidget);
-      await tester.tap(find.text("Retry transcription"));
+      final toast = find.byType(PregoPopupAlertsNotifications);
+      expect(find.text("Couldn’t transcribe that. Please try again."), findsOneWidget);
+      expect(tester.getBottomRight(toast).dy, lessThan(tester.getTopLeft(find.byType(BottomSheet)).dy));
+      expect(find.text("Retry transcription"), findsNothing);
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpAndSettle();
+      expect(toast, findsNothing);
+      await tester.tap(_control(label: "Hold to talk to give feedback"));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.tap(_control(label: "Finish recording"));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 950));
       await tester.pumpAndSettle();
-      expect(find.text("Couldn’t transcribe that. Try again or use the keyboard."), findsNothing);
+      expect(find.text("Couldn’t transcribe that. Please try again."), findsNothing);
       expect(find.byKey(const ValueKey("feedback-text")), findsOneWidget);
       expect(find.text("Feedback sent. Thank you!"), findsNothing);
       expect(tester.takeException(), isNull);

--- a/client/app/test/playbook/feedback_voice_states_test.dart
+++ b/client/app/test/playbook/feedback_voice_states_test.dart
@@ -1,0 +1,240 @@
+import "dart:async";
+
+import "package:flutter/services.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:theme_prego/components/buttons/prego_buttons_solid.dart";
+import "package:theme_prego/module_prego.dart";
+
+import "feedback_flow_playbook.dart";
+
+void main() {
+  const channel = MethodChannel("com.sesori.app/feedback_preview");
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+  final requests = <MethodCall>[];
+  late Completer<bool> permission;
+
+  setUp(() {
+    requests.clear();
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) {
+      requests.add(call);
+      return permission.future;
+    });
+  });
+  tearDown(() => binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null));
+
+  for (final platform in [TargetPlatform.iOS, TargetPlatform.android]) {
+    testWidgets(
+      variant: TargetPlatformVariant.only(platform),
+      "permission grant waits for a fresh gesture and is reused",
+      (tester) async {
+        permission = Completer<bool>();
+        await _open(tester: tester, permissionScenario: true);
+        final originalHold = await _hold(tester: tester);
+        expect(requests.single.method, "requestMicrophoneAccess");
+        expect(requests.single.arguments, isNull);
+        expect(find.text("Microphone access…"), findsOneWidget);
+        expect(find.byType(PregoVoiceWaveform), findsNothing);
+        await originalHold.up();
+        permission.complete(true);
+        await tester.pumpAndSettle();
+        expect(find.text("Hold to talk to give feedback"), findsOneWidget);
+        expect(find.byType(PregoVoiceWaveform), findsNothing);
+        expect(find.text("Transcribing…"), findsNothing);
+
+        final freshHold = await _hold(tester: tester);
+        expect(find.byType(PregoVoiceWaveform), findsOneWidget);
+        expect(requests, hasLength(1));
+        await freshHold.up();
+        await _finishTranscription(tester: tester);
+        expect(_draft(tester: tester), contains("The design is clean"));
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      variant: TargetPlatformVariant.only(platform),
+      "permission denial preserves draft and issues and permits another native request",
+      (tester) async {
+        permission = Completer<bool>();
+        await _open(tester: tester, permissionScenario: true);
+        await _prepareDraft(tester: tester);
+        final hold = await _hold(tester: tester);
+        await hold.up();
+        permission.complete(false);
+        await tester.pumpAndSettle();
+        expect(_draft(tester: tester), _existingDraft);
+        _expectSelectedIssue(tester: tester);
+        expect(find.byType(PregoVoiceWaveform), findsNothing);
+        expect(find.text("Hold to talk more"), findsOneWidget);
+
+        permission = Completer<bool>();
+        final retry = await _hold(tester: tester);
+        expect(requests.map((call) => call.method), ["requestMicrophoneAccess", "requestMicrophoneAccess"]);
+        await retry.up();
+        permission.complete(false);
+        await tester.pumpAndSettle();
+        expect(_draft(tester: tester), _existingDraft);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      variant: TargetPlatformVariant.only(platform),
+      "native microphone failure shows a top toast and restores the idle composer",
+      (tester) async {
+        permission = Completer<bool>();
+        await _open(tester: tester, permissionScenario: true);
+        final hold = await _hold(tester: tester);
+        await hold.up();
+        permission.completeError(PlatformException(code: "settings_unavailable"));
+        await tester.pumpAndSettle();
+        expect(find.text("Couldn’t open microphone settings. Please try again."), findsOneWidget);
+        expect(
+          tester.getBottomRight(find.byType(PregoPopupAlertsNotifications)).dy,
+          lessThan(tester.getTopLeft(find.byType(BottomSheet)).dy),
+        );
+        expect(find.text("Hold to talk to give feedback"), findsOneWidget);
+        expect(find.byType(PregoVoiceWaveform), findsNothing);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      variant: TargetPlatformVariant.only(platform),
+      "closing feedback while native permission is pending ignores its late grant",
+      (tester) async {
+        permission = Completer<bool>();
+        await _open(tester: tester, permissionScenario: true);
+        final hold = await _hold(tester: tester);
+        await hold.up();
+        await _tap(tester: tester, finder: find.text("Cancel"));
+        expect(find.byType(BottomSheet), findsNothing);
+        permission.complete(true);
+        await tester.pumpAndSettle();
+        expect(find.byType(PregoVoiceWaveform), findsNothing);
+        expect(find.text("Transcribing…"), findsNothing);
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
+
+  testWidgets("dragging to Cancel flattens the waveform and discards only the recording", (tester) async {
+    await _open(tester: tester);
+    await _prepareDraft(tester: tester);
+    final hold = await _hold(tester: tester);
+    await hold.moveTo(tester.getCenter(_control(label: "Cancel recording")));
+    await tester.pump();
+    expect(find.text("Release to cancel"), findsOneWidget);
+    expect(tester.widget<PregoVoiceWaveform>(find.byType(PregoVoiceWaveform)).flattenProgress?.value, 1);
+    await hold.up();
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(milliseconds: 950));
+    expect(find.byType(PregoVoiceWaveform), findsNothing);
+    expect(find.text("Transcribing…"), findsNothing);
+    expect(_draft(tester: tester), _existingDraft);
+    _expectSelectedIssue(tester: tester);
+    expect(requests, isEmpty);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets("dragging back out of Cancel restores recording and release appends transcription", (tester) async {
+    await _open(tester: tester);
+    await _prepareDraft(tester: tester);
+    final hold = await _hold(tester: tester);
+    await hold.moveTo(tester.getCenter(_control(label: "Cancel recording")));
+    await tester.pump();
+    expect(find.text("Release to cancel"), findsOneWidget);
+    await hold.moveTo(tester.getTopRight(find.byKey(const ValueKey("feedback-voice"))) + const Offset(-8, 22));
+    await tester.pump();
+    expect(find.text("Release to transcribe"), findsOneWidget);
+    expect(tester.widget<PregoVoiceWaveform>(find.byType(PregoVoiceWaveform)).flattenProgress?.value, 0);
+    await hold.up();
+    await _finishTranscription(tester: tester);
+    expect(_draft(tester: tester), startsWith("$_existingDraft "));
+    expect(_draft(tester: tester), contains("The design is clean"));
+    _expectSelectedIssue(tester: tester);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets("the direct Cancel recording button restores the existing draft", (tester) async {
+    await _open(tester: tester);
+    await _prepareDraft(tester: tester);
+    await tester.tap(find.byKey(const ValueKey("feedback-voice")));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(find.byType(PregoVoiceWaveform), findsOneWidget);
+    await tester.tap(_control(label: "Cancel recording"));
+    await tester.pumpAndSettle();
+    expect(find.byType(PregoVoiceWaveform), findsNothing);
+    expect(_draft(tester: tester), _existingDraft);
+    _expectSelectedIssue(tester: tester);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+const _existingDraft = "Please keep my existing feedback.";
+
+Future<void> _open({required WidgetTester tester, bool permissionScenario = false}) async {
+  tester.view.devicePixelRatio = 1;
+  tester.view.physicalSize = const Size(390, 844);
+  addTearDown(tester.view.resetDevicePixelRatio);
+  addTearDown(tester.view.resetPhysicalSize);
+  addTearDown(() => tester.pumpWidget(const SizedBox.shrink()));
+  await tester.pumpWidget(const FeedbackFlowPlaybook(openOnLaunch: false));
+  await tester.pumpAndSettle();
+  if (permissionScenario) {
+    await _tap(tester: tester, finder: find.byType(DropdownButtonFormField<FeedbackPreviewScenario>));
+    await _tap(tester: tester, finder: find.text(FeedbackPreviewScenario.microphoneDenied.label).last);
+  }
+  await _tap(
+    tester: tester,
+    finder: find.ancestor(of: find.text("Open feedback"), matching: find.byType(PregoButtonsSolid)),
+  );
+  await _tap(tester: tester, finder: find.byKey(const ValueKey("rating-2")));
+}
+
+Future<void> _prepareDraft({required WidgetTester tester}) async {
+  await _tap(tester: tester, finder: find.text("Connection drops"));
+  await _tap(
+    tester: tester,
+    finder: _control(label: "Use keyboard"),
+  );
+  await tester.enterText(find.byKey(const ValueKey("feedback-text")), _existingDraft);
+  await _tap(
+    tester: tester,
+    finder: _control(label: "Use voice input"),
+  );
+}
+
+Future<TestGesture> _hold({required WidgetTester tester}) async {
+  final voice = find.byKey(const ValueKey("feedback-voice"));
+  await tester.ensureVisible(voice);
+  final hold = await tester.startGesture(tester.getCenter(voice));
+  await tester.pump(const Duration(milliseconds: 600));
+  await tester.pump(const Duration(milliseconds: 400));
+  return hold;
+}
+
+Future<void> _finishTranscription({required WidgetTester tester}) async {
+  await tester.pump();
+  expect(find.text("Transcribing…"), findsOneWidget);
+  await tester.pump(const Duration(milliseconds: 950));
+  await tester.pumpAndSettle();
+}
+
+Future<void> _tap({required WidgetTester tester, required Finder finder}) async {
+  await tester.ensureVisible(finder);
+  await tester.pump();
+  await tester.tap(finder);
+  await tester.pumpAndSettle();
+}
+
+String? _draft({required WidgetTester tester}) =>
+    tester.widget<TextField>(find.byKey(const ValueKey("feedback-text"))).controller?.text;
+
+void _expectSelectedIssue({required WidgetTester tester}) =>
+    expect(tester.widget<Semantics>(_control(label: "Connection drops")).properties.checked, isTrue);
+
+Finder _control({required String label}) =>
+    find.byWidgetPredicate((widget) => widget is Semantics && widget.properties.label == label);

--- a/client/app/test/playbook/feedback_voice_states_test.dart
+++ b/client/app/test/playbook/feedback_voice_states_test.dart
@@ -26,7 +26,46 @@ void main() {
   for (final platform in [TargetPlatform.iOS, TargetPlatform.android]) {
     testWidgets(
       variant: TargetPlatformVariant.only(platform),
-      "permission grant waits for a fresh gesture and is reused",
+      "already-authorized access records on the first hold",
+      (tester) async {
+        permission = Completer<bool>()..complete(true);
+        await _open(tester: tester, permissionScenario: true);
+        final hold = await _hold(tester: tester);
+        expect(requests, hasLength(1));
+        expect(find.byType(PregoVoiceWaveform), findsOneWidget);
+        await hold.up();
+        await _finishTranscription(tester: tester);
+        expect(_draft(tester: tester), contains("The design is clean"));
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      variant: TargetPlatformVariant.only(platform),
+      "a native prompt round trip requires a fresh hold even before release",
+      (tester) async {
+        permission = Completer<bool>();
+        await _open(tester: tester, permissionScenario: true);
+        final hold = await _hold(tester: tester);
+        // The native handler returns false after any UI round trip, even a
+        // successful grant. A later check can authorize a fresh gesture.
+        permission.complete(false);
+        await tester.pumpAndSettle();
+        expect(find.byType(PregoVoiceWaveform), findsNothing);
+        await hold.up();
+        permission = Completer<bool>()..complete(true);
+        final freshHold = await _hold(tester: tester);
+        expect(find.byType(PregoVoiceWaveform), findsOneWidget);
+        expect(requests, hasLength(2));
+        await freshHold.up();
+        await _finishTranscription(tester: tester);
+        expect(tester.takeException(), isNull);
+      },
+    );
+
+    testWidgets(
+      variant: TargetPlatformVariant.only(platform),
+      "late authorization after release waits for a fresh gesture",
       (tester) async {
         permission = Completer<bool>();
         await _open(tester: tester, permissionScenario: true);
@@ -44,7 +83,7 @@ void main() {
 
         final freshHold = await _hold(tester: tester);
         expect(find.byType(PregoVoiceWaveform), findsOneWidget);
-        expect(requests, hasLength(1));
+        expect(requests, hasLength(2));
         await freshHold.up();
         await _finishTranscription(tester: tester);
         expect(_draft(tester: tester), contains("The design is clean"));

--- a/docs/regression/motion-tuning.md
+++ b/docs/regression/motion-tuning.md
@@ -18,6 +18,19 @@ motion and automatic dismissal. It is labeled replay only and exposes no
 target-specific tuning controls. Whole-flow replay uses that same presenter;
 native rating requests remain disabled in tuning mode.
 
+The feedback voice preview supports holding to record, releasing to transcribe,
+and dragging onto the red X to cancel. Cancellation preserves existing text and
+selected issues. The destructive gradient and flattened waveform follow the
+finger, and moving away restores recording. The X also supports a direct tap.
+Transcription failure displays the shared top error toast, then returns to the
+composer for a fresh recording or keyboard input without changing the draft.
+
+The explicitly selected microphone permission scenario opens real iOS/Android
+system permission UI, or app settings when access is denied. Recording remains
+simulated. Returning from that UI requires a fresh gesture; permission completion
+must never start a recording after the original hold ended or the sheet closed.
+Automatic motion replay never opens permission UI.
+
 Global animation speed offers Normal (1×), 0.5×, and 0.2× without selecting a
 target. It changes Flutter's scheduler clock immediately across the preview,
 including unconnected animations, and shows slow speed in the collapsed header.
@@ -76,6 +89,10 @@ mobile/desktop consumers using `CatalogScanRowMotion.standard`.
   keyboard; expanding the panel changes the preview's available layout size.
 - Composer action reveals clip the native button's pressed scale or shadow
   against a rectangular boundary inside the voice-input surface.
+- Cancelling a recording starts transcription, deletes an existing draft, or
+  leaves the destructive gradient visible during transcription.
+- Microphone failure adds inline error copy instead of opening native permission
+  UI/settings; transcription failure fails to show the shared top error toast.
 - Ordinary scan-row defaults change, reduced motion is lost, or controllers
   continue after the widget is removed.
 - Production entrypoints import the toolkit or expose its controls.

--- a/docs/regression/motion-tuning.md
+++ b/docs/regression/motion-tuning.md
@@ -29,6 +29,9 @@ The explicitly selected microphone permission scenario opens real iOS/Android
 system permission UI, or app settings when access is denied. Recording remains
 simulated. Returning from that UI requires a fresh gesture; permission completion
 must never start a recording after the original hold ended or the sheet closed.
+Already-authorized access continues the current gesture without requiring an
+extra hold. Restricted iOS access does not send users to an inapplicable settings
+page.
 Automatic motion replay never opens permission UI.
 
 Global animation speed offers Normal (1×), 0.5×, and 0.2× without selecting a
@@ -93,6 +96,9 @@ mobile/desktop consumers using `CatalogScanRowMotion.standard`.
   leaves the destructive gradient visible during transcription.
 - Microphone failure adds inline error copy instead of opening native permission
   UI/settings; transcription failure fails to show the shared top error toast.
+- Permission completion starts a recording after the original hold ended or the
+  sheet closed, or returning from permission UI resumes without a fresh gesture.
+- Already-authorized microphone access discards the first recording gesture.
 - Ordinary scan-row defaults change, reduced motion is lost, or controllers
   continue after the widget is removed.
 - Production entrypoints import the toolkit or expose its controls.


### PR DESCRIPTION
## Complexity
⚙️ Moderate: native debug permission handlers plus a gesture-driven recording/cancel transition in the feedback playbook.

## What
- Replace the simulated inline microphone error with native iOS/Android microphone permission UI or app settings. Already-authorized access continues the first gesture; returning from native UI requires a fresh gesture. Restricted iOS access does not open an inapplicable settings page.
- Show transcription failure through the shared top error toast, with automatic dismissal and a fresh recording/keyboard path that preserves the draft.
- Implement the [Figma cancellation state](https://www.figma.com/design/DTKWZawsS3zfA7TPA4OlGr/PREGO-Design-System?node-id=4590-10192): red X, destructive gradient, flattened waveform, release-to-cancel, and drag-back-to-transcribe. Direct cancellation is also available.
- Match hold/transcription label typography and soften the waveform's two edges, incorporating the separately requested preview refinements.

## Why
The feedback preview exposed inline failure copy and lacked the recording cancellation state. These changes let designers exercise the intended recovery and cancellation interactions without losing existing feedback.

## Risk and test focus
Gesture ownership across state changes, draft/issue preservation, late permission completion, and cancellation versus transcription. The permission scenario is explicitly labeled as opening real system UI. Automatic motion replay stays local and never requests permission; audio capture, transcription, and submission remain simulated.

No database or production user-visible impact. The native preview channel is registered only in debug builds; the production Dart entrypoint has no caller.

## Expected result
Microphone access problems open the native permission/settings flow. Transcription errors appear at the top. Holding and dragging to the X presents the specified cancellation state; releasing there discards only that recording, while moving away resumes normal transcription behavior.

## Verification
- 52 feedback flow, motion, tuning, and voice-state tests pass, including mocked iOS and Android permission flows, first-gesture recording with existing authorization, late grants after release/dismissal, draft-preserving cancellation, drag-back recovery, and top-toast retry behavior.
- Full app Dart analyzer: no issues. Formatting and `git diff --check` pass.
- iOS debug app built and launched on a separate simulator. Native recording/cancellation appearance inspected; existing user previews were preserved.
- Deterministic rendered Flutter captures inspected in light/dark for idle, recording, transcription, cancellation, and the error toast. Hold/transcription font size, weight, and color equality also checked.
- Swift SDK typechecks pass with and without DEBUG. Android native compilation and device permission dialogs remain unverified locally because this machine has no Java/Android SDK. The regular PR mobile job exercises Dart/Flutter tests, not an Android native build.

Stacked on `codex/feedback` (PR #1361).
