### PR TITLE
🌿 Update Codex target to 0.153.4 with normal release checks

### DIFF
--- a/.agents/skills/update-codex-harness/SKILL.md
+++ b/.agents/skills/update-codex-harness/SKILL.md
@@ -24,6 +24,16 @@ root; stop and report a missing handoff if absent. Use the current Codex manifes
 as the asset-layout authority: older instructions may describe obsolete bare
 CLI archives. Do not substitute those for canonical package archives.
 
+## Normal release-check policy
+
+Target refreshes use normal release checks: the official stable release,
+verified hashes for all managed archives, isolated current-host install/version/
+protocol smoke checks, and focused package tests/analyzer. Do not require
+source-to-binary attestations, reproducible builds, or a multi-platform live
+probe matrix. Missing optional provenance evidence is a reporting limitation,
+not a blocker or a reason to ask for an exception on each update. Keep the
+compatibility minimum unchanged unless the user explicitly approves raising it.
+
 ## Scope and invariants
 
 Read `bridge/AGENTS.md` before production edits. Inspect:
@@ -103,18 +113,12 @@ Preserve these invariants:
    downloading. Re-resolve both tags before using a diff and immediately before
    approval; require exact equality. A moved, missing, or ambiguous tag requires
    stopping and restarting the audit. Use recorded SHAs, not tags, afterward.
-5. Verify source-to-artifact provenance for every managed archive. Inspect the
-   designated release workflow and published provenance at the recorded SHA.
-   Accept an attestation only after a trusted verifier cryptographically checks
-   it, enforcing an allowlisted issuer, exact `openai/codex` repository and
-   designated release-workflow identity, audited commit, and artifact digest.
-   Matching unverified fields or a self-signed statement are insufficient.
-   Otherwise reproduce every archive from the recorded SHA in a disposable
-   container/VM/restricted account with no secrets or sensitive mounts and
-   tightly constrained outbound access; compare normalized contents and digest.
-   If neither path is available, mark provenance unverified and pinning blocked.
-   A GitHub digest, platform code signature, or benign probe alone does not prove
-   that the audited source produced the archive.
+5. Inspect release-workflow and packaging changes as part of the source audit.
+   Provenance attestations or reproducible-build evidence may be recorded when
+   already available, but are not required for a normal target refresh. Do not
+   start a separate rebuild/provenance project or block pinning because that
+   evidence is absent. Report checksum integrity separately from source-to-binary
+   provenance; a checksum or smoke test does not prove the latter.
 
 ## Phase 2 — Audit the aggregate release diff
 
@@ -200,7 +204,7 @@ unknown events appropriately, permit legitimately omitted new fields, and retain
 existing behavior. Do not add version branches merely because shapes differ.
 For genuinely incompatible semantics, evaluate a narrow interface with two
 version-specific implementations inside the plugin. Select only from validated
-runtime version/provenance or an explicitly verified handshake identity, never
+runtime version or an explicitly verified handshake identity, never
 an incidental event or an assumed PATH binary version. State branch retirement
 and minimum version. Never weaken approval or sandbox semantics to accommodate
 an older runtime.
@@ -216,8 +220,8 @@ the host result. Record the tested asset and digest, OS/architecture, disposable
 boundary, production extraction/placement, exact version, stdio handshake, and
 WebSocket handshake results. Both current-host transports must be checked.
 
-1. Establish a current-host disposable VM/container/restricted OS account before
-   parsing archive contents. No sensitive mounts; block outbound network access
+1. Establish a current-host native OS sandbox or disposable VM/container/restricted
+   OS account before parsing archive contents. No sensitive mounts; block outbound network access
    (local loopback may be allowed for WebSocket probes). Temporary HOME or
    environment filtering alone is not a sandbox. If no boundary is available,
    do not inspect, extract, or execute the host archive; report the current-host
@@ -317,11 +321,11 @@ WebSocket handshake results. Both current-host transports must be checked.
    capability gates, and required helpers. Schema generation inside the same
    boundary can supplement probes, not replace live protocol checks.
 
-Skipped or failed provenance, current-host extraction, version, or required
-current-host transport checks block the target refresh. Missing install/launch
+Skipped or failed current-host extraction, version, or required transport checks
+block the target refresh. Missing install/launch
 results for other platforms do not block it. Optional platform checks may be
 added for a concrete release change or regression; report any observed failure.
