### PR TITLE
🚧 [claude-inline-subtasks] DeepSeek completes ACP-owned scoped stop [step 5/5]

### DIFF
--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -178,8 +178,8 @@ post-merge E2E gates are unchanged.
 | [x] | DeepSeek | `⚙️ [claude-inline-subtasks] DeepSeek scoped sub-agent stops [step 1/2]` | [#1346](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1346) merged at `2cc1485d7c`; title retained historically |
 | [x] | DeepSeek (adapter) | `🚧 [claude-inline-subtasks] DeepSeek atomic subtree cancellation [step 2/3]` | Adapter #17 merged at `5eecdf68a3` |
 | [x] | DeepSeek (adapter) | `release: prepare v0.1.4 for atomic-stop consumer` | Adapter #18 merged at `e2ea207f21`; v0.1.4 published and verified |
-| [ ] | DeepSeek native stop | `⚙️ [claude-inline-subtasks] DeepSeek native stop contract and input ordering [step 4/5]` | [#1363](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1363) in review; replaces the contract/pin portion of closed #1356 |
-| [ ] | DeepSeek native stop | `🚧 [claude-inline-subtasks] DeepSeek completes ACP-owned scoped stop [step 5/5]` | Pending #1363; completes native authority consumption |
+| [x] | DeepSeek native stop | `⚙️ [claude-inline-subtasks] DeepSeek native stop contract and input ordering [step 4/5]` | [#1363](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1363) merged at `b13d197d51`; replaces the contract/pin portion of closed #1356 |
+| [ ] | DeepSeek native stop | `🚧 [claude-inline-subtasks] DeepSeek completes ACP-owned scoped stop [step 5/5]` | Implemented locally; final phone/desktop E2E remains user-owned |
 | [ ] | DeepSeek | `🌱 [claude-inline-subtasks] docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
 | [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: subtask tiles and stop confirmation for task subagents` | Not started |
 | [ ] | Cursor | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage` | Not started |

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -179,7 +179,7 @@ post-merge E2E gates are unchanged.
 | [x] | DeepSeek (adapter) | `🚧 [claude-inline-subtasks] DeepSeek atomic subtree cancellation [step 2/3]` | Adapter #17 merged at `5eecdf68a3` |
 | [x] | DeepSeek (adapter) | `release: prepare v0.1.4 for atomic-stop consumer` | Adapter #18 merged at `e2ea207f21`; v0.1.4 published and verified |
 | [x] | DeepSeek native stop | `⚙️ [claude-inline-subtasks] DeepSeek native stop contract and input ordering [step 4/5]` | [#1363](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1363) merged at `b13d197d51`; replaces the contract/pin portion of closed #1356 |
-| [ ] | DeepSeek native stop | `🚧 [claude-inline-subtasks] DeepSeek completes ACP-owned scoped stop [step 5/5]` | Implemented locally; final phone/desktop E2E remains user-owned |
+| [ ] | DeepSeek native stop | `🚧 [claude-inline-subtasks] DeepSeek completes ACP-owned scoped stop [step 5/5]` | [#1370](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1370) in review; final phone/desktop E2E remains user-owned |
 | [ ] | DeepSeek | `🌱 [claude-inline-subtasks] docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
 | [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: subtask tiles and stop confirmation for task subagents` | Not started |
 | [ ] | Cursor | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage` | Not started |

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -9,9 +9,9 @@
   also made the scoped stop harness-neutral (OpenCode honors it; rejections
   declare `mainAgentOnlySupported`) and added `docs/HARNESS_CAPABILITIES.md`;
   the series is retired
-- **Next action:** deliver replacement step 4/5 (native input/contract), then
-  step 5/5 (complete ACP-owned stop). PR #1356 closed without merge. Complete
-  user-owned DeepSeek phone/desktop E2E before Codex.
+- **Next action:** finish review of native-stop step 5/5 (#1370); step 4/5
+  (#1363) is merged. PR #1356 remains closed without merge. Complete
+  user-owned DeepSeek phone/desktop E2E after step 5/5 merges, before Codex.
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
   Step 3 capture below (CLI 2.1.257); the completed
   `claude-code-plugin/PROTOCOL.md` is historical and is not edited

--- a/.plan/active/claude-inline-subtasks/followups/deepseek-stop-replacement.md
+++ b/.plan/active/claude-inline-subtasks/followups/deepseek-stop-replacement.md
@@ -1,7 +1,7 @@
 # DeepSeek scoped-stop replacement
 
 PR #1356 is closed without merge; its source is preserved at `58bbe71384a7d5f71b00cad3e573995e4fbb587a`.
-Replacement step 4/5 merged as #1363 at `b13d197d51`; step 5/5 is implemented locally pending review and user-owned E2E.
+Replacement step 4/5 merged as #1363 at `b13d197d51`; step 5/5 is in review as #1370, with user-owned E2E still outstanding.
 Each replacement targets at most 1,500 changed lines including generated code, tests, fixtures, and documentation.
 The adapter checkout is read-only evidence: v0.1.4 is already released, with no new native release planned.
 

--- a/.plan/active/claude-inline-subtasks/followups/deepseek-stop-replacement.md
+++ b/.plan/active/claude-inline-subtasks/followups/deepseek-stop-replacement.md
@@ -1,8 +1,8 @@
 # DeepSeek scoped-stop replacement
 
 PR #1356 is closed without merge; its source is preserved at `58bbe71384a7d5f71b00cad3e573995e4fbb587a`.
-Build from current upstream, not by replaying that branch. Two remaining implementation PRs replace its former step 4/4;
-target at most 1,500 changed lines each, including generated code, tests, fixtures, and documentation.
+Replacement step 4/5 merged as #1363 at `b13d197d51`; step 5/5 is implemented locally pending review and user-owned E2E.
+Each replacement targets at most 1,500 changed lines including generated code, tests, fixtures, and documentation.
 The adapter checkout is read-only evidence: v0.1.4 is already released, with no new native release planned.
 
 ## Step 4/5 — native contract and ordered input

--- a/bridge/app/lib/src/repositories/models/session_abort_result.dart
+++ b/bridge/app/lib/src/repositories/models/session_abort_result.dart
@@ -4,7 +4,10 @@ import "package:sesori_shared/sesori_shared.dart";
 sealed class const SessionAbortResult();
 
 /// The stop was performed; [workKept] says resident work was left running.
-final class const SessionAborted({required final bool workKept}) extends SessionAbortResult;
+final class const SessionAborted({
+  required final bool workKept,
+  required final bool subAgentsHandled,
+}) extends SessionAbortResult;
 
 /// A `confirm` stop the plugin refused because sub-agents are running.
 final class const SessionAbortRejected({required final SessionAbortRejection rejection}) extends SessionAbortResult;

--- a/bridge/app/lib/src/repositories/session_repository.dart
+++ b/bridge/app/lib/src/repositories/session_repository.dart
@@ -989,15 +989,27 @@ class SessionRepository({
   Future<SessionAbortResult> abortSession({
     required String sessionId,
     required SessionAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
   }) => _useSessionPlugin(
     sessionId: sessionId,
     operation: SessionOperation.abortSession,
-    body: (plugin, binding) async => switch (await plugin.abortSession(
-      sessionId: binding.backendSessionId,
-      subAgents: subAgents.toPlugin(),
-    )) {
-      PluginAbortAccepted(:final workKept) => SessionAborted(workKept: workKept),
-      final PluginAbortRejectedSubAgentsRunning rejected => SessionAbortRejected(rejection: rejected.toShared()),
+    body: (plugin, binding) async {
+      final knownSubAgentSessionIds = {
+        for (final descendant in (await _getSessionSubtree(root: binding)).skip(1))
+          if (descendant.pluginId == binding.pluginId) descendant.backendSessionId,
+      };
+      return switch (await plugin.abortSession(
+        sessionId: binding.backendSessionId,
+        subAgents: subAgents.toPlugin(),
+        useAtomicStop: useAtomicStop,
+        knownSubAgentSessionIds: knownSubAgentSessionIds,
+      )) {
+        PluginAbortAccepted(:final workKept, :final subAgentsHandled) => SessionAborted(
+          workKept: workKept,
+          subAgentsHandled: subAgentsHandled,
+        ),
+        final PluginAbortRejectedSubAgentsRunning rejected => SessionAbortRejected(rejection: rejected.toShared()),
+      };
     },
   );
 

--- a/bridge/app/lib/src/routing/abort_session_handler.dart
+++ b/bridge/app/lib/src/routing/abort_session_handler.dart
@@ -25,15 +25,14 @@ class AbortSessionHandler({
       subAgents: body.subAgents,
       useAtomicStop: body.useAtomicStop,
     );
-    if (result case SessionAbortRejected(:final rejection)) {
+    return switch (result) {
+      SessionAborted(:final subAgentsHandled) => SessionAbortResponse(subAgentsHandled: subAgentsHandled),
       // The app parses the 409 body as SessionAbortRejection JSON.
-      throw buildJsonErrorResponse(request: request, status: 409, body: rejection.toJson());
-    }
-    return SessionAbortResponse(
-      subAgentsHandled: switch (result) {
-        SessionAborted(:final subAgentsHandled) => subAgentsHandled,
-        SessionAbortRejected() => false,
-      },
-    );
+      SessionAbortRejected(:final rejection) => throw buildJsonErrorResponse(
+        request: request,
+        status: 409,
+        body: rejection.toJson(),
+      ),
+    };
   }
 }

--- a/bridge/app/lib/src/routing/abort_session_handler.dart
+++ b/bridge/app/lib/src/routing/abort_session_handler.dart
@@ -7,7 +7,7 @@ import "request_handler.dart";
 /// Handles `POST /session/abort` — stops in-progress session execution.
 class AbortSessionHandler({
   required final SessionAbortService _sessionAbortService,
-}) extends BodyRequestHandler<AbortSessionRequest, SuccessEmptyResponse> {
+}) extends BodyRequestHandler<AbortSessionRequest, SessionAbortResponse> {
   this
     : super(
         HttpMethod.post,
@@ -16,15 +16,24 @@ class AbortSessionHandler({
       );
 
   @override
-  Future<SuccessEmptyResponse> handle(
+  Future<SessionAbortResponse> handle(
     RelayRequest request, {
     required AbortSessionRequest body,
   }) async {
-    final result = await _sessionAbortService.abortSession(sessionId: body.sessionId, subAgents: body.subAgents);
+    final result = await _sessionAbortService.abortSession(
+      sessionId: body.sessionId,
+      subAgents: body.subAgents,
+      useAtomicStop: body.useAtomicStop,
+    );
     if (result case SessionAbortRejected(:final rejection)) {
       // The app parses the 409 body as SessionAbortRejection JSON.
       throw buildJsonErrorResponse(request: request, status: 409, body: rejection.toJson());
     }
-    return const SuccessEmptyResponse();
+    return SessionAbortResponse(
+      subAgentsHandled: switch (result) {
+        SessionAborted(:final subAgentsHandled) => subAgentsHandled,
+        SessionAbortRejected() => false,
+      },
+    );
   }
 }

--- a/bridge/app/lib/src/services/session_abort_service.dart
+++ b/bridge/app/lib/src/services/session_abort_service.dart
@@ -27,12 +27,17 @@ class SessionAbortService({
   Future<SessionAbortResult> abortSession({
     required String sessionId,
     required SessionAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
   }) {
     final operation = _dispatcher.dispatch<SessionAbortResult>(
       sessionId: sessionId,
       operation: SessionOperation.abortSession,
       body: () async {
-        final result = await _sessionRepository.abortSession(sessionId: sessionId, subAgents: subAgents);
+        final result = await _sessionRepository.abortSession(
+          sessionId: sessionId,
+          subAgents: subAgents,
+          useAtomicStop: useAtomicStop,
+        );
         // Decided by what the plugin actually did, not by the requested policy:
         // a `keep` with nothing to keep is a full stop.
         if (result case SessionAborted(workKept: false)) {

--- a/bridge/app/test/bridge/debug_server_test.dart
+++ b/bridge/app/test/bridge/debug_server_test.dart
@@ -1181,7 +1181,9 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionAware
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
-  }) async => const PluginAbortAccepted(workKept: false);
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
+  }) async => const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async => [];
@@ -1315,10 +1317,12 @@ class _BlockingRoutesPlugin() extends _FakeBridgePlugin {
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
   }) async {
     _abortStarted.complete();
     await _abortRelease.future;
-    return const PluginAbortAccepted(workKept: false);
+    return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
   }
 }
 
@@ -1437,7 +1441,9 @@ class _TrackingBridgePlugin() implements NativeProjectsPluginApi, _SubscriptionA
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
-  }) async => const PluginAbortAccepted(workKept: false);
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
+  }) async => const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async => [];

--- a/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
+++ b/bridge/app/test/bridge/orchestrator_error_recovery_test.dart
@@ -506,7 +506,9 @@ class _ThrowingSummaryPlugin() implements NativeProjectsPluginApi {
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
-  }) async => const PluginAbortAccepted(workKept: false);
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
+  }) async => const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
 
   @override
   Future<List<PluginAgent>> getAgents({required String projectId}) async => [];

--- a/bridge/app/test/bridge/repositories/session_repository_test.dart
+++ b/bridge/app/test/bridge/repositories/session_repository_test.dart
@@ -7,6 +7,7 @@ import "package:sesori_bridge/src/api/database/tables/projects_table.dart";
 import "package:sesori_bridge/src/api/database/tables/pull_requests_table.dart";
 import "package:sesori_bridge/src/api/database/tables/session_table.dart";
 import "package:sesori_bridge/src/repositories/models/project_not_found_exception.dart";
+import "package:sesori_bridge/src/repositories/models/session_abort_result.dart";
 import "package:sesori_bridge/src/repositories/models/session_operation.dart";
 import "package:sesori_bridge/src/repositories/models/verified_github_login.dart";
 import "package:sesori_bridge/src/repositories/project_catalog_identity_calculator.dart";
@@ -1498,6 +1499,70 @@ void main() {
       expect(statuses.unavailablePluginIds, ["setup-blocked"]);
     });
 
+    test("abort forwards one recursive backend descendant snapshot and acknowledgment", () async {
+      final db = createTestDatabase();
+      addTearDown(db.close);
+      const projectId = "abort-project";
+      await db.projectsDao.insertProjectsIfMissing(projectIds: [projectId]);
+      await db.sessionDao.insertSession(
+        sessionId: "root",
+        backendSessionId: "backend-root",
+        projectId: projectId,
+        isDedicated: false,
+        createdAt: 1,
+        worktreePath: null,
+        branchName: null,
+        baseBranch: null,
+        baseCommit: null,
+        lastAgent: null,
+        lastAgentModel: null,
+        pluginId: plugin.id,
+        preservePullRequestScope: false,
+      );
+      for (final child in const [
+        (id: "child", backendId: "backend-child", parentId: "root"),
+        (id: "grandchild", backendId: "backend-grandchild", parentId: "child"),
+      ]) {
+        await db.sessionDao.insertObservedChild(
+          sessionId: child.id,
+          backendSessionId: child.backendId,
+          projectId: projectId,
+          parentSessionId: child.parentId,
+          directory: projectId,
+          catalogTitle: null,
+          archivedAt: null,
+          createdAt: 1,
+          updatedAt: 1,
+          projectionUpdatedAt: 1,
+          pluginId: plugin.id,
+        );
+      }
+      plugin.abortResult = const PluginAbortAccepted(workKept: true, subAgentsHandled: true);
+      final repository = singlePluginSessionRepository(
+        plugin: plugin,
+        sessionDao: db.sessionDao,
+        projectsDao: db.projectsDao,
+        pullRequestDao: db.pullRequestDao,
+        unseenCalculator: const SessionUnseenCalculator(),
+      );
+
+      final result = await repository.abortSession(
+        sessionId: "root",
+        subAgents: SessionAbortSubAgentPolicy.stop,
+        useAtomicStop: true,
+      );
+
+      expect(plugin.lastAbortSessionId, "backend-root");
+      expect(plugin.lastAbortUseAtomicStop, isTrue);
+      expect(plugin.lastAbortKnownSubAgentSessionIds, {"backend-child", "backend-grandchild"});
+      expect(
+        result,
+        isA<SessionAborted>()
+            .having((result) => result.workKept, "kept", true)
+            .having((result) => result.subAgentsHandled, "handled", true),
+      );
+    });
+
     test("unknown sessions reject message and abort operations", () async {
       final db = createTestDatabase();
       addTearDown(db.close);
@@ -1514,7 +1579,7 @@ void main() {
         throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "isNotFound", isTrue)),
       );
       await expectLater(
-        repository.abortSession(sessionId: "unknown", subAgents: SessionAbortSubAgentPolicy.stop),
+        repository.abortSession(sessionId: "unknown", subAgents: SessionAbortSubAgentPolicy.stop, useAtomicStop: false),
         throwsA(isA<PluginOperationException>().having((error) => error.isNotFound, "isNotFound", isTrue)),
       );
       expect(plugin.lastGetMessagesSessionId, isNull);
@@ -2326,7 +2391,11 @@ void main() {
         ),
         () async => await repository.getSessionMessages(sessionId: "gone"),
         () => repository.notifySessionArchived(sessionId: "gone"),
-        () => repository.abortSession(sessionId: "gone", subAgents: SessionAbortSubAgentPolicy.stop),
+        () => repository.abortSession(
+          sessionId: "gone",
+          subAgents: SessionAbortSubAgentPolicy.stop,
+          useAtomicStop: false,
+        ),
         () async => await repository.getChildSessions(sessionId: "gone"),
       ];
       for (final operation in guardedOperations) {
@@ -2622,6 +2691,9 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
   int getSessionsFailuresRemaining = 0;
   int sendPromptCalls = 0;
   String? lastAbortSessionId;
+  bool? lastAbortUseAtomicStop;
+  Set<String>? lastAbortKnownSubAgentSessionIds;
+  PluginAbortResult abortResult = const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
   List<PluginProjectActivitySummary> activitySummaries = const [];
   Set<String> failingProjectIds = const {};
   Map<String, PluginProject> projectsByDirectory = const {};
@@ -2739,9 +2811,13 @@ class _FakeBridgePlugin() implements NativeProjectsPluginApi {
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
   }) async {
     lastAbortSessionId = sessionId;
-    return const PluginAbortAccepted(workKept: false);
+    lastAbortUseAtomicStop = useAtomicStop;
+    lastAbortKnownSubAgentSessionIds = knownSubAgentSessionIds;
+    return abortResult;
   }
 
   @override

--- a/bridge/app/test/bridge/routing/abort_session_handler_test.dart
+++ b/bridge/app/test/bridge/routing/abort_session_handler_test.dart
@@ -1,6 +1,7 @@
 import "package:sesori_bridge/src/routing/abort_session_handler.dart";
 import "package:sesori_bridge/src/services/session_abort_service.dart";
 import "package:sesori_bridge/src/services/session_operation_dispatcher.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
 
@@ -33,22 +34,24 @@ void main() {
       expect(handler.canHandle(makeRequest("POST", "/session/abort")), isTrue);
     });
 
