### PR TITLE
🌿 Limit Pi and Codex runtime probes to current host

### DIFF
--- a/.agents/skills/update-codex-harness/SKILL.md
+++ b/.agents/skills/update-codex-harness/SKILL.md
@@ -205,20 +205,27 @@ an incidental event or an assumed PATH binary version. State branch retirement
 and minimum version. Never weaken approval or sandbox semantics to accommodate
 an older runtime.
 
-## Phase 3 — Safe per-target probe matrix
+## Phase 3 — Safe current-host probe
 
-Validate each of the six managed archives independently. Record asset name,
-digest, OS/architecture, disposable boundary, production extraction/placement,
-exact version, stdio handshake, and WebSocket handshake results. A host-only
-smoke does not validate other platforms or another transport.
+Verify the downloaded SHA-256 of all six managed archives as opaque bytes;
+checksum validation does not require extracting or launching them. Run the
+installation and live probes below only for the archive matching the current
+host OS and architecture. Other platforms do not need installation or launch
+probes to approve a target refresh; report them as untested, not validated by
+the host result. Record the tested asset and digest, OS/architecture, disposable
+boundary, production extraction/placement, exact version, stdio handshake, and
+WebSocket handshake results. Both current-host transports must be checked.
 
-1. Establish a target-appropriate disposable VM/container/restricted OS account
-   before parsing archive contents. No sensitive mounts; block outbound network
-   access (local loopback may be allowed for WebSocket probes). Temporary HOME
-   or environment filtering alone is not a sandbox. If no boundary is available,
-   do not inspect, extract, or execute the archive; mark the row unvalidated.
-2. Download inside that boundary, or transfer opaque bytes into it. Verify the
-   matching SHA-256 before parsing. Inspect `CodexPluginDescriptor.installRuntime()`
+1. Establish a current-host disposable VM/container/restricted OS account before
+   parsing archive contents. No sensitive mounts; block outbound network access
+   (local loopback may be allowed for WebSocket probes). Temporary HOME or
+   environment filtering alone is not a sandbox. If no boundary is available,
+   do not inspect, extract, or execute the host archive; report the current-host
+   probe as blocked.
+2. Download the current-host archive inside that boundary, or transfer opaque
+   bytes into it. Verify its SHA-256 before parsing. Keep other archives opaque
+   unless an optional platform-specific check is warranted.
+   Inspect `CodexPluginDescriptor.installRuntime()`
    for production wiring, but do not call it for a newer candidate: it hard-codes
    the current manifest. Start at `ManagedRuntimeComposition.createInstaller()`
    with a temporary candidate manifest and matching asset resolver, then exercise
@@ -240,7 +247,7 @@ smoke does not validate other platforms or another transport.
    that `.sesori-runtime-sha256` contains the candidate's bare digest. Generic
    tar extraction or a lone executable check is not a substitute. Apply production
    traversal/link rejection, including rejection of all extracted symlinks.
-   Failure to run this chain blocks the row.
+   Failure to run this chain blocks the current-host probe.
 3. Resolve the extracted entrypoint to an absolute path inside the package.
    Never use bare PATH `codex`, copy the CLI away from its helpers, or launch
    the user's Codex Desktop app or existing app-server.
@@ -310,9 +317,11 @@ smoke does not validate other platforms or another transport.
    capability gates, and required helpers. Schema generation inside the same
    boundary can supplement probes, not replace live protocol checks.
 
-Skipped or failed provenance, extraction, version, or required transport checks
-are hard gates, not passing platform limitations. This manifest has one target
-for all six archives: any unvalidated row blocks the whole target refresh.
+Skipped or failed provenance, current-host extraction, version, or required
+current-host transport checks block the target refresh. Missing install/launch
+results for other platforms do not block it. Optional platform checks may be
+added for a concrete release change or regression; report any observed failure.
+All six archive digests and source-to-artifact verification remain required.
 Never mix old digests with a new shared release URL. Continue source-only audit
 and report useful findings even when pinning is blocked; label them unprobed.
 
@@ -325,7 +334,8 @@ Before editing target or protocol code report:
   separating published metadata, checksum-list agreement, and downloaded hashes;
 - source-to-artifact evidence or blocker; complete diff size/coverage;
 - high/medium findings with immutable links and actual app-server visibility;
-- six-row matrix for extraction, version, stdio and WebSocket, including skips;
+- current-host OS/architecture, extraction, version, stdio and WebSocket results;
+  list other platforms as untested unless optionally checked;
 - proposed version-only edits versus capabilities, simplifications, follow-ups;
 - tolerant-path versus justified version-selected implementation strategy and
   compatibility retirement thresholds.
@@ -339,6 +349,11 @@ internal shims. Apply repository architecture-review rules only to approved
 architecture-bearing production work, not this skill or a target-only edit.
 
 ## Phase 5 — Implement only after approval and passing gates