-All six archive digests and source-to-artifact verification remain required.
+All six archive digests remain required; source-to-binary provenance is optional.
 Never mix old digests with a new shared release URL. Continue source-only audit
 and report useful findings even when pinning is blocked; label them unprobed.
 
@@ -332,7 +336,7 @@ Before editing target or protocol code report:
 - old target, candidate stable version/date, npm agreement, unchanged minimum;
 - recorded old/new SHAs, tag recheck, six asset names/sizes/digests, explicitly
   separating published metadata, checksum-list agreement, and downloaded hashes;
-- source-to-artifact evidence or blocker; complete diff size/coverage;
+- complete diff size/coverage; any optional provenance evidence, clearly labeled;
 - high/medium findings with immutable links and actual app-server visibility;
 - current-host OS/architecture, extraction, version, stdio and WebSocket results;
   list other platforms as untested unless optionally checked;
@@ -340,9 +344,10 @@ Before editing target or protocol code report:
 - tolerant-path versus justified version-selected implementation strategy and
   compatibility retirement thresholds.
 
-Ask approval for proposed production scope only after stating blockers.
-Approval does not turn missing verification into passing evidence. A requested
-skill-only documentation PR may proceed while production changes stay gated.
+An explicit request to update the target approves the version-only bump; do not
+ask for that approval again or request an exception for optional provenance.
+Ask before adding capabilities or raising the minimum. Report failures of the
+required normal checks; approval does not turn them into passing evidence.
 Do not raise the minimum implicitly. If separately approved, remove obsolete
 compatibility branches, tests and docs below the new floor rather than retaining
 internal shims. Apply repository architecture-review rules only to approved
@@ -350,9 +355,9 @@ architecture-bearing production work, not this skill or a target-only edit.
 
 ## Phase 5 — Implement only after approval and passing gates
 
-Require all six archive digests, source-to-artifact verification, successful
-current-host install/version/transport probes, and user approval. Other
-platforms do not require installation or launch probes; their untested status
+Require all six archive digests, successful current-host install/version/transport
+probes, and user approval for the scope. Source-to-binary provenance is optional.
+Other platforms do not require installation or launch probes; their untested status
 does not block the complete six-asset target update.
 
 1. Update `CodexRuntimeManifest.targetVersion`, six matching digests, and
@@ -402,8 +407,9 @@ changed. Do not repeat unchanged passing commands. For skill/docs-only changes,
 validate frontmatter, referenced local paths, protocol examples, Markdown and
 diff hygiene; do not run Dart/Flutter suites.
 
-Keep the requested skill/documentation change in its own PR, separate from
-runtime/protocol implementation. Commit and push when ready, using real multiline
+Include directly related workflow clarifications with a target bump when the
+user requests the same PR; otherwise keep independently requested skill work
+separate. Commit and push when ready, using real multiline
 Markdown via `--body-file`/stdin with `## Complexity`, `## What`, `## Why`,
 `## Risk and test focus`, `## Expected result`, and `## Verification`. Use the
 repository's implementation-complexity emoji prefix and series title convention
@@ -412,5 +418,5 @@ work. Load `monitor-pr` and start `pr_monitor` immediately after opening a PR;
 never enable auto-merge or invent polling loops if monitoring is unavailable.
 
 Final report: old/new target, unchanged minimum, six digest statuses,
-adopted/deferred findings, provenance/probe blockers, tests, PR link, remaining
-upstream/platform risks. An audit stopped at approval is not an implemented bump.
+adopted/deferred findings, normal-check failures or optional evidence gaps,
+tests, PR link, and remaining upstream/platform risks. An audit stopped at approval is not an implemented bump.

--- a/.agents/skills/update-pi-harness/SKILL.md
+++ b/.agents/skills/update-pi-harness/SKILL.md
@@ -28,6 +28,16 @@ mechanism available to the agent, resolving the path from the repository root,
 before proceeding. If that path is absent, stop and report the missing handoff
 rather than assuming this Pi-only workflow covers other backends.
 
+## Normal release-check policy
+
+Target refreshes use normal release checks: the official stable release,
+verified hashes for all managed archives, isolated current-host install/version/
+protocol smoke checks, and focused package tests/analyzer. Do not require
+source-to-binary attestations, reproducible builds, or a multi-platform live
+probe matrix. Missing optional provenance evidence is a reporting limitation,
+not a blocker or a reason to ask for an exception on each update. Keep the
+compatibility minimum unchanged unless the user explicitly approves raising it.
+
 ## Scope and invariants
 
 Relevant production files normally include:
