### PR TITLE
🌿 [claude-inline-subtasks] Remove obsolete Codex child-prompt cache [step 4/7]

### DIFF
--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -8,12 +8,11 @@
 - **Plan date:** 2026-09-02
 - **Base:** `main` at `6e9028c4c6`
 - **Delivery:** one open PR at a time, following current repository rules.
-  Remaining Codex PRs use `<emoji> [claude-inline-subtasks] <description>
-  [step x/6]`: metadata and child sessions are merged steps 1/6 and 2/6;
-  typed child-prompt parsing, tiles, scoped stop, and coverage are steps 3/6
-  through 6/6. Historical merged titles remain unchanged. User-authorized
-  packaging split only; approved behavior and architecture are unchanged. Progress is tracked in `TRACKER.md` "Harness
-  Follow-Ups". The DeepSeek phone handoff is recorded in
+  Codex now has seven steps: merged metadata and child-session work remain
+  steps 1/7 and 2/7; merged PR #1387 remains historical preparation at its
+  original title; causal cleanup is step 4/7, tiles 5/7, scoped stop 6/7, and
+  coverage 7/7. Historical PR titles are unchanged. Progress is tracked in
+  `TRACKER.md` "Harness Follow-Ups". The DeepSeek phone handoff is recorded in
   `followups/deepseek-phone-qa.md`; desktop remains deferred.
 
 ## Goal
@@ -240,13 +239,13 @@ confirmation, no child session or partial stop) and gets that subset.
   status, and the `subtask` part
   (`messageID` = the activity item id, `childSessionID` = `agentThreadId`,
   description from `agentPath` or the resolved nickname, `taskState` running)
-  renders once the prompt is known, because the part requires one and the
-  activity item carries none: the child's first `userMessage` item under the
-  child thread id supplies it, and when the child streams no such item the
-  `thread/read` result is used only after the exact child `turn/started` id
-  matches a typed turn. Forked reads contain copied parent turns, so no
-  heuristic first/last-turn fallback is allowed and missing turn provenance
-  remains no fallback. The child's own `turn/completed` completes it, a
+  renders from child-owned rollout input when a valid plaintext `NEW_TASK`
+  payload exists. On the normal encrypted 0.153.4 path, it uses only the exact
+  nonblank `message` from the `spawn_agent` call whose call id matches the
+  activity id. This user-approved fallback is delegated task text, not a parent
+  `user_message`; parent history, task names, child order, and timing are never
+  prompt provenance. `thread/read(includeTurns: false)` remains metadata-only.
+  The child's own `turn/completed` completes it, a
   child `turn/interrupt` cancels it, and `thread/closed` cancels it only while
   it is pending or running; a prior completed, failed, interrupted, or errored
   terminal state wins over the later close. A child turn failure errors it,
@@ -284,15 +283,22 @@ confirmation, no child session or partial stop) and gets that subset.
 
 | Step | Emoji | Description | Scope |
 |---|---|---|---|
-| 1/6 | 🌿 | `codex: parse sub-agent thread and item metadata` | Merged historical title unchanged; DTO fields, collab/activity parser and enums, fixtures from the probe |
-| 2/6 | ⚙️ | `codex: sub-agent threads become child sessions` | Merged historical title unchanged; repository/mapper/service child-session flow, `parentID` live and from the catalog, roots-only listing, service-owned `getChildSessions` merge, directory attribution, summary rolls busy children into the root. Fixes the root-leak defect |
-| 3/6 | ⚙️ | `codex: parse typed child prompts from thread reads` | `thread/read` includes turn ids/items/content; Layer-2 caches text prompts by turn id for exact child-lifecycle selection, with generated serializers and focused inherited-history/unknown-variant tests. Preparatory packaging only; no tile behavior |
-| 4/6 | 🚧 | `codex: inline subtask tiles for spawned agents` | service-coordinated tracker, mapper cases, cancel on close/disconnect, call-id replacement of the generic spawn card in rollout-tail and full-history replay, child-rollout terminal join |
-| 5/6 | ⚙️ | `codex: scoped stop for sub-agent threads` | policy switch, per-child interrupt, `mainAgentOnlySupported` per probe, `interruptActiveWork` covers children |
-| 6/6 | 🌱 | `docs: record Codex sub-agent coverage` | matrix footnote ³ resolved, regression docs |
+| 1/7 | 🌿 | `codex: parse sub-agent thread and item metadata` | Merged historical title unchanged; DTO fields, collab/activity parser and enums, fixtures from the probe |
+| 2/7 | ⚙️ | `codex: sub-agent threads become child sessions` | Merged historical title unchanged; repository/mapper/service child-session flow, `parentID` live and from the catalog, roots-only listing, service-owned `getChildSessions` merge, directory attribution, summary rolls busy children into the root. Fixes the root-leak defect |
+| 3/7 | ⚙️ | `codex: parse typed child prompts from thread reads [step 3/6]` | PR #1387 merged under this historical title; its prompt cache was preparation only and is superseded by verified 0.153.4 rollout input |
+| 4/7 | 🌿 | `codex: remove obsolete child-prompt cache [step 4/7]` | Restore metadata-only `thread/read`; remove unused turn/item/content DTOs, cache, and synthetic tests |
+| 5/7 | 🚧 | `codex: inline subtask tiles for spawned agents [step 5/7]` | service-coordinated tracker, current persisted activity/input facts, exact-call prompt provenance, call-id replacement, and initial-turn terminal join |
+| 6/7 | ⚙️ | `codex: scoped stop for sub-agent threads [step 6/7]` | policy switch, per-child interrupt, `mainAgentOnlySupported` per probe, `interruptActiveWork` covers children |
+| 7/7 | 🌱 | `docs: record Codex sub-agent coverage [step 7/7]` | matrix footnote ³ resolved, regression docs |
 
-### Probe results (0.148.0, 2026-09-02, details in `followups/codex-probe.md`)
+### Probe results (0.148.0 and 0.153.4; details in `followups/codex-probe.md`)
 
+- Current 0.153.4 rollouts persist activity as
+  `event_msg/item_completed/item/SubAgentActivity`; its item id equals the
+  matching `spawn_agent.call_id`. Normal child input is an encrypted
+  `response_item/agent_message` after `inter_agent_communication_metadata`,
+  while `thread/read` exposes no initial child user item. Existing rollout
+  tails observe the append; no watcher or timer is added.
 - Children never emit `thread/started`; a child first appears as
   `thread/status/changed` followed by the parent's `subAgentActivity started`
   (`agentThreadId`, `agentPath`). No `spawnAgent` collab item was emitted, only