-    test("extracts sessionId from request body", () async {
+    test("extracts sessionId and atomic-stop opt-in from request body", () async {
       await handler.handle(
         makeRequest("POST", "/session/abort"),
-        body: const AbortSessionRequest(sessionId: "s1"),
+        body: const AbortSessionRequest(sessionId: "s1", useAtomicStop: true),
       );
 
       expect(plugin.lastAbortSessionId, equals("s1"));
+      expect(plugin.lastAbortUseAtomicStop, isTrue);
     });
 
-    test("returns 200", () async {
+    test("returns the plugin descendant-handling acknowledgment", () async {
+      plugin.abortResult = const PluginAbortAccepted(workKept: false, subAgentsHandled: true);
       final response = await handler.handle(
         makeRequest("POST", "/session/abort"),
-        body: const AbortSessionRequest(sessionId: "s1"),
+        body: const AbortSessionRequest(sessionId: "s1", useAtomicStop: true),
       );
 
-      expect(response, equals(const SuccessEmptyResponse()));
+      expect(response, equals(const SessionAbortResponse(subAgentsHandled: true)));
     });
   });
 }

--- a/bridge/app/test/bridge/routing/routing_test_helpers.dart
+++ b/bridge/app/test/bridge/routing/routing_test_helpers.dart
@@ -588,7 +588,8 @@ class _NoopSessionRepository() implements SessionRepository {
   Future<SessionAbortResult> abortSession({
     required String sessionId,
     required SessionAbortSubAgentPolicy subAgents,
-  }) async => const SessionAborted(workKept: false);
+    required bool useAtomicStop,
+  }) async => const SessionAborted(workKept: false, subAgentsHandled: false);
 
   @override
   Future<void> notifySessionArchived({required String sessionId}) async {}