@@ -89,26 +99,16 @@ compatibility change:
    Download `SHA256SUMS` when present and confirm every line agrees with the
    GitHub asset digest. Do not guess mappings, accept a missing digest, flatten
    an archive, or invoke Pi's installer scripts.
-4. Verify source-to-artifact provenance before treating the assets as eligible
-   for pinning. Resolve both the current and candidate release tags to full,
-   immutable commit SHAs (`oldCommitSha` and `newCommitSha`) and record them
-   before diffing or downloading. Re-resolve the public tags immediately before
-   approval and require exact equality; if a tag moved, disappeared, or is
-   ambiguous, stop and restart the audit. Inspect the release workflow or other
-   published provenance for every asset. Accept an attestation only after a
-   trusted verifier cryptographically validates its signature and the verifier
-   enforces an allowlisted issuer plus the exact upstream repository and
-   designated release-workflow identity, with the audited commit and asset
-   digest as subjects. Never accept an arbitrary self-signed statement or an
-   attestation merely because its fields match; if no trusted verifier and
-   allowlist are available, provenance is unverified. Otherwise reproduce each
-   target archive from the exact recorded commit SHA (not a re-resolved tag) in
-   a disposable container/VM or restricted account with no sensitive mounts,
-   no inherited secrets, and tightly constrained outbound access. Compare the
-   normalized contents and resulting digest. If neither verifiable provenance
-   nor a reproducible build path can run within that boundary, mark the pin
-   blocked and report why; a GitHub-generated digest and a benign probe prove
-   integrity and basic behavior, not source-to-artifact identity.
+4. Resolve both the current and candidate release tags to full immutable commit
+   SHAs (`oldCommitSha` and `newCommitSha`) and record them before diffing or
+   downloading. Re-resolve the public tags immediately before approval and
+   require exact equality; if a tag moved, disappeared, or is ambiguous, stop and
+   restart the audit. Inspect release-workflow and packaging changes as part of
+   the source audit. Provenance attestations or reproducible-build evidence may
+   be recorded when already available, but are not required for a normal target
+   refresh. Do not start a separate rebuild/provenance project or block pinning
+   because that evidence is absent. Report checksum integrity separately from
+   source-to-binary provenance; a checksum or smoke test does not prove the latter.
 
 ## Phase 2 — Audit the release diff in aggregate
 
@@ -267,7 +267,7 @@ add version branches merely because an API technically permits them.
 If the semantics are genuinely incompatible and the compatibility code is large
 or hard to reason about, explicitly evaluate a narrow shared interface with two
 Pi-version-specific implementations. Select the implementation only from a
