### PR TITLE
⚙️ [claude-inline-subtasks] Codex typed child-prompt parsing [step 3/6]

### DIFF
--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -7,10 +7,13 @@
   and Cursor, merge, then moved back)
 - **Plan date:** 2026-09-02
 - **Base:** `main` at `6e9028c4c6`
-- **Delivery:** PRs titled `<emoji> [claude-inline-subtasks] <description>` with
-  no step counters. The four harness chains run in parallel; within a
-  chain PRs stack. E2E testing happens after each PR merges, not before.
-  Progress is tracked in `TRACKER.md` "Harness Follow-Ups".
+- **Delivery:** one open PR at a time, following current repository rules.
+  Remaining Codex PRs use `<emoji> [claude-inline-subtasks] <description>
+  [step x/5]`: metadata and child sessions are merged steps 1/5 and 2/5;
+  tiles, scoped stop, and coverage are steps 3/5 through 5/5. Historical merged
+  titles remain unchanged. Progress is tracked in `TRACKER.md` "Harness
+  Follow-Ups". The DeepSeek phone handoff is recorded in
+  `followups/deepseek-phone-qa.md`; desktop remains deferred.
 
 ## Goal
 

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -9,9 +9,10 @@
 - **Base:** `main` at `6e9028c4c6`
 - **Delivery:** one open PR at a time, following current repository rules.
   Remaining Codex PRs use `<emoji> [claude-inline-subtasks] <description>
-  [step x/5]`: metadata and child sessions are merged steps 1/5 and 2/5;
-  tiles, scoped stop, and coverage are steps 3/5 through 5/5. Historical merged
-  titles remain unchanged. Progress is tracked in `TRACKER.md` "Harness
+  [step x/6]`: metadata and child sessions are merged steps 1/6 and 2/6;
+  typed child-prompt parsing, tiles, scoped stop, and coverage are steps 3/6
+  through 6/6. Historical merged titles remain unchanged. User-authorized
+  packaging split only; approved behavior and architecture are unchanged. Progress is tracked in `TRACKER.md` "Harness
   Follow-Ups". The DeepSeek phone handoff is recorded in
   `followups/deepseek-phone-qa.md`; desktop remains deferred.
 
@@ -279,13 +280,14 @@ confirmation, no child session or partial stop) and gets that subset.
 
 ### PRs
 
-| Emoji | Description | Scope |
-|---|---|---|
-| 🌿 | `codex: parse sub-agent thread and item metadata` | DTO fields, collab/activity parser and enums, fixtures from the probe |
-| ⚙️ | `codex: sub-agent threads become child sessions` | repository/mapper/service child-session flow, `parentID` live and from the catalog, roots-only listing, service-owned `getChildSessions` merge, directory attribution, summary rolls busy children into the root. Fixes the root-leak defect |
-| 🚧 | `codex: inline subtask tiles for spawned agents` | service-coordinated tracker, mapper cases, cancel on close/disconnect, call-id replacement of the generic spawn card in rollout-tail and full-history replay, child-rollout terminal join |
-| ⚙️ | `codex: scoped stop for sub-agent threads` | policy switch, per-child interrupt, `mainAgentOnlySupported` per probe, `interruptActiveWork` covers children |
-| 🌱 | `docs: record Codex sub-agent coverage` | matrix footnote ³ resolved, regression docs |
+| Step | Emoji | Description | Scope |
+|---|---|---|---|
+| 1/6 | 🌿 | `codex: parse sub-agent thread and item metadata` | Merged historical title unchanged; DTO fields, collab/activity parser and enums, fixtures from the probe |
+| 2/6 | ⚙️ | `codex: sub-agent threads become child sessions` | Merged historical title unchanged; repository/mapper/service child-session flow, `parentID` live and from the catalog, roots-only listing, service-owned `getChildSessions` merge, directory attribution, summary rolls busy children into the root. Fixes the root-leak defect |
+| 3/6 | ⚙️ | `codex: parse typed child prompts from thread reads` | `thread/read` includes turns; typed turn/item/content DTOs and Layer-2 first-user-prompt extraction, with generated serializers and focused tests. Preparatory packaging only; no tile behavior |
+| 4/6 | 🚧 | `codex: inline subtask tiles for spawned agents` | service-coordinated tracker, mapper cases, cancel on close/disconnect, call-id replacement of the generic spawn card in rollout-tail and full-history replay, child-rollout terminal join |
+| 5/6 | ⚙️ | `codex: scoped stop for sub-agent threads` | policy switch, per-child interrupt, `mainAgentOnlySupported` per probe, `interruptActiveWork` covers children |
+| 6/6 | 🌱 | `docs: record Codex sub-agent coverage` | matrix footnote ³ resolved, regression docs |
 
 ### Probe results (0.148.0, 2026-09-02, details in `followups/codex-probe.md`)
 

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -243,8 +243,10 @@ confirmation, no child session or partial stop) and gets that subset.
   renders once the prompt is known, because the part requires one and the
   activity item carries none: the child's first `userMessage` item under the
   child thread id supplies it, and when the child streams no such item the
-  `thread/read` result (the child's turns) is used instead; the tile PR
-  verifies which source 0.148.0 provides. The child's own `turn/completed` completes it, a
+  `thread/read` result is used only after the exact child `turn/started` id
+  matches a typed turn. Forked reads contain copied parent turns, so no
+  heuristic first/last-turn fallback is allowed and missing turn provenance
+  remains no fallback. The child's own `turn/completed` completes it, a
   child `turn/interrupt` cancels it, and `thread/closed` cancels it only while
   it is pending or running; a prior completed, failed, interrupted, or errored
   terminal state wins over the later close. A child turn failure errors it,
@@ -284,7 +286,7 @@ confirmation, no child session or partial stop) and gets that subset.
 |---|---|---|---|
 | 1/6 | 🌿 | `codex: parse sub-agent thread and item metadata` | Merged historical title unchanged; DTO fields, collab/activity parser and enums, fixtures from the probe |
 | 2/6 | ⚙️ | `codex: sub-agent threads become child sessions` | Merged historical title unchanged; repository/mapper/service child-session flow, `parentID` live and from the catalog, roots-only listing, service-owned `getChildSessions` merge, directory attribution, summary rolls busy children into the root. Fixes the root-leak defect |
-| 3/6 | ⚙️ | `codex: parse typed child prompts from thread reads` | `thread/read` includes turns; typed turn/item/content DTOs and Layer-2 first-user-prompt extraction, with generated serializers and focused tests. Preparatory packaging only; no tile behavior |
+| 3/6 | ⚙️ | `codex: parse typed child prompts from thread reads` | `thread/read` includes turn ids/items/content; Layer-2 caches text prompts by turn id for exact child-lifecycle selection, with generated serializers and focused inherited-history/unknown-variant tests. Preparatory packaging only; no tile behavior |
 | 4/6 | 🚧 | `codex: inline subtask tiles for spawned agents` | service-coordinated tracker, mapper cases, cancel on close/disconnect, call-id replacement of the generic spawn card in rollout-tail and full-history replay, child-rollout terminal join |
 | 5/6 | ⚙️ | `codex: scoped stop for sub-agent threads` | policy switch, per-child interrupt, `mainAgentOnlySupported` per probe, `interruptActiveWork` covers children |
 | 6/6 | 🌱 | `docs: record Codex sub-agent coverage` | matrix footnote ³ resolved, regression docs |

--- a/.plan/active/claude-inline-subtasks/PLAN.md
+++ b/.plan/active/claude-inline-subtasks/PLAN.md
@@ -17,7 +17,10 @@
 - **DeepSeek follow-up (2026-09-06):** PR #1356 was closed without merge and
   superseded by two simpler slices: step 4/5 pins and consumes the published
   v0.1.4 native contract/input cancellation; step 5/5 completes ACP-owned stop.
-  Final phone/desktop E2E remains user-owned and precedes Codex work.
+  Both slices merged (#1363, #1370). Agent-run phone QA found the transport
+  crash fixed by #1379; requested phone stop/input checks then passed. See
+  `followups/deepseek-phone-qa.md`. Desktop is deferred by user choice;
+  Codex inline tiles are next, without retiring the overall harness plan.
 
 ## Goal
 

--- a/.plan/active/claude-inline-subtasks/PLAN.md
+++ b/.plan/active/claude-inline-subtasks/PLAN.md
@@ -19,8 +19,10 @@
   v0.1.4 native contract/input cancellation; step 5/5 completes ACP-owned stop.
   Both slices merged (#1363, #1370). Agent-run phone QA found the transport
   crash fixed by #1379; requested phone stop/input checks then passed. See
-  `followups/deepseek-phone-qa.md`. Desktop is deferred by user choice;
-  Codex inline tiles are next, without retiring the overall harness plan.
+  `followups/deepseek-phone-qa.md`. Desktop is deferred by user choice. Codex
+  now uses a user-authorized six-step packaging sequence: typed child-prompt
+  parsing is step 3/6 and inline tiles step 4/6, with approved behavior and
+  architecture unchanged. Overall harness plan remains active.
 
 ## Goal
 

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -8,10 +8,11 @@
   [#1257](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1257), which
   also made the scoped stop harness-neutral (OpenCode honors it; rejections
   declare `mainAgentOnlySupported`) and added `docs/HARNESS_CAPABILITIES.md`;
-  the series is retired
-- **Next action:** finish review of native-stop step 5/5 (#1370); step 4/5
-  (#1363) is merged. PR #1356 remains closed without merge. Complete
-  user-owned DeepSeek phone/desktop E2E after step 5/5 merges, before Codex.
+  the original Claude series is complete; harness follow-ups remain active
+- **Next action:** Codex inline subtask tiles (step 3/5). DeepSeek #1363,
+  #1370, and the live-QA crash fix #1379 are merged. Requested phone-only
+  stop/input checks passed; see `followups/deepseek-phone-qa.md`. Desktop
+  remains deferred by user choice; the overall plan remains active.
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
   Step 3 capture below (CLI 2.1.257); the completed
   `claude-code-plugin/PROTOCOL.md` is historical and is not edited
@@ -179,7 +180,7 @@ post-merge E2E gates are unchanged.
 | [x] | DeepSeek (adapter) | `🚧 [claude-inline-subtasks] DeepSeek atomic subtree cancellation [step 2/3]` | Adapter #17 merged at `5eecdf68a3` |
 | [x] | DeepSeek (adapter) | `release: prepare v0.1.4 for atomic-stop consumer` | Adapter #18 merged at `e2ea207f21`; v0.1.4 published and verified |
 | [x] | DeepSeek native stop | `⚙️ [claude-inline-subtasks] DeepSeek native stop contract and input ordering [step 4/5]` | [#1363](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1363) merged at `b13d197d51`; replaces the contract/pin portion of closed #1356 |
-| [ ] | DeepSeek native stop | `🚧 [claude-inline-subtasks] DeepSeek completes ACP-owned scoped stop [step 5/5]` | [#1370](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1370) in review; final phone/desktop E2E remains user-owned |
+| [x] | DeepSeek native stop | `🚧 [claude-inline-subtasks] DeepSeek completes ACP-owned scoped stop [step 5/5]` | [#1370](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1370) merged; transport crash fixed by #1379; phone handoff in `followups/deepseek-phone-qa.md`, desktop deferred |
 | [ ] | DeepSeek | `🌱 [claude-inline-subtasks] docs: record DeepSeek sub-agent coverage` | Pending final E2E matrix and plan retirement |
 | [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: subtask tiles and stop confirmation for task subagents` | Not started |
 | [ ] | Cursor | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage` | Not started |
@@ -726,9 +727,11 @@ interrupt response fields while retaining required/known-result checks; analysis
 and 104 tests pass. Named foreground children now correctly reject main-only stop
 even when all descendants are background; background named-child keep remains
 supported. ACP analysis + 312 tests and DeepSeek analysis + 106 tests pass.
-Replacement delivery (2026-09-06): PR #1356 closed without merge. Step 4/5
-lands only the frozen v0.1.4 contract, ordered input cancellation, runtime pin,
-and initialize-version boundary. Step 5/5 will replace the existing direct-child
-policy with complete ACP-owned native stop. Until then scoped-stop behavior is
-unchanged. Final phone/desktop E2E is user-owned, then Codex; managed-runtime
-automation remains separately owned.
+Replacement delivery completed (2026-09-08): PR #1356 remains closed without
+merge. #1363 landed the frozen v0.1.4 contract, ordered input cancellation,
+runtime pin, and initialize-version boundary. #1370 landed complete ACP-owned
+native stop. Phone QA found the shared IOSink crash fixed by #1379; the
+corrected independent-scope stop and pending/later-input checks passed.
+`followups/deepseek-phone-qa.md` records the bounded evidence and follow-ups.
+The user deferred desktop and requested progression to Codex after phone checks;
+managed-runtime automation remains separately owned.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -740,18 +740,27 @@ The user deferred desktop and requested progression to Codex after phone checks;
 managed-runtime automation remains separately owned.
 
 Codex delivery split (user-authorized): complete typed-prompt + tile source is
-preserved on local branch `claude-inline-subtasks-codex-tiles-successor` before
-extracting review scope, then rebased without reset as the review-ready local
-branch `claude-inline-subtasks-codex-tiles-successor-ready` atop step 3/6. Full-source Codex `dart analyze --fatal-infos`, focused
-live/replay/terminal tests, and the owning package test suite passed. Step 3/6
-contains typed `thread/read` prompt parsing/codegen only; step 4/6 retains exact
-call-id replacement, service-owned lifecycle, child terminal joins, and cleanup
-without design changes. Review this branch only against `origin/main`; do not
-include the preserved successor in the preparatory PR.
+preserved unchanged on local branch
+`claude-inline-subtasks-codex-tiles-successor` (`8f9923b663`) and the
+review-ready snapshot remains on
+`claude-inline-subtasks-codex-tiles-successor-ready` (`8a2952f318`). Those
+snapshots predate the step 3/6 provenance correction and must be integrated
+later without losing their tile work. Full-source successor Codex
+`dart analyze --fatal-infos`, focused live/replay/terminal tests, and the owning
+package test suite passed before extraction. Step 3/6 contains typed
+`thread/read` prompt parsing/codegen only; step 4/6 retains exact call-id
+replacement, service-owned lifecycle, child terminal joins, and cleanup without
+design changes. Review this branch only against `origin/main`; do not include
+preserved successor source in the preparatory PR.
 
-Codex step 3/6 verification: generated Freezed/JSON sources from typed inputs;
-`dart analyze --fatal-infos` and the complete `sesori_plugin_codex` test suite
-passed on the isolated preparatory tree. Diff is 792 changed lines before this
-verification note (+758/-34 including the one existing integration expectation),
-well below the 1,500-line review target. No tile lifecycle, stop policy, runtime
-pin, native adapter, client, shared contract, or database behavior changes.
+Codex step 3/6 correction: `thread/read` now parses turn ids and caches typed
+`text` prompts by turn id. `initialUserPrompt` requires the child lifecycle's
+exact, nullable `turnId`; null or unmatched provenance returns null instead of
+choosing copied parent history. The step 4/6 integration must resolve this cache
+when the existing `turn/started` owner observes the child turn id, while keeping
+live child-message prompt selection first and this read result as fallback.
+Unsupported rollout-only `input_text` decodes through the unknown content
+variant. Generated Freezed/JSON sources, the focused eight-test metadata suite,
+`dart analyze --fatal-infos`, and the complete `sesori_plugin_codex` test suite
+pass. No tile lifecycle, stop policy, runtime pin, native adapter, client,
+shared contract, or database behavior changes.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -9,7 +9,9 @@
   also made the scoped stop harness-neutral (OpenCode honors it; rejections
   declare `mainAgentOnlySupported`) and added `docs/HARNESS_CAPABILITIES.md`;
   the original Claude series is complete; harness follow-ups remain active
-- **Next action:** Codex inline subtask tiles (step 3/5). DeepSeek #1363,
+- **Next action:** Codex typed child-prompt parsing (step 3/6), followed by
+  inline subtask tiles (step 4/6). This is a user-authorized packaging split;
+  approved behavior and architecture are unchanged. DeepSeek #1363,
   #1370, and the live-QA crash fix #1379 are merged. Requested phone-only
   stop/input checks passed; see `followups/deepseek-phone-qa.md`. Desktop
   remains deferred by user choice; the overall plan remains active.
@@ -161,11 +163,12 @@ post-merge E2E gates are unchanged.
 | Done | Harness | Description | State |
 |---|---|---|---|
 | [x] | all | `🌱 [claude-inline-subtasks] docs: plan Codex, Grok Build, DeepSeek, and Cursor sub-agent follow-ups` | [PR #1260](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1260) merged |
-| [x] | Codex | `🌿 [claude-inline-subtasks] codex: parse sub-agent thread and item metadata` | [PR #1263](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1263) merged |
-| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: sub-agent threads become child sessions` | [PR #1273](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1273) merged; lifecycle hardening [PR #1280](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1280) merged |
-| [ ] | Codex | `🚧 [claude-inline-subtasks] codex: inline subtask tiles for spawned agents` | Not started |
-| [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: scoped stop for sub-agent threads` | Not started |
-| [ ] | Codex | `🌱 [claude-inline-subtasks] docs: record Codex sub-agent coverage` | Not started |
+| [x] | Codex | `🌿 [claude-inline-subtasks] codex: parse sub-agent thread and item metadata` | [PR #1263](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1263) merged; historical title unchanged (step 1/6) |
+| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: sub-agent threads become child sessions` | [PR #1273](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1273) merged; lifecycle hardening [PR #1280](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1280) merged; historical title unchanged (step 2/6) |
+| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse typed child prompts from thread reads [step 3/6]` | Implemented on `claude-inline-subtasks-codex-tiles`; preparatory parsing/codegen only |
+| [ ] | Codex | `🚧 [claude-inline-subtasks] codex: inline subtask tiles for spawned agents [step 4/6]` | Full checkpoint preserved on local branch `claude-inline-subtasks-codex-tiles-successor`; review-ready successor on `claude-inline-subtasks-codex-tiles-successor-ready`; neither published |
+| [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: scoped stop for sub-agent threads [step 5/6]` | Not started |
+| [ ] | Codex | `🌱 [claude-inline-subtasks] docs: record Codex sub-agent coverage [step 6/6]` | Not started |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] grok: parse sub-agent lifecycle notifications` | [PR #1270](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1270) merged |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] acp: child sessions keep the root busy` | [PR #1272](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1272) merged |
 | [ ] | Grok | `🌿 [claude-inline-subtasks] grok: child session history` | Not started |
@@ -735,3 +738,20 @@ corrected independent-scope stop and pending/later-input checks passed.
 `followups/deepseek-phone-qa.md` records the bounded evidence and follow-ups.
 The user deferred desktop and requested progression to Codex after phone checks;
 managed-runtime automation remains separately owned.
+
+Codex delivery split (user-authorized): complete typed-prompt + tile source is
+preserved on local branch `claude-inline-subtasks-codex-tiles-successor` before
+extracting review scope, then rebased without reset as the review-ready local
+branch `claude-inline-subtasks-codex-tiles-successor-ready` atop step 3/6. Full-source Codex `dart analyze --fatal-infos`, focused
+live/replay/terminal tests, and the owning package test suite passed. Step 3/6
+contains typed `thread/read` prompt parsing/codegen only; step 4/6 retains exact
+call-id replacement, service-owned lifecycle, child terminal joins, and cleanup
+without design changes. Review this branch only against `origin/main`; do not
+include the preserved successor in the preparatory PR.
+
+Codex step 3/6 verification: generated Freezed/JSON sources from typed inputs;
+`dart analyze --fatal-infos` and the complete `sesori_plugin_codex` test suite
+passed on the isolated preparatory tree. Diff is 792 changed lines before this
+verification note (+758/-34 including the one existing integration expectation),
+well below the 1,500-line review target. No tile lifecycle, stop policy, runtime
+pin, native adapter, client, shared contract, or database behavior changes.

--- a/.plan/active/claude-inline-subtasks/followups/deepseek-phone-qa.md
+++ b/.plan/active/claude-inline-subtasks/followups/deepseek-phone-qa.md
@@ -1,0 +1,62 @@
+# DeepSeek phone QA handoff
+
+Date: 2026-09-08. Scope: the user's phone-only verification before Codex;
+macOS desktop explicitly deferred. These results do not retire the overall
+harness plan or claim the unexecuted desktop matrix.
+
+## Target
+
+- Scoped-stop consumer #1370 merged at `c88d4ade82`.
+- Live QA found a shared IOSink crash; #1379 fixed it and merged at
+  `c436d3d4ae`. Final input checks ran on that merged source.
+- Real Flutter iOS simulator, auth/relay, isolated bridge slot, and published
+  DeepSeek adapter 0.1.4. Simulator and bridge account matched; YOLO disabled
+  through the phone and verified against local bridge settings.
+- `test-oai` was tried first and produced real permission requests. Its invalid
+  sandbox arguments prevented reliable descendant setup, so the authorized
+  Flash fallback was used for nested work and question checks.
+
+## Observed coverage
+
+| Scenario | Result |
+|---|---|
+| Pending permission | With the real sheet open, atomic Stop through the bridge API returned a handled ACK; permission rejection and idle followed, sheet disappeared, and the probe file was absent. This was not a phone Stop-button test. |
+| Phone confirmation/Cancel | Main plus two nested sub-agents counted; Cancel left all three controlled background jobs alive. |
+| Phone main-only keep | Next confirmation reported main done while descendants remained active. |
+| Independent resident scope | Resumed an existing child independently, started its grandchild, then stopped only the child's own main turn. Confirmation verified main not running with a running descendant. Ancestor Stop from the phone settled root, child, and grandchild idle without exiting bridge or native runtime. |
+| Subsequent prompt | After the corrected Stop, a new prompt produced the expected assistant marker and returned idle without a session error. |
+| Pending question | Open real question sheet disappeared after API Stop; captured question rejection preceded idle. |
+| Later input during Stop | Submitted a new prompt after the Stop request was written but before its response headers arrived (12 ms before response observation). Both requests returned HTTP 200 and Stop acknowledged complete handling. The new, distinct question remained visible and usable on the phone. |
+| Answer after Stop | Selected and submitted an answer to that later question on the phone. Pending questions became empty; assistant acknowledged the selected answer; Stop control disappeared. |
+
+The first ordinary nested-stop attempt used jobs close to natural expiry and
+was not counted as definitive process-cancellation evidence. The independent
+scope rerun used longer jobs and verified bridge/native process survival plus
+actual session settlement, not merely vanished process IDs.
+
+## Boundaries and follow-ups
+
+- Root-owned background shell jobs can remain after agent-turn cancellation.
+  This is separate from stopping descendant agents; no claim that Stop kills
+  every background OS process. Owned QA jobs were cleaned up explicitly.
+- The permission sheet showed a generic tool label and opaque call ID instead
+  of useful command context. Permission cancellation passed; complete permission
+  presentation did not. Keep that UX issue as a separate follow-up.
+- Timing evidence proves one real later-input interleaving, not every possible
+  network schedule. Package tests additionally cover frame ordering, reused
+  question IDs, held responses, and partial failure.
+- Desktop remains untested by explicit user choice. All pre-existing desktop,
+  standalone bridge, and another session's QA slot were preserved. Owned QA
+  processes stopped; simulator shut down and retained.
+
+Private screenshots, HTTP timing records, and logs remain in local QA artifact
+directories. Raw logs/transcripts must be reviewed and redacted before sharing.
+File-watch/stream-trigger timing probes were inconclusive; the successful HTTP
+write/response-timed probe and phone observations above are the evidence.
+
+## Handoff
+
+The requested phone stop/input checks are complete. Continue with Codex inline
+subtask tiles (step 3/5); its metadata and child-session foundations already
+merged in #1263, #1273, and #1280. Do not mark remaining harness coverage or the
+whole plan complete on the strength of this phone-only handoff.

--- a/.plan/active/claude-inline-subtasks/followups/deepseek-phone-qa.md
+++ b/.plan/active/claude-inline-subtasks/followups/deepseek-phone-qa.md
@@ -56,7 +56,7 @@ write/response-timed probe and phone observations above are the evidence.
 
 ## Handoff
 
-The requested phone stop/input checks are complete. Continue with Codex inline
-subtask tiles (step 3/5); its metadata and child-session foundations already
-merged in #1263, #1273, and #1280. Do not mark remaining harness coverage or the
+The requested phone stop/input checks are complete. Continue with Codex typed
+prompt parsing (step 3/6), then inline subtask tiles (step 4/6); its metadata
+and child-session foundations already merged in #1263, #1273, and #1280. Do not mark remaining harness coverage or the
 whole plan complete on the strength of this phone-only handoff.

--- a/.plan/active/claude-inline-subtasks/followups/deepseek-stop-replacement.md
+++ b/.plan/active/claude-inline-subtasks/followups/deepseek-stop-replacement.md
@@ -1,7 +1,9 @@
 # DeepSeek scoped-stop replacement
 
 PR #1356 is closed without merge; its source is preserved at `58bbe71384a7d5f71b00cad3e573995e4fbb587a`.
-Replacement step 4/5 merged as #1363 at `b13d197d51`; step 5/5 is in review as #1370, with user-owned E2E still outstanding.
+Replacement step 4/5 merged as #1363 at `b13d197d51`; step 5/5 merged as #1370 at `c88d4ade82`.
+Phone QA found the shared transport crash fixed by #1379 at `c436d3d4ae`; requested phone checks then passed.
+See `deepseek-phone-qa.md` for evidence and limitations. Desktop remains deferred by user choice.
 Each replacement targets at most 1,500 changed lines including generated code, tests, fixtures, and documentation.
 The adapter checkout is read-only evidence: v0.1.4 is already released, with no new native release planned.
 
@@ -87,4 +89,6 @@ ordering. Step 5 covers delayed admission, settled/nested independent roots, ret
 loads, keep/confirm, partial failure, frames before responses, later-work survival, reset/close, mixed public versions,
 and legacy reload fallback. Run relevant bridge/client and impacted mobile title-hydration/split-pane tests,
 not the old DI fix.
-Final phone/desktop feature E2E remains user-owned and separate from package/CI checks. Finish DeepSeek before Codex.
+Feature E2E remains separate from package/CI checks. The requested agent-run phone stop/input checks passed;
+`deepseek-phone-qa.md` records the handoff to Codex and outstanding desktop/UX coverage. Do not retire the overall
+plan while its required final matrix remains incomplete.

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
@@ -83,7 +83,7 @@ class CodexAppServerApi({required final CodexAppServerTransport _client}) {
   }) async {
     final result = await _client.request(
       method: "thread/read",
-      params: {"threadId": threadId, "includeTurns": false},
+      params: {"threadId": threadId, "includeTurns": true},
     );
     return _decodeResponse(result: result, operation: "thread/read");
   }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.dart
@@ -30,6 +30,7 @@ sealed class CodexThreadEnvelopeDto with _$CodexThreadEnvelopeDto {
 @Freezed(fromJson: true, toJson: false)
 sealed class CodexThreadTurnDto with _$CodexThreadTurnDto {
   const factory({
+    required String? id,
     @JsonKey(defaultValue: <CodexThreadItemDto>[]) required List<CodexThreadItemDto> items,
   }) = _CodexThreadTurnDto;
 
@@ -52,9 +53,6 @@ sealed class CodexThreadItemDto with _$CodexThreadItemDto {
 sealed class CodexThreadContentDto with _$CodexThreadContentDto {
   @FreezedUnionValue("text")
   const factory text({required String text}) = CodexThreadTextContentDto;
-
-  @FreezedUnionValue("input_text")
-  const factory inputText({required String text}) = CodexThreadInputTextContentDto;
 
   const factory unknown() = CodexThreadUnknownContentDto;
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.dart
@@ -28,6 +28,40 @@ sealed class CodexThreadEnvelopeDto with _$CodexThreadEnvelopeDto {
 }
 
 @Freezed(fromJson: true, toJson: false)
+sealed class CodexThreadTurnDto with _$CodexThreadTurnDto {
+  const factory({
+    @JsonKey(defaultValue: <CodexThreadItemDto>[]) required List<CodexThreadItemDto> items,
+  }) = _CodexThreadTurnDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexThreadTurnDtoFromJson(json);
+}
+
+@Freezed(unionKey: "type", fallbackUnion: "unknown", fromJson: true, toJson: false)
+sealed class CodexThreadItemDto with _$CodexThreadItemDto {
+  @FreezedUnionValue("userMessage")
+  const factory userMessage({
+    @JsonKey(defaultValue: <CodexThreadContentDto>[]) required List<CodexThreadContentDto> content,
+  }) = CodexThreadUserMessageItemDto;
+
+  const factory unknown() = CodexThreadUnknownItemDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexThreadItemDtoFromJson(json);
+}
+
+@Freezed(unionKey: "type", fallbackUnion: "unknown", fromJson: true, toJson: false)
+sealed class CodexThreadContentDto with _$CodexThreadContentDto {
+  @FreezedUnionValue("text")
+  const factory text({required String text}) = CodexThreadTextContentDto;
+
+  @FreezedUnionValue("input_text")
+  const factory inputText({required String text}) = CodexThreadInputTextContentDto;
+
+  const factory unknown() = CodexThreadUnknownContentDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexThreadContentDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
 sealed class CodexThreadDto with _$CodexThreadDto {
   const factory({
     required String? id,
@@ -40,6 +74,7 @@ sealed class CodexThreadDto with _$CodexThreadDto {
     required String? agentNickname,
     required String? agentRole,
     @JsonKey(unknownEnumValue: CodexThreadSource.unknown) required CodexThreadSource? threadSource,
+    @JsonKey(defaultValue: <CodexThreadTurnDto>[]) required List<CodexThreadTurnDto> turns,
   }) = _CodexThreadDto;
 
   factory fromJson(Map<String, dynamic> json) => _$CodexThreadDtoFromJson(json);

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.freezed.dart
@@ -176,9 +176,532 @@ $CodexThreadDtoCopyWith<$Res>? get thread {
 
 
 /// @nodoc
+mixin _$CodexThreadTurnDto {
+
+@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> get items;
+/// Create a copy of CodexThreadTurnDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexThreadTurnDtoCopyWith<CodexThreadTurnDto> get copyWith => _$CodexThreadTurnDtoCopyWithImpl<CodexThreadTurnDto>(this as CodexThreadTurnDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadTurnDto&&const DeepCollectionEquality().equals(other.items, items));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(items));
+
+@override
+String toString() {
+  return 'CodexThreadTurnDto(items: $items)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexThreadTurnDtoCopyWith<$Res>  {
+  factory $CodexThreadTurnDtoCopyWith(CodexThreadTurnDto value, $Res Function(CodexThreadTurnDto) _then) = _$CodexThreadTurnDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> items
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexThreadTurnDtoCopyWithImpl<$Res>
+    implements $CodexThreadTurnDtoCopyWith<$Res> {
+  _$CodexThreadTurnDtoCopyWithImpl(this._self, this._then);
+
+  final CodexThreadTurnDto _self;
+  final $Res Function(CodexThreadTurnDto) _then;
+
+/// Create a copy of CodexThreadTurnDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? items = null,}) {
+  return _then(CodexThreadTurnDto(
+items: null == items ? _self.items : items // ignore: cast_nullable_to_non_nullable
+as List<CodexThreadItemDto>,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexThreadTurnDto implements CodexThreadTurnDto {
+  const _CodexThreadTurnDto({@JsonKey(defaultValue: <CodexThreadItemDto>[]) required  List<CodexThreadItemDto> items}): _items = items;
+  factory _CodexThreadTurnDto.fromJson(Map<String, dynamic> json) => _$CodexThreadTurnDtoFromJson(json);
+
+ final  List<CodexThreadItemDto> _items;
+@override@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> get items {
+  if (_items is EqualUnmodifiableListView) return _items;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_items);
+}
+
+
+/// Create a copy of CodexThreadTurnDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexThreadTurnDtoCopyWith<_CodexThreadTurnDto> get copyWith => __$CodexThreadTurnDtoCopyWithImpl<_CodexThreadTurnDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadTurnDto&&const DeepCollectionEquality().equals(other._items, _items));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_items));
+
+@override
+String toString() {
+  return 'CodexThreadTurnDto(items: $items)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexThreadTurnDtoCopyWith<$Res> implements $CodexThreadTurnDtoCopyWith<$Res> {
+  factory _$CodexThreadTurnDtoCopyWith(_CodexThreadTurnDto value, $Res Function(_CodexThreadTurnDto) _then) = __$CodexThreadTurnDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> items
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexThreadTurnDtoCopyWithImpl<$Res>
+    implements _$CodexThreadTurnDtoCopyWith<$Res> {
+  __$CodexThreadTurnDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexThreadTurnDto _self;
+  final $Res Function(_CodexThreadTurnDto) _then;
+
+/// Create a copy of CodexThreadTurnDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? items = null,}) {
+  return _then(_CodexThreadTurnDto(
+items: null == items ? _self._items : items // ignore: cast_nullable_to_non_nullable
+as List<CodexThreadItemDto>,
+  ));
+}
+
+
+}
+
+CodexThreadItemDto _$CodexThreadItemDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'userMessage':
+          return CodexThreadUserMessageItemDto.fromJson(
+            json
+          );
+        
+          default:
+            return CodexThreadUnknownItemDto.fromJson(
+  json
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$CodexThreadItemDto {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadItemDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexThreadItemDto()';
+}
+
+
+}
+
+/// @nodoc
+class $CodexThreadItemDtoCopyWith<$Res>  {
+$CodexThreadItemDtoCopyWith(CodexThreadItemDto _, $Res Function(CodexThreadItemDto) __);
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexThreadUserMessageItemDto implements CodexThreadItemDto {
+  const CodexThreadUserMessageItemDto({@JsonKey(defaultValue: <CodexThreadContentDto>[]) required  List<CodexThreadContentDto> content,  String? $type}): _content = content,$type = $type ?? 'userMessage';
+  factory CodexThreadUserMessageItemDto.fromJson(Map<String, dynamic> json) => _$CodexThreadUserMessageItemDtoFromJson(json);
+
+ final  List<CodexThreadContentDto> _content;
+@JsonKey(defaultValue: <CodexThreadContentDto>[]) List<CodexThreadContentDto> get content {
+  if (_content is EqualUnmodifiableListView) return _content;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_content);
+}
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexThreadItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexThreadUserMessageItemDtoCopyWith<CodexThreadUserMessageItemDto> get copyWith => _$CodexThreadUserMessageItemDtoCopyWithImpl<CodexThreadUserMessageItemDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadUserMessageItemDto&&const DeepCollectionEquality().equals(other._content, _content));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_content));
+
+@override
+String toString() {
+  return 'CodexThreadItemDto.userMessage(content: $content)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexThreadUserMessageItemDtoCopyWith<$Res> implements $CodexThreadItemDtoCopyWith<$Res> {
+  factory $CodexThreadUserMessageItemDtoCopyWith(CodexThreadUserMessageItemDto value, $Res Function(CodexThreadUserMessageItemDto) _then) = _$CodexThreadUserMessageItemDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(defaultValue: <CodexThreadContentDto>[]) List<CodexThreadContentDto> content
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexThreadUserMessageItemDtoCopyWithImpl<$Res>
+    implements $CodexThreadUserMessageItemDtoCopyWith<$Res> {
+  _$CodexThreadUserMessageItemDtoCopyWithImpl(this._self, this._then);
+
+  final CodexThreadUserMessageItemDto _self;
+  final $Res Function(CodexThreadUserMessageItemDto) _then;
+
+/// Create a copy of CodexThreadItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? content = null,}) {
+  return _then(CodexThreadUserMessageItemDto(
+content: null == content ? _self._content : content // ignore: cast_nullable_to_non_nullable
+as List<CodexThreadContentDto>,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexThreadUnknownItemDto implements CodexThreadItemDto {
+  const CodexThreadUnknownItemDto({ String? $type}): $type = $type ?? 'unknown';
+  factory CodexThreadUnknownItemDto.fromJson(Map<String, dynamic> json) => _$CodexThreadUnknownItemDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadUnknownItemDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexThreadItemDto.unknown()';
+}
+
+
+}
+
+
+
+
+CodexThreadContentDto _$CodexThreadContentDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'text':
+          return CodexThreadTextContentDto.fromJson(
+            json
+          );
+                case 'input_text':
+          return CodexThreadInputTextContentDto.fromJson(
+            json
+          );
+        
+          default:
+            return CodexThreadUnknownContentDto.fromJson(
+  json
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$CodexThreadContentDto {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadContentDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexThreadContentDto()';
+}
+
+
+}
+
+/// @nodoc
+class $CodexThreadContentDtoCopyWith<$Res>  {
+$CodexThreadContentDtoCopyWith(CodexThreadContentDto _, $Res Function(CodexThreadContentDto) __);
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexThreadTextContentDto implements CodexThreadContentDto {
+  const CodexThreadTextContentDto({required this.text,  String? $type}): $type = $type ?? 'text';
+  factory CodexThreadTextContentDto.fromJson(Map<String, dynamic> json) => _$CodexThreadTextContentDtoFromJson(json);
+
+ final  String text;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexThreadContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexThreadTextContentDtoCopyWith<CodexThreadTextContentDto> get copyWith => _$CodexThreadTextContentDtoCopyWithImpl<CodexThreadTextContentDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadTextContentDto&&(identical(other.text, text) || other.text == text));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,text);
+
+@override
+String toString() {
+  return 'CodexThreadContentDto.text(text: $text)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexThreadTextContentDtoCopyWith<$Res> implements $CodexThreadContentDtoCopyWith<$Res> {
+  factory $CodexThreadTextContentDtoCopyWith(CodexThreadTextContentDto value, $Res Function(CodexThreadTextContentDto) _then) = _$CodexThreadTextContentDtoCopyWithImpl;
+@useResult
+$Res call({
+ String text
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexThreadTextContentDtoCopyWithImpl<$Res>
+    implements $CodexThreadTextContentDtoCopyWith<$Res> {
+  _$CodexThreadTextContentDtoCopyWithImpl(this._self, this._then);
+
+  final CodexThreadTextContentDto _self;
+  final $Res Function(CodexThreadTextContentDto) _then;
+
+/// Create a copy of CodexThreadContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(CodexThreadTextContentDto(
+text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexThreadInputTextContentDto implements CodexThreadContentDto {
+  const CodexThreadInputTextContentDto({required this.text,  String? $type}): $type = $type ?? 'input_text';
+  factory CodexThreadInputTextContentDto.fromJson(Map<String, dynamic> json) => _$CodexThreadInputTextContentDtoFromJson(json);
+
+ final  String text;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexThreadContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexThreadInputTextContentDtoCopyWith<CodexThreadInputTextContentDto> get copyWith => _$CodexThreadInputTextContentDtoCopyWithImpl<CodexThreadInputTextContentDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadInputTextContentDto&&(identical(other.text, text) || other.text == text));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,text);
+
+@override
+String toString() {
+  return 'CodexThreadContentDto.inputText(text: $text)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexThreadInputTextContentDtoCopyWith<$Res> implements $CodexThreadContentDtoCopyWith<$Res> {
+  factory $CodexThreadInputTextContentDtoCopyWith(CodexThreadInputTextContentDto value, $Res Function(CodexThreadInputTextContentDto) _then) = _$CodexThreadInputTextContentDtoCopyWithImpl;
+@useResult
+$Res call({
+ String text
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexThreadInputTextContentDtoCopyWithImpl<$Res>
+    implements $CodexThreadInputTextContentDtoCopyWith<$Res> {
+  _$CodexThreadInputTextContentDtoCopyWithImpl(this._self, this._then);
+
+  final CodexThreadInputTextContentDto _self;
+  final $Res Function(CodexThreadInputTextContentDto) _then;
+
+/// Create a copy of CodexThreadContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(CodexThreadInputTextContentDto(
+text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexThreadUnknownContentDto implements CodexThreadContentDto {
+  const CodexThreadUnknownContentDto({ String? $type}): $type = $type ?? 'unknown';
+  factory CodexThreadUnknownContentDto.fromJson(Map<String, dynamic> json) => _$CodexThreadUnknownContentDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadUnknownContentDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexThreadContentDto.unknown()';
+}
+
+
+}
+
+
+
+
+
+/// @nodoc
 mixin _$CodexThreadDto {
 
- String? get id; String? get name; String? get cwd; num? get createdAt; num? get updatedAt; String? get modelProvider; String? get parentThreadId; String? get agentNickname; String? get agentRole;@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? get threadSource;
+ String? get id; String? get name; String? get cwd; num? get createdAt; num? get updatedAt; String? get modelProvider; String? get parentThreadId; String? get agentNickname; String? get agentRole;@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? get threadSource;@JsonKey(defaultValue: <CodexThreadTurnDto>[]) List<CodexThreadTurnDto> get turns;
 /// Create a copy of CodexThreadDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -189,16 +712,16 @@ $CodexThreadDtoCopyWith<CodexThreadDto> get copyWith => _$CodexThreadDtoCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.parentThreadId, parentThreadId) || other.parentThreadId == parentThreadId)&&(identical(other.agentNickname, agentNickname) || other.agentNickname == agentNickname)&&(identical(other.agentRole, agentRole) || other.agentRole == agentRole)&&(identical(other.threadSource, threadSource) || other.threadSource == threadSource));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.parentThreadId, parentThreadId) || other.parentThreadId == parentThreadId)&&(identical(other.agentNickname, agentNickname) || other.agentNickname == agentNickname)&&(identical(other.agentRole, agentRole) || other.agentRole == agentRole)&&(identical(other.threadSource, threadSource) || other.threadSource == threadSource)&&const DeepCollectionEquality().equals(other.turns, turns));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,cwd,createdAt,updatedAt,modelProvider,parentThreadId,agentNickname,agentRole,threadSource);
+int get hashCode => Object.hash(runtimeType,id,name,cwd,createdAt,updatedAt,modelProvider,parentThreadId,agentNickname,agentRole,threadSource,const DeepCollectionEquality().hash(turns));
 
 @override
 String toString() {
-  return 'CodexThreadDto(id: $id, name: $name, cwd: $cwd, createdAt: $createdAt, updatedAt: $updatedAt, modelProvider: $modelProvider, parentThreadId: $parentThreadId, agentNickname: $agentNickname, agentRole: $agentRole, threadSource: $threadSource)';
+  return 'CodexThreadDto(id: $id, name: $name, cwd: $cwd, createdAt: $createdAt, updatedAt: $updatedAt, modelProvider: $modelProvider, parentThreadId: $parentThreadId, agentNickname: $agentNickname, agentRole: $agentRole, threadSource: $threadSource, turns: $turns)';
 }
 
 
@@ -209,7 +732,7 @@ abstract mixin class $CodexThreadDtoCopyWith<$Res>  {
   factory $CodexThreadDtoCopyWith(CodexThreadDto value, $Res Function(CodexThreadDto) _then) = _$CodexThreadDtoCopyWithImpl;
 @useResult
 $Res call({
- String? id, String? name, String? cwd, num? createdAt, num? updatedAt, String? modelProvider, String? parentThreadId, String? agentNickname, String? agentRole,@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? threadSource
+ String? id, String? name, String? cwd, num? createdAt, num? updatedAt, String? modelProvider, String? parentThreadId, String? agentNickname, String? agentRole,@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? threadSource,@JsonKey(defaultValue: <CodexThreadTurnDto>[]) List<CodexThreadTurnDto> turns
 });
 
 
@@ -226,7 +749,7 @@ class _$CodexThreadDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexThreadDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? name = freezed,Object? cwd = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? modelProvider = freezed,Object? parentThreadId = freezed,Object? agentNickname = freezed,Object? agentRole = freezed,Object? threadSource = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? name = freezed,Object? cwd = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? modelProvider = freezed,Object? parentThreadId = freezed,Object? agentNickname = freezed,Object? agentRole = freezed,Object? threadSource = freezed,Object? turns = null,}) {
   return _then(CodexThreadDto(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -238,7 +761,8 @@ as String?,parentThreadId: freezed == parentThreadId ? _self.parentThreadId : pa
 as String?,agentNickname: freezed == agentNickname ? _self.agentNickname : agentNickname // ignore: cast_nullable_to_non_nullable
 as String?,agentRole: freezed == agentRole ? _self.agentRole : agentRole // ignore: cast_nullable_to_non_nullable
 as String?,threadSource: freezed == threadSource ? _self.threadSource : threadSource // ignore: cast_nullable_to_non_nullable
-as CodexThreadSource?,
+as CodexThreadSource?,turns: null == turns ? _self.turns : turns // ignore: cast_nullable_to_non_nullable
+as List<CodexThreadTurnDto>,
   ));
 }
 
@@ -250,7 +774,7 @@ as CodexThreadSource?,
 @JsonSerializable(createToJson: false)
 
 class _CodexThreadDto implements CodexThreadDto {
-  const _CodexThreadDto({required this.id, required this.name, required this.cwd, required this.createdAt, required this.updatedAt, required this.modelProvider, required this.parentThreadId, required this.agentNickname, required this.agentRole, @JsonKey(unknownEnumValue: CodexThreadSource.unknown) required this.threadSource});
+  const _CodexThreadDto({required this.id, required this.name, required this.cwd, required this.createdAt, required this.updatedAt, required this.modelProvider, required this.parentThreadId, required this.agentNickname, required this.agentRole, @JsonKey(unknownEnumValue: CodexThreadSource.unknown) required this.threadSource, @JsonKey(defaultValue: <CodexThreadTurnDto>[]) required  List<CodexThreadTurnDto> turns}): _turns = turns;
   factory _CodexThreadDto.fromJson(Map<String, dynamic> json) => _$CodexThreadDtoFromJson(json);
 
 @override final  String? id;
@@ -263,6 +787,13 @@ class _CodexThreadDto implements CodexThreadDto {
 @override final  String? agentNickname;
 @override final  String? agentRole;
 @override@JsonKey(unknownEnumValue: CodexThreadSource.unknown) final  CodexThreadSource? threadSource;
+ final  List<CodexThreadTurnDto> _turns;
+@override@JsonKey(defaultValue: <CodexThreadTurnDto>[]) List<CodexThreadTurnDto> get turns {
+  if (_turns is EqualUnmodifiableListView) return _turns;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_turns);
+}
+
 
 /// Create a copy of CodexThreadDto
 /// with the given fields replaced by the non-null parameter values.
@@ -274,16 +805,16 @@ _$CodexThreadDtoCopyWith<_CodexThreadDto> get copyWith => __$CodexThreadDtoCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.parentThreadId, parentThreadId) || other.parentThreadId == parentThreadId)&&(identical(other.agentNickname, agentNickname) || other.agentNickname == agentNickname)&&(identical(other.agentRole, agentRole) || other.agentRole == agentRole)&&(identical(other.threadSource, threadSource) || other.threadSource == threadSource));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.parentThreadId, parentThreadId) || other.parentThreadId == parentThreadId)&&(identical(other.agentNickname, agentNickname) || other.agentNickname == agentNickname)&&(identical(other.agentRole, agentRole) || other.agentRole == agentRole)&&(identical(other.threadSource, threadSource) || other.threadSource == threadSource)&&const DeepCollectionEquality().equals(other._turns, _turns));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,cwd,createdAt,updatedAt,modelProvider,parentThreadId,agentNickname,agentRole,threadSource);
+int get hashCode => Object.hash(runtimeType,id,name,cwd,createdAt,updatedAt,modelProvider,parentThreadId,agentNickname,agentRole,threadSource,const DeepCollectionEquality().hash(_turns));
 
 @override
 String toString() {
-  return 'CodexThreadDto(id: $id, name: $name, cwd: $cwd, createdAt: $createdAt, updatedAt: $updatedAt, modelProvider: $modelProvider, parentThreadId: $parentThreadId, agentNickname: $agentNickname, agentRole: $agentRole, threadSource: $threadSource)';
+  return 'CodexThreadDto(id: $id, name: $name, cwd: $cwd, createdAt: $createdAt, updatedAt: $updatedAt, modelProvider: $modelProvider, parentThreadId: $parentThreadId, agentNickname: $agentNickname, agentRole: $agentRole, threadSource: $threadSource, turns: $turns)';
 }
 
 
@@ -294,7 +825,7 @@ abstract mixin class _$CodexThreadDtoCopyWith<$Res> implements $CodexThreadDtoCo
   factory _$CodexThreadDtoCopyWith(_CodexThreadDto value, $Res Function(_CodexThreadDto) _then) = __$CodexThreadDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, String? name, String? cwd, num? createdAt, num? updatedAt, String? modelProvider, String? parentThreadId, String? agentNickname, String? agentRole,@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? threadSource
+ String? id, String? name, String? cwd, num? createdAt, num? updatedAt, String? modelProvider, String? parentThreadId, String? agentNickname, String? agentRole,@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? threadSource,@JsonKey(defaultValue: <CodexThreadTurnDto>[]) List<CodexThreadTurnDto> turns
 });
 
 
@@ -311,7 +842,7 @@ class __$CodexThreadDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexThreadDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? name = freezed,Object? cwd = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? modelProvider = freezed,Object? parentThreadId = freezed,Object? agentNickname = freezed,Object? agentRole = freezed,Object? threadSource = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? name = freezed,Object? cwd = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? modelProvider = freezed,Object? parentThreadId = freezed,Object? agentNickname = freezed,Object? agentRole = freezed,Object? threadSource = freezed,Object? turns = null,}) {
   return _then(_CodexThreadDto(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -323,7 +854,8 @@ as String?,parentThreadId: freezed == parentThreadId ? _self.parentThreadId : pa
 as String?,agentNickname: freezed == agentNickname ? _self.agentNickname : agentNickname // ignore: cast_nullable_to_non_nullable
 as String?,agentRole: freezed == agentRole ? _self.agentRole : agentRole // ignore: cast_nullable_to_non_nullable
 as String?,threadSource: freezed == threadSource ? _self.threadSource : threadSource // ignore: cast_nullable_to_non_nullable
-as CodexThreadSource?,
+as CodexThreadSource?,turns: null == turns ? _self._turns : turns // ignore: cast_nullable_to_non_nullable
+as List<CodexThreadTurnDto>,
   ));
 }
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.freezed.dart
@@ -178,7 +178,7 @@ $CodexThreadDtoCopyWith<$Res>? get thread {
 /// @nodoc
 mixin _$CodexThreadTurnDto {
 
-@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> get items;
+ String? get id;@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> get items;
 /// Create a copy of CodexThreadTurnDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -189,16 +189,16 @@ $CodexThreadTurnDtoCopyWith<CodexThreadTurnDto> get copyWith => _$CodexThreadTur
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadTurnDto&&const DeepCollectionEquality().equals(other.items, items));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadTurnDto&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.items, items));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(items));
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(items));
 
 @override
 String toString() {
-  return 'CodexThreadTurnDto(items: $items)';
+  return 'CodexThreadTurnDto(id: $id, items: $items)';
 }
 
 
@@ -209,7 +209,7 @@ abstract mixin class $CodexThreadTurnDtoCopyWith<$Res>  {
   factory $CodexThreadTurnDtoCopyWith(CodexThreadTurnDto value, $Res Function(CodexThreadTurnDto) _then) = _$CodexThreadTurnDtoCopyWithImpl;
 @useResult
 $Res call({
-@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> items
+ String? id,@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> items
 });
 
 
@@ -226,9 +226,10 @@ class _$CodexThreadTurnDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexThreadTurnDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? items = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? items = null,}) {
   return _then(CodexThreadTurnDto(
-items: null == items ? _self.items : items // ignore: cast_nullable_to_non_nullable
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,items: null == items ? _self.items : items // ignore: cast_nullable_to_non_nullable
 as List<CodexThreadItemDto>,
   ));
 }
@@ -241,9 +242,10 @@ as List<CodexThreadItemDto>,
 @JsonSerializable(createToJson: false)
 
 class _CodexThreadTurnDto implements CodexThreadTurnDto {
-  const _CodexThreadTurnDto({@JsonKey(defaultValue: <CodexThreadItemDto>[]) required  List<CodexThreadItemDto> items}): _items = items;
+  const _CodexThreadTurnDto({required this.id, @JsonKey(defaultValue: <CodexThreadItemDto>[]) required  List<CodexThreadItemDto> items}): _items = items;
   factory _CodexThreadTurnDto.fromJson(Map<String, dynamic> json) => _$CodexThreadTurnDtoFromJson(json);
 
+@override final  String? id;
  final  List<CodexThreadItemDto> _items;
 @override@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> get items {
   if (_items is EqualUnmodifiableListView) return _items;
@@ -262,16 +264,16 @@ _$CodexThreadTurnDtoCopyWith<_CodexThreadTurnDto> get copyWith => __$CodexThread
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadTurnDto&&const DeepCollectionEquality().equals(other._items, _items));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadTurnDto&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._items, _items));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_items));
+int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_items));
 
 @override
 String toString() {
-  return 'CodexThreadTurnDto(items: $items)';
+  return 'CodexThreadTurnDto(id: $id, items: $items)';
 }
 
 
@@ -282,7 +284,7 @@ abstract mixin class _$CodexThreadTurnDtoCopyWith<$Res> implements $CodexThreadT
   factory _$CodexThreadTurnDtoCopyWith(_CodexThreadTurnDto value, $Res Function(_CodexThreadTurnDto) _then) = __$CodexThreadTurnDtoCopyWithImpl;
 @override @useResult
 $Res call({
-@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> items
+ String? id,@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> items
 });
 
 
@@ -299,9 +301,10 @@ class __$CodexThreadTurnDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexThreadTurnDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? items = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? items = null,}) {
   return _then(_CodexThreadTurnDto(
-items: null == items ? _self._items : items // ignore: cast_nullable_to_non_nullable
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,items: null == items ? _self._items : items // ignore: cast_nullable_to_non_nullable
 as List<CodexThreadItemDto>,
   ));
 }
@@ -477,10 +480,6 @@ CodexThreadContentDto _$CodexThreadContentDtoFromJson(
           return CodexThreadTextContentDto.fromJson(
             json
           );
-                case 'input_text':
-          return CodexThreadInputTextContentDto.fromJson(
-            json
-          );
         
           default:
             return CodexThreadUnknownContentDto.fromJson(
@@ -583,76 +582,6 @@ class _$CodexThreadTextContentDtoCopyWithImpl<$Res>
 /// with the given fields replaced by the non-null parameter values.
 @pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
   return _then(CodexThreadTextContentDto(
-text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
-as String,
-  ));
-}
-
-
-}
-
-/// @nodoc
-@JsonSerializable(createToJson: false)
-
-class CodexThreadInputTextContentDto implements CodexThreadContentDto {
-  const CodexThreadInputTextContentDto({required this.text,  String? $type}): $type = $type ?? 'input_text';
-  factory CodexThreadInputTextContentDto.fromJson(Map<String, dynamic> json) => _$CodexThreadInputTextContentDtoFromJson(json);
-
- final  String text;
-
-@JsonKey(name: 'type')
-final String $type;
-
-
-/// Create a copy of CodexThreadContentDto
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$CodexThreadInputTextContentDtoCopyWith<CodexThreadInputTextContentDto> get copyWith => _$CodexThreadInputTextContentDtoCopyWithImpl<CodexThreadInputTextContentDto>(this, _$identity);
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadInputTextContentDto&&(identical(other.text, text) || other.text == text));
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => Object.hash(runtimeType,text);
-
-@override
-String toString() {
-  return 'CodexThreadContentDto.inputText(text: $text)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class $CodexThreadInputTextContentDtoCopyWith<$Res> implements $CodexThreadContentDtoCopyWith<$Res> {
-  factory $CodexThreadInputTextContentDtoCopyWith(CodexThreadInputTextContentDto value, $Res Function(CodexThreadInputTextContentDto) _then) = _$CodexThreadInputTextContentDtoCopyWithImpl;
-@useResult
-$Res call({
- String text
-});
-
-
-
-
-}
-/// @nodoc
-class _$CodexThreadInputTextContentDtoCopyWithImpl<$Res>
-    implements $CodexThreadInputTextContentDtoCopyWith<$Res> {
-  _$CodexThreadInputTextContentDtoCopyWithImpl(this._self, this._then);
-
-  final CodexThreadInputTextContentDto _self;
-  final $Res Function(CodexThreadInputTextContentDto) _then;
-
-/// Create a copy of CodexThreadContentDto
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
-  return _then(CodexThreadInputTextContentDto(
 text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
 as String,
   ));

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.g.dart
@@ -20,6 +20,7 @@ _CodexThreadEnvelopeDto _$CodexThreadEnvelopeDtoFromJson(Map json) =>
 
 _CodexThreadTurnDto _$CodexThreadTurnDtoFromJson(Map json) =>
     _CodexThreadTurnDto(
+      id: json['id'] as String?,
       items:
           (json['items'] as List<dynamic>?)
               ?.map(
@@ -54,13 +55,6 @@ CodexThreadTextContentDto _$CodexThreadTextContentDtoFromJson(Map json) =>
       text: json['text'] as String,
       $type: json['type'] as String?,
     );
-
-CodexThreadInputTextContentDto _$CodexThreadInputTextContentDtoFromJson(
-  Map json,
-) => CodexThreadInputTextContentDto(
-  text: json['text'] as String,
-  $type: json['type'] as String?,
-);
 
 CodexThreadUnknownContentDto _$CodexThreadUnknownContentDtoFromJson(Map json) =>
     CodexThreadUnknownContentDto($type: json['type'] as String?);

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.g.dart
@@ -18,6 +18,53 @@ _CodexThreadEnvelopeDto _$CodexThreadEnvelopeDtoFromJson(Map json) =>
       cwd: json['cwd'] as String?,
     );
 
+_CodexThreadTurnDto _$CodexThreadTurnDtoFromJson(Map json) =>
+    _CodexThreadTurnDto(
+      items:
+          (json['items'] as List<dynamic>?)
+              ?.map(
+                (e) => CodexThreadItemDto.fromJson(
+                  Map<String, dynamic>.from(e as Map),
+                ),
+              )
+              .toList() ??
+          [],
+    );
+
+CodexThreadUserMessageItemDto _$CodexThreadUserMessageItemDtoFromJson(
+  Map json,
+) => CodexThreadUserMessageItemDto(
+  content:
+      (json['content'] as List<dynamic>?)
+          ?.map(
+            (e) => CodexThreadContentDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList() ??
+      [],
+  $type: json['type'] as String?,
+);
+
+CodexThreadUnknownItemDto _$CodexThreadUnknownItemDtoFromJson(Map json) =>
+    CodexThreadUnknownItemDto($type: json['type'] as String?);
+
+CodexThreadTextContentDto _$CodexThreadTextContentDtoFromJson(Map json) =>
+    CodexThreadTextContentDto(
+      text: json['text'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexThreadInputTextContentDto _$CodexThreadInputTextContentDtoFromJson(
+  Map json,
+) => CodexThreadInputTextContentDto(
+  text: json['text'] as String,
+  $type: json['type'] as String?,
+);
+
+CodexThreadUnknownContentDto _$CodexThreadUnknownContentDtoFromJson(Map json) =>
+    CodexThreadUnknownContentDto($type: json['type'] as String?);
+
 _CodexThreadDto _$CodexThreadDtoFromJson(Map json) => _CodexThreadDto(
   id: json['id'] as String?,
   name: json['name'] as String?,
@@ -33,6 +80,15 @@ _CodexThreadDto _$CodexThreadDtoFromJson(Map json) => _CodexThreadDto(
     json['threadSource'],
     unknownValue: CodexThreadSource.unknown,
   ),
+  turns:
+      (json['turns'] as List<dynamic>?)
+          ?.map(
+            (e) => CodexThreadTurnDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList() ??
+      [],
 );
 
 const _$CodexThreadSourceEnumMap = {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
@@ -38,6 +38,7 @@ final class const _CodexPromptAttachmentException({required final String message
 
 /// Layer-2 normalization and domain mapping for Codex app-server threads.
 class CodexThreadRepository({required final CodexAppServerApi _appServerApi}) {
+  final Map<String, String> _initialPromptByThread = {};
   static const _supportedImageMimes = {
     "image/bmp",
     "image/gif",
@@ -70,7 +71,27 @@ class CodexThreadRepository({required final CodexAppServerApi _appServerApi}) {
       operation: "thread/read",
       request: () => _appServerApi.readThread(threadId: threadId),
     );
+    final prompt = _initialUserPrompt(thread: dto.thread);
+    if (prompt != null) _initialPromptByThread[threadId] = prompt;
     return _mapRequired(dto: dto, operation: "thread/read");
+  }
+
+  String? initialUserPrompt({required String threadId}) => _initialPromptByThread[threadId];
+
+  String? _initialUserPrompt({required CodexThreadDto? thread}) {
+    if (thread == null) return null;
+    for (final turn in thread.turns) {
+      for (final item in turn.items) {
+        if (item case CodexThreadUserMessageItemDto(:final content)) {
+          final prompt = [
+            for (final part in content)
+              if (part case CodexThreadTextContentDto(:final text) || CodexThreadInputTextContentDto(:final text)) text,
+          ].join();
+          if (prompt.trim().isNotEmpty) return prompt;
+        }
+      }
+    }
+    return null;
   }
 
   Future<CodexThreadRecord> resumeThread({required String threadId}) async {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
@@ -38,7 +38,7 @@ final class const _CodexPromptAttachmentException({required final String message
 
 /// Layer-2 normalization and domain mapping for Codex app-server threads.
 class CodexThreadRepository({required final CodexAppServerApi _appServerApi}) {
-  final Map<String, String> _initialPromptByThread = {};
+  final Map<String, Map<String, String>> _initialPromptByTurnByThread = {};
   static const _supportedImageMimes = {
     "image/bmp",
     "image/gif",
@@ -71,27 +71,38 @@ class CodexThreadRepository({required final CodexAppServerApi _appServerApi}) {
       operation: "thread/read",
       request: () => _appServerApi.readThread(threadId: threadId),
     );
-    final prompt = _initialUserPrompt(thread: dto.thread);
-    if (prompt != null) _initialPromptByThread[threadId] = prompt;
+    _cacheInitialUserPrompts(threadId: threadId, thread: dto.thread);
     return _mapRequired(dto: dto, operation: "thread/read");
   }
 
-  String? initialUserPrompt({required String threadId}) => _initialPromptByThread[threadId];
+  /// Returns the initial user prompt from the exact turn observed through the
+  /// child thread lifecycle. A thread read alone cannot distinguish a child's
+  /// own turn from parent turns copied by `fork_turns`, so missing or unmatched
+  /// turn provenance intentionally returns `null`.
+  String? initialUserPrompt({required String threadId, required String? turnId}) {
+    final usefulTurnId = _usefulText(turnId);
+    return usefulTurnId == null ? null : _initialPromptByTurnByThread[threadId]?[usefulTurnId];
+  }
 
-  String? _initialUserPrompt({required CodexThreadDto? thread}) {
-    if (thread == null) return null;
+  void _cacheInitialUserPrompts({required String threadId, required CodexThreadDto? thread}) {
+    if (thread == null) return;
+    final promptsByTurn = _initialPromptByTurnByThread.putIfAbsent(threadId, () => {});
     for (final turn in thread.turns) {
+      final turnId = _usefulText(turn.id);
+      if (turnId == null) continue;
       for (final item in turn.items) {
         if (item case CodexThreadUserMessageItemDto(:final content)) {
           final prompt = [
             for (final part in content)
-              if (part case CodexThreadTextContentDto(:final text) || CodexThreadInputTextContentDto(:final text)) text,
+              if (part case CodexThreadTextContentDto(:final text)) text,
           ].join();
-          if (prompt.trim().isNotEmpty) return prompt;
+          if (prompt.trim().isNotEmpty) {
+            promptsByTurn[turnId] = prompt;
+            break;
+          }
         }
       }
     }
-    return null;
   }
 
   Future<CodexThreadRecord> resumeThread({required String threadId}) async {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
@@ -79,6 +79,10 @@ class CodexThreadRepository({required final CodexAppServerApi _appServerApi}) {
   /// child thread lifecycle. A thread read alone cannot distinguish a child's
   /// own turn from parent turns copied by `fork_turns`, so missing or unmatched
   /// turn provenance intentionally returns `null`.
+  void forgetThread({required String threadId}) {
+    _initialPromptByTurnByThread.remove(threadId);
+  }
+
   String? initialUserPrompt({required String threadId, required String? turnId}) {
     final usefulTurnId = _usefulText(turnId);
     return usefulTurnId == null ? null : _initialPromptByTurnByThread[threadId]?[usefulTurnId];

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
@@ -75,14 +75,14 @@ class CodexThreadRepository({required final CodexAppServerApi _appServerApi}) {
     return _mapRequired(dto: dto, operation: "thread/read");
   }
 
-  /// Returns the initial user prompt from the exact turn observed through the
-  /// child thread lifecycle. A thread read alone cannot distinguish a child's
-  /// own turn from parent turns copied by `fork_turns`, so missing or unmatched
-  /// turn provenance intentionally returns `null`.
   void forgetThread({required String threadId}) {
     _initialPromptByTurnByThread.remove(threadId);
   }
 
+  /// Returns the initial user prompt from the exact turn observed through the
+  /// child thread lifecycle. A thread read alone cannot distinguish a child's
+  /// own turn from parent turns copied by `fork_turns`, so missing or unmatched
+  /// turn provenance intentionally returns `null`.
   String? initialUserPrompt({required String threadId, required String? turnId}) {
     final usefulTurnId = _usefulText(turnId);
     return usefulTurnId == null ? null : _initialPromptByTurnByThread[threadId]?[usefulTurnId];

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -731,6 +731,7 @@ class CodexSessionService({
     }
     _loadedThreads.remove(sessionId);
     _threadModels.remove(sessionId);
+    _threadRepository?.forgetThread(threadId: sessionId);
   }
 
   Future<CodexSessionMessageRead?> prepareSessionMessageRead({

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -2885,7 +2885,7 @@ void main() {
       expect(childSession.parentID, "root-1");
       expect(childSession.title, "Raman");
       expect(childSession.projectID, "/work/other");
-      expect(fake.sentParamsFor("thread/read"), {"threadId": "child-1", "includeTurns": false});
+      expect(fake.sentParamsFor("thread/read"), {"threadId": "child-1", "includeTurns": true});
       await Future<void>.delayed(Duration.zero);
       final inlineTask = events
           .whereType<BridgeSseMessagePartUpdated>()

--- a/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
@@ -52,6 +52,20 @@ void main() {
     expect(secondRepository.resumeCount, 1);
   });
 
+  test("deleting a session forgets its repository prompt candidates", () async {
+    final service = _newService();
+    final repository = _StubThreadRepository();
+    service.attachAppServerRepositories(
+      threadRepository: repository,
+      modelRepository: _StubModelRepository(),
+      skillRepository: _StubSkillRepository(),
+    );
+
+    await service.deleteSessionSubtree(sessionIds: const ["thread-to-delete"]);
+
+    expect(repository.forgottenThreadIds, ["thread-to-delete"]);
+  });
+
   test("getCommands always includes compact without duplicating an advertised command", () async {
     final service = _newService();
     final threadRepository = _StubThreadRepository();
@@ -550,6 +564,14 @@ class _StubThreadRepository() extends CodexThreadRepository {
           client: CodexAppServerClient(serverUrl: "ws://127.0.0.1:0"),
         ),
       );
+
+  final List<String> forgottenThreadIds = [];
+
+  @override
+  void forgetThread({required String threadId}) {
+    forgottenThreadIds.add(threadId);
+    super.forgetThread(threadId: threadId);
+  }
 
   int resumeCount = 0;
   int compactCount = 0;

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_metadata_dto_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_metadata_dto_test.dart
@@ -25,6 +25,7 @@ void main() {
         "canAcceptDirectInput": false,
         "turns": [
           {
+            "id": "child-turn-1",
             "items": [
               {
                 "type": "userMessage",
@@ -41,12 +42,40 @@ void main() {
       expect(thread.agentNickname, "Raman");
       expect(thread.agentRole, isNull);
       expect(thread.threadSource, isNull);
+      expect(thread.turns.single.id, "child-turn-1");
       final userItem = thread.turns.single.items.single as CodexThreadUserMessageItemDto;
       expect((userItem.content.single as CodexThreadTextContentDto).text, "Inspect child lifecycle.");
     });
 
-    test("thread/read requests turns and retains first typed user prompt", () async {
-      final transport = _ThreadReadTransport();
+    test("thread/read selects the child prompt by exact turn provenance", () async {
+      final transport = _ThreadReadTransport(
+        turns: const [
+          {
+            "id": "parent-turn",
+            "items": [
+              {
+                "type": "userMessage",
+                "content": [
+                  {"type": "text", "text": "Parent prompt copied into child."},
+                ],
+              },
+            ],
+          },
+          {
+            "id": "child-turn",
+            "items": [
+              {"type": "futureItem", "payload": "ignored"},
+              {
+                "type": "userMessage",
+                "content": [
+                  {"type": "input_text", "text": "rollout-only vocabulary"},
+                  {"type": "text", "text": "Actual child prompt."},
+                ],
+              },
+            ],
+          },
+        ],
+      );
       final repository = CodexThreadRepository(
         appServerApi: CodexAppServerApi(client: transport),
       );
@@ -54,7 +83,67 @@ void main() {
       await repository.readThread(threadId: "child-1");
 
       expect(transport.params, {"threadId": "child-1", "includeTurns": true});
-      expect(repository.initialUserPrompt(threadId: "child-1"), "Inspect child lifecycle.");
+      expect(
+        repository.initialUserPrompt(threadId: "child-1", turnId: "child-turn"),
+        "Actual child prompt.",
+      );
+      expect(repository.initialUserPrompt(threadId: "child-1", turnId: null), isNull);
+      expect(repository.initialUserPrompt(threadId: "child-1", turnId: "unobserved-turn"), isNull);
+    });
+
+    test("retains native text for a single provenance-matched turn", () async {
+      final repository = CodexThreadRepository(
+        appServerApi: CodexAppServerApi(
+          client: _ThreadReadTransport(
+            turns: const [
+              {
+                "id": "child-turn",
+                "items": [
+                  {
+                    "type": "userMessage",
+                    "content": [
+                      {"type": "text", "text": "Inspect child lifecycle."},
+                    ],
+                  },
+                ],
+              },
+            ],
+          ),
+        ),
+      );
+
+      await repository.readThread(threadId: "child-1");
+
+      expect(
+        repository.initialUserPrompt(threadId: "child-1", turnId: "child-turn"),
+        "Inspect child lifecycle.",
+      );
+    });
+
+    test("unknown thread items and user content decode as ignored variants", () {
+      final thread = CodexThreadDto.fromJson(const {
+        "id": "child-1",
+        "turns": [
+          {
+            "id": "child-turn",
+            "items": [
+              {"type": "futureItem", "payload": "ignored"},
+              {
+                "type": "userMessage",
+                "content": [
+                  {"type": "input_text", "text": "not app-server UserInput"},
+                  {"type": "text", "text": "Native text."},
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(thread.turns.single.items.first, isA<CodexThreadUnknownItemDto>());
+      final userMessage = thread.turns.single.items.last as CodexThreadUserMessageItemDto;
+      expect(userMessage.content.first, isA<CodexThreadUnknownContentDto>());
+      expect((userMessage.content.last as CodexThreadTextContentDto).text, "Native text.");
     });
 
     test("decodes known thread sources and falls back to unknown", () {
@@ -142,7 +231,7 @@ void main() {
   });
 }
 
-final class _ThreadReadTransport() implements CodexAppServerTransport {
+final class _ThreadReadTransport({required final List<Map<String, Object?>> turns}) implements CodexAppServerTransport {
   Map<String, dynamic>? params;
 
   @override
@@ -160,18 +249,7 @@ final class _ThreadReadTransport() implements CodexAppServerTransport {
       "thread": {
         "id": "child-1",
         "parentThreadId": "parent-1",
-        "turns": [
-          {
-            "items": [
-              {
-                "type": "userMessage",
-                "content": [
-                  {"type": "text", "text": "Inspect child lifecycle."},
-                ],
-              },
-            ],
-          },
-        ],
+        "turns": turns,
       },
     };
   }

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_metadata_dto_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_metadata_dto_test.dart
@@ -91,7 +91,7 @@ void main() {
       expect(repository.initialUserPrompt(threadId: "child-1", turnId: "unobserved-turn"), isNull);
     });
 
-    test("retains native text for a single provenance-matched turn", () async {
+    test("retains provenance-matched prompts until their thread is forgotten", () async {
       final repository = CodexThreadRepository(
         appServerApi: CodexAppServerApi(
           client: _ThreadReadTransport(
@@ -116,6 +116,13 @@ void main() {
 
       expect(
         repository.initialUserPrompt(threadId: "child-1", turnId: "child-turn"),
+        "Inspect child lifecycle.",
+      );
+      await repository.readThread(threadId: "child-2");
+      repository.forgetThread(threadId: "child-1");
+      expect(repository.initialUserPrompt(threadId: "child-1", turnId: "child-turn"), isNull);
+      expect(
+        repository.initialUserPrompt(threadId: "child-2", turnId: "child-turn"),
         "Inspect child lifecycle.",
       );
     });
@@ -247,7 +254,7 @@ final class _ThreadReadTransport({required final List<Map<String, Object?>> turn
     this.params = (params! as Map).cast<String, dynamic>();
     return {
       "thread": {
-        "id": "child-1",
+        "id": this.params!["threadId"],
         "parentThreadId": "parent-1",
         "turns": turns,
       },

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_metadata_dto_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_metadata_dto_test.dart
@@ -1,5 +1,8 @@
+import "package:codex_plugin/src/api/codex_app_server_api.dart";
 import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
 import "package:codex_plugin/src/api/models/codex_thread_dto.dart";
+import "package:codex_plugin/src/codex_app_server_client.dart";
+import "package:codex_plugin/src/repositories/codex_thread_repository.dart";
 import "package:test/test.dart";
 
 // Fixtures mirror codex-cli 0.148.0 captures recorded in
@@ -20,12 +23,38 @@ void main() {
         "updatedAt": 1788356444,
         "status": {"type": "active", "activeFlags": <String>[]},
         "canAcceptDirectInput": false,
+        "turns": [
+          {
+            "items": [
+              {
+                "type": "userMessage",
+                "content": [
+                  {"type": "text", "text": "Inspect child lifecycle."},
+                ],
+              },
+            ],
+          },
+        ],
       });
 
       expect(thread.parentThreadId, "parent-1");
       expect(thread.agentNickname, "Raman");
       expect(thread.agentRole, isNull);
       expect(thread.threadSource, isNull);
+      final userItem = thread.turns.single.items.single as CodexThreadUserMessageItemDto;
+      expect((userItem.content.single as CodexThreadTextContentDto).text, "Inspect child lifecycle.");
+    });
+
+    test("thread/read requests turns and retains first typed user prompt", () async {
+      final transport = _ThreadReadTransport();
+      final repository = CodexThreadRepository(
+        appServerApi: CodexAppServerApi(client: transport),
+      );
+
+      await repository.readThread(threadId: "child-1");
+
+      expect(transport.params, {"threadId": "child-1", "includeTurns": true});
+      expect(repository.initialUserPrompt(threadId: "child-1"), "Inspect child lifecycle.");
     });
 
     test("decodes known thread sources and falls back to unknown", () {
@@ -111,4 +140,39 @@ void main() {
       expect(drifted.threadSource, CodexRolloutThreadSource.unknown);
     });
   });
+}
+
+final class _ThreadReadTransport() implements CodexAppServerTransport {
+  Map<String, dynamic>? params;
+
+  @override
+  Stream<CodexServerNotification> get notifications => const Stream.empty();
+
+  @override
+  Future<dynamic> request({
+    required String method,
+    Object? params,
+    Duration timeout = const Duration(seconds: 30),
+  }) async {
+    expect(method, "thread/read");
+    this.params = (params! as Map).cast<String, dynamic>();
+    return {
+      "thread": {
+        "id": "child-1",
+        "parentThreadId": "parent-1",
+        "turns": [
+          {
+            "items": [
+              {
+                "type": "userMessage",
+                "content": [
+                  {"type": "text", "text": "Inspect child lifecycle."},
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+  }
 }


### PR DESCRIPTION
## Complexity
⚙️ Moderate: typed native boundary models, generated decoding, and lifecycle-keyed prompt provenance. This is the user-approved preparatory split, step 3/6; full tiles with fallback remain step 4/6.

## What
- Request hydrated turns when enriching a Codex child through `thread/read`.
- Parse typed turns, user-message items, and native text content; unknown variants are ignored.
- Cache prompt candidates by thread and turn. Lookup requires the caller's exact lifecycle-observed turn ID; missing/unmatched provenance returns no fallback.
- Evict prompt candidates through existing session-deletion cleanup; connection replacement already discards the repository.
- Record DeepSeek phone QA handoff and the six-step Codex delivery sequence.

## Why
Child spawn activity does not carry prompt text. The forthcoming tile slice needs a typed prompt fallback without confusing inherited parent history with the child's own task. Forked child reads contain parent turns, so first/last-user-message heuristics are unsafe. Rollout-only `input_text` is not accepted as app-server input vocabulary.

## Risk and test focus
Focus: hydrated-read decoding, copied parent history, exact-turn selection, missing provenance, unknown item/content variants, and existing child enrichment. Reads now request more native data; this does not add parent-tree walks or additional RPCs. Tile lifecycle and stop policy are deliberately excluded.

## Expected result
No new user-visible tile or database change in this preparatory PR. Codex repositories can supply a correctly keyed child-prompt fallback when the next slice provides the observed child turn ID. No client/shared-wire, adapter, or runtime-pin change.

## Verification
- Focused metadata/provenance suite: 8 tests passed, including inherited parent-before-child history and unsupported/unknown content.
- Complete Codex package test suite passed; fatal-info analysis clean.
- Freezed/JSON output regenerated; formatting and whitespace checks passed.
- Architecture review approved; independent correctness re-review approved after fixing both provenance and content-vocabulary findings.
- Review follow-up: 22 focused repository/service tests passed, including selective eviction and deletion routing; fatal-info analysis clean.
- Full PR diff: 958 changed lines across 14 files, including generated code, tests, and QA/plan docs.

## Next slice
Full live/replayed inline tiles remain preserved locally for step 4/6. Their fallback call will be adapted to the existing child `turn/started` owner after integrating this prerequisite. Scoped stop is step 5/6; coverage is step 6/6.