+
+Require all six archive digests, source-to-artifact verification, successful
+current-host install/version/transport probes, and user approval. Other
+platforms do not require installation or launch probes; their untested status
+does not block the complete six-asset target update.
 
 1. Update `CodexRuntimeManifest.targetVersion`, six matching digests, and
    target-specific manifest comments. Strip GitHub's `sha256:` prefix: manifest

--- a/.agents/skills/update-pi-harness/SKILL.md
+++ b/.agents/skills/update-pi-harness/SKILL.md
@@ -288,32 +288,30 @@ When a single tolerant path is sufficient, prefer it over the
 two-implementation interface; if neither path has a concrete caller and
 meaningful damage, reject both as speculative machinery.
 
-## Phase 3 — Run a safe per-target probe matrix
+## Phase 3 — Run a safe current-host probe
 
-Before changing the target, validate every managed archive in a temporary,
-platform-appropriate disposable boundary. This is a six-row matrix, not a
-single current-host smoke test. For each of the six assets, record the asset
-name and digest, sandbox/host and architecture, production extraction and
-package-placement result, exact `--version` result, and the JSONL/RPC
-`get_state` result. A host-only extraction or a probe of one architecture does
-not validate another row. Treat every downloaded archive as an untrusted
-executable even after its official digest is verified:
+Verify the downloaded SHA-256 of all six managed archives as opaque bytes;
+checksum validation does not require extracting or launching them. Run the
+installation and live probe below only for the archive matching the current
+host OS and architecture. Other platforms do not need installation or launch
+probes to approve a target refresh; report them as untested, not validated by
+the host result. Record the tested asset and digest, host OS/architecture,
+disposable boundary, production extraction/placement, exact `--version`, and
+JSONL/RPC `get_state` results. Treat downloaded archives as untrusted executables
+even after verifying their official digests:
 
-1. For each asset row, establish the disposable boundary before handling
-   archive contents. Use a native host or suitable target VM/container/restricted
-   OS account with no sensitive mounts and blocked outbound network access. A
-   temporary `HOME`, Pi directories, or allowlisted environment does not sandbox
-   a process running as the maintainer's account. If a target cannot provide
-   this boundary, do not inspect, extract, or execute that archive there; mark
-   that row unvalidated and leave its asset unpinned.
-2. For each row, download the matching official archive into that boundary and
-   verify its SHA-256. If the boundary cannot download directly, transfer the
-   archive as opaque bytes from the host and perform the digest check before
-   parsing it. Do not use one platform's successful checksum or probe as
-   evidence for another row.
-3. Inspect and extract every archive inside its same disposable boundary
-   without changing the repository. For each managed asset, run the production
-   extraction and package-placement path
+1. Establish the current-host disposable boundary before handling archive
+   contents. Use a suitable VM/container/restricted OS account with no sensitive
+   mounts and blocked outbound network access. A temporary `HOME`, Pi directories,
+   or allowlisted environment does not sandbox a process running as the
+   maintainer's account. If this boundary is unavailable, do not inspect, extract,
+   or execute the host archive; report the current-host probe as blocked.
+2. Transfer the matching official archive as opaque bytes into that boundary,
+   or download it there. Verify its SHA-256 before parsing it. Keep every other
+   archive opaque unless an optional platform-specific check is warranted.
+3. Inspect and extract the current-host archive inside the same disposable
+   boundary without changing the repository. Run the production extraction and
+   package-placement path
    (`bridge/sesori_bridge_foundation/lib/src/archive_extractor.dart` and
    `bridge/sesori_plugin_runtime/lib/src/provisioning/runtime_install_service.dart`)
    on a target-appropriate host; do not substitute a generic extractor for this
@@ -321,8 +319,8 @@ executable even after its official digest is verified:
    escaping symlink/hardlink targets before writing; confirm the package tree
    and platform-specific entrypoint remain intact. This repository rejects all
    symlinks after extraction, not only links that escape. If the production
-   path cannot run in the row's sandbox, mark the row unvalidated and leave its
-   asset unpinned. Resolve that entrypoint to an absolute path and invoke that
+   path cannot run in the host sandbox, report the current-host probe as blocked.
+   Resolve that entrypoint to an absolute path and invoke that
    path for every check; never
    invoke a bare PATH-installed `pi` or copy the executable away from its
    package files. If a temporary PATH wrapper is unavoidable, use only a
@@ -344,14 +342,14 @@ executable even after its official digest is verified:
    `SSH_AUTH_SOCK`, credential-helper settings, and other unrelated secrets.
    The probe must remain unauthenticated; use a separately authorized and
    explicitly approved procedure if authenticated behavior needs testing.
-6. For each row, run the separate `--version` process with a bounded 10-second
+6. Run the separate current-host `--version` process with a bounded 10-second
    timeout and the same process-group/Job Object cleanup guarantee. If it hangs
    or exits unexpectedly, terminate its entire process tree before reporting
    failure; do not let it block the RPC probe or filesystem cleanup. Verify that
    its output identifies exactly the candidate release, rather than merely
    returning success. Preserve the normal environment policy in the production
    launch design.