-validated runtime version/provenance (the managed manifest or a validated PATH
+validated runtime version (the managed manifest or a validated PATH
 probe); Pi has no handshake, so never infer a version from an event or silently
 assume the binary behind `PATH`. Keep both implementations inside the Pi plugin
 and do not leak Pi-specific concepts into `bridge/app/` or client contracts.
@@ -301,8 +301,8 @@ JSONL/RPC `get_state` results. Treat downloaded archives as untrusted executable
 even after verifying their official digests:
 
 1. Establish the current-host disposable boundary before handling archive
-   contents. Use a suitable VM/container/restricted OS account with no sensitive
-   mounts and blocked outbound network access. A temporary `HOME`, Pi directories,
+   contents. Use a native OS sandbox or suitable VM/container/restricted OS account
+   with no sensitive mounts and blocked outbound network access. A temporary `HOME`, Pi directories,
    or allowlisted environment does not sandbox a process running as the
    maintainer's account. If this boundary is unavailable, do not inspect, extract,
    or execute the host archive; report the current-host probe as blocked.
@@ -392,7 +392,7 @@ A skipped or failed required current-host probe blocks the target refresh.
 Missing install/launch results for other platforms do not block it. Optional
 platform checks may be added for a concrete release change or regression; report
 any observed failure rather than treating it as a passing host limitation.
-All six archive digests and source-to-artifact verification remain required.
+All six archive digests remain required; source-to-binary provenance is optional.
 When approved, update the complete release consistently; never combine a new
 shared target URL with old asset digests.
 
@@ -407,8 +407,7 @@ Before editing the runtime target or production protocol code, report:
 - current target and candidate stable release/date;
 - unchanged PATH minimum;
 - all six asset names, sizes, and verified SHA-256 values;
-- source-to-artifact provenance or reproducible-build evidence, including any
-  blocker;
+- any optional provenance evidence, clearly distinguished from checksum integrity;
 - aggregate diff size and the high/medium findings with source links;
 - which findings are truly visible on JSONL/RPC stdout;
 - current-host OS/architecture, production extraction/placement, exact version,
@@ -419,9 +418,10 @@ Before editing the runtime target or production protocol code, report:
   version-selected interface with two implementations, including each
   branch's retirement/minimum version.
 
-Ask the user to approve the proposed production changes. A release audit is
-not permission to expand scope, raise the compatibility floor, or implement
-interesting but unverified upstream behavior. If the user approves a higher
+An explicit request to update the target approves the version-only bump; do not
+ask for that approval again or request an exception for optional provenance.
+Ask before adding capabilities or raising the minimum. A release audit is not
+permission to expand scope or implement unverified upstream behavior. If the user approves a higher
 minimum Pi version, inspect the compatibility branches, tests, and docs that
 only support versions below the new floor and delete the obsolete code rather
 than carrying it forward. The skill-only documentation PR may proceed when
@@ -431,8 +431,8 @@ explicitly requested, while the runtime/capability PR remains behind this gate.
 
 Enter this phase only after all six archive digests are verified, the
 current-host sandboxed production extraction/placement and live version/RPC
-probe pass, source-to-artifact provenance is verified (or the artifacts have
-been reproducibly rebuilt), and the user approves the resulting scope.
+probe pass, and the user approves the scope. Source-to-binary provenance is
+optional and does not block the refresh.
 Other platforms do not require installation or launch probes. Report their
 untested status without blocking the complete six-asset target update.
 
@@ -507,8 +507,9 @@ If the change affects shared runtime primitives, also run the owning foundation
 or runtime package tests. Do not rerun unchanged suites without a concrete
 reason.
 
-Keep the skill/documentation change in its own reviewable PR when requested;
-do not mix it with the Pi runtime or protocol implementation PR. Use a real
+Include directly related workflow clarifications with a target bump when the
+user requests the same PR; otherwise keep independently requested skill work
+separate. Use a real
 multiline PR body with these sections:
 
 - `## Complexity`

--- a/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
+++ b/bridge/sesori_plugin_codex/lib/src/runtime/codex_runtime_manifest.dart
@@ -23,13 +23,13 @@ import "package:sesori_plugin_runtime/sesori_plugin_runtime.dart";
 /// the downloaded archive), confirm the [_assets] filenames still match the
 /// release, raise [minPathVersion] only if the bridge starts to require a newer
 /// codex API, and re-run the integration tests. The hashes below are the
-/// published asset digests for codex `rust-v0.148.0`.
+/// published asset digests for codex `rust-v0.153.4`.
 class const CodexRuntimeManifest() extends RuntimeManifest {
   /// Minimum pre-installed codex version the bridge will use as-is.
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: "0.139.0");
 
   /// The latest stable codex release targeted by this plugin.
-  static const String targetVersion = "0.148.0";
+  static const String targetVersion = "0.153.4";
 
   /// The exact codex version the managed runtime installs.
   static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
@@ -44,7 +44,7 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
         assetName: "codex-package-aarch64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "bfae69c7bb7a3fbe68161f2ca9328839c7e6eea053a8871186eb6edbb1346870",
+        sha256: "35438da1fbf7a6db7ddb3bcec84448fa6015ba188461472a97d9d1da7d9c4353",
         archiveBinaryName: "bin/codex",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
@@ -52,7 +52,7 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
         assetName: "codex-package-x86_64-apple-darwin.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "9ac9245ea244629a9ba4db3315f0cdaebb05182b790ee34271a5060875d836e1",
+        sha256: "3ee638d7155c856ef31f3f4a85cb2195de1939962d3924c935b24f0514564a3d",
         archiveBinaryName: "bin/codex",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
@@ -62,7 +62,7 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
         assetName: "codex-package-aarch64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "580db3c7411f5852b550876f185c30b61b674e01b948fd5030f2cd7a30db110a",
+        sha256: "fc395cb043a1093ab0db34f44aba3199bfaa9ce640cd9be7fd588f44b0da64a4",
         archiveBinaryName: "bin/codex",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
@@ -70,7 +70,7 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
         assetName: "codex-package-x86_64-unknown-linux-musl.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "8c790500af2ba6e74ce4948fe26c651ac1f77f6dbb005b47c8d26ff711146262",
+        sha256: "a822187e1a2420c61c5926721bfbd878701ed95547c9bb0d4de4498a16ba1821",
         archiveBinaryName: "bin/codex",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
@@ -80,7 +80,7 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
         assetName: "codex-package-aarch64-pc-windows-msvc.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "0258ac84ebf8fdc6d8e1f4b0541d55a703f3d8996debca157a013cf753134c54",
+        sha256: "ac51b1a5932e07dffcaa6e98f4801f13b25192094739b732fc8b40ddb41bbda2",
         archiveBinaryName: "bin/codex.exe",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
@@ -88,7 +88,7 @@ class const CodexRuntimeManifest() extends RuntimeManifest {
         assetName: "codex-package-x86_64-pc-windows-msvc.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "cc09f725b8ed133b76a2882fda750b3f1672b10701e8172c9680b5ab79b861ff",
+        sha256: "a6ef3442cb12766a88b39311d79244289e4f9763e2c53ff4fbebc2cb653cc5f3",
         archiveBinaryName: "bin/codex.exe",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),

--- a/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_codex/test/runtime/codex_runtime_manifest_test.dart
@@ -16,7 +16,7 @@ void main() {
     });
 
     test("pinned versions", () {
-      expect(CodexRuntimeManifest.targetVersion, "0.148.0");
+      expect(CodexRuntimeManifest.targetVersion, "0.153.4");
       expect(manifest.bundledVersion.toString(), CodexRuntimeManifest.targetVersion);
       expect(manifest.minPathVersion.toString(), "0.139.0");
       expect(manifest.runtimeId, const CodexPluginDescriptor().id);
@@ -29,31 +29,31 @@ void main() {
         PlatformOs.macos: {
           PlatformArch.arm64: (
             assetName: "codex-package-aarch64-apple-darwin.tar.gz",
-            sha256: "bfae69c7bb7a3fbe68161f2ca9328839c7e6eea053a8871186eb6edbb1346870",
+            sha256: "35438da1fbf7a6db7ddb3bcec84448fa6015ba188461472a97d9d1da7d9c4353",
           ),
           PlatformArch.x64: (
             assetName: "codex-package-x86_64-apple-darwin.tar.gz",
-            sha256: "9ac9245ea244629a9ba4db3315f0cdaebb05182b790ee34271a5060875d836e1",
+            sha256: "3ee638d7155c856ef31f3f4a85cb2195de1939962d3924c935b24f0514564a3d",
           ),
         },
         PlatformOs.linux: {
           PlatformArch.arm64: (
             assetName: "codex-package-aarch64-unknown-linux-musl.tar.gz",
-            sha256: "580db3c7411f5852b550876f185c30b61b674e01b948fd5030f2cd7a30db110a",
+            sha256: "fc395cb043a1093ab0db34f44aba3199bfaa9ce640cd9be7fd588f44b0da64a4",
           ),
           PlatformArch.x64: (
             assetName: "codex-package-x86_64-unknown-linux-musl.tar.gz",
-            sha256: "8c790500af2ba6e74ce4948fe26c651ac1f77f6dbb005b47c8d26ff711146262",
+            sha256: "a822187e1a2420c61c5926721bfbd878701ed95547c9bb0d4de4498a16ba1821",
           ),
         },
         PlatformOs.windows: {
           PlatformArch.arm64: (
             assetName: "codex-package-aarch64-pc-windows-msvc.tar.gz",
-            sha256: "0258ac84ebf8fdc6d8e1f4b0541d55a703f3d8996debca157a013cf753134c54",
+            sha256: "ac51b1a5932e07dffcaa6e98f4801f13b25192094739b732fc8b40ddb41bbda2",
           ),
           PlatformArch.x64: (
             assetName: "codex-package-x86_64-pc-windows-msvc.tar.gz",
-            sha256: "cc09f725b8ed133b76a2882fda750b3f1672b10701e8172c9680b5ab79b861ff",
+            sha256: "a6ef3442cb12766a88b39311d79244289e4f9763e2c53ff4fbebc2cb653cc5f3",
           ),
         },
       };
@@ -85,7 +85,7 @@ void main() {
         manifest.downloadUrlFor(asset: asset),
         equals(
           "https://github.com/openai/codex/releases/download/"
-          "rust-v0.148.0/codex-package-aarch64-apple-darwin.tar.gz",
+          "rust-v0.153.4/codex-package-aarch64-apple-darwin.tar.gz",
         ),
       );
     });


