### PR TITLE
⚙️ [opencode-import] Start plugins independently in parallel [step 1/2]

### DIFF
--- a/bridge/app/lib/src/runtime/plugin_generation_factory.dart
+++ b/bridge/app/lib/src/runtime/plugin_generation_factory.dart
@@ -117,12 +117,12 @@ class PluginGenerationFactory({
         try {
           await _attemptBatch(attempt: 1, batch: batch);
         } on Object catch (error, stackTrace) {
-          for (final request in batch) {
-            request.controller.addError(error, stackTrace);
+          if (batch.every((request) => request.controller.isClosed)) {
+            Log.w("Plugin startup infrastructure failed after all requests settled", error, stackTrace);
           }
-        } finally {
           for (final request in batch) {
-            await request.controller.close();
+            _addError(request: request, error: error, stackTrace: stackTrace);
+            await _closeRequest(request: request);
           }
         }
       }
@@ -146,35 +146,12 @@ class PluginGenerationFactory({
         );
         switch (resolution.status) {
           case BridgeInstanceResolutionStatus.allowed:
-            final startSettlements = <Future<void>>[];
-            for (final request in batch) {
-              try {
-                final host = await _buildHost(request: request, resolution: resolution);
-                await for (final event in request.registration.descriptor.ensureRuntime(host: host)) {
-                  request.controller.add(PluginGenerationProvisionProgress(event: event));
-                  if (event case ProvisionReady(:final binaryPath)) {
-                    host.provisionedRuntimePath = binaryPath;
-                  }
-                }
-                startSettlements.add(
-                  _settleDescriptorStart(
-                    request: request,
-                    start: request.registration.descriptor.start(host),
-                  ),
-                );
-              } on PluginStartAbortedException catch (error, stackTrace) {
-                request.controller.addError(error, stackTrace);
-              } on Object catch (error, stackTrace) {
-                request.controller.addError(
-                  PluginGenerationStartFailedException(
-                    pluginId: request.registration.descriptor.id,
-                    cause: error,
-                  ),
-                  stackTrace,
-                );
-              }
-            }
-            await Future.wait(startSettlements);
+            await Future.wait<void>(
+              [
+                for (final request in batch) _startRequest(request: request, resolution: resolution),
+              ],
+              eagerError: false,
+            );
           case BridgeInstanceResolutionStatus.declined:
             throw const BridgeRuntimeServerException(
               "Startup aborted because another Sesori bridge is already running and replacement was declined.",
@@ -217,25 +194,48 @@ class PluginGenerationFactory({
     );
   }
 
-  Future<void> _settleDescriptorStart({
+  Future<void> _startRequest({
     required _GenerationStartRequest request,
-    required Future<BridgePlugin> start,
+    required BridgeInstanceResolution resolution,
   }) async {
     try {
-      request.controller.add(
-        PluginGenerationStarted(plugin: await start),
-      );
+      final host = await _buildHost(request: request, resolution: resolution);
+      await for (final event in request.registration.descriptor.ensureRuntime(host: host)) {
+        request.controller.add(PluginGenerationProvisionProgress(event: event));
+        if (event case ProvisionReady(:final binaryPath)) {
+          host.provisionedRuntimePath = binaryPath;
+        }
+      }
+      final plugin = await request.registration.descriptor.start(host);
+      request.controller.add(PluginGenerationStarted(plugin: plugin));
     } on PluginStartAbortedException catch (error, stackTrace) {
-      request.controller.addError(error, stackTrace);
+      _addError(request: request, error: error, stackTrace: stackTrace);
     } on Object catch (error, stackTrace) {
-      request.controller.addError(
-        PluginGenerationStartFailedException(
+      _addError(
+        request: request,
+        error: PluginGenerationStartFailedException(
           pluginId: request.registration.descriptor.id,
           cause: error,
         ),
-        stackTrace,
+        stackTrace: stackTrace,
       );
+    } finally {
+      await _closeRequest(request: request);
     }
+  }
+
+  void _addError({
+    required _GenerationStartRequest request,
+    required Object error,
+    required StackTrace stackTrace,
+  }) {
+    if (request.controller.isClosed) return;
+    request.controller.addError(error, stackTrace);
+  }
+
+  Future<void> _closeRequest({required _GenerationStartRequest request}) {
+    if (request.controller.isClosed) return Future<void>.value();
+    return request.controller.close();
   }
 
   Future<BridgePluginHostImpl> _buildHost({

--- a/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
+++ b/bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart
@@ -107,6 +107,46 @@ void main() {
       return plugin;
     }
 
+    ManagedRuntimePaths testManagedRuntimePaths() {
+      return ManagedRuntimePaths(
+        installRoot: runtimeDirectory.path,
+        binaryPath: "${runtimeDirectory.path}/bin/sesori-bridge",
+        cacheDirectory: runtimeDirectory.path,
+      );
+    }
+
+    PluginGenerationFactory createFactory() {
+      return PluginGenerationFactory(
+        managedRuntimePaths: testManagedRuntimePaths(),
+        currentBridgeIdentity: currentBridgeIdentity,
+        ownerSessionId: "owner-session",
+        startupMutexRepository: startupMutexRepository,
+        bridgeInstanceService: bridgeInstanceService,
+        processRepository: _FakeProcessRepository(),
+        clock: const ServerClock(),
+        environment: const <String, String>{"HOME": "/home/alex"},
+        currentUser: ProcessUser.fromRawUser("alex"),
+        resolveIdleTimeoutMins: ({required pluginId}) => idleTimeoutMins,
+        settingsChanges: settingsChanges.stream,
+      );
+    }
+
+    PluginRuntimeRegistration registrationFor({required BridgePluginDescriptor testDescriptor}) {
+      final stateDirectory = pluginStateDirectoryPath(
+        paths: testManagedRuntimePaths(),
+        pluginId: testDescriptor.id,
+        stateStorage: testDescriptor.stateStorage,
+      );
+      return PluginRuntimeRegistration(
+        descriptor: testDescriptor,
+        config: const PluginConfig(values: <String, Object?>{}),
+        stateDirectory: stateDirectory,
+        store: BridgeHostJsonStore(
+          fileApi: RuntimeFileApi(runtimeDirectory: stateDirectory),
+        ),
+      );
+    }
+
     test("allowed resolution starts the descriptor on a fully wired host", () async {
       final terminatedBridge = _identity(pid: 200, startMarker: "old-bridge-start");
       bridgeInstanceService.resolution = BridgeInstanceResolution(
@@ -145,6 +185,166 @@ void main() {
         reason: "stale cleanup must be authorized to reclaim records of the bridge this one replaced",
       );
     });
+    test("starts each descriptor provisioning concurrently", () async {
+      final firstProvisionStarted = Completer<void>();
+      final firstProvisionGate = Completer<void>();
+      final secondProvisionStarted = Completer<void>();
+      final slow = _GatedDescriptor(
+        id: "slow-provision",
+        provisionStarted: firstProvisionStarted,
+        provisionGate: firstProvisionGate,
+      );
+      final fast = _GatedDescriptor(
+        id: "fast-provision",
+        provisionStarted: secondProvisionStarted,
+      );
+      final factory = createFactory();
+      final slowStart = _observeGenerationStart(
+        factory.start(
+          registration: registrationFor(testDescriptor: slow),
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+      final fastStart = _observeGenerationStart(
+        factory.start(
+          registration: registrationFor(testDescriptor: fast),
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+
+      try {
+        await firstProvisionStarted.future.timeout(const Duration(seconds: 1));
+        await secondProvisionStarted.future.timeout(const Duration(seconds: 1));
+        expect(slow.startCalls, isZero);
+        expect(fast.startCalls, equals(1));
+      } finally {
+        if (!firstProvisionGate.isCompleted) firstProvisionGate.complete();
+        final observations = await Future.wait([slowStart, fastStart]).timeout(const Duration(seconds: 1));
+        for (final observation in observations) {
+          _retainStartedPlugins(observation: observation, startedPlugins: startedPlugins);
+        }
+      }
+    });
+
+    test("closes fast descriptor stream while another descriptor start is gated", () async {
+      final slowStartStarted = Completer<void>();
+      final slowStartGate = Completer<void>();
+      final fastStartStarted = Completer<void>();
+      final slow = _GatedDescriptor(
+        id: "slow-start",
+        startStarted: slowStartStarted,
+        startGate: slowStartGate,
+      );
+      final fast = _GatedDescriptor(
+        id: "fast-start",
+        startStarted: fastStartStarted,
+      );
+      final factory = createFactory();
+      final slowStart = _observeGenerationStart(
+        factory.start(
+          registration: registrationFor(testDescriptor: slow),
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+      final fastStart = _observeGenerationStart(
+        factory.start(
+          registration: registrationFor(testDescriptor: fast),
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+
+      try {
+        await slowStartStarted.future.timeout(const Duration(seconds: 1));
+        await fastStartStarted.future.timeout(const Duration(seconds: 1));
+        final fastObservation = await fastStart.timeout(const Duration(seconds: 1));
+        expect(fastObservation.events, contains(isA<PluginGenerationStarted>()));
+        expect(slowStartGate.isCompleted, isFalse);
+      } finally {
+        if (!slowStartGate.isCompleted) slowStartGate.complete();
+        final observations = await Future.wait([slowStart, fastStart]).timeout(const Duration(seconds: 1));
+        for (final observation in observations) {
+          _retainStartedPlugins(observation: observation, startedPlugins: startedPlugins);
+        }
+      }
+    });
+
+    test("isolates descriptor provisioning failure from healthy descriptor", () async {
+      final failed = _GatedDescriptor(
+        id: "failed-provision",
+        provisionError: StateError("provisioning failed"),
+      );
+      final healthy = _GatedDescriptor(id: "healthy");
+      final factory = createFactory();
+      final failedStart = _observeGenerationStart(
+        factory.start(
+          registration: registrationFor(testDescriptor: failed),
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+      final healthyStart = _observeGenerationStart(
+        factory.start(
+          registration: registrationFor(testDescriptor: healthy),
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+
+      final observations = await Future.wait([failedStart, healthyStart]).timeout(const Duration(seconds: 1));
+      final failedObservation = observations[0];
+      final healthyObservation = observations[1];
+      expect(failedObservation.errors, hasLength(1));
+      expect(
+        failedObservation.errors.single,
+        isA<PluginGenerationStartFailedException>().having(
+          (error) => error.pluginId,
+          "pluginId",
+          equals("failed-provision"),
+        ),
+      );
+      expect(failed.startCalls, isZero);
+      expect(healthyObservation.errors, isEmpty);
+      expect(healthyObservation.events, contains(isA<PluginGenerationStarted>()));
+      _retainStartedPlugins(observation: healthyObservation, startedPlugins: startedPlugins);
+    });
+
+    test("holds startup mutex until every descriptor start settles", () async {
+      final slowStartStarted = Completer<void>();
+      final slowStartGate = Completer<void>();
+      final slow = _GatedDescriptor(
+        id: "mutex-slow-start",
+        startStarted: slowStartStarted,
+        startGate: slowStartGate,
+      );
+      final fast = _GatedDescriptor(id: "mutex-fast-start");
+      final factory = createFactory();
+      final slowStart = _observeGenerationStart(
+        factory.start(
+          registration: registrationFor(testDescriptor: slow),
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+      final fastStart = _observeGenerationStart(
+        factory.start(
+          registration: registrationFor(testDescriptor: fast),
+          startAborted: StartAbortSignal.never,
+        ),
+      );
+
+      try {
+        await slowStartStarted.future.timeout(const Duration(seconds: 1));
+        final fastObservation = await fastStart.timeout(const Duration(seconds: 1));
+        expect(fastObservation.events, contains(isA<PluginGenerationStarted>()));
+        expect(startupMutexRepository.lockHeld, isTrue);
+        expect(slowStartGate.isCompleted, isFalse);
+      } finally {
+        if (!slowStartGate.isCompleted) slowStartGate.complete();
+        final observations = await Future.wait([slowStart, fastStart]).timeout(const Duration(seconds: 1));
+        for (final observation in observations) {
+          _retainStartedPlugins(observation: observation, startedPlugins: startedPlugins);
+        }
+      }
+      expect(startupMutexRepository.lockHeld, isFalse);
+    });
+
     test("forwards only changed idle timeout values through the plugin host", () async {
       await startPlugin();
       final host = descriptor.startedHosts.single;
@@ -412,6 +612,92 @@ StartupLockRejection _startupLockRejection({String lockFilePath = "/tmp/bridge-s
   );
 }
 
+class _ObservedGenerationStart() {
+  final List<PluginGenerationStartEvent> events = <PluginGenerationStartEvent>[];
+  final List<Object> errors = <Object>[];
+}
+
+Future<_ObservedGenerationStart> _observeGenerationStart(Stream<PluginGenerationStartEvent> stream) async {
+  final observed = _ObservedGenerationStart();
+  final done = Completer<void>();
+  late final StreamSubscription<PluginGenerationStartEvent> subscription;
+  subscription = stream.listen(
+    observed.events.add,
+    onError: (Object error, StackTrace _) => observed.errors.add(error),
+    onDone: () {
+      if (!done.isCompleted) done.complete();
+    },
+  );
+  await done.future;
+  await subscription.cancel();
+  return observed;
+}
+
+void _retainStartedPlugins({
+  required _ObservedGenerationStart observation,
+  required List<BridgePlugin> startedPlugins,
+}) {
+  for (final event in observation.events) {
+    switch (event) {
+      case PluginGenerationProvisionProgress():
+        break;
+      case PluginGenerationStarted(:final plugin):
+        startedPlugins.add(plugin);
+    }
+  }
+}
+
+// ignore: must_be_immutable
+class _GatedDescriptor({
+  @override required final String id,
+  final Completer<void>? provisionStarted,
+  final Completer<void>? provisionGate,
+  final Object? provisionError,
+  final Completer<void>? startStarted,
+  final Completer<void>? startGate,
+}) extends BridgePluginDescriptor {
+  final List<PluginHost> startedHosts = <PluginHost>[];
+  BridgePlugin? startedPlugin;
+  int startCalls = 0;
+
+  @override
+  String get displayName => id;
+
+  @override
+  PluginProjectOwnership get projectOwnership => PluginProjectOwnership.native;
+
+  @override
+  PluginSessionOptionsScope get sessionOptionsScope => PluginSessionOptionsScope.project;
+
+  @override
+  List<PluginOption> get options => const [];
+
+  @override
+  Stream<RuntimeProvisionProgress> ensureRuntime({required PluginHost host}) async* {
+    _signal(provisionStarted);
+    final gate = provisionGate;
+    if (gate != null) await gate.future;
+    final error = provisionError;
+    if (error != null) throw error;
+  }
+
+  @override
+  Future<BridgePlugin> start(PluginHost host) async {
+    startCalls++;
+    startedHosts.add(host);
+    _signal(startStarted);
+    final gate = startGate;
+    if (gate != null) await gate.future;
+    final plugin = _FakeBridgePlugin();
+    startedPlugin = plugin;
+    return plugin;
+  }
+}
+
+void _signal(Completer<void>? signal) {
+  if (signal != null && !signal.isCompleted) signal.complete();
+}
+
 /// Records the host every `start()` receives and returns a steady fake plugin,
 /// so the tests can assert exactly what the runner wires up.
 // ignore: prefer_const_constructors_in_immutables, mutable test logs prevent a const primary constructor
@@ -522,6 +808,7 @@ class _FakeStartupMutexRepository() implements StartupMutexRepository {
   StartupLockRejection? rejection;
   final List<({int pid, String? startMarker})> lockRequests = <({int pid, String? startMarker})>[];
   final List<String> operations = <String>[];
+  bool lockHeld = false;
 
   @override
   Future<T> withLock<T>({
@@ -543,7 +830,12 @@ class _FakeStartupMutexRepository() implements StartupMutexRepository {
             ),
       );
     }
-    return await onLockAcquired();
+    lockHeld = true;
+    try {
+      return await onLockAcquired();
+    } finally {
+      lockHeld = false;
+    }
   }
 }
 

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -36,8 +36,11 @@ idle suspension, the management snapshot, and lifecycle commands.
   any request; later requests fail immediately until a fresh connection is established.
   Without interception the existing ACP transport behavior is unchanged.
 - Runtime resolution before start may resolve a suitable existing or managed binary but
-  never downloads or mutates files, and failure there is non-fatal. The persisted disable
-  list is the only durable eligibility policy, with setup deciding blocked versus routable.
+  never downloads or mutates files, and failure there is non-fatal. Eligible descriptors
+  resolve and start concurrently within one startup batch; each settled descriptor closes
+  its generation stream independently, while the startup mutex remains held until every
+  descriptor settles. The persisted disable list is the only durable eligibility policy,
+  with setup deciding blocked versus routable.
 - Managed selection prefers the pinned target and otherwise takes the newest installed
   managed version still at or above the harness's minimum, so raising the target leaves
   the previous install usable rather than reporting the runtime as missing. A managed
@@ -322,6 +325,9 @@ owned-process exit; and restart.
 - A stalled first handshake holds bridge startup past the cold-start budget, a
   budget-exceeded harness reports connected instead of degraded, or its late
   cold-start failure surfaces as an unhandled error rather than a log line.
+- A slow descriptor's provisioning or start keeps a ready descriptor's generation
+  stream open, a descriptor-local failure takes down another descriptor, or the startup
+  mutex releases before every descriptor start settles.
 - An eligible harness dropped from listings, a drifting or unselectable default, or
   snapshot tokens that miss real changes.
 - A harness card showing raw version-probe output, a rejected runtime's version, or a version
@@ -414,6 +420,9 @@ owned-process exit; and restart.
   scopes, explicit inheritance, byte preservation, pre-log consumption, and cleanup.
 - `bridge/sesori_plugin_interface/lib/src/lifecycle/`; registered production plugin
   descriptors; plugin routing handlers
+- `bridge/app/lib/src/runtime/plugin_generation_factory.dart` and
+  `bridge/app/test/bridge/runtime/plugin_generation_factory_test.dart` cover concurrent
+  provisioning/start, per-descriptor stream settlement and startup mutex ownership.
 - `bridge/app/lib/src/services/plugin_lifecycle_service.dart`,
   `bridge/app/lib/src/services/plugin_warmup_service.dart`,
   `bridge/app/lib/src/listeners/plugin_warmup_setting_listener.dart`,


### PR DESCRIPTION
## Complexity
⚙️ Moderate: concurrent plugin startup under shared ownership protection, with independent request settlement.

## What
- Build hosts, resolve installed runtimes, and start descriptors concurrently within a startup batch.
- Release each plugin's startup stream when that plugin settles, without waiting for slow peers.
- Preserve startup mutex ownership for the whole batch and log late infrastructure failures.

## Why
A cold OpenCode startup delayed other harness imports despite existing parallel import dispatch. This removes cross-plugin blocking; it does not shorten OpenCode's own boot.

## Risk and test focus
Medium lifecycle/concurrency risk: fast-plugin availability, isolated startup failures, and mutex lifetime. No wire or database schema changes; no database migration or data deletion.

## Expected result
Ready harnesses import while slower harnesses boot. Existing catalog content remains available. Step 2 will add read-only OpenCode DB import with server fallback, plus shorter import-only idle residency.

## Verification
- Pinned Dart 3.13.2 formatting passed.
- Plugin generation factory tests: 20 passed.
- bridge/app dart analyze --fatal-infos: no issues.
- Architecture plan and implementation reviews approved; late infrastructure logging finding applied.
- git diff --check passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Starts plugin provisioning and startup concurrently within each startup batch instead of handling descriptors one at a time, so a ready harness can import while another plugin is still booting. Each descriptor now settles its generation stream independently, while the startup mutex remains held until the entire batch completes.

- Isolates provisioning and startup failures to the affected descriptor.
- Adds coverage for concurrent provisioning, independent stream closure, failure isolation, and mutex lifetime.
- Documents the new lifecycle guarantees and regression cases.

<sup>Written for commit 18878f116bfe9e96451a498328df702a5be41989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

