### PR TITLE
🌿 Add Codex harness update audit skill

### DIFF
--- a/.agents/skills/update-codex-harness/SKILL.md
+++ b/.agents/skills/update-codex-harness/SKILL.md
@@ -208,10 +208,12 @@ smoke does not validate other platforms or another transport.
    or environment filtering alone is not a sandbox. If no boundary is available,
    do not inspect, extract, or execute the archive; mark the row unvalidated.
 2. Download inside that boundary, or transfer opaque bytes into it. Verify the
-   matching SHA-256 before parsing. Exercise the production install chain inside
-   the boundary: `CodexPluginDescriptor.installRuntime()` through
-   `ManagedRuntimeComposition.createInstaller()`, `ManagedRuntimeInstallService.install()`,
-   `RuntimeInstallService.install()`, and `ArchiveExtractor.extract()`. Inspect:
+   matching SHA-256 before parsing. Inspect `CodexPluginDescriptor.installRuntime()`
+   for production wiring, but do not call it for a newer candidate: it hard-codes
+   the current manifest. Start at `ManagedRuntimeComposition.createInstaller()`
+   with a temporary candidate manifest and matching asset resolver, then exercise
+   `ManagedRuntimeInstallService.install()`, `RuntimeInstallService.install()`,
+   and `ArchiveExtractor.extract()` inside the boundary. Inspect:
 
    - `bridge/sesori_plugin_runtime/lib/src/composition/managed_runtime_composition.dart`
    - `bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_install_service.dart`
@@ -219,12 +221,16 @@ smoke does not validate other platforms or another transport.
    - `bridge/sesori_bridge_foundation/lib/src/archive_extractor.dart`
 
    Supply only disposable state roots and candidate manifest data in the probe;
-   do not edit the production pin to run it. Assert the final managed path is
-   `<stateDirectory>/codex/<version>/bin/codex` (Windows: `bin/codex.exe`) and
-   compare the complete placed tree with the extracted package, including helper
-   and resource files. Generic tar extraction or a lone executable check is not
-   a substitute. Apply production traversal/link rejection, including rejection
-   of all extracted symlinks. Failure to run this chain blocks the row.
+   do not edit the production pin to run it. Strip GitHub's `sha256:` prefix and
+   require a 64-character hexadecimal digest for each temporary candidate asset.
+   Assert the final managed path is `<stateDirectory>/codex/<version>/bin/codex`
+   (Windows: `bin/codex.exe`). Compare the complete placed archive payload with
+   the extracted package, including helper and resource files, excluding only
+   installer metadata `RuntimeInstallService.sentinelFileName`. Separately assert
+   that `.sesori-runtime-sha256` contains the candidate's bare digest. Generic
+   tar extraction or a lone executable check is not a substitute. Apply production
+   traversal/link rejection, including rejection of all extracted symlinks.
+   Failure to run this chain blocks the row.
 3. Resolve the extracted entrypoint to an absolute path inside the package.
    Never use bare PATH `codex`, copy the CLI away from its helpers, or launch
    the user's Codex Desktop app or existing app-server.
@@ -325,8 +331,10 @@ architecture-bearing production work, not this skill or a target-only edit.
 ## Phase 5 — Implement only after approval and passing gates
 
 1. Update `CodexRuntimeManifest.targetVersion`, six matching digests, and
-   target-specific manifest comments. Keep bundled version derived, minimum
-   unchanged, and every archive format/layout/entrypoint intact.
+   target-specific manifest comments. Strip GitHub's `sha256:` prefix: manifest
+   `sha256` values must contain only the validated 64-character hexadecimal hash.
+   Keep bundled version derived, minimum unchanged, and every archive
+   format/layout/entrypoint intact.
 2. Update target-specific test assertions, URLs and managed-path fixtures.
    Preserve historical behavior and compatibility-floor fixtures.
 3. For approved capabilities, use typed wire models and plugin-local mapping.