### PR DESCRIPTION
## Complexity
🌿 Straightforward runtime pin/hash refresh with related workflow clarification; no protocol implementation changes.

## What
- Update Codex managed target from **0.148.0 to 0.153.4**, including all six canonical package-archive SHA-256 values and manifest tests.
- Preserve PATH/managed compatibility minimum **0.139.0** byte-for-byte. Preserve package-directory layout, helper/resources, archive formats, entrypoints and extraction timeouts.
- Update both `.agents/skills/update-codex-harness/SKILL.md` and `.agents/skills/update-pi-harness/SKILL.md` in this PR, as requested: normal release checks are the standard. Source-to-binary attestations/reproducible builds are optional evidence, not blocking requirements or recurring exception requests.
- An explicit target-update request approves that version-only scope; minimum increases and additional capabilities still require explicit approval.

## Why
Use the current stable Codex release without forcing a compatibility-floor increase or requiring a separate provenance/rebuild project for ordinary updates. GitHub stable `rust-v0.153.4` (2026-09-04) and npm `@openai/codex` agree.

## Risk and test focus
Managed installs move to the newer upstream runtime; compatible PATH installs remain allowed. No Sesori database/schema changes or new client-facing features. Upstream behavior is a release regression risk, covered by focused tests and unauthenticated current-host probes—not authenticated model turns or other OS/architecture launches.

