### PR TITLE
🌿 Prevent concurrent NDJSON dispatch from crashing the bridge

### DIFF
--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -148,10 +148,9 @@ abstract class AcpPlugin({
   /// decisions live on this class — the state object only holds fields.
   final Map<String, _SessionTurnState> _turnStates = {};
 
-  /// Agent updates and server requests that raced the stdin flush for an
-  /// accepted existing-session prompt. The user message cannot publish before
-  /// the flush succeeds, so hold both until that message and any preceding tool
-  /// update have entered the event stream.
+  /// Agent updates and server requests that raced stdin admission for an
+  /// accepted existing-session prompt. Hold both until the admitted user
+  /// message and any preceding tool update have entered the event stream.
   final Map<String, List<AcpNotification>> _promptWriteNotifications = {};
   final Map<String, List<AcpServerRequest>> _promptWriteServerRequests = {};
   final Set<String> _cancelledPromptWriteSessions = {};

--- a/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_turn_serialization_test.dart
@@ -97,35 +97,6 @@ class _PromptOrderedChildMapper({
   }
 }
 
-class _FlushControlledAcpProcess() extends FakeAcpProcess {
-  final _FlushControlledIOSink _controlledStdin = _FlushControlledIOSink();
-
-  @override
-  _FlushControlledIOSink get stdin => _controlledStdin;
-
-  @override
-  List<Map<String, dynamic>> get written => _controlledStdin.frames;
-
-  Completer<void> holdNextFlush() => _controlledStdin.holdNextFlush();
-}
-
-class _FlushControlledIOSink() extends CapturingIOSink {
-  Completer<void>? _nextFlush;
-
-  Completer<void> holdNextFlush() {
-    final gate = Completer<void>();
-    _nextFlush = gate;
-    return gate;
-  }
-
-  @override
-  Future<void> flush() {
-    final gate = _nextFlush;
-    _nextFlush = null;
-    return gate?.future ?? Future<void>.value();
-  }
-}
-
 /// Turn-lifecycle robustness:
 ///
 ///  - prompts on one session are serialized (agents reject or drop overlapping
@@ -140,7 +111,7 @@ class _FlushControlledIOSink() extends CapturingIOSink {
 ///    turn is in flight.
 void main() {
   group("AcpPlugin turn serialization", () {
-    late _FlushControlledAcpProcess fake;
+    late FakeAcpProcess fake;
     late AcpPlugin plugin;
     final emitted = <BridgeSseEvent>[];
     final streamErrors = <Object>[];
@@ -148,7 +119,7 @@ void main() {
     var promptSequence = 0;
 
     setUp(() {
-      fake = _FlushControlledAcpProcess();
+      fake = FakeAcpProcess();
       plugin = composeTestAcpPlugin(processFactory: (_) async => fake, launchDirectory: cwd);
       emitted.clear();
       streamErrors.clear();
@@ -311,59 +282,11 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
-    test("a prompt remains queued until its ACP frame flushes", () async {
+    test("agent output after prompt admission follows the accepted user message", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");
       emitted.clear();
 
-      final flush = fake.holdNextFlush();
-      final promptId = await sendPrompt(sessionId, "wait for flush");
-      final prompt = await waitForFrame("session/prompt");
-      await pump();
-
-      expect((await plugin.getQueuedPrompts(sessionId: sessionId)).single.id, promptId);
-      expect(
-        emitted.whereType<BridgeSseMessageUpdated>().where(
-          (event) => switch (event.info) {
-            PluginMessageUser(promptId: final id) => id == promptId,
-            _ => false,
-          },
-        ),
-        isEmpty,
-      );
-      expect(
-        await plugin.cancelQueuedPrompt(sessionId: sessionId, promptId: promptId),
-        isFalse,
-        reason: "the frame write has started and can no longer be withdrawn",
-      );
-
-      flush.complete();
-      for (var i = 0; i < 20 && (await plugin.getQueuedPrompts(sessionId: sessionId)).isNotEmpty; i++) {
-        await pump();
-      }
-
-      expect(await plugin.getQueuedPrompts(sessionId: sessionId), isEmpty);
-      expect(
-        emitted
-            .whereType<BridgeSseMessageUpdated>()
-            .singleWhere(
-              (event) => switch (event.info) {
-                PluginMessageUser(promptId: final id) => id == promptId,
-                _ => false,
-              },
-            )
-            .info,
-        isA<PluginMessageUser>().having((info) => info.promptId, "promptId", promptId),
-      );
-      respondTo(prompt, {"stopReason": "end_turn"});
-    });
-
-    test("agent output racing the prompt flush follows the accepted user message", () async {
-      await connect();
-      final sessionId = await createSession(cwd, "s1");
-      emitted.clear();
-
-      final flush = fake.holdNextFlush();
       final promptId = await sendPrompt(sessionId, "ordered prompt");
       final prompt = await waitForFrame("session/prompt");
       fake.emit({
@@ -377,11 +300,6 @@ void main() {
           },
         },
       });
-      await pump();
-
-      expect(emitted.whereType<BridgeSseMessageUpdated>(), isEmpty);
-
-      flush.complete();
       for (var i = 0; i < 20 && emitted.whereType<BridgeSseMessageUpdated>().length < 2; i++) {
         await pump();
       }
@@ -394,12 +312,11 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
-    test("a permission racing the prompt flush follows its accepted user and tool", () async {
+    test("a permission after prompt admission follows its accepted user and tool", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");
       emitted.clear();
 
-      final flush = fake.holdNextFlush();
       await sendPrompt(sessionId, "permission ordering");
       final prompt = await waitForFrame("session/prompt");
       fake.emit({
@@ -428,13 +345,6 @@ void main() {
           ],
         },
       });
-      await pump();
-
-      expect(emitted.whereType<BridgeSseMessageUpdated>(), isEmpty);
-      expect(emitted.whereType<BridgeSseMessagePartUpdated>(), isEmpty);
-      expect(emitted.whereType<BridgeSsePermissionAsked>(), isEmpty);
-
-      flush.complete();
       for (var i = 0; i < 20 && emitted.whereType<BridgeSsePermissionAsked>().isEmpty; i++) {
         await pump();
       }
@@ -455,12 +365,11 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
-    test("aborting a writing turn settles its buffered permission after the flush", () async {
+    test("aborting an accepted turn settles its pending permission", () async {
       await connect();
       final sessionId = await createSession(cwd, "s1");
       emitted.clear();
 
-      final flush = fake.holdNextFlush();
       await sendPrompt(sessionId, "cancel permission");
       final prompt = await waitForFrame("session/prompt");
       fake.emit({
@@ -475,8 +384,9 @@ void main() {
           ],
         },
       });
-      await pump();
-      expect(emitted.whereType<BridgeSsePermissionAsked>(), isEmpty);
+      for (var i = 0; i < 20 && emitted.whereType<BridgeSsePermissionAsked>().isEmpty; i++) {
+        await pump();
+      }
 
       await plugin.abortSession(
         sessionId: sessionId,
@@ -484,7 +394,6 @@ void main() {
         useAtomicStop: false,
         knownSubAgentSessionIds: const {},
       );
-      flush.complete();
       for (var i = 0; i < 20 && !fake.written.any((frame) => frame["id"] == 92); i++) {
         await pump();
       }
@@ -532,7 +441,6 @@ void main() {
       await connect();
       final sessionId = await createSession(cwd, "s1");
       emitted.clear();
-      final flush = fake.holdNextFlush();
       await sendPrompt(sessionId, "start a child");
       final prompt = await waitForFrame("session/prompt");
       fake.emit({
@@ -540,10 +448,6 @@ void main() {
         "method": _PromptOrderedChildMapper.childMethod,
         "params": {"sessionId": sessionId, "childSessionId": "child"},
       });
-      await pump();
-      expect(emitted.whereType<BridgeSseSessionCreated>(), isEmpty);
-
-      flush.complete();
       for (var index = 0; index < 20 && emitted.whereType<BridgeSseSessionCreated>().isEmpty; index++) {
         await pump();
       }
@@ -559,13 +463,12 @@ void main() {
       respondTo(prompt, {"stopReason": "end_turn"});
     });
 
-    test("a buffered sessionless permission keeps its writing-turn attribution", () async {
+    test("a sessionless permission keeps its active-turn attribution", () async {
       await connect();
       final firstSessionId = await createSession(cwd, "s1");
       final secondSessionId = await createSession(cwd, "s2");
       emitted.clear();
 
-      final flush = fake.holdNextFlush();
       await sendPrompt(firstSessionId, "first session");
       final firstPrompt = await waitForFrameCount("session/prompt", 1);
       fake.emit({
@@ -579,19 +482,14 @@ void main() {
           ],
         },
       });
-      await pump();
-      expect(emitted.whereType<BridgeSsePermissionAsked>(), isEmpty);
+      for (var i = 0; i < 20 && emitted.whereType<BridgeSsePermissionAsked>().isEmpty; i++) {
+        await pump();
+      }
+      final permission = emitted.whereType<BridgeSsePermissionAsked>().single;
 
       await sendPrompt(secondSessionId, "second session");
       final secondPrompt = await waitForFrameCount("session/prompt", 2);
       await pump();
-
-      flush.complete();
-      for (var i = 0; i < 20 && emitted.whereType<BridgeSsePermissionAsked>().isEmpty; i++) {
-        await pump();
-      }
-
-      final permission = emitted.whereType<BridgeSsePermissionAsked>().single;
       expect(permission.sessionID, firstSessionId);
       await plugin.replyToPermission(
         requestId: permission.requestID,
@@ -747,33 +645,6 @@ void main() {
 
       expect(firstPromptId, isNot(secondPromptId));
       respondTo(second, {"stopReason": "end_turn"});
-    });
-
-    test("a failed ACP frame flush never marks the prompt sent", () async {
-      await connect();
-      final sessionId = await createSession(cwd, "s1");
-      emitted.clear();
-
-      final flush = fake.holdNextFlush();
-      final promptId = await sendPrompt(sessionId, "broken pipe");
-      await waitForFrame("session/prompt");
-      flush.completeError(StateError("broken pipe"));
-      for (var i = 0; i < 20 && idleCount() == 0; i++) {
-        await pump();
-      }
-
-      expect(await plugin.getQueuedPrompts(sessionId: sessionId), isEmpty);
-      expect(
-        emitted.whereType<BridgeSseMessageUpdated>().where(
-          (event) => switch (event.info) {
-            PluginMessageUser(promptId: final id) => id == promptId,
-            _ => false,
-          },
-        ),
-        isEmpty,
-      );
-      expect(emitted.whereType<BridgeSseSessionError>(), hasLength(1));
-      expect(streamErrors, isEmpty);
     });
 
     test("an initial create prompt emits its user-visible text only once", () async {
@@ -1332,17 +1203,24 @@ void main() {
       await connect();
       final sessionId = await createSession(cwd, "s1");
 
-      final flush = fake.holdNextFlush();
       final promptId = await sendPrompt(sessionId, "hi");
       final promptFrame = await waitForFrame("session/prompt");
+      final acceptedMessageCount = emitted
+          .whereType<BridgeSseMessageUpdated>()
+          .where(
+            (event) => switch (event.info) {
+              PluginMessageUser(promptId: final id) => id == promptId,
+              _ => false,
+            },
+          )
+          .length;
 
       await plugin.deleteSession(sessionId);
       expect(frames("session/cancel"), hasLength(1));
       final queueUpdateCount = emitted.whereType<BridgeSseQueuedPromptsUpdated>().length;
 
-      // The prompt flushes and settles after the delete: neither dispatch nor
-      // accounting may publish lifecycle events for the detached session.
-      flush.complete();
+      // The accepted prompt settles after the delete; accounting must not
+      // publish lifecycle events for the detached session.
       await pump();
       respondTo(promptFrame, {"stopReason": "cancelled"});
       for (var i = 0; i < 10; i++) {
@@ -1351,13 +1229,16 @@ void main() {
       expect(await plugin.getSessionStatuses(), isEmpty);
       expect(emitted.whereType<BridgeSseSessionIdle>(), isEmpty);
       expect(
-        emitted.whereType<BridgeSseMessageUpdated>().where(
-          (event) => switch (event.info) {
-            PluginMessageUser(promptId: final id) => id == promptId,
-            _ => false,
-          },
-        ),
-        isEmpty,
+        emitted
+            .whereType<BridgeSseMessageUpdated>()
+            .where(
+              (event) => switch (event.info) {
+                PluginMessageUser(promptId: final id) => id == promptId,
+                _ => false,
+              },
+            )
+            .length,
+        acceptedMessageCount,
       );
       expect(emitted.whereType<BridgeSseQueuedPromptsUpdated>(), hasLength(queueUpdateCount));
     });

--- a/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
@@ -1,5 +1,3 @@
-import "dart:async";
-
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:deepseek_plugin/deepseek_plugin.dart";
@@ -43,9 +41,12 @@ void main() {
     await fake.close();
   });
 
-  test("prompt-write buffering preserves old input, cancel, later reused input order", () async {
-    final fake = _FlushControlledAcpProcess();
+  test("prompt admission preserves user message, old input, cancel, later reused input order", () async {
+    final fake = _PromptInputAcpProcess();
     final plugin = buildDeepSeekTestPlugin(fake: fake);
+    final events = <BridgeSseEvent>[];
+    final subscription = plugin.events.listen(events.add);
+    addTearDown(subscription.cancel);
 
     Future<Map<String, dynamic>> waitForFrame({required String method, int count = 1}) async {
       for (var attempt = 0; attempt < 200; attempt++) {
@@ -95,7 +96,40 @@ void main() {
       });
       await creating;
 
-      final flush = fake.holdNextFlush();
+      // Inject input as the prompt enters stdin, before dispatch yields to
+      // publish the accepted user message. Do not emulate a flush barrier.
+      fake.stdin.onPrompt = () {
+        <Map<String, dynamic>>[
+          {
+            "jsonrpc": "2.0",
+            "id": 81,
+            "method": DeepSeekAcpApi.askUserQuestionMethod,
+            "params": {
+              "sessionId": "session-1",
+              "questions": [
+                {"id": "reused", "text": "Old question"},
+              ],
+            },
+          },
+          {
+            "jsonrpc": "2.0",
+            "id": 82,
+            "method": DeepSeekAcpApi.inputCancelMethod,
+            "params": {"sessionId": "session-1"},
+          },
+          {
+            "jsonrpc": "2.0",
+            "id": 83,
+            "method": DeepSeekAcpApi.askUserQuestionMethod,
+            "params": {
+              "sessionId": "session-1",
+              "questions": [
+                {"id": "reused", "text": "New question"},
+              ],
+            },
+          },
+        ].forEach(fake.emit);
+      };
       await plugin.sendPrompt(
         sessionId: "session-1",
         promptId: "prompt-1",
@@ -105,46 +139,18 @@ void main() {
         model: null,
       );
       final prompt = await waitForFrame(method: AcpMethods.sessionPrompt);
-      <Map<String, dynamic>>[
-        {
-          "jsonrpc": "2.0",
-          "id": 81,
-          "method": DeepSeekAcpApi.askUserQuestionMethod,
-          "params": {
-            "sessionId": "session-1",
-            "questions": [
-              {"id": "reused", "text": "Old question"},
-            ],
-          },
-        },
-        {
-          "jsonrpc": "2.0",
-          "id": 82,
-          "method": DeepSeekAcpApi.inputCancelMethod,
-          "params": {"sessionId": "session-1"},
-        },
-        {
-          "jsonrpc": "2.0",
-          "id": 83,
-          "method": DeepSeekAcpApi.askUserQuestionMethod,
-          "params": {
-            "sessionId": "session-1",
-            "questions": [
-              {"id": "reused", "text": "New question"},
-            ],
-          },
-        },
-      ].forEach(fake.emit);
-      await Future<void>.delayed(Duration.zero);
-      expect(await plugin.getPendingQuestions(sessionId: "session-1"), isEmpty);
-
-      flush.complete();
       for (var attempt = 0; attempt < 20; attempt++) {
         if ((await plugin.getPendingQuestions(sessionId: "session-1")).isNotEmpty) break;
         await Future<void>.delayed(Duration.zero);
       }
       final pending = await plugin.getPendingQuestions(sessionId: "session-1");
       expect(pending.single.questions.single.question, "New question");
+      final userIndex = events.indexWhere(
+        (event) => event is BridgeSseMessageUpdated && event.info is PluginMessageUser,
+      );
+      final questionIndex = events.indexWhere((event) => event is BridgeSseQuestionAsked);
+      expect(userIndex, greaterThanOrEqualTo(0));
+      expect(questionIndex, greaterThan(userIndex));
       expect(fake.written.singleWhere((frame) => frame["id"] == 81)["error"], {
         "code": -32603,
         "message": "aborted",
@@ -265,31 +271,22 @@ void main() {
   });
 }
 
-class _FlushControlledAcpProcess() extends FakeAcpProcess {
-  final _FlushControlledIOSink _controlledStdin = _FlushControlledIOSink();
+class _PromptInputAcpProcess() extends FakeAcpProcess {
+  final _PromptInputIOSink _capturingStdin = _PromptInputIOSink();
 
   @override
-  _FlushControlledIOSink get stdin => _controlledStdin;
+  _PromptInputIOSink get stdin => _capturingStdin;
 
   @override
-  List<Map<String, dynamic>> get written => _controlledStdin.frames;
-
-  Completer<void> holdNextFlush() => _controlledStdin.holdNextFlush();
+  List<Map<String, dynamic>> get written => _capturingStdin.frames;
 }
 
-class _FlushControlledIOSink() extends CapturingIOSink {
-  Completer<void>? _nextFlush;
-
-  Completer<void> holdNextFlush() {
-    final gate = Completer<void>();
-    _nextFlush = gate;
-    return gate;
-  }
+class _PromptInputIOSink() extends CapturingIOSink {
+  void Function()? onPrompt;
 
   @override
-  Future<void> flush() {
-    final gate = _nextFlush;
-    _nextFlush = null;
-    return gate?.future ?? Future<void>.value();
+  void add(List<int> data) {
+    super.add(data);
+    if (frames.last["method"] == AcpMethods.sessionPrompt) onPrompt?.call();
   }
 }

--- a/bridge/sesori_plugin_runtime/lib/src/transport/ndjson_process_client.dart
+++ b/bridge/sesori_plugin_runtime/lib/src/transport/ndjson_process_client.dart
@@ -103,8 +103,17 @@ final class NdjsonProcessClient({
     _process = process;
     _exit = Completer<int>();
     final exit = _exit;
-    unawaited(process.stdin.done.catchError((Object _) {}));
     final generation = token.generation;
+    unawaited(
+      process.stdin.done.then<void>(
+        (_) {},
+        onError: (Object error, StackTrace stackTrace) {
+          if (generation != _generation) return;
+          Log.w("[$_logTag] stdin stream error", error, stackTrace);
+          _failPending(error: error, stackTrace: stackTrace);
+        },
+      ),
+    );
     _stdoutSubscription = process.stdoutLines.listen(
       (line) {
         if (generation == _generation) _handleLine(line: line);
@@ -190,27 +199,20 @@ final class NdjsonProcessClient({
     required Duration timeout,
     required NdjsonActivityMatcher? activityMatcher,
   }) async {
-    final process = _requireProcess();
+    _requireProcess();
     final pending = _PendingResponse(
       completer: Completer<JsonObject>(),
       timeout: timeout,
       activityMatcher: activityMatcher,
     );
+    final response = pending.completer.future;
+    response.ignore();
     _pending[id] = pending;
     _armTimeout(id: id, pending: pending);
     try {
+      // IOSink.add admits bytes synchronously to its FIFO controller. A per-frame
+      // flush binds the sink until I/O drains and makes concurrent adds throw.
       sendFrame(frame: frame);
-    } on Object catch (error, stackTrace) {
-      final failed = _removePending(id);
-      if (failed != null && !failed.completer.isCompleted) {
-        failed.completer.completeError(error, stackTrace);
-      }
-      rethrow;
-    }
-    final response = pending.completer.future;
-    response.ignore();
-    try {
-      await process.stdin.flush();
     } on Object catch (error, stackTrace) {
       final failed = _removePending(id);
       if (failed != null && !failed.completer.isCompleted) {

--- a/bridge/sesori_plugin_runtime/test/ndjson_process_client_test.dart
+++ b/bridge/sesori_plugin_runtime/test/ndjson_process_client_test.dart
@@ -30,6 +30,7 @@ void main() {
   test("dispatch completes after write acceptance before response", () async {
     final fixture = _Fixture();
     final dispatched = await fixture.client.dispatch(id: 1, frame: {"id": 1}, timeout: const Duration(seconds: 1));
+    await fixture.process.stdin.flush();
     expect(fixture.process.frames, ['{"id":1}']);
     var completed = false;
     unawaited(dispatched.response.then((_) => completed = true));
@@ -40,13 +41,73 @@ void main() {
     await fixture.dispose();
   });
 
-  test("dispatch preserves synchronous write error", () async {
+  test("real IOSink admits concurrent requests and notifications in FIFO order", () async {
+    final writeGate = Completer<void>();
+    final fixture = _Fixture(candidate: _FakeProcess(writeGate: writeGate));
+
+    final firstStop = fixture.client.dispatch(
+      id: 1,
+      frame: {"id": 1, "method": "stop"},
+      timeout: const Duration(seconds: 1),
+    );
+    fixture.client.sendFrame(frame: {"method": "cancel-input"});
+    final secondStop = fixture.client.dispatch(
+      id: 2,
+      frame: {"id": 2, "method": "stop"},
+      timeout: const Duration(seconds: 1),
+    );
+    final prompt = fixture.client.dispatch(
+      id: 3,
+      frame: {"id": 3, "method": "prompt"},
+      timeout: const Duration(seconds: 1),
+    );
+    final dispatched = await Future.wait([firstStop, secondStop, prompt]);
+
+    writeGate.complete();
+    await fixture.process.stdin.flush();
+    expect(fixture.process.frames, [
+      '{"id":1,"method":"stop"}',
+      '{"method":"cancel-input"}',
+      '{"id":2,"method":"stop"}',
+      '{"id":3,"method":"prompt"}',
+    ]);
+    for (var id = 1; id <= 3; id++) {
+      fixture.process.emit('{"id":$id}');
+    }
+    await Future.wait(dispatched.map((dispatch) => dispatch.response));
+    await fixture.dispose();
+  });
+
+  test("asynchronous IOSink failure preserves the error for pending responses", () async {
     final error = StateError("broken pipe");
     final fixture = _Fixture(candidate: _FakeProcess(writeError: error));
-    await expectLater(
-      fixture.client.dispatch(id: 1, frame: {"id": 1}, timeout: const Duration(seconds: 1)),
-      throwsA(same(error)),
+    final dispatched = await fixture.client.dispatch(
+      id: 1,
+      frame: {"id": 1},
+      timeout: const Duration(seconds: 1),
     );
+
+    await expectLater(dispatched.response, throwsA(same(error)));
+    await fixture.dispose();
+  });
+
+  test("synchronous IOSink failure does not leave an unhandled pending error", () async {
+    final fixture = _Fixture(candidate: _FakeProcess(autoExitOnClose: false));
+    await fixture.process.stdin.close();
+    final unhandled = <Object>[]; // ignore: no_slop_linter/prefer_specific_type
+
+    await runZonedGuarded<Future<void>>(
+      () async {
+        await expectLater(
+          fixture.client.dispatch(id: 1, frame: {"id": 1}, timeout: const Duration(seconds: 1)),
+          throwsA(isA<StateError>().having((error) => error.message, "message", "StreamSink is closed")),
+        );
+        await _pump();
+      },
+      (error, _) => unhandled.add(error),
+    );
+
+    expect(unhandled, isEmpty);
     await fixture.dispose();
   });
 
@@ -123,6 +184,25 @@ void main() {
     first.emit('{"id":2,"result":"stale"}');
     first.completeExit(9);
     second.emit('{"id":2,"result":"current"}');
+    expect((await pending)["result"], "current");
+    await fixture.dispose();
+  });
+
+  test("old generation stdin failure cannot affect replacement", () async {
+    final writeGate = Completer<void>();
+    final first = _FakeProcess(writeError: StateError("stale stdin"), writeGate: writeGate);
+    final fixture = _Fixture(candidate: first);
+    final old = await fixture.client.dispatch(id: 1, frame: {"id": 1}, timeout: const Duration(seconds: 1));
+    old.response.ignore();
+    await fixture.client.reset(reason: StateError("reset"), stackTrace: null, gracefulTimeout: Duration.zero);
+
+    final second = _FakeProcess();
+    await fixture.client.attach(token: fixture.client.beginAttach(), process: second);
+    final pending = fixture.client.request(id: 2, frame: {"id": 2}, timeout: const Duration(seconds: 1));
+    writeGate.complete();
+    await _pump();
+    second.emit('{"id":2,"result":"current"}');
+
     expect((await pending)["result"], "current");
     await fixture.dispose();
   });
@@ -225,6 +305,7 @@ final class _Fixture({
 
 final class _FakeProcess({
   final Object? writeError, // ignore: no_slop_linter/prefer_specific_type
+  final Completer<void>? writeGate,
   final Object? closeError, // ignore: no_slop_linter/prefer_specific_type
   final Object? gracefulKillError, // ignore: no_slop_linter/prefer_specific_type
   final bool autoExitOnClose = true,
@@ -264,6 +345,7 @@ final class _FakeProcess({
 final class _RecordingConsumer({required final _FakeProcess process}) implements StreamConsumer<List<int>> {
   @override
   Future<void> addStream(Stream<List<int>> stream) async {
+    await process.writeGate?.future;
     if (process.writeError != null) throw process.writeError!;
     await for (final bytes in stream) {
       process.frames.add(String.fromCharCodes(bytes).trim());

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -251,8 +251,12 @@ defaults and queued client sends coherent.
   it supplies another immediate active-turn delivery path; natural-completion
   queueing is not valid production behavior. Cursor, Hermes, DeepSeek, Copilot,
   Grok, and OMP use the shared fallback. Their
-  synthetic user transcript message is published only after its frame flushes
-  successfully to the agent's stdin. A prompt rejected after that dispatch
+  synthetic user transcript message is published only after its frame is
+  synchronously admitted to the agent's stdin. The shared NDJSON transport
+  relies on one IOSink's FIFO admission rather than per-request flushing, so
+  concurrent requests and notifications preserve order without binding the sink;
+  an asynchronous stdin failure is logged and fails every pending response with
+  the original error. A prompt rejected after that dispatch
   renders a durable inline error, preserving the agent's diagnostic detail
   rather than transitioning silently to idle. The shared 30-minute ACP prompt
   safety bound measures same-session inactivity, not total turn duration:
@@ -489,7 +493,9 @@ provider failure, early and late abort, busy stop-and-send, and two sessions.
   instead of updated when compaction ends, or survives an abort or process
   exit.
 - An abort, permission reply, or question reply stalls behind a send to a
-  busy session on the same session lane, or a stop-and-send ACP follow-up waits
+  busy session on the same session lane; concurrent NDJSON dispatch binds stdin,
+  reorders control frames and prompts, or loses an asynchronous sink failure; or
+  a stop-and-send ACP follow-up waits
   for the active turn to finish naturally instead of cancelling it before dispatch.
   A Pi abort waits for the general history/control timeout, lets hidden steering
   resume after Stop, or leaves later sends stuck in their sending state.


### PR DESCRIPTION
## Complexity
🌿 Straightforward transport-local correction: remove unsafe per-request flush and observe write failures at the existing owner. No queue, lock, registry, or API expansion.

## What
- Admit requests and notifications synchronously through the existing FIFO IOSink instead of binding it with per-request `flush()`.
- Observe the pending response before sending, preventing unhandled completer errors on synchronous write failure.
- Propagate/log original asynchronous stdin failures, with existing attachment-generation isolation.
- Add real-SDK IOSink regressions; replace obsolete fake-flush ACP assertions with stdin-admission coverage and correct documentation.

## Why
Live DeepSeek phone QA reproduced a bridge process crash when Stop dispatched multiple native scopes. The first request's flush bound the sink; the next write threw `Bad state: StreamSink is bound to a stream`. Its pending completer also failed before an error observer was attached.

## Risk and test focus
Shared transport serves ACP harnesses and Codex. Focus is FIFO request/notification admission, synchronous and asynchronous write errors, prompt/event ordering, and old-sink isolation after reset. Dispatch now acknowledges sink admission rather than OS drain; later pipe errors remain observable and fail pending requests.

No database or wire-contract impact. User-visible impact: concurrent Stop no longer crashes the bridge. Native Stop policy and adapter version are unchanged.

## Expected result
Multiple scoped STOP requests can be admitted before later prompts without illegal concurrent IOSink writes or unhandled pending errors. The bridge remains usable afterward.

## Verification
- Runtime package tests passed, including 17 focused transport tests using a real SDK IOSink.
- 45 targeted ACP tests and the full DeepSeek package (116 tests) passed.
- Runtime, ACP, and DeepSeek fatal-info analysis clean; whitespace checks clean.
- CI exposed one remaining DeepSeek fake-flush assumption. Its regression now injects old-input/cancel/reused-input frames at actual prompt admission and checks user-message publication precedes the question, retaining cancellation and replacement-input assertions. No production changes in that follow-up.
- Independent correctness/simplicity review approved; stale comment corrected.
- Real iOS simulator, relay, and DeepSeek 0.1.4 / Flash: independently resumed child's main turn settled while its grandchild ran; ancestor Stop from the phone settled all three sessions idle without exiting bridge/native runtime.
- A subsequent prompt produced the expected assistant marker and settled idle without a session error.
- Native root-owned background shell jobs remained after agent-turn cancellation; this PR does not change that behavior. Desktop and the broader question-cancellation matrix were not tested in this bug-fix run.