-7. For each row, launch the extracted entrypoint with exactly these arguments:
+7. Launch the extracted current-host entrypoint with exactly these arguments:
 
    ```text
    --mode rpc --no-session --approve
@@ -390,15 +388,13 @@ executable even after its official digest is verified:
    response-correlation, package-layout, isolation, or required-surface
    regression. Do not pin a candidate based on a version output alone.
 
-A skipped or failed live probe is a hard gate for that asset, not a
-successful platform limitation. Production extraction and package placement
-must be exercised for every managed archive, and the version/RPC launch probe
-must pass for every supported target before its corresponding digest is eligible
-for pinning. Phase 4 may report blocked or unvalidated rows, but do not approve
-or edit/pin those assets in Phase 5. If the manifest requires a complete
-six-asset release, any unvalidated row blocks the target update; otherwise leave
-only the unvalidated asset(s) unchanged. Artifact/source verification and a
-successful probe on another platform cannot substitute for the missing row.
+A skipped or failed required current-host probe blocks the target refresh.
+Missing install/launch results for other platforms do not block it. Optional
+platform checks may be added for a concrete release change or regression; report
+any observed failure rather than treating it as a passing host limitation.
+All six archive digests and source-to-artifact verification remain required.
+When approved, update the complete release consistently; never combine a new
+shared target URL with old asset digests.
 
 Keep probe output redacted and bounded. Do not retain raw frames, credentials,
 transcripts, prompts, user/project/local filesystem paths, or provider/account
@@ -415,8 +411,8 @@ Before editing the runtime target or production protocol code, report:
   blocker;
 - aggregate diff size and the high/medium findings with source links;
 - which findings are truly visible on JSONL/RPC stdout;
-- the six-row probe matrix: production extraction/placement, exact version,
-  and RPC results for every asset, plus any blocked or unvalidated row;
+- current-host OS/architecture, production extraction/placement, exact version,
+  and RPC results; list other platforms as untested unless optionally checked;
 - proposed Sesori edits, explicitly separating version-only changes from
   capability changes, simplifications, and follow-up work;
 - the compatibility strategy: tolerant single path versus a justified
@@ -433,13 +429,12 @@ explicitly requested, while the runtime/capability PR remains behind this gate.
 
 ## Phase 5 — Implement only after approval
 
-Enter this phase only after every asset being pinned has passed the
-sandboxed production extraction/placement and live version/RPC probe on a
-suitable target host, source-to-artifact provenance has been verified (or the
-artifacts have been reproducibly rebuilt), and the user has approved the
-resulting scope. A skipped or failed row blocks that asset; when the manifest
-requires a complete six-asset target, it blocks all target edits. Digest or
-source verification alone is insufficient.
+Enter this phase only after all six archive digests are verified, the
+current-host sandboxed production extraction/placement and live version/RPC
+probe pass, source-to-artifact provenance is verified (or the artifacts have
+been reproducibly rebuilt), and the user approves the resulting scope.
+Other platforms do not require installation or launch probes. Report their
+untested status without blocking the complete six-asset target update.
 
 For an approved target refresh:
 


### PR DESCRIPTION
## Complexity
🌿 Straightforward documentation-only scope change in two existing skills.

## What
- Remove mandatory installation and live-launch checks across all six OS/architecture targets from both Pi and Codex update skills.
- Require installation/version/protocol smoke checks only for the current host.
- Report other platforms as untested without blocking the complete target update.
- Align probe instructions, approval reports and implementation gates with that scope.

## Why
A target refresh should not require access to macOS, Linux and Windows on both architectures. This implements the explicitly requested removal of that requirement.

## Risk and test focus
No production code, runtime pin, compatibility minimum, user-visible behavior or database changes. Cross-platform runtime behavior is no longer a mandatory live verification gate. All six downloaded archive checksums, source-to-artifact provenance, current-host sandbox/cleanup rules and approval gates remain required. Optional platform checks remain available for concrete regressions.

## Expected result
Maintainers can refresh Pi or Codex after current-host smoke checks and remaining release checks pass; absent probes on other platforms no longer block the update.

## Verification
- Validated both skills' current-host scope and absence of stale per-platform row gates.
- Confirmed checksum/provenance requirements remain present.
- Validated frontmatter, JSON examples, Markdown fences and shell syntax after substituting documented version placeholders.
- `git diff --check` passed. No Dart/Flutter suites: documentation only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits Pi and Codex harness update probes to the current host OS/architecture, so target refreshes no longer require access to all six managed platform combinations.

- Removes the mandatory install/version/protocol probe matrix for other platforms; they are reported as untested instead of blocking the update.
- All six archive SHA-256 digests and source-to-artifact verification remain required.
- Documentation-only change to the two skill files; no production code or runtime behavior affected.

<sup>Written for commit 2ed416ddd4c1f9a2c4a4de0b2917814406c48ddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