Source-to-binary provenance was not verified. Per explicit user policy, this is a documented limitation, not a release blocker. All six downloaded archive checksums were verified. Other platforms remain live-untested; no cross-platform success is claimed.

## Expected result
New managed Codex installs use 0.153.4. Existing compatible user installs remain supported from 0.139.0. Future Pi/Codex target refreshes use normal release checks without repeatedly asking to waive optional provenance evidence.

## Verification
- Downloaded all six official canonical package archives; full SHA-256 values match GitHub metadata and `codex-package_SHA256SUMS`. The checksum-list file's own digest also matches GitHub.
- Rechecked immutable release tags: old `3ba0f711642a888aec92a611a3f3b2211157ff89`, new `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`.
- macOS arm64: compiled a disposable harness using production `ManagedRuntimeComposition` → `ManagedRuntimeInstallService` → `RuntimeInstallService` → `ArchiveExtractor` and `RuntimeVersionValidator`, backed by the already verified official archive and an asserted manifest URL.
- Ran installer/candidate under macOS `sandbox-exec`: restricted filesystem access, no inherited credentials, temporary HOME/CODEX_HOME/caches/cwd, network limited to loopback, bounded processes and process-group cleanup.
- Host installer passed; final managed path, complete payload inventory including helper/resources, and separate digest sentinel verified.
- Exact `codex-cli 0.153.4` version passed.
- Stdio `initialize` → `initialized` → empty `thread/list` passed.
- WebSocket production JSON-RPC/capabilities `initialize` → empty `thread/list` passed without adding an `initialized` notification absent from the current production client.
- `dart test --reporter expanded`: **436 passed** in `bridge/sesori_plugin_codex`.
- `dart analyze --fatal-infos`: **No issues found** in the owning package.
- Dart format check: zero changes. Both skill documents' normal-check/minimum policy, JSON examples and Bash syntax validated; diff hygiene passed.
- Removed disposable archives, probe executables, profiles and logs after process cleanup. No normal Codex user profile or managed runtime was changed by the probes.

Historical 0.148.0 protocol observations and compatibility fixtures remain intentionally unchanged. The earlier source audit's potential capability integrations are deferred; none are silently included in this target-only bump.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the managed Codex runtime from 0.148.0 to 0.153.4 and makes provenance verification optional for future target refreshes.

- Updates all six canonical package archive SHA-256 hashes and manifest tests.
- Keeps the PATH compatibility minimum at 0.139.0.
- Revises both update skill docs so normal release checks are standard; source-to-binary attestations are no longer required or blocking.

**Migration**

- No user action required; existing PATH installs from 0.139.0 remain supported.

<sup>Written for commit 5bfe7ca854f7baeb85ff182af8e57d1009d80b7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