--- a/.agents/skills/update-codex-harness/SKILL.md
+++ b/.agents/skills/update-codex-harness/SKILL.md
@@ -1,0 +1,383 @@
+---
+name: update-codex-harness
+description: >-
+  Audit and update Sesori's Codex harness target while finding app-server
+  protocol capabilities, event changes, and simplifications worth integrating.
+  Use when refreshing the Codex runtime pin or reviewing a new Codex release.
+metadata:
+  audience: maintainers
+  workflow: github
+---
+
+# Update the Codex Harness Target
+
+Refresh the Codex plugin against the latest stable release of
+[`openai/codex`](https://github.com/openai/codex). Treat a target bump as a
+protocol audit, not a version-only edit. Find useful upstream capabilities and
+small simplifications, distinguish app-server wire behavior from internal/TUI
+behavior, and obtain approval before changing production code.
+
+This is the Codex counterpart of `.agents/skills/update-pi-harness/SKILL.md`,
+not a Pi RPC recipe. It is intentionally Codex-only. For a multi-harness refresh,
+read `.opencode/skills/update-backend-runtimes/SKILL.md` from the repository
+root; stop and report a missing handoff if absent. Use the current Codex manifest
+as the asset-layout authority: older instructions may describe obsolete bare
+CLI archives. Do not substitute those for canonical package archives.
+
+## Scope and invariants
+
+Read `bridge/AGENTS.md` before production edits. Inspect:
+
+- `bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart`
+- `bridge/sesori_plugin_codex/lib/src/runtime/codex_plugin_descriptor.dart`
+- `bridge/sesori_plugin_codex/lib/src/runtime/codex_managed_api.dart`
+- `bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_policy.dart`
+- `bridge/sesori_plugin_codex/lib/src/codex_plugin_impl.dart`
+- `bridge/sesori_plugin_codex/lib/src/codex_app_server_client.dart`
+- `bridge/sesori_plugin_codex/lib/src/codex_stdio_app_server_client.dart`
+- `bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart`
+- `bridge/sesori_plugin_codex/lib/src/api/models/`
+- `bridge/sesori_plugin_codex/lib/src/codex_event_mapper.dart`
+- `bridge/sesori_plugin_codex/lib/src/services/`
+- `bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart`
+- `bridge/sesori_plugin_codex/test/runtime/codex_plugin_descriptor_setup_test.dart`
+- `bridge/app/lib/src/runtime/plugin_registry.dart`
+
+Preserve these invariants:
+
+- Keep the `minPathVersion` backing declaration byte-for-byte unchanged unless
+  the user separately approves a higher compatibility floor.
+- Keep all six canonical package-directory archives, including Windows tar.gz.
+  Preserve `bin/codex` / `bin/codex.exe`, `codex-code-mode-host`, and resources
+  in their original relative positions. Never flatten to a lone executable.
+- Preserve request-ID correlation, server-request versus response separation,
+  capability negotiation, and each production transport's handshake. Stdio sends
+  `initialized` after `initialize`; the current WebSocket client does not.
+  Verify upstream requirements before proposing a handshake change.
+- Distinguish request acceptance from completion. Verify `turn/completed`,
+  item finalization, interrupt, steering, and queued-work semantics from source;
+  do not import Pi's `agent_settled` or `get_state` assumptions.
+- Preserve production user profiles, credential sources, settings, approval
+  and sandbox policy. Credential-free probes must not replace production policy.
+- Never put secrets, prompts, transcripts, user/project/local filesystem paths,
+  account identifiers, or raw provider errors in audit reports or commits.
+  Public upstream source paths and immutable links are useful evidence.
+- Keep Codex concepts inside its plugin; never hand-edit generated Dart files.
+- Use the caller's dedicated worktree. Do not create another worktree or checkout
+  when prohibited. Source-only Git objects and scratch audit files may live in
+  the existing worktree; never execute upstream build code there.
+
+## Phase 1 — Establish the candidate
+
+1. Record current target, PATH minimum, descriptor registration, manifest wiring,
+   and package layout from source and tests before touching anything.
+2. Fetch stable GitHub release metadata and, when available, npm's stable version:
+
+   ```bash
+   gh api repos/openai/codex/releases/latest
+   npm view @openai/codex version
+   ```
+
+   Process the response into a bounded report: tag, date, draft/prerelease flags,
+   release notes, and relevant asset names/digests/sizes. Require a stable
+   `rust-vX.Y.Z` tag; store only `X.Y.Z` in the manifest. Require npm agreement
+   when npm is available; report unavailable evidence or channel disagreement,
+   never silently choose `main`, an alpha, or a different distribution.
+3. Require exactly one of each managed asset with a non-null `sha256:` digest:
+
+   - `codex-package-aarch64-apple-darwin.tar.gz`
+   - `codex-package-x86_64-apple-darwin.tar.gz`
+   - `codex-package-aarch64-unknown-linux-musl.tar.gz`
+   - `codex-package-x86_64-unknown-linux-musl.tar.gz`
+   - `codex-package-aarch64-pc-windows-msvc.tar.gz`
+   - `codex-package-x86_64-pc-windows-msvc.tar.gz`
+
+   Other release assets are allowed, but cannot replace these six. Download
+   `codex-package_SHA256SUMS` when present, verify its own GitHub digest, and
+   require each managed asset line to agree with GitHub. Metadata agreement is
+   not downloaded-archive verification. Do not guess renamed/missing mappings
+   or execute installers.
+4. Resolve current and candidate tags to full immutable commit SHAs through
+   `repos/openai/codex/commits/rust-v<version>`. Record both before diffing or
+   downloading. Re-resolve both tags before using a diff and immediately before
+   approval; require exact equality. A moved, missing, or ambiguous tag requires
+   stopping and restarting the audit. Use recorded SHAs, not tags, afterward.
+5. Verify source-to-artifact provenance for every managed archive. Inspect the
+   designated release workflow and published provenance at the recorded SHA.
+   Accept an attestation only after a trusted verifier cryptographically checks
+   it, enforcing an allowlisted issuer, exact `openai/codex` repository and
+   designated release-workflow identity, audited commit, and artifact digest.
+   Matching unverified fields or a self-signed statement are insufficient.
+   Otherwise reproduce every archive from the recorded SHA in a disposable
+   container/VM/restricted account with no secrets or sensitive mounts and
+   tightly constrained outbound access; compare normalized contents and digest.
+   If neither path is available, mark provenance unverified and pinning blocked.
+   A GitHub digest, platform code signature, or benign probe alone does not prove
+   that the audited source produced the archive.
+
+## Phase 2 — Audit the aggregate release diff
+
+Compare recorded old/new SHAs directly using
+`repos/openai/codex/compare/<oldSha>...<newSha>` before individual commits.
+Check comparison status, total/returned commits, file count, pagination/Link
+metadata, and truncation indicators. Paginate where advertised. GitHub caps
+compare-file lists; a 300-file response is not a complete inventory. An absent
+patch is not proof of an unchanged surface.
+
+If completeness cannot be established, obtain exact source-only objects and
+use a complete Git diff. When another checkout is forbidden, this can run in
+this worktree without changing HEAD, index, branch refs, or working files:
+
+```bash
+# Set these to the recorded full 40-hex SHAs; never substitute mutable tags.
+git fetch --no-tags --no-write-fetch-head --depth=1 https://github.com/openai/codex.git "$old_commit_sha"
+git fetch --no-tags --no-write-fetch-head --depth=1 https://github.com/openai/codex.git "$new_commit_sha"
+git cat-file -e "$old_commit_sha^{commit}"
+git cat-file -e "$new_commit_sha^{commit}"
+git diff --name-status "$old_commit_sha" "$new_commit_sha"
+git diff --stat "$old_commit_sha" "$new_commit_sha"
+git diff --no-ext-diff --no-textconv "$old_commit_sha" "$new_commit_sha" -- > codex-release.patch
+```
+
+Use a fresh, non-colliding scratch filename for the patch. Retain it until all
+changed paths have been inspected, or record interruption/incompleteness; do
+not delete it in an early EXIT trap. Inspect every changed area, including
+release workflows, package builders, dependencies, schemas, and launch wrappers.
+Use `git show <recordedSha>:<path>` for source without checking it out. Summarize
+large patches in code; do not dump raw JSON or full patches into conversation.
+Clean up only scratch files created by this audit after consuming them.
+
+For nontrivial delegated reasoning, inspect available agents/models and prefer
+registered `openai-codex/gpt-5.6-luna` with maximum thinking when selectable.
+If unavailable, use the current model/effort or another available selector and
+record the fallback. Keep lightweight inventory separate from synthesis; do not
+let a delegate edit production files or create another worktree.
+
+Inspect source at both SHAs, aggregate patches, intermediate stable release
+notes, and checked-in generated schemas. Search these surfaces:
+
+- `codex-rs/app-server-protocol/`, `codex-rs/app-server/`, their tests and schemas;
+- initialization, experimental capabilities, connection authentication and
+  attestation requests, WebSocket versus stdio behavior, field casing/types;
+- `thread/*` and `turn/*` lifecycle, list/read/resume/fork/archive/rollback,
+  steering, interrupts, compaction, queue ownership and completion ordering;
+- `item/*` deltas and final items, tools/code mode, subagents, images, files,
+  tool-result persistence and rollout/history representation;
+- server-originated approval, permissions, user-input, dynamic-tool and auth
+  requests; matching replies, cancellation and resolution;
+- model/provider/account discovery, login/rate-limit notifications, skills,
+  collaboration modes, launch flags, and package/helper/resource changes.
+
+For each candidate capability record immutable upstream source links, exact
+wire names/types/casing, ordering/acceptance/completion semantics, capability or
+experimental gates, transport visibility, and the smallest concrete Sesori flow
+that benefits. A Rust enum, core event, TUI feature, or `codex exec --json` record
+is not automatically an app-server v2 notification: trace serialization and
+forwarding through the app-server protocol and processor. Schema presence alone
+does not prove emission or ordering; release-note silence does not prove absence.
+
+Classify findings:
+
+- **Adopt now:** stable, observable, fixes a demonstrated limitation or removes
+  an existing workaround; still subject to approval and live validation.
+- **Probe first:** authenticated, experimental, platform-specific, a new launch
+  surface, or ordering not yet demonstrated.
+- **Track only:** internal/TUI/exec-only, unrelated, or no current consumer.
+- **Reject:** speculative defenses, unneeded compatibility, or broad refactors.
+
+Prefer one tolerant implementation for supported older PATH runtimes: ignore
+unknown events appropriately, permit legitimately omitted new fields, and retain
+existing behavior. Do not add version branches merely because shapes differ.
+For genuinely incompatible semantics, evaluate a narrow interface with two
+version-specific implementations inside the plugin. Select only from validated
+runtime version/provenance or an explicitly verified handshake identity, never
+an incidental event or an assumed PATH binary version. State branch retirement
+and minimum version. Never weaken approval or sandbox semantics to accommodate
+an older runtime.
+
+## Phase 3 — Safe per-target probe matrix
+
+Validate each of the six managed archives independently. Record asset name,
+digest, OS/architecture, disposable boundary, production extraction/placement,
+exact version, stdio handshake, and WebSocket handshake results. A host-only
+smoke does not validate other platforms or another transport.
+
+1. Establish a target-appropriate disposable VM/container/restricted OS account
+   before parsing archive contents. No sensitive mounts; block outbound network
+   access (local loopback may be allowed for WebSocket probes). Temporary HOME
+   or environment filtering alone is not a sandbox. If no boundary is available,
+   do not inspect, extract, or execute the archive; mark the row unvalidated.
+2. Download inside that boundary, or transfer opaque bytes into it. Verify the
+   matching SHA-256 before parsing. Exercise the production install chain inside
+   the boundary: `CodexPluginDescriptor.installRuntime()` through
+   `ManagedRuntimeComposition.createInstaller()`, `ManagedRuntimeInstallService.install()`,
+   `RuntimeInstallService.install()`, and `ArchiveExtractor.extract()`. Inspect:
+
+   - `bridge/sesori_plugin_runtime/lib/src/composition/managed_runtime_composition.dart`
+   - `bridge/sesori_plugin_runtime/lib/src/provisioning/managed_runtime_install_service.dart`
+   - `bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_install_service.dart`
+   - `bridge/sesori_bridge_foundation/lib/src/archive_extractor.dart`
+
+   Supply only disposable state roots and candidate manifest data in the probe;
+   do not edit the production pin to run it. Assert the final managed path is
+   `<stateDirectory>/codex/<version>/bin/codex` (Windows: `bin/codex.exe`) and
+   compare the complete placed tree with the extracted package, including helper
+   and resource files. Generic tar extraction or a lone executable check is not
+   a substitute. Apply production traversal/link rejection, including rejection
+   of all extracted symlinks. Failure to run this chain blocks the row.
+3. Resolve the extracted entrypoint to an absolute path inside the package.
+   Never use bare PATH `codex`, copy the CLI away from its helpers, or launch
+   the user's Codex Desktop app or existing app-server.
+4. Create empty temporary project, HOME, `CODEX_HOME`, config/cache/temp roots;
+   on Windows also isolate `USERPROFILE`, `APPDATA`, and `LOCALAPPDATA`.
+   Construct an allowlisted child environment with only required system/locale
+   variables and safe runtime paths. Exclude API keys, tokens, cloud credentials,
+   `SSH_AUTH_SOCK`, credential helpers, and user/project config or MCP servers.
+   Do not authenticate, submit prompts, or read existing sessions. Authenticated
+   probes require a separately authorized procedure and approved credentials.
+5. Run the exact entrypoint's `--version`, bounded to 10 seconds. Assert it
+   identifies the candidate version exactly, not merely exit success. Use the
+   same process-tree cleanup guarantee as below even for this short process.
+6. Launch that entrypoint with `app-server --listen stdio://` from the empty cwd.
+   Confirm these fields against the candidate source and production client; send
+   newline-delimited requests without adding a `jsonrpc` field by assumption:
+
+   ```json
+   {"id":"probe-init","method":"initialize","params":{"clientInfo":{"name":"sesori_runtime_probe","title":"Sesori Bridge","version":"0.0.0"}}}
+   ```
+
+   Within 10 seconds require matching ID, no `error`, and object `result` with
+   required typed identity fields from `CodexInitializeResult` (inspect current
+   source). Do not print returned local paths or identity details. Then send:
+
+   ```json
+   {"method":"initialized"}
+   {"id":"probe-list","method":"thread/list","params":{"limit":1}}
+   ```
+
+   Require a matching successful result with array `data` and the candidate's
+   pagination shape; the isolated profile should contain no user threads.
+   Drain unrelated notifications; a server-originated request with `method`
+   plus `id` is never a response. Fail on malformed JSON, unexpected matching
+   response, startup failure, or timeout. Keep this production stdio probe free
+   of experimental capabilities; test experimental surfaces separately.
+7. Probe managed WebSocket separately, using `codex_runtime_policy.dart` launch
+   arguments (`app-server --listen ws://127.0.0.1:<port>`) and the client composed
+   in `codex_plugin_impl.dart`. Bind only loopback with a fresh available port.
+   Send each object below as its own WebSocket text frame, not an NDJSON stream:
+
+   ```json
+   {"jsonrpc":"2.0","id":"probe-init","method":"initialize","params":{"clientInfo":{"name":"sesori_runtime_probe","title":null,"version":"0.0.0"},"capabilities":{"experimentalApi":true,"requestAttestation":false,"optOutNotificationMethods":null}}}
+   ```
+
+   Require the same correlated typed initialization result within 10 seconds.
+   The current production WebSocket client sends no `initialized` notification;
+   reproduce that behavior and verify candidate source accepts it. If it does
+   not, report a compatibility regression rather than silently adding the frame
+   to make the probe pass. After successful initialization, send:
+
+   ```json
+   {"jsonrpc":"2.0","id":"probe-list","method":"thread/list","params":{"limit":1}}
+   ```
+
+   Apply the same 10-second deadline, result-shape checks, malformed-frame and
+   server-request separation rules as stdio. Preserve production capabilities
+   and reject unexpected listener/authentication changes. Do not reuse stdio
+   envelopes or treat stdio success as validation of the WebSocket connection.
+8. Put every launch and assertion inside `try/finally`. Close stdin/socket, wait
+   at most 2 seconds, then terminate the complete process tree. POSIX: dedicated
+   process group/session, SIGTERM then SIGKILL if needed. Windows: kill-on-close
+   Job Object or recursive descendant termination with re-enumeration; killing
+   only the parent is insufficient. Keep cleanup bounded. Remove probe files,
+   logs and sandbox only after descendants are gone, on success or failure.
+9. Run focused probes for every proposed changed surface, including ordering,
+   capability gates, and required helpers. Schema generation inside the same
+   boundary can supplement probes, not replace live protocol checks.
+
+Skipped or failed provenance, extraction, version, or required transport checks
+are hard gates, not passing platform limitations. This manifest has one target
+for all six archives: any unvalidated row blocks the whole target refresh.
+Never mix old digests with a new shared release URL. Continue source-only audit
+and report useful findings even when pinning is blocked; label them unprobed.
+
+## Phase 4 — Report and approval gate
+
+Before editing target or protocol code report:
+
+- old target, candidate stable version/date, npm agreement, unchanged minimum;
+- recorded old/new SHAs, tag recheck, six asset names/sizes/digests, explicitly
+  separating published metadata, checksum-list agreement, and downloaded hashes;
+- source-to-artifact evidence or blocker; complete diff size/coverage;
+- high/medium findings with immutable links and actual app-server visibility;
+- six-row matrix for extraction, version, stdio and WebSocket, including skips;
+- proposed version-only edits versus capabilities, simplifications, follow-ups;
+- tolerant-path versus justified version-selected implementation strategy and
+  compatibility retirement thresholds.
+
+Ask approval for proposed production scope only after stating blockers.
+Approval does not turn missing verification into passing evidence. A requested
+skill-only documentation PR may proceed while production changes stay gated.
+Do not raise the minimum implicitly. If separately approved, remove obsolete
+compatibility branches, tests and docs below the new floor rather than retaining
+internal shims. Apply repository architecture-review rules only to approved
+architecture-bearing production work, not this skill or a target-only edit.
+
+## Phase 5 — Implement only after approval and passing gates
+
+1. Update `CodexRuntimeManifest.targetVersion`, six matching digests, and
+   target-specific manifest comments. Keep bundled version derived, minimum
+   unchanged, and every archive format/layout/entrypoint intact.
+2. Update target-specific test assertions, URLs and managed-path fixtures.
+   Preserve historical behavior and compatibility-floor fixtures.
+3. For approved capabilities, use typed wire models and plugin-local mapping.
+   Test exact casing, correlation, ordering, unknown-field degradation and
+   failure behavior. Preserve server-request responses and security policy.
+   Prove Sesori admission-queue versus Codex queue ownership before replacing
+   existing interruption, teardown, retry, or completion behavior.
+4. For retained version-specific fields/branches read current product version
+   from `bridge/app/pubspec.yaml` immediately before adding a concrete marker
+   directly above the field/branch, never above its enclosing declaration:
+
+   ```dart
+   // COMPATIBILITY YYYY-MM-DD (vX.Y.Z): Codex <= <old> omits <behavior>; remove
+   // this fallback when CodexRuntimeManifest.minPathVersion is raised to <new>.
+   ```
+
+   Replace all placeholders, use product version not library version, and give
+   exact older behavior and retirement minimum. Prefer no branch when one
+   tolerant path works.
+5. Update `docs/regression/` for materially changed behavior or compatibility
+   floors, not target-only tombstones. Update `docs/HARNESS_CAPABILITIES.md` for
+   verified capability gaps or lifted limitations. Keep other harnesses' code
+   untouched in this explicitly Codex-scoped audit.
+6. Format changed Dart source; regenerate, never hand-edit generated outputs.
+
+## Verification and delivery
+
+For production changes run focused tests and analyze the owning package:
+
+```bash
+(cd bridge/sesori_plugin_codex && dart test && dart analyze --fatal-infos)
+git status --short
+git diff HEAD --check
+git diff HEAD -- bridge/sesori_plugin_codex
+```
+
+Also inspect staged and untracked files explicitly; `git diff HEAD` omits
+untracked files. Run shared foundation/runtime tests only if those primitives
+changed. Do not repeat unchanged passing commands. For skill/docs-only changes,
+validate frontmatter, referenced local paths, protocol examples, Markdown and
+diff hygiene; do not run Dart/Flutter suites.
+
+Keep the requested skill/documentation change in its own PR, separate from
+runtime/protocol implementation. Commit and push when ready, using real multiline
+Markdown via `--body-file`/stdin with `## Complexity`, `## What`, `## Why`,
+`## Risk and test focus`, `## Expected result`, and `## Verification`. Use the
+repository's implementation-complexity emoji prefix and series title convention
+when applicable. State no user-visible/database impact for documentation-only
+work. Load `monitor-pr` and start `pr_monitor` immediately after opening a PR;
+never enable auto-merge or invent polling loops if monitoring is unavailable.
+
+Final report: old/new target, unchanged minimum, six digest statuses,
+adopted/deferred findings, provenance/probe blockers, tests, PR link, remaining
+upstream/platform risks. An audit stopped at approval is not an implemented bump.

--- a/.agents/skills/update-codex-harness/SKILL.md
+++ b/.agents/skills/update-codex-harness/SKILL.md
@@ -64,8 +64,9 @@ Preserve these invariants:
   Public upstream source paths and immutable links are useful evidence.
 - Keep Codex concepts inside its plugin; never hand-edit generated Dart files.
 - Use the caller's dedicated worktree. Do not create another worktree or checkout
-  when prohibited. Source-only Git objects and scratch audit files may live in
-  the existing worktree; never execute upstream build code there.
+  when prohibited. Use a temporary bare object store under the existing worktree
+  for upstream source, never Sesori's shared Git database or shallow metadata.
+  Never execute upstream build code there.
 
 ## Phase 1 — Establish the candidate
 
@@ -125,27 +126,36 @@ compare-file lists; a 300-file response is not a complete inventory. An absent
 patch is not proof of an unchanged surface.
 
 If completeness cannot be established, obtain exact source-only objects and
-use a complete Git diff. When another checkout is forbidden, this can run in
-this worktree without changing HEAD, index, branch refs, or working files:
+use a complete Git diff. Create a disposable bare object store under the current
+worktree, not another checkout or working directory. Keep every upstream Git
+command bound to that store: `--no-write-fetch-head` alone does not isolate
+objects or `.git/shallow` from Sesori's shared repository. Stop on any command
+failure and retain partial evidence until the interruption is recorded.
 
 ```bash
 # Set these to the recorded full 40-hex SHAs; never substitute mutable tags.
-git fetch --no-tags --no-write-fetch-head --depth=1 https://github.com/openai/codex.git "$old_commit_sha"
-git fetch --no-tags --no-write-fetch-head --depth=1 https://github.com/openai/codex.git "$new_commit_sha"
-git cat-file -e "$old_commit_sha^{commit}"
-git cat-file -e "$new_commit_sha^{commit}"
-git diff --name-status "$old_commit_sha" "$new_commit_sha"
-git diff --stat "$old_commit_sha" "$new_commit_sha"
-git diff --no-ext-diff --no-textconv "$old_commit_sha" "$new_commit_sha" -- > codex-release.patch
+set -e
+audit_git_dir="$(mktemp -d "$PWD/.codex-audit-git.XXXXXX")"
+git init --bare "$audit_git_dir"
+audit_git() { git --git-dir="$audit_git_dir" "$@"; }
+audit_git fetch --no-tags --no-write-fetch-head --depth=1 https://github.com/openai/codex.git "$old_commit_sha"
+audit_git fetch --no-tags --no-write-fetch-head --depth=1 https://github.com/openai/codex.git "$new_commit_sha"
+audit_git cat-file -e "$old_commit_sha^{commit}"
+audit_git cat-file -e "$new_commit_sha^{commit}"
+audit_git diff --name-status "$old_commit_sha" "$new_commit_sha"
+audit_git diff --stat "$old_commit_sha" "$new_commit_sha"
+audit_git diff --no-ext-diff --no-textconv "$old_commit_sha" "$new_commit_sha" -- > "$audit_git_dir/release.patch"
 ```
 
-Use a fresh, non-colliding scratch filename for the patch. Retain it until all
-changed paths have been inspected, or record interruption/incompleteness; do
-not delete it in an early EXIT trap. Inspect every changed area, including
-release workflows, package builders, dependencies, schemas, and launch wrappers.
-Use `git show <recordedSha>:<path>` for source without checking it out. Summarize
-large patches in code; do not dump raw JSON or full patches into conversation.
-Clean up only scratch files created by this audit after consuming them.
+Retain the store and patch until all changed paths have been inspected, or record
+interruption/incompleteness; do not delete them in an early EXIT trap. Inspect
+every changed area, including release workflows, package builders, dependencies,
+schemas, and launch wrappers. Use
+`git --git-dir="$audit_git_dir" show <recordedSha>:<path>` for source without
+checking it out. Summarize large patches in code; do not dump raw JSON or full
+patches into conversation. After consuming the evidence, explicitly remove only
+this audit's temporary store with `rm -rf -- "$audit_git_dir"`; never clean,
+prune, or rewrite Sesori's shared Git metadata as part of this recipe.
 
 For nontrivial delegated reasoning, inspect available agents/models and prefer
 registered `openai-codex/gpt-5.6-luna` with maximum thinking when selectable.


### PR DESCRIPTION
## Complexity
🌿 Straightforward documentation-only adaptation of the Pi audit workflow to Codex app-server.

## What
- Add `.agents/skills/update-codex-harness/SKILL.md` with stable-release discovery, immutable source audit, six-package verification, sandboxed probes, approval and delivery gates.
- Preserve canonical package trees, unchanged compatibility minimums, and distinct production stdio/WebSocket envelopes and handshakes.
- Require the production installer chain and complete package placement, not generic extraction or a lone executable smoke.

## Why
A runtime refresh should find useful protocol capabilities and simplifications, not merely replace a version string. Codex requires its own app-server and package-layout checks rather than Pi RPC assumptions.

## Risk and test focus
Documentation only. No user-visible behavior, database, runtime pin, or protocol changes. Focus: correct paths, transport framing, security gates and honest blocked evidence. Production changes remain subject to separate approval and passing verification.

## Expected result
Maintainers can audit a Codex release consistently and distinguish validated integration work from experimental or unprobed follow-ups.

## Verification
- Reviewed against the Pi skill, current Codex manifest, descriptor, clients, runtime policy and installer.
- Applied review corrections for launch ownership, transport-specific handshake/framing and full installer validation.
- Validated frontmatter fields, 24 local references, five JSON frames, Markdown fences and whitespace; staged diff check passed.
- No Dart/Flutter tests: no production code changed.

## First execution: release audit
- Current target **0.148.0**; candidate stable **0.153.4**, published **2026-09-04T23:25:48Z**. npm agrees. PATH minimum remains **0.139.0**.
- Old SHA: `3ba0f711642a888aec92a611a3f3b2211157ff89`; candidate SHA: `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`. Both public tags rechecked unchanged before this report.
- Complete immutable-object diff: **2,572 paths, +255,977 / −44,216**; 17,557,715 patch bytes processed. GitHub compare is divergent and capped at 250 of 800 commits / 300 files, so it was not used as the complete inventory. Focused semantic review covered protocol, processors, local consumers and release packaging.
- The audit child reached its time limit after writing its report. The report was recovered; key protocol findings were independently checked. The timeout is not counted as a successful execution gate.

### Candidate integrity and probe matrix
All six published hashes agree with the downloaded `codex-package_SHA256SUMS`; the checksum-list file's own hash also matches GitHub (`645fb8d4a1f821357a7160f04a6d15bf54ff97ab6946a79239c551ebed734d23`). This is metadata agreement, **not** downloaded archive verification.

| Canonical archive | Bytes | Published SHA-256 | Production install / version / stdio / WebSocket |
| --- | ---: | --- | --- |
| `codex-package-aarch64-apple-darwin.tar.gz` | 111554884 | `35438da1fbf7a6db7ddb3bcec84448fa6015ba188461472a97d9d1da7d9c4353` | All unvalidated |
| `codex-package-x86_64-apple-darwin.tar.gz` | 121093282 | `3ee638d7155c856ef31f3f4a85cb2195de1939962d3924c935b24f0514564a3d` | All unvalidated |
| `codex-package-aarch64-unknown-linux-musl.tar.gz` | 117238842 | `fc395cb043a1093ab0db34f44aba3199bfaa9ce640cd9be7fd588f44b0da64a4` | All unvalidated |
| `codex-package-x86_64-unknown-linux-musl.tar.gz` | 126196303 | `a822187e1a2420c61c5926721bfbd878701ed95547c9bb0d4de4498a16ba1821` | All unvalidated |
| `codex-package-aarch64-pc-windows-msvc.tar.gz` | 126141441 | `ac51b1a5932e07dffcaa6e98f4801f13b25192094739b732fc8b40ddb41bbda2` | All unvalidated |
| `codex-package-x86_64-pc-windows-msvc.tar.gz` | 136067504 | `a6ef3442cb12766a88b39311d79244289e4f9763e2c53ff4fbebc2cb653cc5f3` | All unvalidated |

No candidate executable archive was downloaded, extracted or run. No validated target-appropriate disposable boundaries were available; the local Docker daemon was unavailable. Source-to-artifact provenance also remains unverified. The [release workflow](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/.github/workflows/rust-release.yml) has platform signatures/checksums, but those alone do not prove each package came from the audited commit. No trusted verifier or reproducible-build evidence was obtained. **The complete runtime refresh is blocked; no assets were repinned.**

### Source-backed findings and proposed follow-ups
1. **High — probe before bump: approval kinds.** [`CommandExecutionRequestApprovalParams`](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/app-server-protocol/src/protocol/v2/item.rs#L1519-L1605) adds `kind: command | writeStdin`, defaulting to command. App-server emits it on `item/commandExecution/requestApproval`. Current local generic execution approval does not distinguish stdin input or honor the advertised decision set. Review presentation/decision semantics without weakening approval policy; maintain opaque request correlation.
2. **High — adopt candidate, after focused probes/approval: stable history pagination.** [`thread/turns/list` and `thread/items/list`](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/app-server-protocol/src/protocol/common.rs#L787-L802) lose their experimental gate. Typed cursor pages could reduce rollout-history coupling. Check supported storage modes and reversed-cursor anchor semantics before replacing existing reads.
3. **Medium — adopt candidate, after tests/approval: auth recovery status.** [`modelProvider/authRecoveryStarted` / `Completed`](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/app-server/src/bespoke_event_handling.rs#L261-L284) are truly forwarded app-server notifications with `threadId`, `turnId`, `provider`, `message`. A failed recovery may omit completed, so terminal errors still own failure. Consider neutral, privacy-safe status mapping.
4. **Probe first:** stable destructive `thread/revert` (conversation history only, not filesystem rollback); newly experimental [`turn/settings/update`](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/app-server-protocol/src/protocol/v2/turn.rs#L39-L90) (`applied | targetUnavailable`); experimental `thread/timeline/list`; `functionCallOutput` visibility and typed error details. `thread/settings/update` already existed at the old target—it is not a newly added route.
5. **Track only:** Codex-native projects, realtime, MCP event streams and arbitrary-process controls without a current Sesori consumer. Existing async-question support should not be duplicated.

No capabilities adopted in this PR. Prefer one tolerant plugin-local path for older supported PATH versions; no minimum increase, version-selected interface, new compatibility branches, or speculative refactor proposed. Any larger history or client-facing capability change needs its own approved scope and relevant architecture review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `update-codex-harness` skill to `.agents/skills/` so maintainers can audit Codex runtime bumps consistently. Documentation-only: it adapts the existing Pi audit workflow to Codex's app-server protocol, six-package layout, and approval gates, without changing runtime pins, transports, or production behavior.

- Requires stable-release discovery, immutable commit comparison, source-to-artifact provenance checks, and a per-target probe matrix before any bump; probes run through the managed-install creation path against a temporary candidate manifest, since `installRuntime()` hard-codes the current target.
- Audits the aggregate diff in a disposable bare Git object store so upstream objects and shallow metadata never touch Sesori's shared repository.
- Classifies capabilities as adopt now, probe first, track only, or reject, and keeps tolerances for older PATH minimums unchanged.

<sup>Written for commit a24be7820b237cd792f95a7d7e77ea233abb14ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

