### PR TITLE
🌿 Link Claude Fable aliases to catalog models

### DIFF
--- a/bridge/sesori_plugin_claude/lib/src/repositories/claude_backend_catalog_repository.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/claude_backend_catalog_repository.dart
@@ -9,16 +9,18 @@ final class const ClaudeBackendCatalog({
   required final PluginProvidersResult providers,
   required final List<PluginCommand> commands,
 
-  /// Picker id per catalog `resolvedModel` (`claude-opus-5[1m]` → `opus[1m]`).
-  required final Map<String, String> modelIdsByResolvedModel,
+  /// Picker id per API-reported model token. Includes catalog
+  /// `resolvedModel` values and short family/context aliases such as
+  /// `fable[1m]`.
+  required final Map<String, String> modelIdsByApiModel,
 }) {
   /// The picker id behind an API model name, or null when the catalog has no
-  /// such model. The stream reports `claude-opus-5` for both `opus` and
-  /// `opus[1m]`, so a bare match takes the first entry sharing the name.
+  /// such model. Claude can omit a context suffix from a resolved name, so a
+  /// bare match takes the first entry sharing the name.
   String? catalogModelId({required String apiModel}) {
-    if (modelIdsByResolvedModel[apiModel] case final id?) return id;
+    if (modelIdsByApiModel[apiModel] case final id?) return id;
     final bare = _bareModel(apiModel);
-    for (final entry in modelIdsByResolvedModel.entries) {
+    for (final entry in modelIdsByApiModel.entries) {
       if (_bareModel(entry.key) == bare) return entry.value;
     }
     return null;
@@ -37,7 +39,7 @@ final class const ClaudeBackendCatalogRepository() {
   static const String _cliDefaultModelId = "default";
 
   /// Sesori's default selection, named explicitly in place of [_cliDefaultModelId].
-  static const String _defaultModelIdPrefix = "opus";
+  static const String _defaultModelFamily = "opus";
   static const ClaudeEffortLevel _defaultEffort = ClaudeEffortLevel.high;
 
   /// Model families strongest first, as the picker lists them. The CLI's own
@@ -51,11 +53,11 @@ final class const ClaudeBackendCatalogRepository() {
       for (final model in dto.models) ?_model(model),
     ];
     final models = [
-      for (final family in _familiesByStrength) ...unranked.where((model) => model.id.startsWith(family)),
-      ...unranked.where((model) => !_familiesByStrength.any(model.id.startsWith)),
+      for (final family in _familiesByStrength) ...unranked.where((model) => _family(modelId: model.id) == family),
+      ...unranked.where((model) => _family(modelId: model.id) == null),
     ];
     final defaultModel =
-        models.where((model) => model.id.startsWith(_defaultModelIdPrefix)).firstOrNull ?? models.firstOrNull;
+        models.where((model) => _family(modelId: model.id) == _defaultModelFamily).firstOrNull ?? models.firstOrNull;
     final agentModel = defaultModel == null
         ? null
         : PluginAgentModel(
@@ -91,12 +93,44 @@ final class const ClaudeBackendCatalogRepository() {
       commands: List.unmodifiable([
         for (final command in dto.commands) ?_command(command),
       ]),
-      modelIdsByResolvedModel: Map.unmodifiable({
-        for (final model in dto.models)
-          if (_model(model) case final mapped? when model.resolvedModel?.trim().isNotEmpty ?? false)
-            model.resolvedModel!.trim(): mapped.id,
-      }),
+      modelIdsByApiModel: Map.unmodifiable(_modelIdsByApiModel(dto.models)),
     );
+  }
+
+  Map<String, String> _modelIdsByApiModel(List<ClaudeModelDto> models) {
+    final mappedModels = [
+      for (final dto in models)
+        if (_model(dto) case final model?) (dto: dto, model: model),
+    ];
+    final ids = <String, String>{};
+    for (final entry in mappedModels) {
+      if (entry.dto.resolvedModel?.trim() case final resolved? when resolved.isNotEmpty) {
+        ids[resolved] = entry.model.id;
+      }
+    }
+    for (final entry in mappedModels) {
+      if (_familyAlias(modelId: entry.model.id) case final alias?) {
+        ids.putIfAbsent(alias, () => entry.model.id);
+      }
+    }
+    return ids;
+  }
+
+  String? _family({required String modelId}) {
+    final bare = ClaudeBackendCatalog._bareModel(modelId);
+    for (final family in _familiesByStrength) {
+      if (bare == family || bare.startsWith("$family-") || bare.contains("-$family-") || bare.endsWith("-$family")) {
+        return family;
+      }
+    }
+    return null;
+  }
+
+  String? _familyAlias({required String modelId}) {
+    final family = _family(modelId: modelId);
+    if (family == null) return null;
+    final bare = ClaudeBackendCatalog._bareModel(modelId);
+    return "$family${modelId.substring(bare.length)}";
   }
 
   PluginModel? _model(ClaudeModelDto dto) {

--- a/bridge/sesori_plugin_claude/test/claude_backend_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_claude/test/claude_backend_catalog_repository_test.dart
@@ -85,23 +85,29 @@ void main() {
       expect(model.defaultVariant, isNull);
     });
 
-    test("maps API model names back to picker ids, exactly or by bare name", () {
+    test("maps resolved and short API model names back to picker ids", () {
       final catalog = repository.map(
         handshake: {
           "models": [
             {"value": "default", "resolvedModel": "claude-opus-5[1m]"},
             {"value": "opus[1m]", "resolvedModel": "claude-opus-5[1m]"},
-            {"value": "fable", "resolvedModel": "claude-fable-5-1"},
+            {"value": "claude-fable-5-1[1m]", "resolvedModel": "claude-fable-5-1"},
             {"value": "haiku"},
           ],
         },
       );
 
-      expect(catalog.catalogModelId(apiModel: "claude-fable-5-1"), "fable");
+      expect(catalog.providers.providers.single.models.map((model) => model.id), [
+        "claude-fable-5-1[1m]",
+        "opus[1m]",
+        "haiku",
+      ]);
+      expect(catalog.catalogModelId(apiModel: "claude-fable-5-1"), "claude-fable-5-1[1m]");
+      expect(catalog.catalogModelId(apiModel: "fable[1m]"), "claude-fable-5-1[1m]");
       expect(catalog.catalogModelId(apiModel: "claude-opus-5[1m]"), "opus[1m]");
       expect(catalog.catalogModelId(apiModel: "claude-opus-5"), "opus[1m]");
+      expect(catalog.catalogModelId(apiModel: "opus[1m]"), "opus[1m]");
       expect(catalog.catalogModelId(apiModel: "claude-haiku-5"), isNull);
-      expect(catalog.catalogModelId(apiModel: "opus[1m]"), isNull);
     });
 
     test("filters malformed entries and falls back to the first model", () {

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -16,11 +16,11 @@ variant, and worktree mode, and creating the session with its first input.
 - Claude's catalog drops the CLI's own `default` model entry and names the
   selection instead: Opus is the default model and `high` the default effort, so
   every picker entry states what will actually run.
-- Claude stamps assistant and error messages with the picker id and effort the
-  turn ran with (`fable` / `high`), never the API name the stream reports
-  (`claude-fable-5-1`), so a reopened session keeps its model and variants
-  selected. Replayed transcripts map the API name through the catalog's
-  `resolvedModel`; a name the catalog does not know stays as recorded.
+- Claude stamps assistant and error messages with the catalog picker id and
+  effort the turn ran with, so a reopened session keeps its model and variants
+  selected. Replayed transcripts and live turns without an explicit selection
+  map resolved names (`claude-fable-5-1`) and short family/context aliases
+  (`fable[1m]`) through the current catalog; an unknown name stays as recorded.
 - No picker offers an unnamed "Default" option. Plugins declare effort variants
   in picker order and may name a default; when switching models, an existing
   compatible variant is kept; otherwise a model that offers variants uses the


### PR DESCRIPTION
## Complexity

🌿 Straightforward — localized Claude catalog normalization.

## What

- Map Claude's short family/context model tokens back to catalog picker IDs.
- Recognize versioned picker IDs as their known family for model ordering and default selection.
- Cover Claude Code's current Fable catalog shape and update regression guidance.

## Why

Claude Code 2.1.263 advertises Fable as `claude-fable-5-1[1m]` with resolved model `claude-fable-5-1`, while live metadata can report `fable[1m]`. Existing lookup indexed only resolved names. Client then retained raw `fable[1m]`, could not find it in provider catalog, and lost display-name and effort-variant linkage.

## Risk and test focus

Low, Claude-plugin-only mapping change. No database or wire-contract impact. User-visible impact: Fable resolves to catalog display name and keeps effort controls. Test focus: short alias resolution, context suffix handling, and Fable strength ordering.

## Expected result

Claude messages reporting `fable[1m]` resolve to current `claude-fable-5-1[1m]` picker entry, render as Fable, and retain supported effort variants.

## Verification

- Claude plugin test suite: 301 passed
- `dart analyze --fatal-infos`: no issues
- Dart LSP diagnostics: no diagnostics in changed Dart files
- `git diff --check`: passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links Claude's short family/context aliases (like `fable[1m]`) back to catalog picker entries, so live metadata that reports those aliases resolves to the picker's display name and keeps effort variants. Previously only resolved model names were indexed, so short aliases stayed unmapped and lost that linkage.

<sup>Written for commit 8b2b6ad974776335df02d79a46c16e9ba21a8943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