--- a/.plan/active/claude-inline-subtasks/PLAN.md
+++ b/.plan/active/claude-inline-subtasks/PLAN.md
@@ -20,9 +20,10 @@
   Both slices merged (#1363, #1370). Agent-run phone QA found the transport
   crash fixed by #1379; requested phone stop/input checks then passed. See
   `followups/deepseek-phone-qa.md`. Desktop is deferred by user choice. Codex
-  now uses a user-authorized six-step packaging sequence: typed child-prompt
-  parsing is step 3/6 and inline tiles step 4/6, with approved behavior and
-  architecture unchanged. Overall harness plan remains active.
+  now uses a user-authorized seven-step sequence: merged PR #1387 is historical
+  preparation superseded by the verified 0.153.4 rollout-input seam; causal
+  cleanup is step 4/7, tiles step 5/7, scoped stop step 6/7, and coverage step
+  7/7. Overall harness plan remains active.
 
 ## Goal
 

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -9,8 +9,8 @@
   also made the scoped stop harness-neutral (OpenCode honors it; rejections
   declare `mainAgentOnlySupported`) and added `docs/HARNESS_CAPABILITIES.md`;
   the original Claude series is complete; harness follow-ups remain active
-- **Next action:** finish Codex causal cleanup step 4/7 locally, then integrate
-  corrected inline tiles as step 5/7. Merged PR #1387 is historical preparation
+- **Next action:** land Codex causal cleanup [PR #1396](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1396)
+  (step 4/7), then integrate corrected inline tiles as step 5/7. Merged PR #1387 is historical preparation
   superseded by the verified 0.153.4 rollout-input seam. DeepSeek #1363,
   #1370, and the live-QA crash fix #1379 are merged. Requested phone-only
   stop/input checks passed; see `followups/deepseek-phone-qa.md`. Desktop
@@ -165,8 +165,8 @@ post-merge E2E gates are unchanged.
 | [x] | all | `🌱 [claude-inline-subtasks] docs: plan Codex, Grok Build, DeepSeek, and Cursor sub-agent follow-ups` | [PR #1260](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1260) merged |
 | [x] | Codex | `🌿 [claude-inline-subtasks] codex: parse sub-agent thread and item metadata` | [PR #1263](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1263) merged; historical title unchanged (now step 1/7) |
 | [x] | Codex | `⚙️ [claude-inline-subtasks] codex: sub-agent threads become child sessions` | [PR #1273](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1273) merged; lifecycle hardening [PR #1280](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1280) merged; historical title unchanged (now step 2/7) |
-| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse typed child prompts from thread reads [step 3/6]` | [PR #1387](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1387) merged; historical title unchanged; preparation superseded by 0.153.4 evidence |
-| [x] | Codex | `🌿 [claude-inline-subtasks] codex: remove obsolete child-prompt cache [step 4/7]` | Completed locally on `claude-inline-subtasks-codex-cleanup-step4`; no tile code |
+| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse typed child prompts from thread reads [step 3/6]` | [PR #1387](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1387) merged; historical title unchanged (now step 3/7); preparation superseded by 0.153.4 evidence |
+| [x] | Codex | `🌿 [claude-inline-subtasks] codex: remove obsolete child-prompt cache [step 4/7]` | [PR #1396](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1396) open; implemented, awaiting merge; no tile code |
 | [ ] | Codex | `🚧 [claude-inline-subtasks] codex: inline subtask tiles for spawned agents [step 5/7]` | Rejected incomplete checkpoint preserved on `claude-inline-subtasks-codex-tiles-step4-integrated`; original successor refs remain preserved and unpublished |
 | [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: scoped stop for sub-agent threads [step 6/7]` | Not started |
 | [ ] | Codex | `🌱 [claude-inline-subtasks] docs: record Codex sub-agent coverage [step 7/7]` | Not started |

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -9,9 +9,9 @@
   also made the scoped stop harness-neutral (OpenCode honors it; rejections
   declare `mainAgentOnlySupported`) and added `docs/HARNESS_CAPABILITIES.md`;
   the original Claude series is complete; harness follow-ups remain active
-- **Next action:** Codex typed child-prompt parsing (step 3/6), followed by
-  inline subtask tiles (step 4/6). This is a user-authorized packaging split;
-  approved behavior and architecture are unchanged. DeepSeek #1363,
+- **Next action:** finish Codex causal cleanup step 4/7 locally, then integrate
+  corrected inline tiles as step 5/7. Merged PR #1387 is historical preparation
+  superseded by the verified 0.153.4 rollout-input seam. DeepSeek #1363,
   #1370, and the live-QA crash fix #1379 are merged. Requested phone-only
   stop/input checks passed; see `followups/deepseek-phone-qa.md`. Desktop
   remains deferred by user choice; the overall plan remains active.
@@ -163,12 +163,13 @@ post-merge E2E gates are unchanged.
 | Done | Harness | Description | State |
 |---|---|---|---|
 | [x] | all | `🌱 [claude-inline-subtasks] docs: plan Codex, Grok Build, DeepSeek, and Cursor sub-agent follow-ups` | [PR #1260](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1260) merged |
-| [x] | Codex | `🌿 [claude-inline-subtasks] codex: parse sub-agent thread and item metadata` | [PR #1263](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1263) merged; historical title unchanged (step 1/6) |
-| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: sub-agent threads become child sessions` | [PR #1273](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1273) merged; lifecycle hardening [PR #1280](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1280) merged; historical title unchanged (step 2/6) |
-| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse typed child prompts from thread reads [step 3/6]` | Implemented on `claude-inline-subtasks-codex-tiles`; preparatory parsing/codegen only |
-| [ ] | Codex | `🚧 [claude-inline-subtasks] codex: inline subtask tiles for spawned agents [step 4/6]` | Full checkpoint preserved on local branch `claude-inline-subtasks-codex-tiles-successor`; review-ready successor on `claude-inline-subtasks-codex-tiles-successor-ready`; neither published |
-| [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: scoped stop for sub-agent threads [step 5/6]` | Not started |
-| [ ] | Codex | `🌱 [claude-inline-subtasks] docs: record Codex sub-agent coverage [step 6/6]` | Not started |
+| [x] | Codex | `🌿 [claude-inline-subtasks] codex: parse sub-agent thread and item metadata` | [PR #1263](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1263) merged; historical title unchanged (now step 1/7) |
+| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: sub-agent threads become child sessions` | [PR #1273](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1273) merged; lifecycle hardening [PR #1280](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1280) merged; historical title unchanged (now step 2/7) |
+| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse typed child prompts from thread reads [step 3/6]` | [PR #1387](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1387) merged; historical title unchanged; preparation superseded by 0.153.4 evidence |
+| [x] | Codex | `🌿 [claude-inline-subtasks] codex: remove obsolete child-prompt cache [step 4/7]` | Completed locally on `claude-inline-subtasks-codex-cleanup-step4`; no tile code |
+| [ ] | Codex | `🚧 [claude-inline-subtasks] codex: inline subtask tiles for spawned agents [step 5/7]` | Rejected incomplete checkpoint preserved on `claude-inline-subtasks-codex-tiles-step4-integrated`; original successor refs remain preserved and unpublished |
+| [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: scoped stop for sub-agent threads [step 6/7]` | Not started |
+| [ ] | Codex | `🌱 [claude-inline-subtasks] docs: record Codex sub-agent coverage [step 7/7]` | Not started |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] grok: parse sub-agent lifecycle notifications` | [PR #1270](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1270) merged |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] acp: child sessions keep the root busy` | [PR #1272](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1272) merged |
 | [ ] | Grok | `🌿 [claude-inline-subtasks] grok: child session history` | Not started |
@@ -739,28 +740,28 @@ corrected independent-scope stop and pending/later-input checks passed.
 The user deferred desktop and requested progression to Codex after phone checks;
 managed-runtime automation remains separately owned.
 
-Codex delivery split (user-authorized): complete typed-prompt + tile source is
-preserved unchanged on local branch
-`claude-inline-subtasks-codex-tiles-successor` (`8f9923b663`) and the
-review-ready snapshot remains on
-`claude-inline-subtasks-codex-tiles-successor-ready` (`8a2952f318`). Those
-snapshots predate the step 3/6 provenance correction and must be integrated
-later without losing their tile work. Full-source successor Codex
-`dart analyze --fatal-infos`, focused live/replay/terminal tests, and the owning
-package test suite passed before extraction. Step 3/6 contains typed
-`thread/read` prompt parsing/codegen only; step 4/6 retains exact call-id
-replacement, service-owned lifecycle, child terminal joins, and cleanup without
-design changes. Review this branch only against `origin/main`; do not include
-preserved successor source in the preparatory PR.
+Codex seven-step correction (user-authorized): merged PR #1387 keeps its
+historical `[step 3/6]` title but is superseded preparation. Current 0.153.4
+persists started activity as `event_msg/item_completed/item/SubAgentActivity`;
+its item id exactly matches `spawn_agent.call_id`. Normal child input appends as
+`inter_agent_communication_metadata` plus encrypted
+`response_item/agent_message`; `thread/read` exposes no initial child user item.
+The existing rollout tail sees this append, so no new watcher or timer is needed.
 
-Codex step 3/6 correction: `thread/read` now parses turn ids and caches typed
-`text` prompts by turn id. `initialUserPrompt` requires the child lifecycle's
-exact, nullable `turnId`; null or unmatched provenance returns null instead of
-choosing copied parent history. The step 4/6 integration must resolve this cache
-when the existing `turn/started` owner observes the child turn id, while keeping
-live child-message prompt selection first and this read result as fallback.
-Unsupported rollout-only `input_text` decodes through the unknown content
-variant. Generated Freezed/JSON sources, the focused eight-test metadata suite,
-`dart analyze --fatal-infos`, and the complete `sesori_plugin_codex` test suite
-pass. No tile lifecycle, stop policy, runtime pin, native adapter, client,
-shared contract, or database behavior changes.
+User decision: for encrypted child input, tile prompt may use only the exact
+nonblank `message` from the matching `spawn_agent` call. It must never use an
+unrelated parent `user_message`, copied parent history, task-name/order/timing
+match, or envelope header. Valid child-owned plaintext `NEW_TASK` input may
+replace that fallback for the initial delegated turn.
+
+Step 4/7 therefore removes only obsolete #1387 machinery: turn/item/content
+thread DTOs, `includeTurns: true`, prompt cache/lookups/cleanup, and synthetic
+prompt-cache tests. Parent/source/nickname metadata remains. Workspace codegen,
+focused metadata/write-path/service tests, the complete Codex package suite,
+and `dart analyze --fatal-infos` pass. Corrected tiles are step 5/7; scoped stop
+is 6/7; coverage is 7/7. Rejected tile work remains at
+`claude-inline-subtasks-codex-tiles-step4-integrated` (`c6aa29a8ce`), while
+`claude-inline-subtasks-codex-tiles-successor` (`8f9923b663`) and
+`claude-inline-subtasks-codex-tiles-successor-ready` (`8a2952f318`) remain
+untouched. No runtime pin, native source, client/shared contract, database, or
+stop behavior changes in cleanup step 4/7.

--- a/.plan/active/claude-inline-subtasks/followups/codex-probe.md
+++ b/.plan/active/claude-inline-subtasks/followups/codex-probe.md
@@ -11,6 +11,30 @@ Three runs: (A) spawn one sub-agent that replies "done"; (B) spawn a child
 that runs `sleep 90`, then `turn/interrupt` the parent; (C) same, then
 `turn/interrupt` the child.
 
+## Current-pin correction (codex-cli 0.153.4, 2026-09-08)
+
+A bounded production-shaped stdio probe against managed 0.153.4 supersedes the
+0.148.0 rollout-input assumptions below without erasing their historical value:
+
+- persisted started activity is
+  `event_msg/item_completed/item/SubAgentActivity`; its `id` exactly equals the
+  preceding `spawn_agent.call_id` for both forked and nonforked children;
+- `thread/read(includeTurns: true)` exposed no initial child user item, and live
+  app-server output emitted no stable child `userMessage` or public raw-response
+  notification;
+- initial child input appended after child `turn/started` as adjacent
+  `inter_agent_communication_metadata` and `response_item/agent_message` records;
+  normal model-origin payload was encrypted, while existing rollout tails can
+  observe the append without another watcher or timer;
+- user-approved prompt provenance for encrypted input is only the exact nonblank
+  `message` from the matching spawn call id. Never use a parent user message,
+  copied history, task name, child order, timing, or the agent-message envelope
+  header. A valid child-owned plaintext `NEW_TASK` payload may replace that
+  fallback for the initial delegated turn.
+
+Raw probe payloads remain private under the owned `/tmp` artifacts. Native source
+was pinned to Codex commit `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`.
+
 ## Frame order on the parent connection (run A)
 
 1. `thread/started {thread: {id: P, parentThreadId: null, agentNickname: null,

--- a/.plan/active/claude-inline-subtasks/followups/deepseek-phone-qa.md
+++ b/.plan/active/claude-inline-subtasks/followups/deepseek-phone-qa.md
@@ -56,7 +56,8 @@ write/response-timed probe and phone observations above are the evidence.
 
 ## Handoff
 
-The requested phone stop/input checks are complete. Continue with Codex typed
-prompt parsing (step 3/6), then inline subtask tiles (step 4/6); its metadata
-and child-session foundations already merged in #1263, #1273, and #1280. Do not mark remaining harness coverage or the
-whole plan complete on the strength of this phone-only handoff.
+The requested phone stop/input checks are complete. Codex #1387 remains
+historical preparation; continue through cleanup step 4/7, inline tiles 5/7,
+scoped stop 6/7, and coverage 7/7. Metadata and child-session foundations
+already merged in #1263, #1273, and #1280. Do not mark remaining harness
+coverage or the whole plan complete on the strength of this phone-only handoff.

--- a/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/codex_app_server_api.dart
@@ -83,7 +83,7 @@ class CodexAppServerApi({required final CodexAppServerTransport _client}) {
   }) async {
     final result = await _client.request(
       method: "thread/read",
-      params: {"threadId": threadId, "includeTurns": true},
+      params: {"threadId": threadId, "includeTurns": false},
     );
     return _decodeResponse(result: result, operation: "thread/read");
   }

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.dart
@@ -28,38 +28,6 @@ sealed class CodexThreadEnvelopeDto with _$CodexThreadEnvelopeDto {
 }
 
 @Freezed(fromJson: true, toJson: false)
-sealed class CodexThreadTurnDto with _$CodexThreadTurnDto {
-  const factory({
-    required String? id,
-    @JsonKey(defaultValue: <CodexThreadItemDto>[]) required List<CodexThreadItemDto> items,
-  }) = _CodexThreadTurnDto;
-
-  factory fromJson(Map<String, dynamic> json) => _$CodexThreadTurnDtoFromJson(json);
-}
-
-@Freezed(unionKey: "type", fallbackUnion: "unknown", fromJson: true, toJson: false)
-sealed class CodexThreadItemDto with _$CodexThreadItemDto {
-  @FreezedUnionValue("userMessage")
-  const factory userMessage({
-    @JsonKey(defaultValue: <CodexThreadContentDto>[]) required List<CodexThreadContentDto> content,
-  }) = CodexThreadUserMessageItemDto;
-
-  const factory unknown() = CodexThreadUnknownItemDto;
-
-  factory fromJson(Map<String, dynamic> json) => _$CodexThreadItemDtoFromJson(json);
-}
-
-@Freezed(unionKey: "type", fallbackUnion: "unknown", fromJson: true, toJson: false)
-sealed class CodexThreadContentDto with _$CodexThreadContentDto {
-  @FreezedUnionValue("text")
-  const factory text({required String text}) = CodexThreadTextContentDto;
-
-  const factory unknown() = CodexThreadUnknownContentDto;
-
-  factory fromJson(Map<String, dynamic> json) => _$CodexThreadContentDtoFromJson(json);
-}
-
-@Freezed(fromJson: true, toJson: false)
 sealed class CodexThreadDto with _$CodexThreadDto {
   const factory({
     required String? id,
@@ -72,7 +40,6 @@ sealed class CodexThreadDto with _$CodexThreadDto {
     required String? agentNickname,
     required String? agentRole,
     @JsonKey(unknownEnumValue: CodexThreadSource.unknown) required CodexThreadSource? threadSource,
-    @JsonKey(defaultValue: <CodexThreadTurnDto>[]) required List<CodexThreadTurnDto> turns,
   }) = _CodexThreadDto;
 
   factory fromJson(Map<String, dynamic> json) => _$CodexThreadDtoFromJson(json);

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.freezed.dart
@@ -176,461 +176,9 @@ $CodexThreadDtoCopyWith<$Res>? get thread {
 
 
 /// @nodoc
-mixin _$CodexThreadTurnDto {
-
- String? get id;@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> get items;
-/// Create a copy of CodexThreadTurnDto
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$CodexThreadTurnDtoCopyWith<CodexThreadTurnDto> get copyWith => _$CodexThreadTurnDtoCopyWithImpl<CodexThreadTurnDto>(this as CodexThreadTurnDto, _$identity);
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadTurnDto&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other.items, items));
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(items));
-
-@override
-String toString() {
-  return 'CodexThreadTurnDto(id: $id, items: $items)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class $CodexThreadTurnDtoCopyWith<$Res>  {
-  factory $CodexThreadTurnDtoCopyWith(CodexThreadTurnDto value, $Res Function(CodexThreadTurnDto) _then) = _$CodexThreadTurnDtoCopyWithImpl;
-@useResult
-$Res call({
- String? id,@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> items
-});
-
-
-
-
-}
-/// @nodoc
-class _$CodexThreadTurnDtoCopyWithImpl<$Res>
-    implements $CodexThreadTurnDtoCopyWith<$Res> {
-  _$CodexThreadTurnDtoCopyWithImpl(this._self, this._then);
-
-  final CodexThreadTurnDto _self;
-  final $Res Function(CodexThreadTurnDto) _then;
-
-/// Create a copy of CodexThreadTurnDto
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? items = null,}) {
-  return _then(CodexThreadTurnDto(
-id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String?,items: null == items ? _self.items : items // ignore: cast_nullable_to_non_nullable
-as List<CodexThreadItemDto>,
-  ));
-}
-
-}
-
-
-
-/// @nodoc
-@JsonSerializable(createToJson: false)
-
-class _CodexThreadTurnDto implements CodexThreadTurnDto {
-  const _CodexThreadTurnDto({required this.id, @JsonKey(defaultValue: <CodexThreadItemDto>[]) required  List<CodexThreadItemDto> items}): _items = items;
-  factory _CodexThreadTurnDto.fromJson(Map<String, dynamic> json) => _$CodexThreadTurnDtoFromJson(json);
-
-@override final  String? id;
- final  List<CodexThreadItemDto> _items;
-@override@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> get items {
-  if (_items is EqualUnmodifiableListView) return _items;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_items);
-}
-
-
-/// Create a copy of CodexThreadTurnDto
-/// with the given fields replaced by the non-null parameter values.
-@override @JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-_$CodexThreadTurnDtoCopyWith<_CodexThreadTurnDto> get copyWith => __$CodexThreadTurnDtoCopyWithImpl<_CodexThreadTurnDto>(this, _$identity);
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadTurnDto&&(identical(other.id, id) || other.id == id)&&const DeepCollectionEquality().equals(other._items, _items));
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => Object.hash(runtimeType,id,const DeepCollectionEquality().hash(_items));
-
-@override
-String toString() {
-  return 'CodexThreadTurnDto(id: $id, items: $items)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class _$CodexThreadTurnDtoCopyWith<$Res> implements $CodexThreadTurnDtoCopyWith<$Res> {
-  factory _$CodexThreadTurnDtoCopyWith(_CodexThreadTurnDto value, $Res Function(_CodexThreadTurnDto) _then) = __$CodexThreadTurnDtoCopyWithImpl;
-@override @useResult
-$Res call({
- String? id,@JsonKey(defaultValue: <CodexThreadItemDto>[]) List<CodexThreadItemDto> items
-});
-
-
-
-
-}
-/// @nodoc
-class __$CodexThreadTurnDtoCopyWithImpl<$Res>
-    implements _$CodexThreadTurnDtoCopyWith<$Res> {
-  __$CodexThreadTurnDtoCopyWithImpl(this._self, this._then);
-
-  final _CodexThreadTurnDto _self;
-  final $Res Function(_CodexThreadTurnDto) _then;
-
-/// Create a copy of CodexThreadTurnDto
-/// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? items = null,}) {
-  return _then(_CodexThreadTurnDto(
-id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
-as String?,items: null == items ? _self._items : items // ignore: cast_nullable_to_non_nullable
-as List<CodexThreadItemDto>,
-  ));
-}
-
-
-}
-
-CodexThreadItemDto _$CodexThreadItemDtoFromJson(
-  Map<String, dynamic> json
-) {
-        switch (json['type']) {
-                  case 'userMessage':
-          return CodexThreadUserMessageItemDto.fromJson(
-            json
-          );
-        
-          default:
-            return CodexThreadUnknownItemDto.fromJson(
-  json
-);
-        }
-      
-}
-
-/// @nodoc
-mixin _$CodexThreadItemDto {
-
-
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadItemDto);
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => runtimeType.hashCode;
-
-@override
-String toString() {
-  return 'CodexThreadItemDto()';
-}
-
-
-}
-
-/// @nodoc
-class $CodexThreadItemDtoCopyWith<$Res>  {
-$CodexThreadItemDtoCopyWith(CodexThreadItemDto _, $Res Function(CodexThreadItemDto) __);
-}
-
-
-
-/// @nodoc
-@JsonSerializable(createToJson: false)
-
-class CodexThreadUserMessageItemDto implements CodexThreadItemDto {
-  const CodexThreadUserMessageItemDto({@JsonKey(defaultValue: <CodexThreadContentDto>[]) required  List<CodexThreadContentDto> content,  String? $type}): _content = content,$type = $type ?? 'userMessage';
-  factory CodexThreadUserMessageItemDto.fromJson(Map<String, dynamic> json) => _$CodexThreadUserMessageItemDtoFromJson(json);
-
- final  List<CodexThreadContentDto> _content;
-@JsonKey(defaultValue: <CodexThreadContentDto>[]) List<CodexThreadContentDto> get content {
-  if (_content is EqualUnmodifiableListView) return _content;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_content);
-}
-
-
-@JsonKey(name: 'type')
-final String $type;
-
-
-/// Create a copy of CodexThreadItemDto
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$CodexThreadUserMessageItemDtoCopyWith<CodexThreadUserMessageItemDto> get copyWith => _$CodexThreadUserMessageItemDtoCopyWithImpl<CodexThreadUserMessageItemDto>(this, _$identity);
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadUserMessageItemDto&&const DeepCollectionEquality().equals(other._content, _content));
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_content));
-
-@override
-String toString() {
-  return 'CodexThreadItemDto.userMessage(content: $content)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class $CodexThreadUserMessageItemDtoCopyWith<$Res> implements $CodexThreadItemDtoCopyWith<$Res> {
-  factory $CodexThreadUserMessageItemDtoCopyWith(CodexThreadUserMessageItemDto value, $Res Function(CodexThreadUserMessageItemDto) _then) = _$CodexThreadUserMessageItemDtoCopyWithImpl;
-@useResult
-$Res call({
-@JsonKey(defaultValue: <CodexThreadContentDto>[]) List<CodexThreadContentDto> content
-});
-
-
-
-
-}
-/// @nodoc
-class _$CodexThreadUserMessageItemDtoCopyWithImpl<$Res>
-    implements $CodexThreadUserMessageItemDtoCopyWith<$Res> {
-  _$CodexThreadUserMessageItemDtoCopyWithImpl(this._self, this._then);
-
-  final CodexThreadUserMessageItemDto _self;
-  final $Res Function(CodexThreadUserMessageItemDto) _then;
-
-/// Create a copy of CodexThreadItemDto
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? content = null,}) {
-  return _then(CodexThreadUserMessageItemDto(
-content: null == content ? _self._content : content // ignore: cast_nullable_to_non_nullable
-as List<CodexThreadContentDto>,
-  ));
-}
-
-
-}
-
-/// @nodoc
-@JsonSerializable(createToJson: false)
-
-class CodexThreadUnknownItemDto implements CodexThreadItemDto {
-  const CodexThreadUnknownItemDto({ String? $type}): $type = $type ?? 'unknown';
-  factory CodexThreadUnknownItemDto.fromJson(Map<String, dynamic> json) => _$CodexThreadUnknownItemDtoFromJson(json);
-
-
-
-@JsonKey(name: 'type')
-final String $type;
-
-
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadUnknownItemDto);
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => runtimeType.hashCode;
-
-@override
-String toString() {
-  return 'CodexThreadItemDto.unknown()';
-}
-
-
-}
-
-
-
-
-CodexThreadContentDto _$CodexThreadContentDtoFromJson(
-  Map<String, dynamic> json
-) {
-        switch (json['type']) {
-                  case 'text':
-          return CodexThreadTextContentDto.fromJson(
-            json
-          );
-        
-          default:
-            return CodexThreadUnknownContentDto.fromJson(
-  json
-);
-        }
-      
-}
-
-/// @nodoc
-mixin _$CodexThreadContentDto {
-
-
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadContentDto);
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => runtimeType.hashCode;
-
-@override
-String toString() {
-  return 'CodexThreadContentDto()';
-}
-
-
-}
-
-/// @nodoc
-class $CodexThreadContentDtoCopyWith<$Res>  {
-$CodexThreadContentDtoCopyWith(CodexThreadContentDto _, $Res Function(CodexThreadContentDto) __);
-}
-
-
-
-/// @nodoc
-@JsonSerializable(createToJson: false)
-
-class CodexThreadTextContentDto implements CodexThreadContentDto {
-  const CodexThreadTextContentDto({required this.text,  String? $type}): $type = $type ?? 'text';
-  factory CodexThreadTextContentDto.fromJson(Map<String, dynamic> json) => _$CodexThreadTextContentDtoFromJson(json);
-
- final  String text;
-
-@JsonKey(name: 'type')
-final String $type;
-
-
-/// Create a copy of CodexThreadContentDto
-/// with the given fields replaced by the non-null parameter values.
-@JsonKey(includeFromJson: false, includeToJson: false)
-@pragma('vm:prefer-inline')
-$CodexThreadTextContentDtoCopyWith<CodexThreadTextContentDto> get copyWith => _$CodexThreadTextContentDtoCopyWithImpl<CodexThreadTextContentDto>(this, _$identity);
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadTextContentDto&&(identical(other.text, text) || other.text == text));
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => Object.hash(runtimeType,text);
-
-@override
-String toString() {
-  return 'CodexThreadContentDto.text(text: $text)';
-}
-
-
-}
-
-/// @nodoc
-abstract mixin class $CodexThreadTextContentDtoCopyWith<$Res> implements $CodexThreadContentDtoCopyWith<$Res> {
-  factory $CodexThreadTextContentDtoCopyWith(CodexThreadTextContentDto value, $Res Function(CodexThreadTextContentDto) _then) = _$CodexThreadTextContentDtoCopyWithImpl;
-@useResult
-$Res call({
- String text
-});
-
-
-
-
-}
-/// @nodoc
-class _$CodexThreadTextContentDtoCopyWithImpl<$Res>
-    implements $CodexThreadTextContentDtoCopyWith<$Res> {
-  _$CodexThreadTextContentDtoCopyWithImpl(this._self, this._then);
-
-  final CodexThreadTextContentDto _self;
-  final $Res Function(CodexThreadTextContentDto) _then;
-
-/// Create a copy of CodexThreadContentDto
-/// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
-  return _then(CodexThreadTextContentDto(
-text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
-as String,
-  ));
-}
-
-
-}
-
-/// @nodoc
-@JsonSerializable(createToJson: false)
-
-class CodexThreadUnknownContentDto implements CodexThreadContentDto {
-  const CodexThreadUnknownContentDto({ String? $type}): $type = $type ?? 'unknown';
-  factory CodexThreadUnknownContentDto.fromJson(Map<String, dynamic> json) => _$CodexThreadUnknownContentDtoFromJson(json);
-
-
-
-@JsonKey(name: 'type')
-final String $type;
-
-
-
-
-
-@override
-bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadUnknownContentDto);
-}
-
-@JsonKey(includeFromJson: false, includeToJson: false)
-@override
-int get hashCode => runtimeType.hashCode;
-
-@override
-String toString() {
-  return 'CodexThreadContentDto.unknown()';
-}
-
-
-}
-
-
-
-
-
-/// @nodoc
 mixin _$CodexThreadDto {
 
- String? get id; String? get name; String? get cwd; num? get createdAt; num? get updatedAt; String? get modelProvider; String? get parentThreadId; String? get agentNickname; String? get agentRole;@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? get threadSource;@JsonKey(defaultValue: <CodexThreadTurnDto>[]) List<CodexThreadTurnDto> get turns;
+ String? get id; String? get name; String? get cwd; num? get createdAt; num? get updatedAt; String? get modelProvider; String? get parentThreadId; String? get agentNickname; String? get agentRole;@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? get threadSource;
 /// Create a copy of CodexThreadDto
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -641,16 +189,16 @@ $CodexThreadDtoCopyWith<CodexThreadDto> get copyWith => _$CodexThreadDtoCopyWith
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.parentThreadId, parentThreadId) || other.parentThreadId == parentThreadId)&&(identical(other.agentNickname, agentNickname) || other.agentNickname == agentNickname)&&(identical(other.agentRole, agentRole) || other.agentRole == agentRole)&&(identical(other.threadSource, threadSource) || other.threadSource == threadSource)&&const DeepCollectionEquality().equals(other.turns, turns));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexThreadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.parentThreadId, parentThreadId) || other.parentThreadId == parentThreadId)&&(identical(other.agentNickname, agentNickname) || other.agentNickname == agentNickname)&&(identical(other.agentRole, agentRole) || other.agentRole == agentRole)&&(identical(other.threadSource, threadSource) || other.threadSource == threadSource));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,cwd,createdAt,updatedAt,modelProvider,parentThreadId,agentNickname,agentRole,threadSource,const DeepCollectionEquality().hash(turns));
+int get hashCode => Object.hash(runtimeType,id,name,cwd,createdAt,updatedAt,modelProvider,parentThreadId,agentNickname,agentRole,threadSource);
 
 @override
 String toString() {
-  return 'CodexThreadDto(id: $id, name: $name, cwd: $cwd, createdAt: $createdAt, updatedAt: $updatedAt, modelProvider: $modelProvider, parentThreadId: $parentThreadId, agentNickname: $agentNickname, agentRole: $agentRole, threadSource: $threadSource, turns: $turns)';
+  return 'CodexThreadDto(id: $id, name: $name, cwd: $cwd, createdAt: $createdAt, updatedAt: $updatedAt, modelProvider: $modelProvider, parentThreadId: $parentThreadId, agentNickname: $agentNickname, agentRole: $agentRole, threadSource: $threadSource)';
 }
 
 
@@ -661,7 +209,7 @@ abstract mixin class $CodexThreadDtoCopyWith<$Res>  {
   factory $CodexThreadDtoCopyWith(CodexThreadDto value, $Res Function(CodexThreadDto) _then) = _$CodexThreadDtoCopyWithImpl;
 @useResult
 $Res call({
- String? id, String? name, String? cwd, num? createdAt, num? updatedAt, String? modelProvider, String? parentThreadId, String? agentNickname, String? agentRole,@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? threadSource,@JsonKey(defaultValue: <CodexThreadTurnDto>[]) List<CodexThreadTurnDto> turns
+ String? id, String? name, String? cwd, num? createdAt, num? updatedAt, String? modelProvider, String? parentThreadId, String? agentNickname, String? agentRole,@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? threadSource
 });
 
 
@@ -678,7 +226,7 @@ class _$CodexThreadDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexThreadDto
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? name = freezed,Object? cwd = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? modelProvider = freezed,Object? parentThreadId = freezed,Object? agentNickname = freezed,Object? agentRole = freezed,Object? threadSource = freezed,Object? turns = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = freezed,Object? name = freezed,Object? cwd = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? modelProvider = freezed,Object? parentThreadId = freezed,Object? agentNickname = freezed,Object? agentRole = freezed,Object? threadSource = freezed,}) {
   return _then(CodexThreadDto(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -690,8 +238,7 @@ as String?,parentThreadId: freezed == parentThreadId ? _self.parentThreadId : pa
 as String?,agentNickname: freezed == agentNickname ? _self.agentNickname : agentNickname // ignore: cast_nullable_to_non_nullable
 as String?,agentRole: freezed == agentRole ? _self.agentRole : agentRole // ignore: cast_nullable_to_non_nullable
 as String?,threadSource: freezed == threadSource ? _self.threadSource : threadSource // ignore: cast_nullable_to_non_nullable
-as CodexThreadSource?,turns: null == turns ? _self.turns : turns // ignore: cast_nullable_to_non_nullable
-as List<CodexThreadTurnDto>,
+as CodexThreadSource?,
   ));
 }
 
@@ -703,7 +250,7 @@ as List<CodexThreadTurnDto>,
 @JsonSerializable(createToJson: false)
 
 class _CodexThreadDto implements CodexThreadDto {
-  const _CodexThreadDto({required this.id, required this.name, required this.cwd, required this.createdAt, required this.updatedAt, required this.modelProvider, required this.parentThreadId, required this.agentNickname, required this.agentRole, @JsonKey(unknownEnumValue: CodexThreadSource.unknown) required this.threadSource, @JsonKey(defaultValue: <CodexThreadTurnDto>[]) required  List<CodexThreadTurnDto> turns}): _turns = turns;
+  const _CodexThreadDto({required this.id, required this.name, required this.cwd, required this.createdAt, required this.updatedAt, required this.modelProvider, required this.parentThreadId, required this.agentNickname, required this.agentRole, @JsonKey(unknownEnumValue: CodexThreadSource.unknown) required this.threadSource});
   factory _CodexThreadDto.fromJson(Map<String, dynamic> json) => _$CodexThreadDtoFromJson(json);
 
 @override final  String? id;
@@ -716,13 +263,6 @@ class _CodexThreadDto implements CodexThreadDto {
 @override final  String? agentNickname;
 @override final  String? agentRole;
 @override@JsonKey(unknownEnumValue: CodexThreadSource.unknown) final  CodexThreadSource? threadSource;
- final  List<CodexThreadTurnDto> _turns;
-@override@JsonKey(defaultValue: <CodexThreadTurnDto>[]) List<CodexThreadTurnDto> get turns {
-  if (_turns is EqualUnmodifiableListView) return _turns;
-  // ignore: implicit_dynamic_type
-  return EqualUnmodifiableListView(_turns);
-}
-
 
 /// Create a copy of CodexThreadDto
 /// with the given fields replaced by the non-null parameter values.
@@ -734,16 +274,16 @@ _$CodexThreadDtoCopyWith<_CodexThreadDto> get copyWith => __$CodexThreadDtoCopyW
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.parentThreadId, parentThreadId) || other.parentThreadId == parentThreadId)&&(identical(other.agentNickname, agentNickname) || other.agentNickname == agentNickname)&&(identical(other.agentRole, agentRole) || other.agentRole == agentRole)&&(identical(other.threadSource, threadSource) || other.threadSource == threadSource)&&const DeepCollectionEquality().equals(other._turns, _turns));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexThreadDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.cwd, cwd) || other.cwd == cwd)&&(identical(other.createdAt, createdAt) || other.createdAt == createdAt)&&(identical(other.updatedAt, updatedAt) || other.updatedAt == updatedAt)&&(identical(other.modelProvider, modelProvider) || other.modelProvider == modelProvider)&&(identical(other.parentThreadId, parentThreadId) || other.parentThreadId == parentThreadId)&&(identical(other.agentNickname, agentNickname) || other.agentNickname == agentNickname)&&(identical(other.agentRole, agentRole) || other.agentRole == agentRole)&&(identical(other.threadSource, threadSource) || other.threadSource == threadSource));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name,cwd,createdAt,updatedAt,modelProvider,parentThreadId,agentNickname,agentRole,threadSource,const DeepCollectionEquality().hash(_turns));
+int get hashCode => Object.hash(runtimeType,id,name,cwd,createdAt,updatedAt,modelProvider,parentThreadId,agentNickname,agentRole,threadSource);
 
 @override
 String toString() {
-  return 'CodexThreadDto(id: $id, name: $name, cwd: $cwd, createdAt: $createdAt, updatedAt: $updatedAt, modelProvider: $modelProvider, parentThreadId: $parentThreadId, agentNickname: $agentNickname, agentRole: $agentRole, threadSource: $threadSource, turns: $turns)';
+  return 'CodexThreadDto(id: $id, name: $name, cwd: $cwd, createdAt: $createdAt, updatedAt: $updatedAt, modelProvider: $modelProvider, parentThreadId: $parentThreadId, agentNickname: $agentNickname, agentRole: $agentRole, threadSource: $threadSource)';
 }
 
 
@@ -754,7 +294,7 @@ abstract mixin class _$CodexThreadDtoCopyWith<$Res> implements $CodexThreadDtoCo
   factory _$CodexThreadDtoCopyWith(_CodexThreadDto value, $Res Function(_CodexThreadDto) _then) = __$CodexThreadDtoCopyWithImpl;
 @override @useResult
 $Res call({
- String? id, String? name, String? cwd, num? createdAt, num? updatedAt, String? modelProvider, String? parentThreadId, String? agentNickname, String? agentRole,@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? threadSource,@JsonKey(defaultValue: <CodexThreadTurnDto>[]) List<CodexThreadTurnDto> turns
+ String? id, String? name, String? cwd, num? createdAt, num? updatedAt, String? modelProvider, String? parentThreadId, String? agentNickname, String? agentRole,@JsonKey(unknownEnumValue: CodexThreadSource.unknown) CodexThreadSource? threadSource
 });
 
 
@@ -771,7 +311,7 @@ class __$CodexThreadDtoCopyWithImpl<$Res>
 
 /// Create a copy of CodexThreadDto
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? name = freezed,Object? cwd = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? modelProvider = freezed,Object? parentThreadId = freezed,Object? agentNickname = freezed,Object? agentRole = freezed,Object? threadSource = freezed,Object? turns = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? name = freezed,Object? cwd = freezed,Object? createdAt = freezed,Object? updatedAt = freezed,Object? modelProvider = freezed,Object? parentThreadId = freezed,Object? agentNickname = freezed,Object? agentRole = freezed,Object? threadSource = freezed,}) {
   return _then(_CodexThreadDto(
 id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String?,name: freezed == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -783,8 +323,7 @@ as String?,parentThreadId: freezed == parentThreadId ? _self.parentThreadId : pa
 as String?,agentNickname: freezed == agentNickname ? _self.agentNickname : agentNickname // ignore: cast_nullable_to_non_nullable
 as String?,agentRole: freezed == agentRole ? _self.agentRole : agentRole // ignore: cast_nullable_to_non_nullable
 as String?,threadSource: freezed == threadSource ? _self.threadSource : threadSource // ignore: cast_nullable_to_non_nullable
-as CodexThreadSource?,turns: null == turns ? _self._turns : turns // ignore: cast_nullable_to_non_nullable
-as List<CodexThreadTurnDto>,
+as CodexThreadSource?,
   ));
 }
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_thread_dto.g.dart
@@ -18,47 +18,6 @@ _CodexThreadEnvelopeDto _$CodexThreadEnvelopeDtoFromJson(Map json) =>
       cwd: json['cwd'] as String?,
     );
 
-_CodexThreadTurnDto _$CodexThreadTurnDtoFromJson(Map json) =>
-    _CodexThreadTurnDto(
-      id: json['id'] as String?,
-      items:
-          (json['items'] as List<dynamic>?)
-              ?.map(
-                (e) => CodexThreadItemDto.fromJson(
-                  Map<String, dynamic>.from(e as Map),
-                ),
-              )
-              .toList() ??
-          [],
-    );
-
-CodexThreadUserMessageItemDto _$CodexThreadUserMessageItemDtoFromJson(
-  Map json,
-) => CodexThreadUserMessageItemDto(
-  content:
-      (json['content'] as List<dynamic>?)
-          ?.map(
-            (e) => CodexThreadContentDto.fromJson(
-              Map<String, dynamic>.from(e as Map),
-            ),
-          )
-          .toList() ??
-      [],
-  $type: json['type'] as String?,
-);
-
-CodexThreadUnknownItemDto _$CodexThreadUnknownItemDtoFromJson(Map json) =>
-    CodexThreadUnknownItemDto($type: json['type'] as String?);
-
-CodexThreadTextContentDto _$CodexThreadTextContentDtoFromJson(Map json) =>
-    CodexThreadTextContentDto(
-      text: json['text'] as String,
-      $type: json['type'] as String?,
-    );
-
-CodexThreadUnknownContentDto _$CodexThreadUnknownContentDtoFromJson(Map json) =>
-    CodexThreadUnknownContentDto($type: json['type'] as String?);
-
 _CodexThreadDto _$CodexThreadDtoFromJson(Map json) => _CodexThreadDto(
   id: json['id'] as String?,
   name: json['name'] as String?,
@@ -74,15 +33,6 @@ _CodexThreadDto _$CodexThreadDtoFromJson(Map json) => _CodexThreadDto(
     json['threadSource'],
     unknownValue: CodexThreadSource.unknown,
   ),
-  turns:
-      (json['turns'] as List<dynamic>?)
-          ?.map(
-            (e) => CodexThreadTurnDto.fromJson(
-              Map<String, dynamic>.from(e as Map),
-            ),
-          )
-          .toList() ??
-      [],
 );
 
 const _$CodexThreadSourceEnumMap = {

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_thread_repository.dart
@@ -38,7 +38,6 @@ final class const _CodexPromptAttachmentException({required final String message
 
 /// Layer-2 normalization and domain mapping for Codex app-server threads.
 class CodexThreadRepository({required final CodexAppServerApi _appServerApi}) {
-  final Map<String, Map<String, String>> _initialPromptByTurnByThread = {};
   static const _supportedImageMimes = {
     "image/bmp",
     "image/gif",
@@ -71,42 +70,7 @@ class CodexThreadRepository({required final CodexAppServerApi _appServerApi}) {
       operation: "thread/read",
       request: () => _appServerApi.readThread(threadId: threadId),
     );
-    _cacheInitialUserPrompts(threadId: threadId, thread: dto.thread);
     return _mapRequired(dto: dto, operation: "thread/read");
-  }
-
-  void forgetThread({required String threadId}) {
-    _initialPromptByTurnByThread.remove(threadId);
-  }
-
-  /// Returns the initial user prompt from the exact turn observed through the
-  /// child thread lifecycle. A thread read alone cannot distinguish a child's
-  /// own turn from parent turns copied by `fork_turns`, so missing or unmatched
-  /// turn provenance intentionally returns `null`.
-  String? initialUserPrompt({required String threadId, required String? turnId}) {
-    final usefulTurnId = _usefulText(turnId);
-    return usefulTurnId == null ? null : _initialPromptByTurnByThread[threadId]?[usefulTurnId];
-  }
-
-  void _cacheInitialUserPrompts({required String threadId, required CodexThreadDto? thread}) {
-    if (thread == null) return;
-    final promptsByTurn = _initialPromptByTurnByThread.putIfAbsent(threadId, () => {});
-    for (final turn in thread.turns) {
-      final turnId = _usefulText(turn.id);
-      if (turnId == null) continue;
-      for (final item in turn.items) {
-        if (item case CodexThreadUserMessageItemDto(:final content)) {
-          final prompt = [
-            for (final part in content)
-              if (part case CodexThreadTextContentDto(:final text)) text,
-          ].join();
-          if (prompt.trim().isNotEmpty) {
-            promptsByTurn[turnId] = prompt;
-            break;
-          }
-        }
-      }
-    }
   }
 
   Future<CodexThreadRecord> resumeThread({required String threadId}) async {

--- a/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
+++ b/bridge/sesori_plugin_codex/lib/src/services/codex_session_service.dart
@@ -731,7 +731,6 @@ class CodexSessionService({
     }
     _loadedThreads.remove(sessionId);
     _threadModels.remove(sessionId);
-    _threadRepository?.forgetThread(threadId: sessionId);
   }
 
   Future<CodexSessionMessageRead?> prepareSessionMessageRead({

--- a/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_plugin_write_path_test.dart
@@ -2885,7 +2885,7 @@ void main() {
       expect(childSession.parentID, "root-1");
       expect(childSession.title, "Raman");
       expect(childSession.projectID, "/work/other");
-      expect(fake.sentParamsFor("thread/read"), {"threadId": "child-1", "includeTurns": true});
+      expect(fake.sentParamsFor("thread/read"), {"threadId": "child-1", "includeTurns": false});
       await Future<void>.delayed(Duration.zero);
       final inlineTask = events
           .whereType<BridgeSseMessagePartUpdated>()

--- a/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_session_service_test.dart
@@ -52,20 +52,6 @@ void main() {
     expect(secondRepository.resumeCount, 1);
   });
 
-  test("deleting a session forgets its repository prompt candidates", () async {
-    final service = _newService();
-    final repository = _StubThreadRepository();
-    service.attachAppServerRepositories(
-      threadRepository: repository,
-      modelRepository: _StubModelRepository(),
-      skillRepository: _StubSkillRepository(),
-    );
-
-    await service.deleteSessionSubtree(sessionIds: const ["thread-to-delete"]);
-
-    expect(repository.forgottenThreadIds, ["thread-to-delete"]);
-  });
-
   test("getCommands always includes compact without duplicating an advertised command", () async {
     final service = _newService();
     final threadRepository = _StubThreadRepository();
@@ -564,14 +550,6 @@ class _StubThreadRepository() extends CodexThreadRepository {
           client: CodexAppServerClient(serverUrl: "ws://127.0.0.1:0"),
         ),
       );
-
-  final List<String> forgottenThreadIds = [];
-
-  @override
-  void forgetThread({required String threadId}) {
-    forgottenThreadIds.add(threadId);
-    super.forgetThread(threadId: threadId);
-  }
 
   int resumeCount = 0;
   int compactCount = 0;

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_metadata_dto_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_metadata_dto_test.dart
@@ -1,8 +1,5 @@
-import "package:codex_plugin/src/api/codex_app_server_api.dart";
 import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
 import "package:codex_plugin/src/api/models/codex_thread_dto.dart";
-import "package:codex_plugin/src/codex_app_server_client.dart";
-import "package:codex_plugin/src/repositories/codex_thread_repository.dart";
 import "package:test/test.dart";
 
 // Fixtures mirror codex-cli 0.148.0 captures recorded in
@@ -23,134 +20,12 @@ void main() {
         "updatedAt": 1788356444,
         "status": {"type": "active", "activeFlags": <String>[]},
         "canAcceptDirectInput": false,
-        "turns": [
-          {
-            "id": "child-turn-1",
-            "items": [
-              {
-                "type": "userMessage",
-                "content": [
-                  {"type": "text", "text": "Inspect child lifecycle."},
-                ],
-              },
-            ],
-          },
-        ],
       });
 
       expect(thread.parentThreadId, "parent-1");
       expect(thread.agentNickname, "Raman");
       expect(thread.agentRole, isNull);
       expect(thread.threadSource, isNull);
-      expect(thread.turns.single.id, "child-turn-1");
-      final userItem = thread.turns.single.items.single as CodexThreadUserMessageItemDto;
-      expect((userItem.content.single as CodexThreadTextContentDto).text, "Inspect child lifecycle.");
-    });
-
-    test("thread/read selects the child prompt by exact turn provenance", () async {
-      final transport = _ThreadReadTransport(
-        turns: const [
-          {
-            "id": "parent-turn",
-            "items": [
-              {
-                "type": "userMessage",
-                "content": [
-                  {"type": "text", "text": "Parent prompt copied into child."},
-                ],
-              },
-            ],
-          },
-          {
-            "id": "child-turn",
-            "items": [
-              {"type": "futureItem", "payload": "ignored"},
-              {
-                "type": "userMessage",
-                "content": [
-                  {"type": "input_text", "text": "rollout-only vocabulary"},
-                  {"type": "text", "text": "Actual child prompt."},
-                ],
-              },
-            ],
-          },
-        ],
-      );
-      final repository = CodexThreadRepository(
-        appServerApi: CodexAppServerApi(client: transport),
-      );
-
-      await repository.readThread(threadId: "child-1");
-
-      expect(transport.params, {"threadId": "child-1", "includeTurns": true});
-      expect(
-        repository.initialUserPrompt(threadId: "child-1", turnId: "child-turn"),
-        "Actual child prompt.",
-      );
-      expect(repository.initialUserPrompt(threadId: "child-1", turnId: null), isNull);
-      expect(repository.initialUserPrompt(threadId: "child-1", turnId: "unobserved-turn"), isNull);
-    });
-
-    test("retains provenance-matched prompts until their thread is forgotten", () async {
-      final repository = CodexThreadRepository(
-        appServerApi: CodexAppServerApi(
-          client: _ThreadReadTransport(
-            turns: const [
-              {
-                "id": "child-turn",
-                "items": [
-                  {
-                    "type": "userMessage",
-                    "content": [
-                      {"type": "text", "text": "Inspect child lifecycle."},
-                    ],
-                  },
-                ],
-              },
-            ],
-          ),
-        ),
-      );
-
-      await repository.readThread(threadId: "child-1");
-
-      expect(
-        repository.initialUserPrompt(threadId: "child-1", turnId: "child-turn"),
-        "Inspect child lifecycle.",
-      );
-      await repository.readThread(threadId: "child-2");
-      repository.forgetThread(threadId: "child-1");
-      expect(repository.initialUserPrompt(threadId: "child-1", turnId: "child-turn"), isNull);
-      expect(
-        repository.initialUserPrompt(threadId: "child-2", turnId: "child-turn"),
-        "Inspect child lifecycle.",
-      );
-    });
-
-    test("unknown thread items and user content decode as ignored variants", () {
-      final thread = CodexThreadDto.fromJson(const {
-        "id": "child-1",
-        "turns": [
-          {
-            "id": "child-turn",
-            "items": [
-              {"type": "futureItem", "payload": "ignored"},
-              {
-                "type": "userMessage",
-                "content": [
-                  {"type": "input_text", "text": "not app-server UserInput"},
-                  {"type": "text", "text": "Native text."},
-                ],
-              },
-            ],
-          },
-        ],
-      });
-
-      expect(thread.turns.single.items.first, isA<CodexThreadUnknownItemDto>());
-      final userMessage = thread.turns.single.items.last as CodexThreadUserMessageItemDto;
-      expect(userMessage.content.first, isA<CodexThreadUnknownContentDto>());
-      expect((userMessage.content.last as CodexThreadTextContentDto).text, "Native text.");
     });
 
     test("decodes known thread sources and falls back to unknown", () {
@@ -236,28 +111,4 @@ void main() {
       expect(drifted.threadSource, CodexRolloutThreadSource.unknown);
     });
   });
-}
-
-final class _ThreadReadTransport({required final List<Map<String, Object?>> turns}) implements CodexAppServerTransport {
-  Map<String, dynamic>? params;
-
-  @override
-  Stream<CodexServerNotification> get notifications => const Stream.empty();
-
-  @override
-  Future<dynamic> request({
-    required String method,
-    Object? params,
-    Duration timeout = const Duration(seconds: 30),
-  }) async {
-    expect(method, "thread/read");
-    this.params = (params! as Map).cast<String, dynamic>();
-    return {
-      "thread": {
-        "id": this.params!["threadId"],
-        "parentThreadId": "parent-1",
-        "turns": turns,
-      },
-    };
-  }
 }

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -188,9 +188,11 @@ its observed-child snapshot retains legacy client fanout.
 through parent activity and status, never `thread/started`; persisted activity
 is `event_msg/item_completed/item/SubAgentActivity`, whose item id exactly
 matches `spawn_agent.call_id`. Normal initial child input is encrypted in the
-rollout and absent from `thread/read`. These are native probe findings;
-exact-call tile correlation, nested activity replay, and plaintext `NEW_TASK`
-prompt projection are **not implemented** in Sesori yet.
+rollout and absent from `thread/read`. These are native probe findings.
+The table's tile checkmark covers existing live/replayed spawn-tool card
+projection with best-effort raw task-path child linkage; cards can remain
+unlinked. Exact-call tile correlation, nested activity replay, and plaintext
+`NEW_TASK` prompt projection are **not implemented** in Sesori yet.
 Sesori exposes child threads under their direct parent and keeps running
 descendants in root busy state. Metadata-only
 `thread/read(includeTurns: false)` retains parent and nickname enrichment. Raw task paths remain stable identity and are formatted

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -187,14 +187,13 @@ its observed-child snapshot retains legacy client fanout.
 ³ Codex (managed codex-cli 0.153.4, probed 2026-09-08): live children announce
 through parent activity and status, never `thread/started`; persisted activity
 is `event_msg/item_completed/item/SubAgentActivity`, whose item id exactly
-matches `spawn_agent.call_id`. Sesori exposes child threads under their direct
-parent, keeps running descendants in root busy state, and links live/replayed
-spawn tiles to the child. Normal initial child input is encrypted in the rollout
-and absent from `thread/read`; tile prompt provenance is therefore only the exact
-nonblank message from that matching spawn call, never parent history or an
-envelope header. A valid child-owned plaintext `NEW_TASK` payload may replace
-that fallback. Metadata-only `thread/read(includeTurns: false)` retains parent
-and nickname enrichment. Raw task paths remain stable identity and are formatted
+matches `spawn_agent.call_id`. Normal initial child input is encrypted in the
+rollout and absent from `thread/read`. These are native probe findings;
+exact-call tile correlation, nested activity replay, and plaintext `NEW_TASK`
+prompt projection are **not implemented** in Sesori yet.
+Sesori exposes child threads under their direct parent and keeps running
+descendants in root busy state. Metadata-only
+`thread/read(includeTurns: false)` retains parent and nickname enrichment. Raw task paths remain stable identity and are formatted
 for display. `turn/interrupt` works per child with its `turnId`, while parent
 interrupt leaves children running, so main-agent-only is supportable.
 

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -184,20 +184,19 @@ the two apart, so the option is not offered.
 Atomic subtree completion acknowledgment is **not implemented** for OpenCode;
 its observed-child snapshot retains legacy client fanout.
 
-³ Codex (codex-cli 0.148.0, `multi_agent` stable, probed 2026-09-02): a child
-announces itself through the parent's `subAgentActivity started`
-(`agentThreadId`) and `thread/status/changed`, never `thread/started`;
-`receiverThreadIds` stays empty. Sesori exposes the verified child thread and
-persisted rollout under its direct parent and rolls running descendants into
-the root's busy state. Spawn calls appear as inline subtask tiles both live
-and in saved history, linked to the child thread; the tile follows the child's
-session status instead of treating spawn completion as task completion.
-Raw task-path fallbacks are formatted for display (for example,
-`/root/architecture_review_1271` becomes `Architecture review · 1271`), while
-raw paths remain the identity used to match saved spawn calls to children.
-`turn/interrupt` works per child thread with its
-`turnId`, and interrupting the parent leaves children running, so
-main-agent-only is supportable.
+³ Codex (managed codex-cli 0.153.4, probed 2026-09-08): live children announce
+through parent activity and status, never `thread/started`; persisted activity
+is `event_msg/item_completed/item/SubAgentActivity`, whose item id exactly
+matches `spawn_agent.call_id`. Sesori exposes child threads under their direct
+parent, keeps running descendants in root busy state, and links live/replayed
+spawn tiles to the child. Normal initial child input is encrypted in the rollout
+and absent from `thread/read`; tile prompt provenance is therefore only the exact
+nonblank message from that matching spawn call, never parent history or an
+envelope header. A valid child-owned plaintext `NEW_TASK` payload may replace
+that fallback. Metadata-only `thread/read(includeTurns: false)` retains parent
+and nickname enrichment. Raw task paths remain stable identity and are formatted
+for display. `turn/interrupt` works per child with its `turnId`, while parent
+interrupt leaves children running, so main-agent-only is supportable.
 
 ⁴ Copilot CLI (plugin targets 1.0.80) runs custom agents as subagents, but its
 Agent Client Protocol server exposes no subagent lifecycle, no child session,

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -187,8 +187,9 @@ state.
   a root also removes its `subagents/` directory; deleting a child removes its
   transcript and meta file.
 - A live Codex `subAgentActivity started` resolves the named thread through
-  `thread/read`, announces it under its direct parent with the parent's project
-  directory and Codex nickname (or agent path), and never depends on a missing
+  metadata-only `thread/read(includeTurns: false)`, announces it under its
+  direct parent with the parent's project directory and Codex nickname (or agent
+  path), and never depends on a missing
   child `thread/started`. Later child activity and title updates retain that
   parent. Connection startup restores persisted lifecycle ancestry before
   pending-input routing, and resuming a child restores the same mapper context.

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -147,11 +147,7 @@ reconnect or restart.
   the child's leading `thread_source == subagent` metadata followed by the
   copied parent `session_meta`; root sessions, ordinary forks, malformed
   headers, and copies whose first child-turn boundary is unresolved remain
-  untouched. Current 0.153.4 activity replays from nested
-  `item_completed/SubAgentActivity` and joins its exact id to
-  `spawn_agent.call_id`. Initial child input is selected only after copied-prefix
-  trimming; encrypted input falls back to that exact spawn call's nonblank
-  message, never a parent user message or envelope text.
+  untouched.
 - Claude's CLI-authored API-failure assistant frame and its terminal result
   render as one error with the persisted assistant message identity. Transcript
   records marked `isApiErrorMessage` replay as that same error rather than as a

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -147,7 +147,11 @@ reconnect or restart.
   the child's leading `thread_source == subagent` metadata followed by the
   copied parent `session_meta`; root sessions, ordinary forks, malformed
   headers, and copies whose first child-turn boundary is unresolved remain
-  untouched.
+  untouched. Current 0.153.4 activity replays from nested
+  `item_completed/SubAgentActivity` and joins its exact id to
+  `spawn_agent.call_id`. Initial child input is selected only after copied-prefix
+  trimming; encrypted input falls back to that exact spawn call's nonblank
+  message, never a parent user message or envelope text.
 - Claude's CLI-authored API-failure assistant frame and its terminal result
   render as one error with the persisted assistant message identity. Transcript
   records marked `isApiErrorMessage` replay as that same error rather than as a

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -84,9 +84,13 @@ defaults and queued client sends coherent.
   must not stop its spinner while the child runs. Readable child nicknames and
   titles are preserved; raw path fallbacks such as
   `/root/architecture_review_1271` display as `Architecture review · 1271`.
-  Matching uses the raw task path under the direct parent, not the formatted
-  label. An interrupted launch that never creates a child retains its own
-  terminal tool status.
+  Matching uses exact spawn/activity call identity, not description, task name,
+  child order, timing, or copied parent history. On current Codex 0.153.4 the
+  initial child input is normally encrypted, so the tile uses only the nonblank
+  message from that matching `spawn_agent` call; a valid child-owned plaintext
+  `NEW_TASK` payload for the initial turn may replace it. The encrypted envelope
+  header is never rendered. An interrupted launch that never creates a child
+  retains its own terminal tool status.
 - A Codex root remains effectively busy after its own turn completes while any
   tracked descendant turn is running. The root's idle status and completion
   signal are deferred and released exactly once after the last child settles;
@@ -97,7 +101,8 @@ defaults and queued client sends coherent.
   busy child thread ids, and roll a child's pending permission or question up
   to the root's awaiting-input state and pending-input snapshot, including a
   restored request with no live status and a request that arrives while
-  `thread/read` is still enriching the spawn. A stop or deletion accepted before
+  metadata-only `thread/read(includeTurns: false)` is still enriching the spawn.
+  A stop or deletion accepted before
   the child's `turn/started` queues its interrupt until the turn id arrives.
   Closing an active child emits its idle status before any deferred root release.
 - A plain Claude prompt sent while its resident process is working is written

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -77,12 +77,13 @@ defaults and queued client sends coherent.
   client user-message id in either case. The bridge keeps the authoritative
   active turn until its terminal event even when an older app server returns a
   separate submission id for the steering request.
-- Codex spawn calls render as one inline subtask card in the parent chat as
-  well as a child in the tasks widget, on phone and desktop. Cards open the
-  correct child transcript and survive history reload. A linked card follows
-  the child's session status; completing the spawn call or the parent turn
-  must not stop its spinner while the child runs. Readable child nicknames and
-  titles are preserved; raw path fallbacks such as
+- Codex live and replayed spawn-tool records use the inline subtask card
+  projection on phone and desktop. Child linkage is best-effort: matching uses
+  the raw task path under the direct parent, not the formatted label; a card
+  can remain unlinked when no child matches. Linked cards open that child's
+  transcript and follow its session status; completing the spawn call or the
+  parent turn must not stop their spinner while the child runs. Readable child
+  nicknames and titles are preserved; raw path fallbacks such as
   `/root/architecture_review_1271` display as `Architecture review · 1271`.
   An interrupted launch that never creates a child retains its own terminal
   tool status.

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -84,13 +84,8 @@ defaults and queued client sends coherent.
   must not stop its spinner while the child runs. Readable child nicknames and
   titles are preserved; raw path fallbacks such as
   `/root/architecture_review_1271` display as `Architecture review · 1271`.
-  Matching uses exact spawn/activity call identity, not description, task name,
-  child order, timing, or copied parent history. On current Codex 0.153.4 the
-  initial child input is normally encrypted, so the tile uses only the nonblank
-  message from that matching `spawn_agent` call; a valid child-owned plaintext
-  `NEW_TASK` payload for the initial turn may replace it. The encrypted envelope
-  header is never rendered. An interrupted launch that never creates a child
-  retains its own terminal tool status.
+  An interrupted launch that never creates a child retains its own terminal
+  tool status.
 - A Codex root remains effectively busy after its own turn completes while any
   tracked descendant turn is running. The root's idle status and completion
   signal are deferred and released exactly once after the last child settles;


### PR DESCRIPTION
## Complexity
🌿 Straightforward removal of unused parsing/cache machinery, including regenerated DTO output.

## What
- Remove the child-prompt cache and turn/item/content DTOs introduced by #1387.
- Restore metadata-only `thread/read(includeTurns: false)` and retain child parentage/nickname enrichment.
- Remove obsolete cache tests and update the approved seven-step series and native probe findings.
- Keep pending tile behavior out of current regression claims.

## Why
Real managed Codex 0.153.4 probes show normal child input is encrypted and absent from `thread/read` user items. The preparation therefore has no usable production consumer. The approved tile approach will use the exact matching `spawn_agent` message, not copied parent history or encrypted envelope text.

This separate cleanup keeps corrected tiles in step 5/7; scoped stop remains step 6/7 and coverage step 7/7. Existing tile snapshots are preserved.

## Risk and test focus
No user-visible or database impact. Verify metadata-only child enrichment, parent/source/nickname mapping, and ordinary session deletion remain intact. No runtime-pin, native-adapter, client, shared-wire, tile, or stop behavior changes.

## Expected result
The obsolete prompt preparation is removed without changing current child-session behavior. Corrected native tile support remains a follow-up, not a capability claimed by this PR.

## Verification
- Full owning Codex suite: 439/439 passed.
- `dart analyze --fatal-infos`: no issues.
- Generated DTO output verified; whitespace checks passed.
- Independent architecture review approved; correctness review approved runtime removal and identified premature documentation claims, which were corrected before publication.
- Final documentation-only correction did not rerun unchanged passing Dart suites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the obsolete child-prompt cache and its turn/item/content DTOs introduced in #1387, since managed Codex 0.153.4 probes show normal child input is encrypted and absent from `thread/read`. Restores metadata-only `thread/read(includeTurns: false)` while retaining child parentage and nickname enrichment; no behavior or database changes.

**Docs**
- Regression and capability docs now claim only the existing best-effort spawn-card projection and defer exact-call tile correlation, nested activity replay, and plaintext `NEW_TASK` prompt projection to step 5/7.

<sup>Written for commit 52f212039ea110691c42f35bf017386563f7eb8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