@@ -1090,9 +1091,18 @@ class FakeSessionRepository({
   Future<SessionAbortResult> abortSession({
     required String sessionId,
     required SessionAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
   }) async {
-    await _plugin.abortSession(sessionId: sessionId, subAgents: subAgents.toPlugin());
-    return const SessionAborted(workKept: false);
+    final result = await _plugin.abortSession(
+      sessionId: sessionId,
+      subAgents: subAgents.toPlugin(),
+      useAtomicStop: useAtomicStop,
+      knownSubAgentSessionIds: const {},
+    );
+    return SessionAborted(
+      workKept: result is PluginAbortAccepted && result.workKept,
+      subAgentsHandled: result is PluginAbortAccepted && result.subAgentsHandled,
+    );
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_abort_service_test.dart
+++ b/bridge/app/test/bridge/services/session_abort_service_test.dart
@@ -43,7 +43,11 @@ void main() {
       addTearDown(startedSubscription.cancel);
       addTearDown(subscription.cancel);
 
-      final abortFuture = service.abortSession(sessionId: "session-1", subAgents: SessionAbortSubAgentPolicy.stop);
+      final abortFuture = service.abortSession(
+        sessionId: "session-1",
+        subAgents: SessionAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+      );
       await abortStarted.future;
 
       expect(startedSessionIds, equals(["session-1"]));
@@ -71,7 +75,7 @@ void main() {
       addTearDown(failedSubscription.cancel);
 
       await expectLater(
-        service.abortSession(sessionId: "session-1", subAgents: SessionAbortSubAgentPolicy.stop),
+        service.abortSession(sessionId: "session-1", subAgents: SessionAbortSubAgentPolicy.stop, useAtomicStop: false),
         throwsA(isA<StateError>()),
       );
 
@@ -90,7 +94,7 @@ void main() {
       addTearDown(failedSubscription.cancel);
 
       await expectLater(
-        service.abortSession(sessionId: "missing", subAgents: SessionAbortSubAgentPolicy.stop),
+        service.abortSession(sessionId: "missing", subAgents: SessionAbortSubAgentPolicy.stop, useAtomicStop: false),
         throwsStateError,
       );
 
@@ -109,9 +113,10 @@ class _FakeSessionRepository() implements SessionRepository {
   Future<SessionAbortResult> abortSession({
     required String sessionId,
     required SessionAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
   }) async {
     await onAbort?.call(sessionId: sessionId);
-    return const SessionAborted(workKept: false);
+    return const SessionAborted(workKept: false, subAgentsHandled: false);
   }
 
   @override

--- a/bridge/app/test/bridge/services/session_prompt_service_test.dart
+++ b/bridge/app/test/bridge/services/session_prompt_service_test.dart
@@ -242,7 +242,11 @@ void main() {
       while (plugin.lastSendCommandSessionId == null) {
         await Future<void>.delayed(Duration.zero);
       }
-      final abort = abortService.abortSession(sessionId: "s1", subAgents: SessionAbortSubAgentPolicy.stop);
+      final abort = abortService.abortSession(
+        sessionId: "s1",
+        subAgents: SessionAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+      );
       final prompt = service.sendPrompt(
         promptId: "prompt-1",
         sessionId: "s1",

--- a/bridge/app/test/helpers/fakes/fake_bridge_plugin.dart
+++ b/bridge/app/test/helpers/fakes/fake_bridge_plugin.dart
@@ -76,6 +76,9 @@ class FakeBridgePlugin() implements NativeProjectsPluginApi {
   String? lastSendCommandAgent;
   ({String providerID, String modelID})? lastSendCommandModel;
   String? lastAbortSessionId;
+  bool? lastAbortUseAtomicStop;
+  Set<String>? lastAbortKnownSubAgentSessionIds;
+  PluginAbortResult abortResult = const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
   String? lastReplyQuestionId;
   String? lastReplySessionId;
   List<List<String>>? lastReplyAnswers;
@@ -287,9 +290,13 @@ class FakeBridgePlugin() implements NativeProjectsPluginApi {
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
   }) async {
     lastAbortSessionId = sessionId;
-    return const PluginAbortAccepted(workKept: false);
+    lastAbortUseAtomicStop = useAtomicStop;
+    lastAbortKnownSubAgentSessionIds = knownSubAgentSessionIds;
+    return abortResult;
   }
 
   @override

--- a/bridge/sesori_plugin_acp/lib/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/acp_plugin.dart
@@ -44,6 +44,7 @@ export "src/acp_session_loader.dart";
 export "src/acp_session_options_service.dart";
 export "src/acp_stdio_client.dart";
 export "src/api/acp_agent_api.dart";
+export "src/models/acp_scoped_stop.dart";
 export "src/repositories/acp_session_config_repository.dart";
 export "src/repositories/mappers/acp_content_mapper.dart";
 export "src/repositories/trackers/acp_child_session_tracker.dart";

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -18,6 +18,7 @@ import "acp_session_loader.dart";
 import "acp_session_options_service.dart";
 import "acp_stdio_client.dart";
 import "api/acp_agent_api.dart";
+import "models/acp_scoped_stop.dart";
 import "repositories/acp_session_config_repository.dart";
 import "repositories/trackers/acp_child_session_tracker.dart";
 
@@ -1749,70 +1750,111 @@ abstract class AcpPlugin({
     required String childSessionId,
   }) => throw UnsupportedError("$id does not support scoped child cancellation");
 
+  Future<AcpScopedStopResult> stopScopedTree({
+    required AcpStdioClient client,
+    required AcpScopedStopTarget target,
+  }) => throw UnsupportedError("$id does not support complete scoped cancellation");
+
   @override
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
   }) async {
     if (!supportsScopedStop) {
       await _abortSession(sessionId: sessionId, sendSessionCancel: true);
-      return const PluginAbortAccepted(workKept: false);
+      return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
     }
-    final children = childSessionTracker.runningChildren(sessionId: sessionId);
-    final namedChild = childSessionTracker.runningChild(sessionId: sessionId);
-    final hasOwnPrompt = (_turnStates[sessionId]?.pending ?? 0) > 0;
-    final mainRunning = hasOwnPrompt || namedChild != null;
-    final mainOnlySupported =
-        (hasOwnPrompt || namedChild == null || namedChild.isBackground) &&
-        children.every((child) => child.isBackground);
-    if (children.isNotEmpty &&
-        (subAgents == PluginAbortSubAgentPolicy.confirm ||
-            subAgents == PluginAbortSubAgentPolicy.keep && mainRunning && !mainOnlySupported)) {
-      return PluginAbortRejectedSubAgentsRunning(
-        runningSubAgentCount: children.length,
-        mainAgentRunning: mainRunning,
-        mainAgentOnlySupported: mainOnlySupported,
-      );
-    }
-    if (subAgents == PluginAbortSubAgentPolicy.keep && children.isNotEmpty && !mainRunning) {
-      return const PluginAbortAccepted(workKept: true);
-    }
-    final mainResult = await _cancelScopedSession(
-      sessionId: sessionId,
-      parentSessionId: namedChild?.parentSessionId,
-    );
-    if (subAgents != PluginAbortSubAgentPolicy.stop) {
-      return PluginAbortAccepted(
-        workKept: children.isNotEmpty || mainResult == AcpChildCancelResult.notCancellable,
-      );
-    }
-    final results = await Future.wait([
-      for (final child in children)
-        _cancelScopedSession(sessionId: child.childSessionId, parentSessionId: child.parentSessionId),
-    ]);
-    final cancelled = <String>{
-      if (mainResult != AcpChildCancelResult.notCancellable) sessionId,
-      for (var i = 0; i < children.length; i++)
-        if (results[i] != AcpChildCancelResult.notCancellable) children[i].childSessionId,
+
+    final allDescendantSessionIds = {
+      ...knownSubAgentSessionIds,
+      ...childSessionTracker.childSessionIds(sessionId: sessionId),
+    }..remove(sessionId);
+    final independentResidentSessionIds = {
+      for (final descendantSessionId in allDescendantSessionIds)
+        if (_residentSessions.contains(descendantSessionId)) descendantSessionId,
     };
-    final byId = {for (final child in children) child.childSessionId: child};
-    bool coveredByParent({required AcpRunningChild child}) {
-      var current = child;
-      while (!current.isBackground) {
-        if (cancelled.contains(current.parentSessionId)) return true;
-        final parent = byId[current.parentSessionId];
-        if (parent == null) return false;
-        current = parent;
+
+    bool belongsToIndependentScope({required String childSessionId}) {
+      String? currentSessionId = childSessionId;
+      while (currentSessionId != null && currentSessionId != sessionId) {
+        if (independentResidentSessionIds.contains(currentSessionId)) return true;
+        currentSessionId = childSessionTracker.parentOf(sessionId: currentSessionId);
       }
       return false;
     }
 
-    // Pending lifecycle delivery is not retained work. A foreground descendant
-    // is covered by its parent's cancellation even when it has no own interrupt.
+    final children = childSessionTracker.runningChildren(sessionId: sessionId);
+    final mainScopeChildren = [
+      for (final child in children)
+        if (!belongsToIndependentScope(childSessionId: child.childSessionId)) child,
+    ];
+    final namedChild = childSessionTracker.runningChild(sessionId: sessionId);
+    // Queue presence is logical work for keep/confirm even before load admits
+    // the session. Native target selection below remains residency-based.
+    final hasOwnPrompt = (_turnStates[sessionId]?.pending ?? 0) > 0;
+    final activeSubAgentSessionIds = {
+      ...children.map((child) => child.childSessionId),
+      for (final descendantSessionId in independentResidentSessionIds)
+        if (_inFlightTurnSessions.contains(descendantSessionId) ||
+            childSessionTracker.hasActiveWorkForSession(sessionId: descendantSessionId))
+          descendantSessionId,
+    };
+    final mainRunning = hasOwnPrompt || namedChild != null;
+    final mainOnlySupported =
+        (hasOwnPrompt || namedChild == null || namedChild.isBackground) &&
+        mainScopeChildren.every((child) => child.isBackground);
+    if (activeSubAgentSessionIds.isNotEmpty &&
+        (subAgents == PluginAbortSubAgentPolicy.confirm ||
+            subAgents == PluginAbortSubAgentPolicy.keep && mainRunning && !mainOnlySupported)) {
+      return PluginAbortRejectedSubAgentsRunning(
+        runningSubAgentCount: activeSubAgentSessionIds.length,
+        mainAgentRunning: mainRunning,
+        mainAgentOnlySupported: mainOnlySupported,
+      );
+    }
+    if (subAgents == PluginAbortSubAgentPolicy.keep && activeSubAgentSessionIds.isNotEmpty && !mainRunning) {
+      return const PluginAbortAccepted(workKept: true, subAgentsHandled: true);
+    }
+
+    if (useAtomicStop && subAgents != PluginAbortSubAgentPolicy.keep) {
+      for (final targetSessionId in {sessionId, ...allDescendantSessionIds}) {
+        _prepareSessionAbort(sessionId: targetSessionId, cancelBufferedInputs: false);
+      }
+      final client = _client;
+      if (client == null) {
+        return const PluginAbortAccepted(workKept: false, subAgentsHandled: true);
+      }
+      final parentSessionId = childSessionTracker.parentOf(sessionId: sessionId);
+      final targets = <AcpScopedStopTarget>[
+        if (_residentSessions.contains(sessionId))
+          AcpScopedStopSessionTarget(sessionId: sessionId)
+        else if (parentSessionId != null)
+          AcpScopedStopChildTarget(parentSessionId: parentSessionId, childSessionId: sessionId),
+        for (final descendantSessionId in independentResidentSessionIds)
+          AcpScopedStopSessionTarget(sessionId: descendantSessionId),
+      ];
+      // Calling every hook constructs and dispatches every native request before
+      // Future.wait observes a response. Its default behavior still waits for
+      // every already-dispatched request when one fails.
+      final stopFutures = [
+        for (final target in targets) stopScopedTree(client: client, target: target),
+      ];
+      final results = await Future.wait(stopFutures);
+      return PluginAbortAccepted(
+        workKept: results.any((result) => result.workKept),
+        subAgentsHandled: true,
+      );
+    }
+
+    final mainResult = await _cancelScopedSession(
+      sessionId: sessionId,
+      parentSessionId: childSessionTracker.parentOf(sessionId: sessionId),
+    );
     return PluginAbortAccepted(
-      workKept:
-          mainResult == AcpChildCancelResult.notCancellable ||
-          children.any((child) => !cancelled.contains(child.childSessionId) && !coveredByParent(child: child)),
+      workKept: activeSubAgentSessionIds.isNotEmpty || mainResult == AcpChildCancelResult.notCancellable,
+      subAgentsHandled: false,
     );
   }
 
@@ -1820,11 +1862,12 @@ abstract class AcpPlugin({
     required String sessionId,
     required String? parentSessionId,
   }) async {
-    // An opened child may own a new standard prompt after its delegation ends.
-    // Prompt ownership, not ancestry alone, determines cancellation transport.
-    final standardCancel = parentSessionId == null || (_turnStates[sessionId]?.pending ?? 0) > 0;
+    // Residency, not a turn still waiting for load, determines native session
+    // authority. A queued-only root is fenced locally without a fake target;
+    // a retained nonresident child still uses its exact direct parent.
+    final standardCancel = _residentSessions.contains(sessionId);
     await _abortSession(sessionId: sessionId, sendSessionCancel: standardCancel);
-    if (standardCancel) return AcpChildCancelResult.interrupted;
+    if (standardCancel || parentSessionId == null) return AcpChildCancelResult.interrupted;
     final client = _client;
     if (client == null) return AcpChildCancelResult.unknownChild;
     try {
@@ -1835,11 +1878,9 @@ abstract class AcpPlugin({
     }
   }
 
-  Future<void> _abortSession({required String sessionId, required bool sendSessionCancel}) async {
-    // Aborting means "stop this conversation now": drop the queued-but-
-    // undispatched turns first so they don't dispatch after the cancel. The
-    // in-flight turn (if any) ends via the agent's cancellation, which
-    // resolves its `session/prompt` future and settles the accounting.
+  void _prepareSessionAbort({required String sessionId, required bool cancelBufferedInputs}) {
+    // Discard only work accepted before this stop. A later prompt captures the
+    // incremented generation and is never cleaned up from the stop response.
     final state = _turnStates[sessionId];
     if (state != null) {
       state.generation++;
@@ -1856,7 +1897,17 @@ abstract class AcpPlugin({
         _emitQueueUpdate(sessionId: sessionId, state: state);
       }
     }
-    if (_isPromptFrameWriting(sessionId: sessionId)) _cancelledPromptWriteSessions.add(sessionId);
+    if (cancelBufferedInputs && _isPromptFrameWriting(sessionId: sessionId)) {
+      _cancelledPromptWriteSessions.add(sessionId);
+    }
+  }
+
+  Future<void> _abortSession({required String sessionId, required bool sendSessionCancel}) async {
+    // Aborting means "stop this conversation now": drop the queued-but-
+    // undispatched turns first so they don't dispatch after the cancel. The
+    // in-flight turn (if any) ends via the agent's cancellation, which
+    // resolves its `session/prompt` future and settles the accounting.
+    _prepareSessionAbort(sessionId: sessionId, cancelBufferedInputs: true);
     final client = _client;
     if (client == null) return;
     if (sendSessionCancel) {
@@ -1893,7 +1944,13 @@ abstract class AcpPlugin({
             if (entry.value.pending > 0 && childSessionTracker.runningChild(sessionId: entry.key) == null) entry.key,
         };
         await Future.wait([
-          for (final sessionId in roots) abortSession(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop),
+          for (final sessionId in roots)
+            abortSession(
+              sessionId: sessionId,
+              subAgents: PluginAbortSubAgentPolicy.stop,
+              useAtomicStop: true,
+              knownSubAgentSessionIds: childSessionTracker.childSessionIds(sessionId: sessionId).toSet(),
+            ),
         ]);
       } else {
         await Future.wait([

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1750,6 +1750,8 @@ abstract class AcpPlugin({
     required String childSessionId,
   }) => throw UnsupportedError("$id does not support scoped child cancellation");
 
+  /// Stops native work and orders cancellation of its pending input on the stream.
+  /// Callers fence local queued turns without racing the native input owner.
   Future<AcpScopedStopResult> stopScopedTree({
     required AcpStdioClient client,
     required AcpScopedStopTarget target,
@@ -1796,9 +1798,10 @@ abstract class AcpPlugin({
     final hasOwnPrompt = (_turnStates[sessionId]?.pending ?? 0) > 0;
     final activeSubAgentSessionIds = {
       ...children.map((child) => child.childSessionId),
-      for (final descendantSessionId in independentResidentSessionIds)
-        if (_inFlightTurnSessions.contains(descendantSessionId) ||
-            childSessionTracker.hasActiveWorkForSession(sessionId: descendantSessionId))
+      for (final descendantSessionId in allDescendantSessionIds)
+        if ((_turnStates[descendantSessionId]?.pending ?? 0) > 0 ||
+            independentResidentSessionIds.contains(descendantSessionId) &&
+                childSessionTracker.hasActiveWorkForSession(sessionId: descendantSessionId))
           descendantSessionId,
     };
     final mainRunning = hasOwnPrompt || namedChild != null;

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1941,10 +1941,6 @@ abstract class AcpPlugin({
       if (supportsScopedStop) {
         final roots = {
           for (final sessionId in activeSessionIds) childSessionTracker.rootOf(sessionId: sessionId),
-          // A finished delegated child can now own a directly prompted turn,
-          // which is no longer covered by the root's running-child snapshot.
-          for (final entry in _turnStates.entries)
-            if (entry.value.pending > 0 && childSessionTracker.runningChild(sessionId: entry.key) == null) entry.key,
         };
         await Future.wait([
           for (final sessionId in roots)

--- a/bridge/sesori_plugin_acp/lib/src/models/acp_scoped_stop.dart
+++ b/bridge/sesori_plugin_acp/lib/src/models/acp_scoped_stop.dart
@@ -1,0 +1,14 @@
+/// One native scoped-stop authority selected by the generic ACP plugin.
+sealed class const AcpScopedStopTarget();
+
+/// Stops a session and the native descendants it owns.
+final class const AcpScopedStopSessionTarget({required final String sessionId}) extends AcpScopedStopTarget;
+
+/// Stops one retained delegated child through its exact direct parent.
+final class const AcpScopedStopChildTarget({
+  required final String parentSessionId,
+  required final String childSessionId,
+}) extends AcpScopedStopTarget;
+
+/// The native adapter's accepted scoped-stop outcome.
+final class const AcpScopedStopResult({required final bool workKept});

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -478,7 +478,12 @@ void main() {
       await pump();
       expect(emitted.whereType<BridgeSsePermissionAsked>(), isEmpty);
 
-      await plugin.abortSession(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop);
+      await plugin.abortSession(
+        sessionId: sessionId,
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       flush.complete();
       for (var i = 0; i < 20 && !fake.written.any((frame) => frame["id"] == 92); i++) {
         await pump();
@@ -1158,7 +1163,12 @@ void main() {
       final firstPrompt = await waitForFrame("session/prompt");
       await sendPrompt(sessionId, "queued");
 
-      await plugin.abortSession(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop);
+      await plugin.abortSession(
+        sessionId: sessionId,
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       expect(
         frames("session/cancel"),
         hasLength(2),
@@ -1302,7 +1312,12 @@ void main() {
       for (var i = 0; i < 5; i++) {
         await pump();
       }
-      await gated.abortSession(sessionId: "s1", subAgents: PluginAbortSubAgentPolicy.stop);
+      await gated.abortSession(
+        sessionId: "s1",
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       gate.complete();
       for (var i = 0; i < 10; i++) {
         await pump();

--- a/bridge/sesori_plugin_antigravity/test/antigravity_plugin_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_plugin_test.dart
@@ -419,7 +419,12 @@ void main() {
       _question(process: process, session: first.id, id: "cancel");
       _question(process: process, session: second.id, id: "delete");
       await _settle();
-      await h.plugin.abortSession(sessionId: first.id, subAgents: PluginAbortSubAgentPolicy.stop);
+      await h.plugin.abortSession(
+        sessionId: first.id,
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       expect(await h.plugin.getPendingQuestions(sessionId: first.id), isEmpty);
       expect(await h.plugin.getPendingQuestions(sessionId: second.id), hasLength(1));
       expect(process.held, hasLength(1));

--- a/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_plugin_impl.dart
@@ -309,8 +309,12 @@ final class ClaudePlugin({
       _sessions.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId);
 
   @override
-  Future<PluginAbortResult> abortSession({required String sessionId, required PluginAbortSubAgentPolicy subAgents}) =>
-      _sessions.abort(sessionId: sessionId, subAgents: subAgents);
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
+  }) => _sessions.abort(sessionId: sessionId, subAgents: subAgents);
 
   @override
   // Claude declares plugin-scoped options, so projectId does not select a catalog.

--- a/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
+++ b/bridge/sesori_plugin_claude/lib/src/services/claude_session_service.dart
@@ -488,7 +488,7 @@ final class ClaudeSessionService({
   /// task with it.
   Future<PluginAbortResult> abort({required String sessionId, required PluginAbortSubAgentPolicy subAgents}) async {
     final state = _turns[sessionId];
-    if (state == null) return const PluginAbortAccepted(workKept: false);
+    if (state == null) return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
     final activeAbort = state.aborting;
     if (activeAbort != null) {
       // The in-flight abort may have kept work this caller wants stopped; run
@@ -506,7 +506,7 @@ final class ClaudeSessionService({
     }
     if (!state.hasWork) {
       _approvals.cancelForSession(sessionId: sessionId);
-      return const PluginAbortAccepted(workKept: false);
+      return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
     }
     // The CLI's only stop primitive, `interrupt`, also stops background agents
     // (observed on 2.1.257), so sub-agents can be kept only when no main turn
@@ -534,7 +534,7 @@ final class ClaudeSessionService({
         // run. The process stays resident for them, pending approvals are left
         // alone (a kept sub-agent may be waiting on one), and the running set
         // keeps the session busy until the tasks report and wake the main agent.
-        return const PluginAbortAccepted(workKept: true);
+        return const PluginAbortAccepted(workKept: true, subAgentsHandled: false);
       }
       _approvals.cancelForSession(sessionId: sessionId);
       // Teardown kills the CLI's in-process wakeup timer, and `--resume` does
@@ -556,7 +556,7 @@ final class ClaudeSessionService({
         _completeSelfStartedTurn(state: state);
         _settleIdle(sessionId: sessionId, state: state);
       }
-      return const PluginAbortAccepted(workKept: false);
+      return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
     } finally {
       if (identical(state.aborting, aborting)) state.aborting = null;
       if (!aborting.isCompleted) aborting.complete();

--- a/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_plugin_impl_test.dart
@@ -521,7 +521,12 @@ void main() {
       final subscription = harness.plugin.events.listen(events.add);
       final written = first.written.lastWhere((frame) => frame["type"] == "user");
       first.emit(_replayOf(written, uuid: "late-echo"));
-      final abort = harness.plugin.abortSession(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
+      final abort = harness.plugin.abortSession(
+        sessionId: testSessionId,
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       final interrupt = await _waitForControl(first, "interrupt");
       first.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
       await abort;
@@ -806,7 +811,12 @@ void main() {
       final process = harness.processes.single;
       await waitForFrame(process, "user");
 
-      await harness.plugin.abortSession(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
+      await harness.plugin.abortSession(
+        sessionId: testSessionId,
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       process.emit({
         "type": "result",
         "subtype": "error_during_execution",
@@ -864,7 +874,12 @@ void main() {
       await pump();
       // An explicit stop tears the process down without a natural exit; the
       // sub-agent must still surface as cancelled.
-      final abort = harness.plugin.abortSession(sessionId: testSessionId, subAgents: PluginAbortSubAgentPolicy.stop);
+      final abort = harness.plugin.abortSession(
+        sessionId: testSessionId,
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       final interrupt = await _waitForControl(process, "interrupt");
       process.emitControlResponse(requestId: interrupt["request_id"]! as String, payload: const {});
       await abort;

--- a/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
+++ b/bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart
@@ -953,9 +953,11 @@ class CodexPlugin._({
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
   }) async {
     await _abortSession(sessionId: sessionId);
-    return const PluginAbortAccepted(workKept: false);
+    return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
   }
 
   Future<void> _abortSession({required String sessionId}) async {

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -1412,7 +1412,12 @@ void main() {
       // Give the event subscription a microtask to process.
       await Future<void>.delayed(Duration.zero);
 
-      await plugin.abortSession(sessionId: "t-1", subAgents: PluginAbortSubAgentPolicy.stop);
+      await plugin.abortSession(
+        sessionId: "t-1",
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
 
       expect(fake.sentMethods, contains("turn/interrupt"));
       final params = fake.sentParamsFor("turn/interrupt");
@@ -1592,7 +1597,12 @@ void main() {
 
       expect((await plugin.getSessionStatuses())["t-steered"], isA<PluginSessionStatusIdle>());
       expect(plugin.getActiveSessionsSummary(), isEmpty);
-      await plugin.abortSession(sessionId: "t-steered", subAgents: PluginAbortSubAgentPolicy.stop);
+      await plugin.abortSession(
+        sessionId: "t-steered",
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       expect(fake.sentMethods.where((method) => method == "turn/interrupt"), isEmpty);
     });
 
@@ -1784,7 +1794,12 @@ void main() {
         mode: FileMode.append,
       );
 
-      await plugin.abortSession(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop);
+      await plugin.abortSession(
+        sessionId: sessionId,
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
 
       expect((await terminalTool.timeout(const Duration(seconds: 1))).part.state.status, PluginToolStatus.error);
       expect((await idleEvent).sessionID, sessionId);
@@ -1860,7 +1875,12 @@ void main() {
         mode: FileMode.append,
       );
 
-      await plugin.abortSession(sessionId: sessionId, subAgents: PluginAbortSubAgentPolicy.stop);
+      await plugin.abortSession(
+        sessionId: sessionId,
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       await idle;
 
       final errorIndex = emittedEvents.indexWhere(
@@ -1921,7 +1941,12 @@ void main() {
       final emittedEvents = <BridgeSseEvent>[];
       final eventSubscription = plugin.events.listen(emittedEvents.add);
 
-      final abort = plugin.abortSession(sessionId: "t-abort-race", subAgents: PluginAbortSubAgentPolicy.stop);
+      final abort = plugin.abortSession(
+        sessionId: "t-abort-race",
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       await interruptRequested.future;
       await Future<void>.delayed(const Duration(milliseconds: 20));
       fake.pushNotification("turn/started", {
@@ -3022,7 +3047,12 @@ void main() {
           error: {"code": -32600, "message": "no active turn to interrupt"},
         ),
       ]);
-      await plugin.abortSession(sessionId: "child-1", subAgents: PluginAbortSubAgentPolicy.stop);
+      await plugin.abortSession(
+        sessionId: "child-1",
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {},
+      );
       await rootIdle;
       await Future<void>.delayed(const Duration(milliseconds: 20));
       expect(events.whereType<BridgeSseSessionIdle>().where((event) => event.sessionID == "root-1"), hasLength(1));
@@ -3078,6 +3108,8 @@ void main() {
         await plugin.abortSession(
           sessionId: "child-pending-start",
           subAgents: PluginAbortSubAgentPolicy.stop,
+          useAtomicStop: false,
+          knownSubAgentSessionIds: const {},
         ),
         isA<PluginAbortAccepted>(),
       );

--- a/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/api/deepseek_acp_api.dart
@@ -209,6 +209,15 @@ class const DeepSeekAcpApi({required final String pluginId}) {
     return parseSubagentInterruptResponse(_json(raw, method: subagentInterruptMethod)).result;
   }
 
+  Future<DeepSeekSessionStopResponseDto> stopSession({
+    required AcpStdioClient client,
+    required DeepSeekSessionStopRequestDto request,
+  }) async {
+    _validateSessionStopRequest(request: request);
+    final raw = await client.request(method: sessionStopMethod, params: request.toJson());
+    return parseSessionStopResponse(_json(raw, method: sessionStopMethod));
+  }
+
   // ignore: no_slop_linter/prefer_specific_type, ACP JSON object values are heterogeneous
   DeepSeekSessionStopRequestDto parseSessionStopRequest(Map<String, dynamic> json) {
     final request = DeepSeekSessionStopRequestDto.fromJson(json);

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -40,6 +40,12 @@ class DeepSeekPlugin({
   bool get supportsScopedStop => true;
 
   @override
+  Future<AcpScopedStopResult> stopScopedTree({
+    required AcpStdioClient client,
+    required AcpScopedStopTarget target,
+  }) => deepSeekSessionService.stopScopedTree(client: client, target: target);
+
+  @override
   Future<AcpChildCancelResult> cancelChild({
     required AcpStdioClient client,
     required String sessionId,

--- a/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_session_repository.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/repositories/deepseek_session_repository.dart
@@ -16,6 +16,37 @@ class const DeepSeekSessionRepository({required final DeepSeekAcpApi api}) {
     return SemanticVersion.tryParse(value: parsed.adapterVersion);
   }
 
+  Future<AcpScopedStopResult> stopScopedTree({
+    required AcpStdioClient client,
+    required AcpScopedStopTarget target,
+  }) async {
+    final request = switch (target) {
+      AcpScopedStopSessionTarget(:final sessionId) => DeepSeekSessionStopRequestDto.session(sessionId: sessionId),
+      AcpScopedStopChildTarget(:final parentSessionId, :final childSessionId) => DeepSeekSessionStopRequestDto.child(
+        sessionId: parentSessionId,
+        childSessionId: childSessionId,
+      ),
+    };
+    try {
+      final response = await api.stopSession(client: client, request: request);
+      return AcpScopedStopResult(workKept: response.workKept);
+    } on Object catch (error, stackTrace) {
+      final targetContext = switch (target) {
+        AcpScopedStopSessionTarget(:final sessionId) => "session $sessionId",
+        AcpScopedStopChildTarget(:final parentSessionId, :final childSessionId) =>
+          "child $childSessionId under parent $parentSessionId",
+      };
+      Error.throwWithStackTrace(
+        PluginOperationException(
+          DeepSeekAcpApi.sessionStopMethod,
+          message: "DeepSeek scoped stop failed for $targetContext",
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+  }
+
   Future<AcpChildCancelResult> cancelChild({
     required AcpStdioClient client,
     required String sessionId,

--- a/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
@@ -19,6 +19,11 @@ class const DeepSeekSessionService({
     }
   }
 
+  Future<AcpScopedStopResult> stopScopedTree({
+    required AcpStdioClient client,
+    required AcpScopedStopTarget target,
+  }) => repository.stopScopedTree(client: client, target: target);
+
   Future<AcpChildCancelResult> cancelChild({
     required AcpStdioClient client,
     required String sessionId,

--- a/bridge/sesori_plugin_deepseek/test/deepseek_scoped_stop_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_scoped_stop_test.dart
@@ -34,6 +34,34 @@ void main() {
       expect(harness.fake.written, hasLength(before));
     });
 
+    for (final resident in [false, true]) {
+      test("confirm preserves an accepted child turn before dispatch (resident: $resident)", () async {
+        await harness.spawn(child: "child", parent: "root", background: true);
+        await harness.end(child: "child", parent: "root");
+        if (resident) {
+          harness.settlePrompt(await harness.prompt(sessionId: "child"));
+          await harness.waitForIdle();
+        }
+        await harness.queuePromptUntilLoad(sessionId: "child");
+
+        final result = await harness.atomicAbort(
+          sessionId: "root",
+          policy: PluginAbortSubAgentPolicy.confirm,
+          knownSubAgentSessionIds: const {"child"},
+        );
+
+        expect(result, isA<PluginAbortRejectedSubAgentsRunning>());
+        expect(harness.stops, isEmpty);
+        expect(harness.cancels, isEmpty);
+        expect(harness.interrupts, isEmpty);
+        if (!resident) {
+          final load = await harness.waitForSession(method: AcpMethods.sessionLoad, sessionId: "child");
+          harness.reply(frame: load, result: <String, dynamic>{});
+        }
+        harness.settlePrompt(await harness.waitFor(method: AcpMethods.sessionPrompt, count: resident ? 2 : 1));
+      });
+    }
+
     test("unsupported keep is side-effect free", () async {
       await harness.prompt(sessionId: "root");
       await harness.spawn(child: "foreground", parent: "root", background: false);

--- a/bridge/sesori_plugin_deepseek/test/deepseek_scoped_stop_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_scoped_stop_test.dart
@@ -1,3 +1,5 @@
+import "dart:async";
+
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:deepseek_plugin/deepseek_plugin.dart";
@@ -15,194 +17,295 @@ void main() {
     });
     tearDown(() => harness.close());
 
-    test("confirm is side-effect free and reports main/background capability", () async {
+    test("confirm rejection is side-effect free", () async {
       await harness.prompt(sessionId: "root");
       await harness.spawn(child: "child", parent: "root", background: true);
       final before = harness.fake.written.length;
-      final result = await harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.confirm);
+
+      final result = await harness.atomicAbort(sessionId: "root", policy: PluginAbortSubAgentPolicy.confirm);
+
       expect(
         result,
         isA<PluginAbortRejectedSubAgentsRunning>()
-            .having((r) => r.runningSubAgentCount, "children", 1)
-            .having((r) => r.mainAgentRunning, "main", true)
-            .having((r) => r.mainAgentOnlySupported, "keep supported", true),
+            .having((result) => result.runningSubAgentCount, "children", 1)
+            .having((result) => result.mainAgentRunning, "main", true)
+            .having((result) => result.mainAgentOnlySupported, "keep supported", true),
       );
       expect(harness.fake.written, hasLength(before));
-      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isTrue);
     });
 
-    test("keep rejects mixed foreground work without side effects", () async {
+    test("unsupported keep is side-effect free", () async {
       await harness.prompt(sessionId: "root");
       await harness.spawn(child: "foreground", parent: "root", background: false);
-      await harness.spawn(child: "background", parent: "root", background: true);
       final before = harness.fake.written.length;
-      final result = await harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.keep);
+
+      final result = await harness.atomicAbort(sessionId: "root", policy: PluginAbortSubAgentPolicy.keep);
+
       expect(
         result,
-        isA<PluginAbortRejectedSubAgentsRunning>().having((r) => r.mainAgentOnlySupported, "keep supported", false),
+        isA<PluginAbortRejectedSubAgentsRunning>().having(
+          (result) => result.mainAgentOnlySupported,
+          "keep supported",
+          false,
+        ),
       );
       expect(harness.fake.written, hasLength(before));
     });
 
-    test("foreground named child cannot offer main-only stop even with background descendants", () async {
-      await harness.spawn(child: "foreground", parent: "root", background: false);
-      await harness.spawn(child: "background", parent: "foreground", background: true);
-      final before = harness.fake.written.length;
-      for (final policy in [PluginAbortSubAgentPolicy.confirm, PluginAbortSubAgentPolicy.keep]) {
-        final result = await harness.plugin.abortSession(sessionId: "foreground", subAgents: policy);
-        expect(
-          result,
-          isA<PluginAbortRejectedSubAgentsRunning>()
-              .having((r) => r.runningSubAgentCount, "children", 1)
-              .having((r) => r.mainAgentRunning, "main", true)
-              .having((r) => r.mainAgentOnlySupported, "keep supported", false),
-        );
-        expect(harness.fake.written, hasLength(before));
-      }
-    });
-
-    test("background named child can be interrupted while retaining its background descendant", () async {
-      await harness.spawn(child: "parent", parent: "root", background: true);
-      await harness.spawn(child: "child", parent: "parent", background: true);
-      final stopping = harness.plugin.abortSession(sessionId: "parent", subAgents: PluginAbortSubAgentPolicy.keep);
-      await harness.replyInterrupts(results: const {"parent": "interrupted"});
-      expect(await stopping, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", true));
-      expect(harness.cancels, isEmpty);
-      expect(harness.interrupts.single["params"], {"sessionId": "root", "childSessionId": "parent"});
-      expect(harness.plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"parent", "child"});
-    });
-
-    test("keep cancels only main when every child is background", () async {
+    test("independently resident foreground child does not reject root keep", () async {
       await harness.prompt(sessionId: "root");
-      await harness.spawn(child: "child", parent: "root", background: true);
-      final result = await harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.keep);
-      expect(result, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", true));
+      await harness.spawn(child: "child", parent: "root", background: false);
+      await harness.prompt(sessionId: "child");
+
+      final result = await harness.atomicAbort(
+        sessionId: "root",
+        policy: PluginAbortSubAgentPolicy.keep,
+        knownSubAgentSessionIds: const {"child"},
+      );
+
+      expect(result, isA<PluginAbortAccepted>().having((result) => result.workKept, "kept", true));
       expect(harness.cancels.single["params"], {"sessionId": "root"});
-      expect(harness.interrupts, isEmpty);
-      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isTrue);
+      expect(harness.stops, isEmpty);
     });
 
-    test("child-only keep sends no cancellation", () async {
-      await harness.spawn(child: "child", parent: "root", background: true);
-      final before = harness.fake.written.length;
-      final result = await harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.keep);
-      expect(result, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", true));
-      expect(harness.fake.written, hasLength(before));
-    });
-
-    test("stop uses each direct parent and keeps cancellation settlement authoritative", () async {
+    test("native root scope covers delayed nested admission", () async {
       await harness.prompt(sessionId: "root");
-      await harness.spawn(child: "background", parent: "root", background: true);
-      await harness.spawn(child: "foreground", parent: "background", background: false);
-      final stopping = harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.stop);
-      await harness.replyInterrupts(results: const {"background": "interrupted", "foreground": "not_cancellable"});
-      expect(await stopping, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", false));
+      final stopping = harness.atomicAbort(sessionId: "root");
+      final stop = await harness.waitFor(method: DeepSeekAcpApi.sessionStopMethod, count: 1);
+      expect(stop["params"], {"kind": "session", "sessionId": "root"});
+
+      await harness.spawn(child: "child", parent: "root", background: true);
+      await harness.spawn(child: "grandchild", parent: "child", background: true);
+      harness.reply(frame: stop, result: {"workKept": false});
+
       expect(
-        harness.interrupts.map((f) => f["params"]),
+        await stopping,
+        isA<PluginAbortAccepted>()
+            .having((result) => result.workKept, "kept", false)
+            .having((result) => result.subAgentsHandled, "handled", true),
+      );
+      expect(harness.stops, hasLength(1));
+      expect(harness.plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"child", "grandchild"});
+    });
+
+    test("settled independent child remains a scope while its grandchild runs", () async {
+      final rootPrompt = await harness.prompt(sessionId: "root");
+      await harness.spawn(child: "child", parent: "root", background: true);
+      final childPrompt = await harness.prompt(sessionId: "child");
+      harness.settlePrompt(childPrompt);
+      await harness.spawn(child: "grandchild", parent: "child", background: true);
+
+      final stopping = harness.atomicAbort(
+        sessionId: "root",
+        knownSubAgentSessionIds: const {"child", "grandchild"},
+      );
+      await harness.waitFor(method: DeepSeekAcpApi.sessionStopMethod, count: 2);
+      expect(
+        harness.stops.map((frame) => frame["params"]),
         unorderedEquals([
-          {"sessionId": "root", "childSessionId": "background"},
-          {"sessionId": "background", "childSessionId": "foreground"},
+          {"kind": "session", "sessionId": "root"},
+          {"kind": "session", "sessionId": "child"},
         ]),
       );
-      expect(harness.cancels.single["params"], {"sessionId": "root"});
-      expect(harness.plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"background", "foreground"});
-      await harness.end(child: "foreground", parent: "background");
-      await harness.end(child: "background", parent: "root");
-      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isFalse);
+      harness.replyStops(workKeptBySession: const {"root": false, "child": true});
+
+      expect(await stopping, isA<PluginAbortAccepted>().having((result) => result.workKept, "OR result", true));
+      harness.settlePrompt(rootPrompt);
     });
 
-    test("unknown child during settlement is neither kept nor synthetically finished", () async {
+    test("nested independently resident roots all receive native stops", () async {
+      final prompts = <Map<String, dynamic>>[await harness.prompt(sessionId: "root")];
       await harness.spawn(child: "child", parent: "root", background: true);
-      final stopping = harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.stop);
-      await harness.replyInterrupts(results: const {"child": "unknown_child"});
-      expect(await stopping, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", false));
-      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isTrue);
-      await harness.end(child: "child", parent: "root");
-      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isFalse);
+      prompts.add(await harness.prompt(sessionId: "child"));
+      await harness.spawn(child: "grandchild", parent: "child", background: true);
+      prompts.add(await harness.prompt(sessionId: "grandchild"));
+
+      final stopping = harness.atomicAbort(
+        sessionId: "root",
+        knownSubAgentSessionIds: const {"child", "grandchild"},
+      );
+      await harness.waitFor(method: DeepSeekAcpApi.sessionStopMethod, count: 3);
+      expect(
+        harness.stops.map((frame) => (frame["params"] as Map)["sessionId"]),
+        unorderedEquals(["root", "child", "grandchild"]),
+      );
+      harness.replyStops(workKeptBySession: const {"root": false, "child": false, "grandchild": false});
+      expect(await stopping, isA<PluginAbortAccepted>());
+      prompts.forEach(harness.settlePrompt);
     });
 
-    test("non-cancellable named child is retained without cancelling its parent or sibling", () async {
-      await harness.spawn(child: "child", parent: "root", background: false);
-      await harness.spawn(child: "sibling", parent: "root", background: true);
-      final stopping = harness.plugin.abortSession(sessionId: "child", subAgents: PluginAbortSubAgentPolicy.stop);
-      await harness.replyInterrupts(results: const {"child": "not_cancellable"});
-      expect(await stopping, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", true));
-      expect(harness.cancels, isEmpty);
-      expect(harness.interrupts, hasLength(1));
-      expect(harness.plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"child", "sibling"});
-    });
-
-    test("a finished child opened for a new user turn uses standard cancellation", () async {
+    test("all stop frames precede a later prompt and responses cannot erase it", () async {
+      final rootPrompt = await harness.prompt(sessionId: "root");
+      harness.settlePrompt(rootPrompt);
       await harness.spawn(child: "child", parent: "root", background: true);
-      await harness.end(child: "child", parent: "root");
+      final childPrompt = await harness.prompt(sessionId: "child");
+      harness.settlePrompt(childPrompt);
+
+      final stopping = harness.atomicAbort(sessionId: "root", knownSubAgentSessionIds: const {"child"});
+      await harness.waitFor(method: DeepSeekAcpApi.sessionStopMethod, count: 2);
+      final laterPrompt = await harness.prompt(sessionId: "root");
+      final laterPromptIndex = harness.fake.written.indexOf(laterPrompt);
+      expect(harness.stops.every((frame) => harness.fake.written.indexOf(frame) < laterPromptIndex), isTrue);
+
+      harness.replyStops(workKeptBySession: const {"root": false, "child": false});
+      expect(await stopping, isA<PluginAbortAccepted>());
+      expect(harness.fake.written, contains(same(laterPrompt)));
+      harness.settlePrompt(laterPrompt);
+    });
+
+    test("partial native failure still dispatches and waits for every scope", () async {
+      await harness.prompt(sessionId: "root");
+      await harness.spawn(child: "child", parent: "root", background: true);
       await harness.prompt(sessionId: "child");
-      final result = await harness.plugin.abortSession(sessionId: "child", subAgents: PluginAbortSubAgentPolicy.stop);
-      expect(result, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", false));
-      expect(harness.cancels.single["params"], {"sessionId": "child"});
-      expect(harness.interrupts, isEmpty);
-    });
-
-    test("whole-plugin stop also cancels a new user turn on a finished child", () async {
-      await harness.spawn(child: "child", parent: "root", background: true);
-      await harness.end(child: "child", parent: "root");
-      await harness.prompt(sessionId: "child");
-      final stopping = harness.plugin.interruptActiveWork(budget: const Duration(seconds: 2));
-      await harness.waitFor(method: AcpMethods.sessionCancel, count: 2);
-      expect(harness.cancels.map((frame) => (frame["params"] as Map)["sessionId"]), contains("child"));
-      final prompt = await harness.waitFor(method: AcpMethods.sessionPrompt, count: 1);
-      harness.fake.emit({
-        "jsonrpc": "2.0",
-        "id": prompt["id"],
-        "result": {"stopReason": "cancelled"},
-      });
-      expect(await stopping, contains("child"));
-      expect(harness.interrupts, isEmpty);
-    });
-
-    test("foreground descendants are covered by root cancellation", () async {
-      await harness.spawn(child: "parent", parent: "root", background: false);
-      await harness.spawn(child: "child", parent: "parent", background: false);
-      final stopping = harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.stop);
-      await harness.replyInterrupts(results: const {"parent": "not_cancellable", "child": "not_cancellable"});
-      expect(await stopping, isA<PluginAbortAccepted>().having((r) => r.workKept, "kept", false));
-      expect(harness.plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"parent", "child"});
-    });
-
-    test("interrupt failure keeps original RPC error and busy child state", () async {
-      await harness.spawn(child: "child", parent: "root", background: true);
-      final stopping = harness.plugin.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.stop);
+      var completed = false;
+      final stopping = harness
+          .atomicAbort(sessionId: "root", knownSubAgentSessionIds: const {"child"})
+          .whenComplete(() => completed = true);
       final failure = expectLater(
         stopping,
         throwsA(
-          isA<AcpRpcException>()
-              .having((error) => error.code, "code", -32603)
-              .having((error) => error.message, "message", "interrupt failed"),
+          isA<PluginOperationException>().having(
+            (error) => error.cause,
+            "cause",
+            isA<AcpRpcException>().having((error) => error.message, "message", "stop failed"),
+          ),
         ),
       );
-      final request = await harness.waitFor(method: DeepSeekAcpApi.subagentInterruptMethod, count: 1);
+      await harness.waitFor(method: DeepSeekAcpApi.sessionStopMethod, count: 2);
+      final rootStop = harness.stopFor(sessionId: "root");
       harness.fake.emit({
         "jsonrpc": "2.0",
-        "id": request["id"],
-        "error": {"code": -32603, "message": "interrupt failed"},
+        "id": rootStop["id"],
+        "error": {"code": -32603, "message": "stop failed"},
       });
+      await Future<void>.delayed(Duration.zero);
+      expect(completed, isFalse);
+      harness.reply(
+        frame: harness.stopFor(sessionId: "child"),
+        result: {"workKept": false},
+      );
       await failure;
-      expect(harness.plugin.childSessionTracker.hasActiveWorkForRoot(sessionId: "root"), isTrue);
+      expect(harness.stops, hasLength(2));
     });
 
-    test("whole-plugin interruption waits for lifecycle instead of fabricating idle", () async {
+    test("pending-load child is cleared without inventing native ownership", () async {
+      final rootPrompt = await harness.prompt(sessionId: "root");
+      harness.settlePrompt(rootPrompt);
+      await harness.queuePromptUntilLoad(sessionId: "queued-child");
+      final loading = await harness.waitForSession(method: AcpMethods.sessionLoad, sessionId: "queued-child");
+
+      final stopping = harness.atomicAbort(
+        sessionId: "root",
+        knownSubAgentSessionIds: const {"queued-child"},
+      );
+      final stop = await harness.waitFor(method: DeepSeekAcpApi.sessionStopMethod, count: 1);
+      expect(stop["params"], {"kind": "session", "sessionId": "root"});
+      harness.reply(frame: stop, result: {"workKept": false});
+      expect(await stopping, isA<PluginAbortAccepted>());
+
+      harness.reply(frame: loading, result: <String, dynamic>{});
+      await harness.waitForIdle();
+      expect(harness.stops, hasLength(1));
+      expect(
+        harness.fake.written.where(
+          (frame) =>
+              frame["method"] == AcpMethods.sessionPrompt && (frame["params"] as Map)["sessionId"] == "queued-child",
+        ),
+        isEmpty,
+      );
+    });
+
+    test("keep clears a queued root without inventing native ownership", () async {
+      await harness.spawn(child: "child", parent: "root", background: true);
+      await harness.queuePromptUntilLoad(sessionId: "root");
+      final loading = await harness.waitForSession(method: AcpMethods.sessionLoad, sessionId: "root");
+      final before = harness.fake.written.length;
+
+      final result = await harness.atomicAbort(
+        sessionId: "root",
+        policy: PluginAbortSubAgentPolicy.keep,
+        knownSubAgentSessionIds: const {"child"},
+      );
+
+      expect(result, isA<PluginAbortAccepted>().having((result) => result.workKept, "kept", true));
+      expect(harness.fake.written, hasLength(before));
+      harness.reply(frame: loading, result: <String, dynamic>{});
+      await harness.end(child: "child", parent: "root");
+      await harness.waitForIdle();
+      expect(
+        harness.fake.written.where(
+          (frame) => frame["method"] == AcpMethods.sessionPrompt && (frame["params"] as Map)["sessionId"] == "root",
+        ),
+        isEmpty,
+      );
+    });
+
+    test("terminal retained named child uses exact direct-parent authority", () async {
+      await harness.spawn(child: "child", parent: "root", background: true);
+      await harness.end(child: "child", parent: "root");
+
+      final stopping = harness.atomicAbort(sessionId: "child");
+      final stop = await harness.waitFor(method: DeepSeekAcpApi.sessionStopMethod, count: 1);
+      expect(stop["params"], {"kind": "child", "sessionId": "root", "childSessionId": "child"});
+      harness.reply(frame: stop, result: {"workKept": false});
+      expect(await stopping, isA<PluginAbortAccepted>());
+      expect(harness.cancels, isEmpty);
+    });
+
+    test("released-client opt-out preserves named cancellation and client fanout", () async {
+      await harness.prompt(sessionId: "root");
+      await harness.spawn(child: "child", parent: "root", background: true);
+
+      final result = await harness.plugin.abortSession(
+        sessionId: "root",
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {"child"},
+      );
+
+      expect(result, isA<PluginAbortAccepted>().having((result) => result.subAgentsHandled, "handled", false));
+      expect(harness.cancels.single["params"], {"sessionId": "root"});
+      expect(harness.stops, isEmpty);
+      expect(harness.interrupts, isEmpty);
+    });
+
+    test("delete, reset, and no-client paths do not retain native ownership", () async {
+      final rootPrompt = await harness.prompt(sessionId: "root");
+      harness.settlePrompt(rootPrompt);
+      await harness.plugin.deleteSession("root");
+      final afterDelete = await harness.atomicAbort(sessionId: "root");
+      expect(afterDelete, isA<PluginAbortAccepted>().having((result) => result.subAgentsHandled, "handled", true));
+      expect(harness.stops, isEmpty);
+
+      final otherPrompt = await harness.prompt(sessionId: "other");
+      harness.settlePrompt(otherPrompt);
+      await harness.plugin.resetConnectionAfterExit();
+      final afterReset = await harness.atomicAbort(sessionId: "other");
+      expect(afterReset, isA<PluginAbortAccepted>());
+      expect(harness.stops, isEmpty);
+
+      final disconnected = _StopHarness();
+      final noClient = await disconnected.atomicAbort(sessionId: "never-loaded");
+      expect(noClient, isA<PluginAbortAccepted>().having((result) => result.subAgentsHandled, "handled", true));
+      await disconnected.close();
+    });
+
+    test("whole-plugin stop uses native authority and waits for lifecycle", () async {
+      await harness.prompt(sessionId: "root");
       await harness.spawn(child: "child", parent: "root", background: true);
       var settled = false;
       final stopping = harness.plugin.interruptActiveWork(budget: const Duration(seconds: 2)).then((value) {
         settled = true;
         return value;
       });
-      await harness.replyInterrupts(results: const {"child": "interrupted"});
+      final stop = await harness.waitFor(method: DeepSeekAcpApi.sessionStopMethod, count: 1);
+      harness.reply(frame: stop, result: {"workKept": false});
       await Future<void>.delayed(Duration.zero);
       expect(settled, isFalse);
-      expect(harness.plugin.currentWorkState, isNot(PluginWorkState.idle));
       await harness.end(child: "child", parent: "root");
+      final prompt = await harness.waitForSession(method: AcpMethods.sessionPrompt, sessionId: "root");
+      harness.settlePrompt(prompt);
       expect(await stopping, containsAll(["root", "child"]));
-      expect(harness.plugin.currentWorkState, PluginWorkState.idle);
     });
   });
 }
@@ -210,10 +313,25 @@ void main() {
 class _StopHarness() {
   final fake = FakeAcpProcess();
   late final DeepSeekPlugin plugin = buildDeepSeekTestPlugin(fake: fake);
+  var _promptIndex = 0;
 
-  List<Map<String, dynamic>> get cancels => fake.written.where((f) => f["method"] == AcpMethods.sessionCancel).toList();
+  List<Map<String, dynamic>> get cancels =>
+      fake.written.where((frame) => frame["method"] == AcpMethods.sessionCancel).toList();
   List<Map<String, dynamic>> get interrupts =>
-      fake.written.where((f) => f["method"] == DeepSeekAcpApi.subagentInterruptMethod).toList();
+      fake.written.where((frame) => frame["method"] == DeepSeekAcpApi.subagentInterruptMethod).toList();
+  List<Map<String, dynamic>> get stops =>
+      fake.written.where((frame) => frame["method"] == DeepSeekAcpApi.sessionStopMethod).toList();
+
+  Future<PluginAbortResult> atomicAbort({
+    required String sessionId,
+    PluginAbortSubAgentPolicy policy = PluginAbortSubAgentPolicy.stop,
+    Set<String> knownSubAgentSessionIds = const {},
+  }) => plugin.abortSession(
+    sessionId: sessionId,
+    subAgents: policy,
+    useAtomicStop: true,
+    knownSubAgentSessionIds: knownSubAgentSessionIds,
+  );
 
   Future<Map<String, dynamic>> waitFor({required String method, required int count}) async {
     for (var i = 0; i < 100; i++) {
@@ -224,13 +342,39 @@ class _StopHarness() {
     throw StateError("Missing frame $count: $method");
   }
 
+  Future<Map<String, dynamic>> waitForSession({required String method, required String sessionId}) async {
+    for (var i = 0; i < 100; i++) {
+      for (final frame in fake.written.reversed) {
+        if (frame["method"] == method && (frame["params"] as Map)["sessionId"] == sessionId) return frame;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    throw StateError("Missing $method for $sessionId");
+  }
+
+  Map<String, dynamic> stopFor({required String sessionId}) => stops.singleWhere(
+    (frame) => (frame["params"] as Map)["sessionId"] == sessionId,
+  );
+
+  void reply({required Map<String, dynamic> frame, required Map<String, dynamic> result}) {
+    fake.emit({"jsonrpc": "2.0", "id": frame["id"], "result": result});
+  }
+
+  void replyStops({required Map<String, bool> workKeptBySession}) {
+    for (final frame in stops) {
+      final sessionId = (frame["params"] as Map)["sessionId"] as String;
+      if (workKeptBySession.containsKey(sessionId)) {
+        reply(frame: frame, result: {"workKept": workKeptBySession[sessionId]});
+      }
+    }
+  }
+
   Future<void> connect() async {
     final connecting = plugin.ensureConnected();
     final frame = await waitFor(method: AcpMethods.initialize, count: 1);
-    fake.emit({
-      "jsonrpc": "2.0",
-      "id": frame["id"],
-      "result": {
+    reply(
+      frame: frame,
+      result: {
         "protocolVersion": 1,
         "agentCapabilities": <String, dynamic>{"loadSession": true},
         "authMethods": <Object?>[],
@@ -243,24 +387,49 @@ class _StopHarness() {
           },
         },
       },
-    });
+    );
     expect(await connecting, isTrue);
     plugin.mapper.setSessionProject("root", "/repo");
   }
 
-  Future<void> prompt({required String sessionId}) async {
-    await plugin.sendPrompt(
-      sessionId: sessionId,
-      promptId: "prompt",
-      parts: const [PluginPromptPart.text(text: "Work")],
-      variant: null,
-      agent: null,
-      model: null,
-    );
-    final loading = await waitFor(method: AcpMethods.sessionLoad, count: 1);
-    expect((loading["params"] as Map)["sessionId"], sessionId);
-    fake.emit({"jsonrpc": "2.0", "id": loading["id"], "result": <String, dynamic>{}});
-    await waitFor(method: AcpMethods.sessionPrompt, count: 1);
+  Future<Map<String, dynamic>> prompt({required String sessionId}) async {
+    final firstNewFrame = fake.written.length;
+    await queuePromptUntilLoad(sessionId: sessionId);
+    Map<String, dynamic>? repliedLoad;
+    for (var i = 0; i < 100; i++) {
+      final newFrames = fake.written.skip(firstNewFrame);
+      for (final frame in newFrames) {
+        if ((frame["params"] as Map? ?? const {})["sessionId"] != sessionId) continue;
+        if (frame["method"] == AcpMethods.sessionLoad && !identical(frame, repliedLoad)) {
+          repliedLoad = frame;
+          reply(frame: frame, result: <String, dynamic>{});
+        }
+        if (frame["method"] == AcpMethods.sessionPrompt) return frame;
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    throw StateError("Missing new prompt for $sessionId");
+  }
+
+  Future<void> waitForIdle() async {
+    for (var i = 0; i < 100; i++) {
+      if (plugin.currentWorkState == PluginWorkState.idle) return;
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    throw StateError("Plugin did not become idle");
+  }
+
+  Future<void> queuePromptUntilLoad({required String sessionId}) => plugin.sendPrompt(
+    sessionId: sessionId,
+    promptId: "prompt-${_promptIndex++}",
+    parts: const [PluginPromptPart.text(text: "Work")],
+    variant: null,
+    agent: null,
+    model: null,
+  );
+
+  void settlePrompt(Map<String, dynamic> frame) {
+    reply(frame: frame, result: {"stopReason": "cancelled"});
   }
 
   Future<void> spawn({required String child, required String parent, required bool background}) async {
@@ -294,24 +463,19 @@ class _StopHarness() {
     await Future<void>.delayed(Duration.zero);
   }
 
-  Future<void> replyInterrupts({required Map<String, String> results}) async {
-    await waitFor(method: DeepSeekAcpApi.subagentInterruptMethod, count: results.length);
-    for (final frame in interrupts) {
-      final child = (frame["params"] as Map)["childSessionId"];
-      fake.emit({
-        "jsonrpc": "2.0",
-        "id": frame["id"],
-        "result": {"result": results[child]},
-      });
-    }
-  }
-
   Future<void> close() async {
     for (final frame in fake.written.where((frame) => frame["method"] == AcpMethods.sessionPrompt)) {
       fake.emit({
         "jsonrpc": "2.0",
         "id": frame["id"],
         "result": {"stopReason": "cancelled"},
+      });
+    }
+    for (final frame in stops) {
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": frame["id"],
+        "result": {"workKept": false},
       });
     }
     await Future<void>.delayed(Duration.zero);

--- a/bridge/sesori_plugin_deepseek/test/deepseek_scoped_stop_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_scoped_stop_test.dart
@@ -318,22 +318,27 @@ void main() {
       await disconnected.close();
     });
 
-    test("whole-plugin stop uses native authority and waits for lifecycle", () async {
+    test("whole-plugin stop deduplicates native scopes and waits for lifecycle", () async {
       await harness.prompt(sessionId: "root");
       await harness.spawn(child: "child", parent: "root", background: true);
+      await harness.end(child: "child", parent: "root");
+      final childPrompt = await harness.prompt(sessionId: "child");
+      await harness.spawn(child: "grandchild", parent: "child", background: true);
       var settled = false;
       final stopping = harness.plugin.interruptActiveWork(budget: const Duration(seconds: 2)).then((value) {
         settled = true;
         return value;
       });
-      final stop = await harness.waitFor(method: DeepSeekAcpApi.sessionStopMethod, count: 1);
-      harness.reply(frame: stop, result: {"workKept": false});
+      await harness.waitFor(method: DeepSeekAcpApi.sessionStopMethod, count: 2);
+      expect(harness.stops, hasLength(2));
+      harness.replyStops(workKeptBySession: const {"root": false, "child": false});
       await Future<void>.delayed(Duration.zero);
       expect(settled, isFalse);
-      await harness.end(child: "child", parent: "root");
+      await harness.end(child: "grandchild", parent: "child");
       final prompt = await harness.waitForSession(method: AcpMethods.sessionPrompt, sessionId: "root");
       harness.settlePrompt(prompt);
-      expect(await stopping, containsAll(["root", "child"]));
+      harness.settlePrompt(childPrompt);
+      expect(await stopping, containsAll(["root", "child", "grandchild"]));
     });
   });
 }

--- a/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
+++ b/bridge/sesori_plugin_interface/lib/src/bridge_plugin.dart
@@ -189,7 +189,12 @@ sealed class BridgePluginApi() {
   /// Stops the session's in-progress work. [subAgents] scopes the stop for
   /// plugins whose sessions run sub-agents; every other plugin ignores it and
   /// answers [PluginAbortAccepted].
-  Future<PluginAbortResult> abortSession({required String sessionId, required PluginAbortSubAgentPolicy subAgents});
+  Future<PluginAbortResult> abortSession({
+    required String sessionId,
+    required PluginAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
+  });
 
   /// Returns the agents available for the given project.
   ///

--- a/bridge/sesori_plugin_interface/lib/src/models/plugin_abort.dart
+++ b/bridge/sesori_plugin_interface/lib/src/models/plugin_abort.dart
@@ -16,7 +16,10 @@ sealed class const PluginAbortResult();
 /// The stop was performed. [workKept] is true only when resident work (running
 /// sub-agents) was deliberately left alive, so the caller knows the session
 /// will still finish something later.
-final class const PluginAbortAccepted({required final bool workKept}) extends PluginAbortResult;
+final class const PluginAbortAccepted({
+  required final bool workKept,
+  required final bool subAgentsHandled,
+}) extends PluginAbortResult;
 
 /// A `confirm` stop refused because sub-agents are running.
 final class const PluginAbortRejectedSubAgentsRunning({

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_plugin_impl.dart
@@ -637,6 +637,8 @@ class OpenCodePlugin._({
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
   }) => _call(() => _service.abortSession(sessionId: sessionId, subAgents: subAgents));
 
   Future<void> _abortSession({required String sessionId}) => _call(() => _service.abortRoot(sessionId: sessionId));

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -253,7 +253,7 @@ class OpenCodeService(
             mainAgentOnlySupported: false,
           );
         case PluginAbortSubAgentPolicy.keep:
-          return const PluginAbortAccepted(workKept: true);
+          return const PluginAbortAccepted(workKept: true, subAgentsHandled: false);
         case PluginAbortSubAgentPolicy.stop:
           break;
       }
@@ -263,7 +263,7 @@ class OpenCodeService(
       abortRoot(sessionId: sessionId),
       for (final child in children) abortRoot(sessionId: child),
     ]);
-    return const PluginAbortAccepted(workKept: false);
+    return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
   }
 
   /// Aborts exactly [sessionId] without touching its children.

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -263,7 +263,7 @@ class OpenCodeService(
       abortRoot(sessionId: sessionId),
       for (final child in children) abortRoot(sessionId: child),
     ]);
-    return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
+    return const PluginAbortAccepted(workKept: false, subAgentsHandled: true);
   }
 
   /// Aborts exactly [sessionId] without touching its children.

--- a/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/opencode_service.dart
@@ -263,7 +263,7 @@ class OpenCodeService(
       abortRoot(sessionId: sessionId),
       for (final child in children) abortRoot(sessionId: child),
     ]);
-    return const PluginAbortAccepted(workKept: false, subAgentsHandled: true);
+    return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
   }
 
   /// Aborts exactly [sessionId] without touching its children.

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -13,20 +13,6 @@ import "support/fake_open_code_api.dart";
 import "support/open_code_fixtures.dart";
 
 void main() {
-  test("OpenCodeService acknowledges completed root and child stop", () async {
-    final repository = FakeOpenCodeRepository();
-    final tracker = ActiveSessionTracker(repository);
-    tracker.registerSession(sessionId: "child", directory: "/repo", parentId: "root");
-    tracker.markTurnAccepted(sessionId: "child");
-    final service = OpenCodeService(repository, tracker);
-    addTearDown(service.dispose);
-
-    final result = await service.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.stop);
-
-    expect(repository.api.abortedSessionIds, ["root", "child"]);
-    expect(result, isA<PluginAbortAccepted>().having((result) => result.subAgentsHandled, "handled", true));
-  });
-
   group("OpenCodeService.getProjects", () {
     test("returns projects and owns tracker alias bookkeeping", () async {
       final repository = FakeOpenCodeRepository(

--- a/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
+++ b/bridge/sesori_plugin_opencode/test/opencode_service_test.dart
@@ -13,6 +13,20 @@ import "support/fake_open_code_api.dart";
 import "support/open_code_fixtures.dart";
 
 void main() {
+  test("OpenCodeService acknowledges completed root and child stop", () async {
+    final repository = FakeOpenCodeRepository();
+    final tracker = ActiveSessionTracker(repository);
+    tracker.registerSession(sessionId: "child", directory: "/repo", parentId: "root");
+    tracker.markTurnAccepted(sessionId: "child");
+    final service = OpenCodeService(repository, tracker);
+    addTearDown(service.dispose);
+
+    final result = await service.abortSession(sessionId: "root", subAgents: PluginAbortSubAgentPolicy.stop);
+
+    expect(repository.api.abortedSessionIds, ["root", "child"]);
+    expect(result, isA<PluginAbortAccepted>().having((result) => result.subAgentsHandled, "handled", true));
+  });
+
   group("OpenCodeService.getProjects", () {
     test("returns projects and owns tracker alias bookkeeping", () async {
       final repository = FakeOpenCodeRepository(

--- a/bridge/sesori_plugin_opencode/test/support/fake_open_code_api.dart
+++ b/bridge/sesori_plugin_opencode/test/support/fake_open_code_api.dart
@@ -21,6 +21,7 @@ class FakeOpenCodeApi({
   String? lastPromptDirectory;
   SendPromptBody? lastPromptBody;
   final List<SendPromptBody> promptBodies = [];
+  final List<String> abortedSessionIds = [];
   Part? lastUpdatedPart;
   String? lastUpdatedMessageId;
   String? lastUpdatedPartId;
@@ -107,7 +108,10 @@ class FakeOpenCodeApi({
     lastCommandBody = body;
   }
 
-  Future<void> abortSession({required String sessionId, required String? directory}) async {}
+  Future<void> abortSession({required String sessionId, required String? directory}) async {
+    abortedSessionIds.add(sessionId);
+  }
+
   Future<List<Agent>> listAgents({required String directory}) async => [];
   Future<List<QuestionRequest>> getPendingQuestions({required String? directory}) async => [];
   Future<List<PermissionRequest>> getPendingPermissions({required String? directory}) async => [];

--- a/bridge/sesori_plugin_opencode/test/support/fake_open_code_api.dart
+++ b/bridge/sesori_plugin_opencode/test/support/fake_open_code_api.dart
@@ -21,7 +21,6 @@ class FakeOpenCodeApi({
   String? lastPromptDirectory;
   SendPromptBody? lastPromptBody;
   final List<SendPromptBody> promptBodies = [];
-  final List<String> abortedSessionIds = [];
   Part? lastUpdatedPart;
   String? lastUpdatedMessageId;
   String? lastUpdatedPartId;
@@ -108,10 +107,7 @@ class FakeOpenCodeApi({
     lastCommandBody = body;
   }
 
-  Future<void> abortSession({required String sessionId, required String? directory}) async {
-    abortedSessionIds.add(sessionId);
-  }
-
+  Future<void> abortSession({required String sessionId, required String? directory}) async {}
   Future<List<Agent>> listAgents({required String directory}) async => [];
   Future<List<QuestionRequest>> getPendingQuestions({required String? directory}) async => [];
   Future<List<PermissionRequest>> getPendingPermissions({required String? directory}) async => [];

--- a/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
+++ b/bridge/sesori_plugin_pi/lib/src/pi_plugin_impl.dart
@@ -413,9 +413,11 @@ final class PiPlugin._({
   Future<PluginAbortResult> abortSession({
     required String sessionId,
     required PluginAbortSubAgentPolicy subAgents,
+    required bool useAtomicStop,
+    required Set<String> knownSubAgentSessionIds,
   }) async {
     await _sessionService.abort(sessionId: sessionId);
-    return const PluginAbortAccepted(workKept: false);
+    return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
   }
 
   Future<Set<String>> interruptActiveWork({required Duration budget}) =>

--- a/client/module_core/lib/src/api/session_api.dart
+++ b/client/module_core/lib/src/api/session_api.dart
@@ -346,14 +346,14 @@ class SessionApi({required final RelayHttpApiClient _client}) {
 
   /// Stops a session with the given sub-agent scope. A 409 carrying a
   /// [SessionAbortRejection] surfaces as [SessionAbortApiRejectedException].
-  Future<ApiResponse<SuccessEmptyResponse>> abortSession({
+  Future<ApiResponse<SessionAbortResponse>> abortSession({
     required String sessionId,
     required SessionAbortSubAgentPolicy subAgents,
   }) async {
     final response = await _client.post(
       "/session/abort",
-      fromJson: SuccessEmptyResponse.fromJson,
-      body: AbortSessionRequest(sessionId: sessionId, subAgents: subAgents),
+      fromJson: SessionAbortResponse.fromJson,
+      body: AbortSessionRequest(sessionId: sessionId, subAgents: subAgents, useAtomicStop: true),
     );
     if (response case ErrorResponse(error: NonSuccessCodeError(errorCode: 409, rawErrorString: final String rawBody))) {
       final SessionAbortRejection rejection;

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -2314,7 +2314,7 @@ class SessionDetailCubit(
       _clearLocalPromptQueue();
 
       // Prefer post-stop status truth, but retain the request snapshot when an
-      // abort-driven reload temporarily replaces the loaded detail state.
+      // concurrent reload temporarily replaces the loaded detail state.
       final current = state;
       final childStatuses = current is SessionDetailLoaded ? current.childStatuses : requestChildStatuses;
       if (subAgents != SessionAbortSubAgentPolicy.keep && !subAgentsHandled) {

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -2301,17 +2301,26 @@ class SessionDetailCubit(
   /// children are real sessions keep today's stop-everything behavior.
   Future<SessionAbortOutcome> abort({required SessionAbortSubAgentPolicy subAgents}) async {
     try {
+      final requestChildStatuses = switch (state) {
+        SessionDetailLoaded(:final childStatuses) => Map<String, SessionStatus>.of(childStatuses),
+        SessionDetailLoading() || SessionDetailFailed() => const <String, SessionStatus>{},
+      };
       if (subAgents != SessionAbortSubAgentPolicy.confirm) _clearLocalPromptQueue();
       final root = await _sessionRepository.abortSession(sessionId: _sessionId, subAgents: subAgents);
       if (root case ErrorResponse(:final error)) throw error;
       _clearLocalPromptQueue();
 
-      // Read state after the await: an abort-driven status or transcript event
-      // may have landed meanwhile and must not be overwritten by a stale copy.
+      // Prefer post-stop status truth, but retain the request snapshot when an
+      // abort-driven reload temporarily replaces the loaded detail state.
       final current = state;
-      if (subAgents != SessionAbortSubAgentPolicy.keep && current is SessionDetailLoaded) {
+      final childStatuses = current is SessionDetailLoaded ? current.childStatuses : requestChildStatuses;
+      final subAgentsHandled = switch (root) {
+        SuccessResponse(:final data) => data,
+        ErrorResponse() => false,
+      };
+      if (subAgents != SessionAbortSubAgentPolicy.keep && !subAgentsHandled) {
         final results = await Future.wait([
-          for (final MapEntry(key: childId, value: status) in current.childStatuses.entries)
+          for (final MapEntry(key: childId, value: status) in childStatuses.entries)
             if (status is SessionStatusBusy || status is SessionStatusRetry)
               _sessionRepository.abortSession(sessionId: childId, subAgents: SessionAbortSubAgentPolicy.stop),
         ]);

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -2307,17 +2307,16 @@ class SessionDetailCubit(
       };
       if (subAgents != SessionAbortSubAgentPolicy.confirm) _clearLocalPromptQueue();
       final root = await _sessionRepository.abortSession(sessionId: _sessionId, subAgents: subAgents);
-      if (root case ErrorResponse(:final error)) throw error;
+      final subAgentsHandled = switch (root) {
+        SuccessResponse(:final data) => data,
+        ErrorResponse(:final error) => throw error,
+      };
       _clearLocalPromptQueue();
 
       // Prefer post-stop status truth, but retain the request snapshot when an
       // abort-driven reload temporarily replaces the loaded detail state.
       final current = state;
       final childStatuses = current is SessionDetailLoaded ? current.childStatuses : requestChildStatuses;
-      final subAgentsHandled = switch (root) {
-        SuccessResponse(:final data) => data,
-        ErrorResponse() => false,
-      };
       if (subAgents != SessionAbortSubAgentPolicy.keep && !subAgentsHandled) {
         final results = await Future.wait([
           for (final MapEntry(key: childId, value: status) in childStatuses.entries)

--- a/client/module_core/lib/src/repositories/session_repository.dart
+++ b/client/module_core/lib/src/repositories/session_repository.dart
@@ -62,12 +62,15 @@ class SessionRepository({
   }
 
   /// Throws [SessionAbortRejectedException] for a refused `confirm`.
-  Future<ApiResponse<void>> abortSession({
+  Future<ApiResponse<bool>> abortSession({
     required String sessionId,
     required SessionAbortSubAgentPolicy subAgents,
   }) async {
     try {
-      return await _api.abortSession(sessionId: sessionId, subAgents: subAgents);
+      return switch (await _api.abortSession(sessionId: sessionId, subAgents: subAgents)) {
+        SuccessResponse(:final data) => ApiResponse.success(data.subAgentsHandled),
+        ErrorResponse(:final error) => ApiResponse.error(error),
+      };
     } on SessionAbortApiRejectedException catch (error, stackTrace) {
       Error.throwWithStackTrace(
         SessionAbortRejectedException(rejection: error.rejection, innerError: error),

--- a/client/module_core/test/cubits/session_detail/session_detail_bridge_queue_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_bridge_queue_test.dart
@@ -1451,7 +1451,7 @@ void main() {
           subAgents: any(named: "subAgents"),
         ),
       ).thenAnswer(
-        (_) async => ApiResponse.success(null),
+        (_) async => ApiResponse.success(false),
       );
       final cubit = await createLoadedCubit();
       await cubit.sendMessage(text: "parked", command: null, inputMode: ComposerInputMode.typed, attachments: const []);
@@ -1760,7 +1760,7 @@ void main() {
           subAgents: any(named: "subAgents"),
         ),
       ).thenAnswer(
-        (_) async => ApiResponse.success(null),
+        (_) async => ApiResponse.success(false),
       );
       final sendCompleter = Completer<ApiResponse<void>>();
       when(

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_permission_test.dart
@@ -427,7 +427,7 @@ void main() {
           sessionId: any(named: "sessionId"),
           subAgents: any(named: "subAgents"),
         ),
-      ).thenAnswer((_) async => ApiResponse<void>.success(null));
+      ).thenAnswer((_) async => ApiResponse<bool>.success(false));
       final analyticsService = stubbedProductAnalyticsService();
       final cubit = _buildCubit(
         sessionId: sessionId,

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
@@ -8,6 +8,7 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/models/connection_status.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/models/sse_event.dart";
 import "package:sesori_dart_core/src/capabilities/server_connection/server_connection_config.dart";
+import "package:sesori_dart_core/src/cubits/session_detail/session_abort_outcome.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_cubit.dart";
 import "package:sesori_dart_core/src/cubits/session_detail/session_detail_state.dart";
 import "package:sesori_dart_core/src/foundation/models/composer/composer_attachment.dart";
@@ -723,6 +724,101 @@ void main() {
         ).called(1);
       },
     );
+
+    test("abort skips legacy descendant fanout after bridge acknowledgment", () async {
+      const childId = "child-1";
+      when(() => mockSessionService.getChildren(sessionId: sessionId)).thenAnswer(
+        (_) async => ApiResponse.success(
+          SessionListResponse(
+            items: [testSession(id: childId, parentID: sessionId)],
+          ),
+        ),
+      );
+      when(() => mockSessionService.getSessionStatuses()).thenAnswer(
+        (_) async => ApiResponse.success(
+          const SessionStatusResponse(statuses: {childId: SessionStatus.busy()}),
+        ),
+      );
+      when(
+        () => mockSessionService.abortSession(
+          sessionId: sessionId,
+          subAgents: SessionAbortSubAgentPolicy.stop,
+        ),
+      ).thenAnswer((_) async => ApiResponse.success(true));
+      final cubit = buildCubit();
+      await _awaitLoaded(cubit);
+
+      final outcome = await cubit.abort(subAgents: SessionAbortSubAgentPolicy.stop);
+
+      expect(outcome, isA<SessionAbortAccepted>());
+      verifyNever(
+        () => mockSessionService.abortSession(
+          sessionId: childId,
+          subAgents: SessionAbortSubAgentPolicy.stop,
+        ),
+      );
+      await cubit.close();
+    });
+
+    test("old bridge fallback retains the request snapshot while detail reloads", () async {
+      const childId = "child-1";
+      when(() => mockSessionService.getChildren(sessionId: sessionId)).thenAnswer(
+        (_) async => ApiResponse.success(
+          SessionListResponse(
+            items: [testSession(id: childId, parentID: sessionId)],
+          ),
+        ),
+      );
+      when(() => mockSessionService.getSessionStatuses()).thenAnswer(
+        (_) async => ApiResponse.success(
+          const SessionStatusResponse(statuses: {childId: SessionStatus.busy()}),
+        ),
+      );
+      final rootAbort = Completer<ApiResponse<bool>>();
+      when(
+        () => mockSessionService.abortSession(
+          sessionId: sessionId,
+          subAgents: SessionAbortSubAgentPolicy.stop,
+        ),
+      ).thenAnswer((_) => rootAbort.future);
+      final cubit = buildCubit();
+      await _awaitLoaded(cubit);
+      final aborting = cubit.abort(subAgents: SessionAbortSubAgentPolicy.stop);
+      await Future<void>.delayed(Duration.zero);
+
+      final reloadMessages = Completer<ApiResponse<MessageWithPartsResponse>>();
+      when(
+        () => mockSessionService.getMessages(
+          sessionId: sessionId,
+          limit: any(named: "limit"),
+          before: any(named: "before"),
+        ),
+      ).thenAnswer((_) => reloadMessages.future);
+      final reloading = cubit.reload();
+      await Future<void>.delayed(Duration.zero);
+      expect(cubit.state, isA<SessionDetailLoading>());
+
+      rootAbort.complete(ApiResponse.success(false));
+      expect(await aborting, isA<SessionAbortAccepted>());
+      verify(
+        () => mockSessionService.abortSession(
+          sessionId: childId,
+          subAgents: SessionAbortSubAgentPolicy.stop,
+        ),
+      ).called(1);
+
+      reloadMessages.complete(
+        ApiResponse.success(
+          MessageWithPartsResponse(
+            messages: [testMessageWithParts()],
+            nextCursor: null,
+            replayedPromptDefaults: null,
+          ),
+        ),
+      );
+      await reloading;
+      await cubit.close();
+    });
 
     blocTest<SessionDetailCubit, SessionDetailState>(
       "replyToQuestion optimistically removes pending question and calls API",
@@ -2310,7 +2406,7 @@ void _stubAllDefaults(
       sessionId: any(named: "sessionId"),
       subAgents: any(named: "subAgents"),
     ),
-  ).thenAnswer((_) async => ApiResponse.success(null));
+  ).thenAnswer((_) async => ApiResponse.success(false));
   when(
     () => service.replyToQuestion(
       requestId: any(named: "requestId"),

--- a/client/module_core/test/repositories/session_repository_test.dart
+++ b/client/module_core/test/repositories/session_repository_test.dart
@@ -95,7 +95,7 @@ void main() {
     ).thenAnswer((_) async => ApiResponse.success(null));
     when(
       () => api.abortSession(sessionId: "session-1", subAgents: SessionAbortSubAgentPolicy.stop),
-    ).thenAnswer((_) async => ApiResponse.success(const SuccessEmptyResponse()));
+    ).thenAnswer((_) async => ApiResponse.success(const SessionAbortResponse(subAgentsHandled: true)));
     when(
       () => api.replyToQuestion(
         requestId: "question-1",
@@ -126,7 +126,11 @@ void main() {
       variant: const SessionVariant(id: "xhigh"),
       command: "review",
     );
-    await repository.abortSession(sessionId: "session-1", subAgents: SessionAbortSubAgentPolicy.stop);
+    final abortResult = await repository.abortSession(
+      sessionId: "session-1",
+      subAgents: SessionAbortSubAgentPolicy.stop,
+    );
+    expect(abortResult, isA<SuccessResponse<bool>>().having((response) => response.data, "acknowledgment", true));
     await repository.replyToQuestion(
       requestId: "question-1",
       sessionId: "session-1",

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -109,6 +109,8 @@ background sub-agents together with the running main turn.
 ² OpenCode's task tool cancels a foreground child when its root is aborted
 (verified on 1.18.25); background children survive, and the tracker cannot tell
 the two apart, so the option is not offered.
+Atomic subtree completion acknowledgment is **not implemented** for OpenCode;
+its observed-child snapshot retains legacy client fanout.
 
 ³ Codex (codex-cli 0.148.0, `multi_agent` stable, probed 2026-09-02): a child
 announces itself through the parent's `subAgentActivity started`

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -149,11 +149,10 @@ generic `tool_call` with no ids or lifecycle notifications; those exist only in
 turn.
 
 ⁹ DeepSeek's published adapter 0.1.4 over dsh 0.1.1-rc.2 is the managed target
-and minimum accepted runtime. The consumer handles its typed native stop/input
-contract while preserving the existing direct-parent scoped-stop policy until
-step 5/5 moves complete native stop authority into ACP. Live/replayed tiles,
-child catalogs, exact-child cancellation, and authoritative lifecycle remain
-implemented; final DeepSeek phone/desktop E2E is still outstanding.
+and minimum accepted runtime. ACP uses native subtree stop for the named scope
+and every independently resident descendant root, while ordered input cancel,
+exact-child authority, lifecycle, tiles, and child catalogs remain native-backed.
+Released clients retain their own child fanout; final phone/desktop E2E remains outstanding.
 
 ¹⁰ Grok Build (1.0.5, probed 2026-09-03) sends `subagent_spawned`/`subagent_progress`/
 `subagent_finished` with parent and child session ids as

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -114,6 +114,8 @@ defaults and queued client sends coherent.
   down, cancelling every sub-agent. With no sub-agents running, stop behaves
   as before with no dialog. An older app stops everything; an older bridge
   ignores the scope.
+  OpenCode acknowledges completed root/child aborts so current clients do not
+  issue duplicate child stops.
 - DeepSeek 0.1.4 supports side-effect-free `confirm` rejection and child-only
   `keep`. For a current-client stop, ACP captures the named native scope plus
   every independently resident descendant root, queues all native subtree STOPs

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -115,12 +115,17 @@ defaults and queued client sends coherent.
   as before with no dialog. An older app stops everything; an older bridge
   ignores the scope.
 - DeepSeek 0.1.4 supports side-effect-free `confirm` rejection and child-only
-  `keep`. The bridge validates the native adapter floor and handles ordered
-  `deepseek/input/cancel`: input admitted before cancellation is rejected, while
-  later input survives even when question IDs are reused or prompt output was
-  buffered behind an unfinished stdin flush. Scoped stop otherwise retains the
-  existing direct-parent interrupt behavior until replacement step 5/5 consumes
-  native atomic subtree authority. Other ACP harnesses remain unchanged.
+  `keep`. For a current-client stop, ACP captures the named native scope plus
+  every independently resident descendant root, queues all native subtree STOPs
+  before awaiting responses, and waits for all of them. Persisted descendants
+  clear queued-only turns without inventing native ownership; retained children
+  use exact direct-parent authority. A partial native failure stays observable,
+  later prompts survive STOP responses, and lifecycle alone settles busy state.
+  Released clients keep named cancellation plus their own child fanout; a current
+  client treats an older bridge's `{}` response as no acknowledgment and falls
+  back to refreshed visible busy children or its request snapshot during reload.
+  `deepseek/input/cancel` remains ordered before later reused-ID input. Other ACP
+  harnesses remain unchanged.
 - Pi keeps at most one lazy resident RPC process per active session and allows
   different sessions to run concurrently. A cold resident starts with the
   turn's requested model and thinking level on Pi's command line so

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -114,8 +114,8 @@ defaults and queued client sends coherent.
   down, cancelling every sub-agent. With no sub-agents running, stop behaves
   as before with no dialog. An older app stops everything; an older bridge
   ignores the scope.
-  OpenCode acknowledges completed root/child aborts so current clients do not
-  issue duplicate child stops.
+  OpenCode retains legacy client fallback: its observed-child snapshot does not
+  prove atomic subtree completion across separate HTTP/SSE channels.
 - DeepSeek 0.1.4 supports side-effect-free `confirm` rejection and child-only
   `keep`. For a current-client stop, ACP captures the named native scope plus
   every independently resident descendant root, queues all native subtree STOPs

--- a/shared/sesori_shared/lib/src/models/sesori/abort_session_request.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/abort_session_request.dart
@@ -31,9 +31,26 @@ sealed class AbortSessionRequest with _$AbortSessionRequest {
     // subAgents and mean today's stop-everything. Make it required once those
     // apps are unsupported.
     @Default(SessionAbortSubAgentPolicy.stop) SessionAbortSubAgentPolicy subAgents,
+    // COMPATIBILITY 2026-09-03 (v1.8.4): Released apps omit the atomic-stop
+    // handshake and retain their own child fanout. Remove the default once
+    // v1.8.3 clients are unsupported.
+    @Default(false) bool useAtomicStop,
   }) = _AbortSessionRequest;
 
   factory fromJson(Map<String, dynamic> json) => _$AbortSessionRequestFromJson(json);
+}
+
+/// Successful `POST /session/abort` response.
+@Freezed(fromJson: true, toJson: true)
+sealed class SessionAbortResponse with _$SessionAbortResponse {
+  const factory({
+    // COMPATIBILITY 2026-09-03 (v1.8.4): Released bridges return `{}` and do
+    // not acknowledge bridge-owned descendant handling. Remove the default
+    // once v1.8.3 bridges are unsupported.
+    @Default(false) bool subAgentsHandled,
+  }) = _SessionAbortResponse;
+
+  factory fromJson(Map<String, dynamic> json) => _$SessionAbortResponseFromJson(json);
 }
 
 /// 409 body for a `confirm` stop the bridge refused because sub-agents run.

--- a/shared/sesori_shared/lib/src/models/sesori/abort_session_request.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/abort_session_request.freezed.dart
@@ -16,7 +16,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$AbortSessionRequest {
 
- String get sessionId; SessionAbortSubAgentPolicy get subAgents;
+ String get sessionId; SessionAbortSubAgentPolicy get subAgents; bool get useAtomicStop;
 /// Create a copy of AbortSessionRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -29,16 +29,16 @@ $AbortSessionRequestCopyWith<AbortSessionRequest> get copyWith => _$AbortSession
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is AbortSessionRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.subAgents, subAgents) || other.subAgents == subAgents));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is AbortSessionRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.subAgents, subAgents) || other.subAgents == subAgents)&&(identical(other.useAtomicStop, useAtomicStop) || other.useAtomicStop == useAtomicStop));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,sessionId,subAgents);
+int get hashCode => Object.hash(runtimeType,sessionId,subAgents,useAtomicStop);
 
 @override
 String toString() {
-  return 'AbortSessionRequest(sessionId: $sessionId, subAgents: $subAgents)';
+  return 'AbortSessionRequest(sessionId: $sessionId, subAgents: $subAgents, useAtomicStop: $useAtomicStop)';
 }
 
 
@@ -49,7 +49,7 @@ abstract mixin class $AbortSessionRequestCopyWith<$Res>  {
   factory $AbortSessionRequestCopyWith(AbortSessionRequest value, $Res Function(AbortSessionRequest) _then) = _$AbortSessionRequestCopyWithImpl;
 @useResult
 $Res call({
- String sessionId, SessionAbortSubAgentPolicy subAgents
+ String sessionId, SessionAbortSubAgentPolicy subAgents, bool useAtomicStop
 });
 
 
@@ -66,11 +66,12 @@ class _$AbortSessionRequestCopyWithImpl<$Res>
 
 /// Create a copy of AbortSessionRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? subAgents = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? subAgents = null,Object? useAtomicStop = null,}) {
   return _then(AbortSessionRequest(
 sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
 as String,subAgents: null == subAgents ? _self.subAgents : subAgents // ignore: cast_nullable_to_non_nullable
-as SessionAbortSubAgentPolicy,
+as SessionAbortSubAgentPolicy,useAtomicStop: null == useAtomicStop ? _self.useAtomicStop : useAtomicStop // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -82,11 +83,12 @@ as SessionAbortSubAgentPolicy,
 @JsonSerializable()
 
 class _AbortSessionRequest implements AbortSessionRequest {
-  const _AbortSessionRequest({required this.sessionId, this.subAgents = SessionAbortSubAgentPolicy.stop});
+  const _AbortSessionRequest({required this.sessionId, this.subAgents = SessionAbortSubAgentPolicy.stop, this.useAtomicStop = false});
   factory _AbortSessionRequest.fromJson(Map<String, dynamic> json) => _$AbortSessionRequestFromJson(json);
 
 @override final  String sessionId;
 @override@JsonKey() final  SessionAbortSubAgentPolicy subAgents;
+@override@JsonKey() final  bool useAtomicStop;
 
 /// Create a copy of AbortSessionRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -101,16 +103,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AbortSessionRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.subAgents, subAgents) || other.subAgents == subAgents));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _AbortSessionRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.subAgents, subAgents) || other.subAgents == subAgents)&&(identical(other.useAtomicStop, useAtomicStop) || other.useAtomicStop == useAtomicStop));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,sessionId,subAgents);
+int get hashCode => Object.hash(runtimeType,sessionId,subAgents,useAtomicStop);
 
 @override
 String toString() {
-  return 'AbortSessionRequest(sessionId: $sessionId, subAgents: $subAgents)';
+  return 'AbortSessionRequest(sessionId: $sessionId, subAgents: $subAgents, useAtomicStop: $useAtomicStop)';
 }
 
 
@@ -121,7 +123,7 @@ abstract mixin class _$AbortSessionRequestCopyWith<$Res> implements $AbortSessio
   factory _$AbortSessionRequestCopyWith(_AbortSessionRequest value, $Res Function(_AbortSessionRequest) _then) = __$AbortSessionRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String sessionId, SessionAbortSubAgentPolicy subAgents
+ String sessionId, SessionAbortSubAgentPolicy subAgents, bool useAtomicStop
 });
 
 
@@ -138,11 +140,146 @@ class __$AbortSessionRequestCopyWithImpl<$Res>
 
 /// Create a copy of AbortSessionRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? subAgents = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? subAgents = null,Object? useAtomicStop = null,}) {
   return _then(_AbortSessionRequest(
 sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
 as String,subAgents: null == subAgents ? _self.subAgents : subAgents // ignore: cast_nullable_to_non_nullable
-as SessionAbortSubAgentPolicy,
+as SessionAbortSubAgentPolicy,useAtomicStop: null == useAtomicStop ? _self.useAtomicStop : useAtomicStop // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$SessionAbortResponse {
+
+ bool get subAgentsHandled;
+/// Create a copy of SessionAbortResponse
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$SessionAbortResponseCopyWith<SessionAbortResponse> get copyWith => _$SessionAbortResponseCopyWithImpl<SessionAbortResponse>(this as SessionAbortResponse, _$identity);
+
+  /// Serializes this SessionAbortResponse to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionAbortResponse&&(identical(other.subAgentsHandled, subAgentsHandled) || other.subAgentsHandled == subAgentsHandled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,subAgentsHandled);
+
+@override
+String toString() {
+  return 'SessionAbortResponse(subAgentsHandled: $subAgentsHandled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $SessionAbortResponseCopyWith<$Res>  {
+  factory $SessionAbortResponseCopyWith(SessionAbortResponse value, $Res Function(SessionAbortResponse) _then) = _$SessionAbortResponseCopyWithImpl;
+@useResult
+$Res call({
+ bool subAgentsHandled
+});
+
+
+
+
+}
+/// @nodoc
+class _$SessionAbortResponseCopyWithImpl<$Res>
+    implements $SessionAbortResponseCopyWith<$Res> {
+  _$SessionAbortResponseCopyWithImpl(this._self, this._then);
+
+  final SessionAbortResponse _self;
+  final $Res Function(SessionAbortResponse) _then;
+
+/// Create a copy of SessionAbortResponse
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? subAgentsHandled = null,}) {
+  return _then(SessionAbortResponse(
+subAgentsHandled: null == subAgentsHandled ? _self.subAgentsHandled : subAgentsHandled // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _SessionAbortResponse implements SessionAbortResponse {
+  const _SessionAbortResponse({this.subAgentsHandled = false});
+  factory _SessionAbortResponse.fromJson(Map<String, dynamic> json) => _$SessionAbortResponseFromJson(json);
+
+@override@JsonKey() final  bool subAgentsHandled;
+
+/// Create a copy of SessionAbortResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$SessionAbortResponseCopyWith<_SessionAbortResponse> get copyWith => __$SessionAbortResponseCopyWithImpl<_SessionAbortResponse>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$SessionAbortResponseToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionAbortResponse&&(identical(other.subAgentsHandled, subAgentsHandled) || other.subAgentsHandled == subAgentsHandled));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,subAgentsHandled);
+
+@override
+String toString() {
+  return 'SessionAbortResponse(subAgentsHandled: $subAgentsHandled)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$SessionAbortResponseCopyWith<$Res> implements $SessionAbortResponseCopyWith<$Res> {
+  factory _$SessionAbortResponseCopyWith(_SessionAbortResponse value, $Res Function(_SessionAbortResponse) _then) = __$SessionAbortResponseCopyWithImpl;
+@override @useResult
+$Res call({
+ bool subAgentsHandled
+});
+
+
+
+
+}
+/// @nodoc
+class __$SessionAbortResponseCopyWithImpl<$Res>
+    implements _$SessionAbortResponseCopyWith<$Res> {
+  __$SessionAbortResponseCopyWithImpl(this._self, this._then);
+
+  final _SessionAbortResponse _self;
+  final $Res Function(_SessionAbortResponse) _then;
+
+/// Create a copy of SessionAbortResponse
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? subAgentsHandled = null,}) {
+  return _then(_SessionAbortResponse(
+subAgentsHandled: null == subAgentsHandled ? _self.subAgentsHandled : subAgentsHandled // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/abort_session_request.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/abort_session_request.g.dart
@@ -15,6 +15,7 @@ _AbortSessionRequest _$AbortSessionRequestFromJson(Map json) =>
             json['subAgents'],
           ) ??
           SessionAbortSubAgentPolicy.stop,
+      useAtomicStop: json['useAtomicStop'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$AbortSessionRequestToJson(
@@ -22,6 +23,7 @@ Map<String, dynamic> _$AbortSessionRequestToJson(
 ) => <String, dynamic>{
   'sessionId': instance.sessionId,
   'subAgents': _$SessionAbortSubAgentPolicyEnumMap[instance.subAgents]!,
+  'useAtomicStop': instance.useAtomicStop,
 };
 
 const _$SessionAbortSubAgentPolicyEnumMap = {
@@ -29,6 +31,15 @@ const _$SessionAbortSubAgentPolicyEnumMap = {
   SessionAbortSubAgentPolicy.keep: 'keep',
   SessionAbortSubAgentPolicy.stop: 'stop',
 };
+
+_SessionAbortResponse _$SessionAbortResponseFromJson(Map json) =>
+    _SessionAbortResponse(
+      subAgentsHandled: json['subAgentsHandled'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$SessionAbortResponseToJson(
+  _SessionAbortResponse instance,
+) => <String, dynamic>{'subAgentsHandled': instance.subAgentsHandled};
 
 _SessionAbortRejection _$SessionAbortRejectionFromJson(Map json) =>
     _SessionAbortRejection(

--- a/shared/sesori_shared/test/models/session_abort_response_test.dart
+++ b/shared/sesori_shared/test/models/session_abort_response_test.dart
@@ -1,0 +1,30 @@
+import "package:sesori_shared/sesori_shared.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("released request omission preserves client-owned descendant fanout", () {
+    final request = AbortSessionRequest.fromJson({"sessionId": "session", "subAgents": "stop"});
+
+    expect(request.useAtomicStop, isFalse);
+    expect(request.toJson()["useAtomicStop"], isFalse);
+  });
+
+  test("released empty response decodes as no bridge descendant acknowledgment", () {
+    final response = SessionAbortResponse.fromJson(const {});
+
+    expect(response.subAgentsHandled, isFalse);
+    expect(response.toJson(), {"subAgentsHandled": false});
+  });
+
+  test("current handshake round-trips explicit atomic handling", () {
+    const request = AbortSessionRequest(
+      sessionId: "session",
+      subAgents: SessionAbortSubAgentPolicy.stop,
+      useAtomicStop: true,
+    );
+    const response = SessionAbortResponse(subAgentsHandled: true);
+
+    expect(AbortSessionRequest.fromJson(request.toJson()), request);
+    expect(SessionAbortResponse.fromJson(response.toJson()), response);
+  });
+}


### PR DESCRIPTION
## Complexity

🚧 Complex — cancellation ownership, asynchronous dispatch, and public-client compatibility cross existing bridge/plugin/client boundaries. The full diff is **1,491 changed lines** (+1,175/-316, 47 files), including generated code, tests, and documentation.

## What

- Complete DeepSeek scoped stop inside ACP: the named native scope plus every independently resident descendant root, including roots whose own prompt has settled.
- Reuse existing residency, ancestry, queue generations, and the bridge family-operation dispatcher. Queue all native STOP requests before awaiting; wait for all and surface failures with their original causes.
- Preserve exact named-child authority, later prompts/input, side-effect-free confirmation, and main-only `keep` semantics.
- Add only request `useAtomicStop` and response `subAgentsHandled` compatibility flags. Keep released-client cancellation/fanout behavior; retain current-client fallback during reload against old bridges.
- Update internal plugin consumers together, capabilities, and regression coverage. OpenCode retains conservative legacy fanout: its observed-child snapshot is not an atomic completion boundary. Other harness stop policy remains unchanged.

## Why

This completes the simpler replacement for closed, unmerged #1356 after merged prerequisite #1363. The complete original source remains preserved at `58bbe71384a7d5f71b00cad3e573995e4fbb587a`.

ACP now finishes the operation rather than exporting unfinished descendant work to the UI. There is **no residual-ID wire protocol, partial-coverage hierarchy, client abort service/DI, new registry/lock/timer/epoch, or response-time cleanup**. Native adapter 0.1.4 was already published and pinned; no native release or automatic-upgrade changes are included.

## Risk and test focus

High functional risk if cancellation scope/order is wrong: unrelated or later work must not be stopped, and independent descendants must not be missed. Focused regressions cover settled/nested resident roots, foreground `keep` partitioning, queued-root `keep`, delayed admission, pending loads, retained child authority, partial failure, dispatch-before-response, later-work survival, reset/close, mixed public versions, and reload fallback.

Compatibility baseline is public **v1.8.3**. Omitted opt-in preserves its compiled client fanout; an old bridge's `{}` maps to false acknowledgment. Internal/prerelease contracts are not retained.

## Expected result

Current clients stop the complete DeepSeek scope through one bridge-owned operation without duplicate client fanout. `keep` leaves independent descendants running while clearing accepted main work. Other harness policies and phone/desktop composition remain unchanged.

**No database schema, migration, or persisted-data change.** The client/bridge wire additions are backward compatible. Final real phone/desktop feature E2E remains outstanding and user-owned; DeepSeek must finish that gate before Codex work.

## Verification

- Fatal-info analysis: bridge workspace, client core, and shared package all pass.
- Initial focused suites: DeepSeek scoped stop **14**, bridge abort/repository **57**, client repository/cubit **61**, shared compatibility **3**, affected mobile title-hydration/split-pane **17** — all pass.
- Review fixes: DeepSeek scoped stop **16**, abort routing **3**, session-detail cubit **49**, and OpenCode service **71** pass; fatal-info analysis passes in ACP, DeepSeek, OpenCode, bridge app, and client core. LSP reports zero diagnostics across the four affected production files.
- Quiescence follow-up: removed redundant child-root expansion; the existing lifecycle regression now verifies exactly one native stop per scope with an independently prompted former child. All 16 scoped-stop tests and ACP/DeepSeek analysis pass.
- Shared serializers generated from source; whitespace checks pass.
- LSP: no diagnostics across 12 key changed files.
- Independent correctness/simplicity review found no consequential findings; architecture implementation review approved all three workspaces for `b13d197d517adeb51810e05011b300b31a20b014..60b86e49c7f1c05de78cbe098e69a0fff21864b0`.
- No downloaded native executable was run. Package checks do not replace the outstanding real phone/desktop E2E gate.
