### PR TITLE
🌱 Use info alerts for copied bridge commands

### DIFF
--- a/client/app/lib/features/project_list/onboarding/onboarding_view.dart
+++ b/client/app/lib/features/project_list/onboarding/onboarding_view.dart
@@ -753,7 +753,7 @@ class _CommandActionRowState() extends State<_CommandActionRow> {
     reportCopied(cubit);
     popupAlertPresenter.show(
       title: loc.projectsOnboardingCommandCopied,
-      variant: PregoPopupAlertsNotificationsVariant.success,
+      variant: PregoPopupAlertsNotificationsVariant.info,
     );
   }
 

--- a/client/app/test/features/project_list/onboarding_analytics_test.dart
+++ b/client/app/test/features/project_list/onboarding_analytics_test.dart
@@ -159,6 +159,12 @@ void main() {
     ).called(1);
   }
 
+  void expectCommandCopiedInfoAlert({required WidgetTester tester}) {
+    final alert = tester.widget<PregoPopupAlertsNotifications>(find.byType(PregoPopupAlertsNotifications));
+    expect(alert.title, "Command copied to clipboard");
+    expect(alert.variant, PregoPopupAlertsNotificationsVariant.info);
+  }
+
   group("connect-your-computer setup onboarding", () {
     testWidgets("keeps mobile CLI installation and omits desktop supervised start", (tester) async {
       await pumpConnectSetup(tester);
@@ -256,11 +262,13 @@ void main() {
 
     // Two command rows on this surface: the install box (step 1) first, the
     // run box (step 2) below it — hence copy/share at index 0 vs 1.
-    testWidgets("copying the default install command logs curl on unix", (tester) async {
+    testWidgets("copying the default install command shows an info alert and logs curl on unix", (tester) async {
       await pumpConnectSetup(tester);
 
       await tester.tap(find.bySemanticsLabel("Copy command").at(0));
       await tester.pumpAndSettle();
+
+      expectCommandCopiedInfoAlert(tester: tester);
 
       verifyLogged(
         const ProductAnalyticsEvent.installCommandCopied(
@@ -432,11 +440,13 @@ void main() {
       );
     });
 
-    testWidgets("copying the step-2 run command logs the run event", (tester) async {
+    testWidgets("copying the step-2 run command shows an info alert and logs the run event", (tester) async {
       await pumpConnectSetup(tester);
 
       await tester.tap(find.bySemanticsLabel("Copy command").at(1));
       await tester.pumpAndSettle();
+
+      expectCommandCopiedInfoAlert(tester: tester);
 
       verifyLogged(
         const ProductAnalyticsEvent.runCommandCopied(surface: OnboardingSurface.connectSetup),
@@ -445,7 +455,7 @@ void main() {
   });
 
   group("bridge-offline recovery view", () {
-    testWidgets("copying the run command logs the bridge-offline surface", (tester) async {
+    testWidgets("copying the run command shows an info alert and logs the bridge-offline surface", (tester) async {
       await pumpBridgeOffline(tester);
 
       // The install disclosure starts collapsed, so the always-visible run box
@@ -453,6 +463,7 @@ void main() {
       await tester.tap(find.bySemanticsLabel("Copy command"));
       await tester.pumpAndSettle();
 
+      expectCommandCopiedInfoAlert(tester: tester);
       verifyLogged(
         const ProductAnalyticsEvent.runCommandCopied(surface: OnboardingSurface.bridgeOffline),
       );
@@ -479,6 +490,8 @@ void main() {
       // the body, so it sits after the always-visible run box.
       await tester.tap(find.bySemanticsLabel("Copy command").at(1));
       await tester.pumpAndSettle();
+
+      expectCommandCopiedInfoAlert(tester: tester);
 
       verifyLogged(
         const ProductAnalyticsEvent.installCommandCopied(

--- a/docs/regression/account-and-onboarding.md
+++ b/docs/regression/account-and-onboarding.md
@@ -30,6 +30,9 @@ participates.
 - With no bridge, Projects shows install and start commands, the explainer, and
   support links, and copy/share hand off the command unchanged; connected with no
   projects shows the add-project call to action instead.
+- Copying install or start commands on onboarding or bridge-disconnected pages
+  shows the informational "Command copied to clipboard" popup, not the success
+  variant.
 - An account that never registered a bridge parks offline silently; the
   bridge-offline banner is reserved for accounts that have one.
 - A persisted registered-bridge read that completes after logout cannot restore


### PR DESCRIPTION
## Complexity
🌱 Trivial — one shared command-row alert variant changes; existing widget tests gain focused assertions.

## What
- Use the info popup variant when install or start commands are copied on onboarding and bridge-disconnected pages.
- Assert the info variant and unchanged copy text for both command types on both surfaces.
- Document the expected copy notification in onboarding regression guidance.

## Why
Command-copy feedback should be informational rather than success-styled, as requested in the [design reference](https://www.figma.com/design/NILKXLD9cwuWHhLnGqPqeJ/Sesori?node-id=4903-35035).

## Risk and test focus
Low risk, localized presentation-only change. User-visible impact is the info icon and neutral alert styling. No database, transport, authentication, clipboard-content, or analytics behavior changes. Existing design-system styling and localized wording are preserved.

## Expected result
Copying an install or start command displays the informational “Command copied to clipboard” popup on onboarding and bridge-disconnected pages.

## Verification
- `dart pub get` in `client/` — passed.
- `flutter test test/features/project_list/onboarding_analytics_test.dart` in `client/app/` — all 20 tests passed, including install/start info-alert assertions for onboarding and bridge-offline recovery.
- `dart analyze` in `client/app/` — no issues.
- `flutter build ios --simulator --debug --no-pub` — passed.
- Manual UI QA used **only iPhone 17 (iOS 26.5)**: disconnected-page start and expanded install commands showed the info popup; clipboard contents matched exactly; light/dark rendering and automatic dismissal verified. Original dark appearance restored, sign-in preserved, no live bridge changes.
- Onboarding state was widget-tested, not manually forced on the signed-in account with an existing registered bridge.
- Local screenshots: `client/app/build/command-copied-qa/` (ignored build artifacts).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the command-copied popup from success to info alert on onboarding and bridge-disconnected pages, so users see neutral feedback instead of success styling.

- Adds widget test assertions for the info variant and updates regression guidance.

<sup>Written for commit 431d8df7f648a1d933c8f2fb2874759cbc0c8930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

