### PR TITLE
⚙️ [claude-inline-subtasks] Parse native Codex rollout facts [step 5/9]

### DIFF
--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -8,10 +8,10 @@
 - **Plan date:** 2026-09-02
 - **Base:** `main` at `6e9028c4c6`
 - **Delivery:** one open PR at a time, following current repository rules.
-  Codex now has seven steps: merged metadata and child-session work remain
-  steps 1/7 and 2/7; merged PR #1387 remains historical preparation at its
-  original title; causal cleanup is step 4/7, tiles 5/7, scoped stop 6/7, and
-  coverage 7/7. Historical PR titles are unchanged. Progress is tracked in
+  Codex now has nine steps: merged metadata, child-session, historical prompt
+  preparation, and cleanup remain steps 1/9–4/9. Native rollout facts are
+  step 5/9, replay tiles 6/9, live lifecycle tiles 7/9, scoped stop 8/9, and
+  coverage 9/9. Historical PR titles are unchanged. Progress is tracked in
   `TRACKER.md` "Harness Follow-Ups". The DeepSeek phone handoff is recorded in
   `followups/deepseek-phone-qa.md`; desktop remains deferred.
 
@@ -283,13 +283,15 @@ confirmation, no child session or partial stop) and gets that subset.
 
 | Step | Emoji | Description | Scope |
 |---|---|---|---|
-| 1/7 | 🌿 | `codex: parse sub-agent thread and item metadata` | Merged historical title unchanged; DTO fields, collab/activity parser and enums, fixtures from the probe |
-| 2/7 | ⚙️ | `codex: sub-agent threads become child sessions` | Merged historical title unchanged; repository/mapper/service child-session flow, `parentID` live and from the catalog, roots-only listing, service-owned `getChildSessions` merge, directory attribution, summary rolls busy children into the root. Fixes the root-leak defect |
-| 3/7 | ⚙️ | `codex: parse typed child prompts from thread reads [step 3/6]` | PR #1387 merged under this historical title; its prompt cache was preparation only and is superseded by verified 0.153.4 rollout input |
-| 4/7 | 🌿 | `codex: remove obsolete child-prompt cache [step 4/7]` | Restore metadata-only `thread/read`; remove unused turn/item/content DTOs, cache, and synthetic tests |
-| 5/7 | 🚧 | `codex: inline subtask tiles for spawned agents [step 5/7]` | service-coordinated tracker, current persisted activity/input facts, exact-call prompt provenance, call-id replacement, and initial-turn terminal join |
-| 6/7 | ⚙️ | `codex: scoped stop for sub-agent threads [step 6/7]` | policy switch, per-child interrupt, `mainAgentOnlySupported` per probe, `interruptActiveWork` covers children |
-| 7/7 | 🌱 | `docs: record Codex sub-agent coverage [step 7/7]` | matrix footnote ³ resolved, regression docs |
+| 1/9 | 🌿 | `codex: parse sub-agent thread and item metadata` | Merged historical title unchanged; DTO fields, collab/activity parser and enums, fixtures from the probe |
+| 2/9 | ⚙️ | `codex: sub-agent threads become child sessions` | Merged historical title unchanged; repository/mapper/service child-session flow, roots-only listing, and busy-child summaries |
+| 3/9 | ⚙️ | `codex: parse typed child prompts from thread reads [step 3/6]` | PR #1387 merged under this historical title; preparation superseded by 0.153.4 evidence |
+| 4/9 | 🌿 | `codex: remove obsolete child-prompt cache [step 4/7]` | PR #1396 merged at `7f6fb8cb50`; metadata-only `thread/read`, no discarded cache |
+| 5/9 | ⚙️ | `codex: parse native rollout facts for sub-agent tiles [step 5/9]` | Local predecessor `claude-inline-subtasks-codex-native-facts-step5`; typed DTOs and repository facts only, no tile activation |
+| 6/9 | ⚙️ | `codex: replay inline subtask tiles [step 6/9]` | Local successor; exact-call replay replacement and initial-turn result |
+| 7/9 | 🚧 | `codex: wire live subtask lifecycle tiles [step 7/9]` | Local successor; existing-tail live wiring, lifecycle, busy accounting, and docs |
+| 8/9 | ⚙️ | `codex: scoped stop for sub-agent threads [step 8/9]` | policy switch, per-child interrupt, `mainAgentOnlySupported` per probe |
+| 9/9 | 🌱 | `docs: record Codex sub-agent coverage [step 9/9]` | matrix closure after live plugin QA |
 
 ### Probe results (0.148.0 and 0.153.4; details in `followups/codex-probe.md`)
 

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -287,7 +287,7 @@ confirmation, no child session or partial stop) and gets that subset.
 | 2/9 | ⚙️ | `codex: sub-agent threads become child sessions` | Merged historical title unchanged; repository/mapper/service child-session flow, roots-only listing, and busy-child summaries |
 | 3/9 | ⚙️ | `codex: parse typed child prompts from thread reads [step 3/6]` | PR #1387 merged under this historical title; preparation superseded by 0.153.4 evidence |
 | 4/9 | 🌿 | `codex: remove obsolete child-prompt cache [step 4/7]` | PR #1396 merged at `7f6fb8cb50`; metadata-only `thread/read`, no discarded cache |
-| 5/9 | ⚙️ | `codex: parse native rollout facts for sub-agent tiles [step 5/9]` | Local predecessor `claude-inline-subtasks-codex-native-facts-step5`; typed DTOs and repository facts only, no tile activation |
+| 5/9 | ⚙️ | `codex: parse native rollout facts for sub-agent tiles [step 5/9]` | PR #1398 open, awaiting merge; typed DTOs and repository facts only, no tile activation |
 | 6/9 | 🚧 | `codex: integrate live and replay tiles [step 6/9]` | Local successor; full live/replay production integration, lifecycle, busy accounting, and focused tests |
 | 7/9 | 🌿 | `codex: cover live tile lifecycle [step 7/9]` | Local successor; write-path coverage and capability/regression documentation; no production changes |
 | 8/9 | ⚙️ | `codex: scoped stop for sub-agent threads [step 8/9]` | policy switch, per-child interrupt, `mainAgentOnlySupported` per probe |

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -10,7 +10,7 @@
 - **Delivery:** one open PR at a time, following current repository rules.
   Codex now has nine steps: merged metadata, child-session, historical prompt
   preparation, and cleanup remain steps 1/9–4/9. Native rollout facts are
-  step 5/9, replay tiles 6/9, live lifecycle tiles 7/9, scoped stop 8/9, and
+  step 5/9, live/replay tile integration 6/9, lifecycle coverage 7/9, scoped stop 8/9, and
   coverage 9/9. Historical PR titles are unchanged. Progress is tracked in
   `TRACKER.md` "Harness Follow-Ups". The DeepSeek phone handoff is recorded in
   `followups/deepseek-phone-qa.md`; desktop remains deferred.
@@ -288,8 +288,8 @@ confirmation, no child session or partial stop) and gets that subset.
 | 3/9 | ⚙️ | `codex: parse typed child prompts from thread reads [step 3/6]` | PR #1387 merged under this historical title; preparation superseded by 0.153.4 evidence |
 | 4/9 | 🌿 | `codex: remove obsolete child-prompt cache [step 4/7]` | PR #1396 merged at `7f6fb8cb50`; metadata-only `thread/read`, no discarded cache |
 | 5/9 | ⚙️ | `codex: parse native rollout facts for sub-agent tiles [step 5/9]` | Local predecessor `claude-inline-subtasks-codex-native-facts-step5`; typed DTOs and repository facts only, no tile activation |
-| 6/9 | ⚙️ | `codex: replay inline subtask tiles [step 6/9]` | Local successor; exact-call replay replacement and initial-turn result |
-| 7/9 | 🚧 | `codex: wire live subtask lifecycle tiles [step 7/9]` | Local successor; existing-tail live wiring, lifecycle, busy accounting, and docs |
+| 6/9 | 🚧 | `codex: integrate live and replay tiles [step 6/9]` | Local successor; full live/replay production integration, lifecycle, busy accounting, and focused tests |
+| 7/9 | 🌿 | `codex: cover live tile lifecycle [step 7/9]` | Local successor; write-path coverage and capability/regression documentation; no production changes |
 | 8/9 | ⚙️ | `codex: scoped stop for sub-agent threads [step 8/9]` | policy switch, per-child interrupt, `mainAgentOnlySupported` per probe |
 | 9/9 | 🌱 | `docs: record Codex sub-agent coverage [step 9/9]` | matrix closure after live plugin QA |
 

--- a/.plan/active/claude-inline-subtasks/PLAN.md
+++ b/.plan/active/claude-inline-subtasks/PLAN.md
@@ -20,10 +20,11 @@
   Both slices merged (#1363, #1370). Agent-run phone QA found the transport
   crash fixed by #1379; requested phone stop/input checks then passed. See
   `followups/deepseek-phone-qa.md`. Desktop is deferred by user choice. Codex
-  now uses a user-authorized seven-step sequence: merged PR #1387 is historical
-  preparation superseded by the verified 0.153.4 rollout-input seam; causal
-  cleanup is step 4/7, tiles step 5/7, scoped stop step 6/7, and coverage step
-  7/7. Overall harness plan remains active.
+  now uses nine steps after automatic size-based splitting: #1387 remains
+  historical preparation, and cleanup #1396 is merged. Native facts are step
+  5/9 (#1398, under review), live/replay tile integration 6/9, lifecycle coverage
+  7/9, scoped stop 8/9, and final coverage 9/9. Historical merged PR titles
+  remain unchanged. Overall harness plan remains active.
 
 ## Goal
 

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -9,9 +9,8 @@
   also made the scoped stop harness-neutral (OpenCode honors it; rejections
   declare `mainAgentOnlySupported`) and added `docs/HARNESS_CAPABILITIES.md`;
   the original Claude series is complete; harness follow-ups remain active
-- **Next action:** publish local Codex native-facts predecessor
-  `claude-inline-subtasks-codex-native-facts-step5` (step 5/9), then stacked
-  replay and live tile slices. Cleanup #1396 merged at `7f6fb8cb50`; #1387 is
+- **Next action:** land native-facts PR #1398 (step 5/9), then the stacked
+  live/replay integration (6/9) and lifecycle coverage (7/9) slices. Cleanup #1396 merged at `7f6fb8cb50`; #1387 is
   historical preparation superseded by the verified 0.153.4 rollout seam. DeepSeek #1363,
   #1370, and the live-QA crash fix #1379 are merged. Requested phone-only
   stop/input checks passed; see `followups/deepseek-phone-qa.md`. Desktop
@@ -168,7 +167,7 @@ post-merge E2E gates are unchanged.
 | [x] | Codex | `⚙️ [claude-inline-subtasks] codex: sub-agent threads become child sessions` | #1273/#1280 merged; historical title unchanged (now step 2/9) |
 | [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse typed child prompts from thread reads [step 3/6]` | #1387 merged; historical title unchanged (now step 3/9) |
 | [x] | Codex | `🌿 [claude-inline-subtasks] codex: remove obsolete child-prompt cache [step 4/7]` | #1396 merged at `7f6fb8cb50`; no tile code |
-| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse native rollout facts for sub-agent tiles [step 5/9]` | Local predecessor complete; no tile capability activated |
+| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse native rollout facts for sub-agent tiles [step 5/9]` | [PR #1398](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1398) open; implemented, awaiting merge; no tile capability activated |
 | [ ] | Codex | `🚧 [claude-inline-subtasks] codex: integrate live and replay tiles [step 6/9]` | Stacked local successor; full live/replay production and focused tests |
 | [ ] | Codex | `🌿 [claude-inline-subtasks] codex: cover live tile lifecycle [step 7/9]` | Stacked local successor; write-path coverage and capability/regression docs only |
 | [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: scoped stop for sub-agent threads [step 8/9]` | Not started |
@@ -743,7 +742,7 @@ corrected independent-scope stop and pending/later-input checks passed.
 The user deferred desktop and requested progression to Codex after phone checks;
 managed-runtime automation remains separately owned.
 
-Codex seven-step correction (user-authorized): merged PR #1387 keeps its
+Codex correction (now nine steps after automatic size-based splitting): #1387 keeps its
 historical `[step 3/6]` title but is superseded preparation. Current 0.153.4
 persists started activity as `event_msg/item_completed/item/SubAgentActivity`;
 its item id exactly matches `spawn_agent.call_id`. Normal child input appends as
@@ -757,14 +756,15 @@ unrelated parent `user_message`, copied parent history, task-name/order/timing
 match, or envelope header. Valid child-owned plaintext `NEW_TASK` input may
 replace that fallback for the initial delegated turn.
 
-Step 4/7 therefore removes only obsolete #1387 machinery: turn/item/content
+Merged cleanup #1396 (historical step 4/7, now 4/9) removed obsolete #1387 machinery: turn/item/content
 thread DTOs, `includeTurns: true`, prompt cache/lookups/cleanup, and synthetic
 prompt-cache tests. Parent/source/nickname metadata remains. Workspace codegen,
 focused metadata/write-path/service tests, the complete Codex package suite,
-and `dart analyze --fatal-infos` pass. Corrected tiles are step 5/7; scoped stop
-is 6/7; coverage is 7/7. Rejected tile work remains at
+and `dart analyze --fatal-infos` passed. Native facts are step 5/9, full
+live/replay integration 6/9, lifecycle coverage 7/9, scoped stop 8/9, and final
+coverage 9/9. Rejected tile work remains at
 `claude-inline-subtasks-codex-tiles-step4-integrated` (`c6aa29a8ce`), while
 `claude-inline-subtasks-codex-tiles-successor` (`8f9923b663`) and
 `claude-inline-subtasks-codex-tiles-successor-ready` (`8a2952f318`) remain
 untouched. No runtime pin, native source, client/shared contract, database, or
-stop behavior changes in cleanup step 4/7.
+stop behavior changed in cleanup #1396.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -9,9 +9,10 @@
   also made the scoped stop harness-neutral (OpenCode honors it; rejections
   declare `mainAgentOnlySupported`) and added `docs/HARNESS_CAPABILITIES.md`;
   the original Claude series is complete; harness follow-ups remain active
-- **Next action:** land Codex causal cleanup [PR #1396](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1396)
-  (step 4/7), then integrate corrected inline tiles as step 5/7. Merged PR #1387 is historical preparation
-  superseded by the verified 0.153.4 rollout-input seam. DeepSeek #1363,
+- **Next action:** publish local Codex native-facts predecessor
+  `claude-inline-subtasks-codex-native-facts-step5` (step 5/9), then stacked
+  replay and live tile slices. Cleanup #1396 merged at `7f6fb8cb50`; #1387 is
+  historical preparation superseded by the verified 0.153.4 rollout seam. DeepSeek #1363,
   #1370, and the live-QA crash fix #1379 are merged. Requested phone-only
   stop/input checks passed; see `followups/deepseek-phone-qa.md`. Desktop
   remains deferred by user choice; the overall plan remains active.
@@ -163,13 +164,15 @@ post-merge E2E gates are unchanged.
 | Done | Harness | Description | State |
 |---|---|---|---|
 | [x] | all | `🌱 [claude-inline-subtasks] docs: plan Codex, Grok Build, DeepSeek, and Cursor sub-agent follow-ups` | [PR #1260](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1260) merged |
-| [x] | Codex | `🌿 [claude-inline-subtasks] codex: parse sub-agent thread and item metadata` | [PR #1263](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1263) merged; historical title unchanged (now step 1/7) |
-| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: sub-agent threads become child sessions` | [PR #1273](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1273) merged; lifecycle hardening [PR #1280](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1280) merged; historical title unchanged (now step 2/7) |
-| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse typed child prompts from thread reads [step 3/6]` | [PR #1387](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1387) merged; historical title unchanged (now step 3/7); preparation superseded by 0.153.4 evidence |
-| [x] | Codex | `🌿 [claude-inline-subtasks] codex: remove obsolete child-prompt cache [step 4/7]` | [PR #1396](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1396) open; implemented, awaiting merge; no tile code |
-| [ ] | Codex | `🚧 [claude-inline-subtasks] codex: inline subtask tiles for spawned agents [step 5/7]` | Rejected incomplete checkpoint preserved on `claude-inline-subtasks-codex-tiles-step4-integrated`; original successor refs remain preserved and unpublished |
-| [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: scoped stop for sub-agent threads [step 6/7]` | Not started |
-| [ ] | Codex | `🌱 [claude-inline-subtasks] docs: record Codex sub-agent coverage [step 7/7]` | Not started |
+| [x] | Codex | `🌿 [claude-inline-subtasks] codex: parse sub-agent thread and item metadata` | #1263 merged; historical title unchanged (now step 1/9) |
+| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: sub-agent threads become child sessions` | #1273/#1280 merged; historical title unchanged (now step 2/9) |
+| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse typed child prompts from thread reads [step 3/6]` | #1387 merged; historical title unchanged (now step 3/9) |
+| [x] | Codex | `🌿 [claude-inline-subtasks] codex: remove obsolete child-prompt cache [step 4/7]` | #1396 merged at `7f6fb8cb50`; no tile code |
+| [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse native rollout facts for sub-agent tiles [step 5/9]` | Local predecessor complete; no tile capability activated |
+| [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: replay inline subtask tiles [step 6/9]` | Stacked local successor |
+| [ ] | Codex | `🚧 [claude-inline-subtasks] codex: wire live subtask lifecycle tiles [step 7/9]` | Stacked local successor |
+| [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: scoped stop for sub-agent threads [step 8/9]` | Not started |
+| [ ] | Codex | `🌱 [claude-inline-subtasks] docs: record Codex sub-agent coverage [step 9/9]` | Live plugin QA outstanding |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] grok: parse sub-agent lifecycle notifications` | [PR #1270](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1270) merged |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] acp: child sessions keep the root busy` | [PR #1272](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1272) merged |
 | [ ] | Grok | `🌿 [claude-inline-subtasks] grok: child session history` | Not started |

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -169,8 +169,8 @@ post-merge E2E gates are unchanged.
 | [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse typed child prompts from thread reads [step 3/6]` | #1387 merged; historical title unchanged (now step 3/9) |
 | [x] | Codex | `🌿 [claude-inline-subtasks] codex: remove obsolete child-prompt cache [step 4/7]` | #1396 merged at `7f6fb8cb50`; no tile code |
 | [x] | Codex | `⚙️ [claude-inline-subtasks] codex: parse native rollout facts for sub-agent tiles [step 5/9]` | Local predecessor complete; no tile capability activated |
-| [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: replay inline subtask tiles [step 6/9]` | Stacked local successor |
-| [ ] | Codex | `🚧 [claude-inline-subtasks] codex: wire live subtask lifecycle tiles [step 7/9]` | Stacked local successor |
+| [ ] | Codex | `🚧 [claude-inline-subtasks] codex: integrate live and replay tiles [step 6/9]` | Stacked local successor; full live/replay production and focused tests |
+| [ ] | Codex | `🌿 [claude-inline-subtasks] codex: cover live tile lifecycle [step 7/9]` | Stacked local successor; write-path coverage and capability/regression docs only |
 | [ ] | Codex | `⚙️ [claude-inline-subtasks] codex: scoped stop for sub-agent threads [step 8/9]` | Not started |
 | [ ] | Codex | `🌱 [claude-inline-subtasks] docs: record Codex sub-agent coverage [step 9/9]` | Live plugin QA outstanding |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] grok: parse sub-agent lifecycle notifications` | [PR #1270](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1270) merged |

--- a/.plan/active/claude-inline-subtasks/followups/deepseek-phone-qa.md
+++ b/.plan/active/claude-inline-subtasks/followups/deepseek-phone-qa.md
@@ -57,7 +57,8 @@ write/response-timed probe and phone observations above are the evidence.
 ## Handoff
 
 The requested phone stop/input checks are complete. Codex #1387 remains
-historical preparation; continue through cleanup step 4/7, inline tiles 5/7,
-scoped stop 6/7, and coverage 7/7. Metadata and child-session foundations
+historical preparation, and cleanup #1396 is merged. Continue through native
+facts 5/9, live/replay tiles 6/9, lifecycle coverage 7/9, scoped stop 8/9, and
+final coverage 9/9. Metadata and child-session foundations
 already merged in #1263, #1273, and #1280. Do not mark remaining harness
 coverage or the whole plan complete on the strength of this phone-only handoff.

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.dart
@@ -1,6 +1,8 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
+import "codex_sub_agent_item_dto.dart";
+
 part "codex_rollout_dto.freezed.dart";
 part "codex_rollout_dto.g.dart";
 
@@ -60,6 +62,12 @@ sealed class CodexRolloutLineDto with _$CodexRolloutLineDto {
     required CodexRolloutEventDto payload,
   }) = CodexRolloutEventMessageLineDto;
 
+  @FreezedUnionValue("inter_agent_communication_metadata")
+  const factory interAgentCommunicationMetadata({
+    required String? timestamp,
+    required CodexRolloutInterAgentCommunicationMetadataDto payload,
+  }) = CodexRolloutInterAgentCommunicationMetadataLineDto;
+
   @FreezedUnionValue("compacted")
   const factory compacted({
     required String? timestamp,
@@ -83,6 +91,13 @@ sealed class CodexRolloutEventDto with _$CodexRolloutEventDto {
   const factory userMessage({
     required String message,
   }) = CodexRolloutUserMessageEventDto;
+
+  @FreezedUnionValue("item_completed")
+  const factory itemCompleted({
+    @JsonKey(name: "thread_id") required String threadId,
+    @JsonKey(name: "turn_id") required String turnId,
+    required CodexRolloutCompletedItemDto item,
+  }) = CodexRolloutItemCompletedEventDto;
 
   @FreezedUnionValue("image_generation_end")
   const factory imageGenerationEnd({
@@ -118,6 +133,35 @@ sealed class CodexRolloutEventDto with _$CodexRolloutEventDto {
   const factory unknown() = CodexRolloutUnknownEventDto;
 
   factory fromJson(Map<String, dynamic> json) => _$CodexRolloutEventDtoFromJson(json);
+}
+
+@Freezed(fromJson: true, toJson: false)
+sealed class CodexRolloutInterAgentCommunicationMetadataDto with _$CodexRolloutInterAgentCommunicationMetadataDto {
+  const factory({
+    @JsonKey(name: "trigger_turn") required bool triggerTurn,
+  }) = _CodexRolloutInterAgentCommunicationMetadataDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexRolloutInterAgentCommunicationMetadataDtoFromJson(json);
+}
+
+@Freezed(
+  unionKey: "type",
+  fallbackUnion: "unknown",
+  fromJson: true,
+  toJson: false,
+)
+sealed class CodexRolloutCompletedItemDto with _$CodexRolloutCompletedItemDto {
+  @FreezedUnionValue("SubAgentActivity")
+  const factory subAgentActivity({
+    required String id,
+    @JsonKey(unknownEnumValue: CodexSubAgentActivityKind.unknown) required CodexSubAgentActivityKind kind,
+    @JsonKey(name: "agent_thread_id") required String agentThreadId,
+    @JsonKey(name: "agent_path") required String agentPath,
+  }) = CodexRolloutCompletedSubAgentActivityDto;
+
+  const factory unknown() = CodexRolloutUnknownCompletedItemDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexRolloutCompletedItemDtoFromJson(json);
 }
 
 @Freezed(fromJson: true, toJson: false)
@@ -192,6 +236,15 @@ sealed class CodexRolloutResponseItemDto with _$CodexRolloutResponseItemDto {
     @CodexRolloutContentListConverter() required List<CodexRolloutContentDto> summary,
   }) = CodexRolloutReasoningDto;
 
+  @FreezedUnionValue("agent_message")
+  const factory agentMessage({
+    required String? id,
+    required String author,
+    required String recipient,
+    @CodexRolloutAgentMessageContentListConverter() required List<CodexRolloutAgentMessageContentDto> content,
+    @JsonKey(name: "internal_chat_message_metadata_passthrough") required CodexRolloutItemMetadataDto? metadata,
+  }) = CodexRolloutAgentMessageDto;
+
   @FreezedUnionValue("function_call")
   const factory functionCall({
     required String? id,
@@ -239,6 +292,52 @@ sealed class CodexRolloutResponseItemDto with _$CodexRolloutResponseItemDto {
   const factory unknown() = CodexRolloutUnknownResponseItemDto;
 
   factory fromJson(Map<String, dynamic> json) => _$CodexRolloutResponseItemDtoFromJson(json);
+}
+
+@Freezed(
+  unionKey: "type",
+  fallbackUnion: "unknown",
+  fromJson: true,
+  toJson: false,
+)
+sealed class CodexRolloutAgentMessageContentDto with _$CodexRolloutAgentMessageContentDto {
+  @FreezedUnionValue("input_text")
+  const factory inputText({
+    required String text,
+  }) = CodexRolloutAgentMessageInputTextDto;
+
+  @FreezedUnionValue("encrypted_content")
+  const factory encrypted({
+    @JsonKey(name: "encrypted_content") required String encryptedContent,
+  }) = CodexRolloutAgentMessageEncryptedContentDto;
+
+  const factory unknown() = CodexRolloutUnknownAgentMessageContentDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CodexRolloutAgentMessageContentDtoFromJson(json);
+}
+
+class const CodexRolloutAgentMessageContentListConverter()
+    implements JsonConverter<List<CodexRolloutAgentMessageContentDto>, Object?> {
+  @override
+  List<CodexRolloutAgentMessageContentDto> fromJson(Object? json) {
+    if (json == null) return const [];
+    if (json is! List) {
+      Log.w("[codex] skipping malformed agent-message content list");
+      return const [];
+    }
+    final content = <CodexRolloutAgentMessageContentDto>[];
+    for (final item in json) {
+      try {
+        content.add(CodexRolloutAgentMessageContentDto.fromJson((item as Map).cast<String, dynamic>()));
+      } on Object {
+        Log.w("[codex] skipping malformed agent-message content item");
+      }
+    }
+    return content;
+  }
+
+  @override
+  Object toJson(List<CodexRolloutAgentMessageContentDto> object) => throw UnsupportedError("serialization disabled");
 }
 
 @Freezed(

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.freezed.dart
@@ -167,6 +167,10 @@ CodexRolloutLineDto _$CodexRolloutLineDtoFromJson(
           return CodexRolloutEventMessageLineDto.fromJson(
             json
           );
+                case 'inter_agent_communication_metadata':
+          return CodexRolloutInterAgentCommunicationMetadataLineDto.fromJson(
+            json
+          );
                 case 'compacted':
           return CodexRolloutCompactedLineDto.fromJson(
             json
@@ -569,6 +573,87 @@ $CodexRolloutEventDtoCopyWith<$Res> get payload {
 /// @nodoc
 @JsonSerializable(createToJson: false)
 
+class CodexRolloutInterAgentCommunicationMetadataLineDto implements CodexRolloutLineDto {
+  const CodexRolloutInterAgentCommunicationMetadataLineDto({required this.timestamp, required this.payload,  String? $type}): $type = $type ?? 'inter_agent_communication_metadata';
+  factory CodexRolloutInterAgentCommunicationMetadataLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutInterAgentCommunicationMetadataLineDtoFromJson(json);
+
+@override final  String? timestamp;
+ final  CodexRolloutInterAgentCommunicationMetadataDto payload;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutInterAgentCommunicationMetadataLineDtoCopyWith<CodexRolloutInterAgentCommunicationMetadataLineDto> get copyWith => _$CodexRolloutInterAgentCommunicationMetadataLineDtoCopyWithImpl<CodexRolloutInterAgentCommunicationMetadataLineDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutInterAgentCommunicationMetadataLineDto&&(identical(other.timestamp, timestamp) || other.timestamp == timestamp)&&(identical(other.payload, payload) || other.payload == payload));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,timestamp,payload);
+
+@override
+String toString() {
+  return 'CodexRolloutLineDto.interAgentCommunicationMetadata(timestamp: $timestamp, payload: $payload)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutInterAgentCommunicationMetadataLineDtoCopyWith<$Res> implements $CodexRolloutLineDtoCopyWith<$Res> {
+  factory $CodexRolloutInterAgentCommunicationMetadataLineDtoCopyWith(CodexRolloutInterAgentCommunicationMetadataLineDto value, $Res Function(CodexRolloutInterAgentCommunicationMetadataLineDto) _then) = _$CodexRolloutInterAgentCommunicationMetadataLineDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String? timestamp, CodexRolloutInterAgentCommunicationMetadataDto payload
+});
+
+
+$CodexRolloutInterAgentCommunicationMetadataDtoCopyWith<$Res> get payload;
+
+}
+/// @nodoc
+class _$CodexRolloutInterAgentCommunicationMetadataLineDtoCopyWithImpl<$Res>
+    implements $CodexRolloutInterAgentCommunicationMetadataLineDtoCopyWith<$Res> {
+  _$CodexRolloutInterAgentCommunicationMetadataLineDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutInterAgentCommunicationMetadataLineDto _self;
+  final $Res Function(CodexRolloutInterAgentCommunicationMetadataLineDto) _then;
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? timestamp = freezed,Object? payload = null,}) {
+  return _then(CodexRolloutInterAgentCommunicationMetadataLineDto(
+timestamp: freezed == timestamp ? _self.timestamp : timestamp // ignore: cast_nullable_to_non_nullable
+as String?,payload: null == payload ? _self.payload : payload // ignore: cast_nullable_to_non_nullable
+as CodexRolloutInterAgentCommunicationMetadataDto,
+  ));
+}
+
+/// Create a copy of CodexRolloutLineDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexRolloutInterAgentCommunicationMetadataDtoCopyWith<$Res> get payload {
+  
+  return $CodexRolloutInterAgentCommunicationMetadataDtoCopyWith<$Res>(_self.payload, (value) {
+    return _then(_self.copyWith(payload: value));
+  });
+}
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
 class CodexRolloutCompactedLineDto implements CodexRolloutLineDto {
   const CodexRolloutCompactedLineDto({required this.timestamp,  String? $type}): $type = $type ?? 'compacted';
   factory CodexRolloutCompactedLineDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutCompactedLineDtoFromJson(json);
@@ -714,6 +799,10 @@ CodexRolloutEventDto _$CodexRolloutEventDtoFromJson(
           return CodexRolloutUserMessageEventDto.fromJson(
             json
           );
+                case 'item_completed':
+          return CodexRolloutItemCompletedEventDto.fromJson(
+            json
+          );
                 case 'image_generation_end':
           return CodexRolloutImageGenerationEndEventDto.fromJson(
             json
@@ -842,6 +931,89 @@ as String,
 }
 
 
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutItemCompletedEventDto implements CodexRolloutEventDto {
+  const CodexRolloutItemCompletedEventDto({@JsonKey(name: "thread_id") required this.threadId, @JsonKey(name: "turn_id") required this.turnId, required this.item,  String? $type}): $type = $type ?? 'item_completed';
+  factory CodexRolloutItemCompletedEventDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutItemCompletedEventDtoFromJson(json);
+
+@JsonKey(name: "thread_id") final  String threadId;
+@JsonKey(name: "turn_id") final  String turnId;
+ final  CodexRolloutCompletedItemDto item;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutEventDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutItemCompletedEventDtoCopyWith<CodexRolloutItemCompletedEventDto> get copyWith => _$CodexRolloutItemCompletedEventDtoCopyWithImpl<CodexRolloutItemCompletedEventDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutItemCompletedEventDto&&(identical(other.threadId, threadId) || other.threadId == threadId)&&(identical(other.turnId, turnId) || other.turnId == turnId)&&(identical(other.item, item) || other.item == item));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,threadId,turnId,item);
+
+@override
+String toString() {
+  return 'CodexRolloutEventDto.itemCompleted(threadId: $threadId, turnId: $turnId, item: $item)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutItemCompletedEventDtoCopyWith<$Res> implements $CodexRolloutEventDtoCopyWith<$Res> {
+  factory $CodexRolloutItemCompletedEventDtoCopyWith(CodexRolloutItemCompletedEventDto value, $Res Function(CodexRolloutItemCompletedEventDto) _then) = _$CodexRolloutItemCompletedEventDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "thread_id") String threadId,@JsonKey(name: "turn_id") String turnId, CodexRolloutCompletedItemDto item
+});
+
+
+$CodexRolloutCompletedItemDtoCopyWith<$Res> get item;
+
+}
+/// @nodoc
+class _$CodexRolloutItemCompletedEventDtoCopyWithImpl<$Res>
+    implements $CodexRolloutItemCompletedEventDtoCopyWith<$Res> {
+  _$CodexRolloutItemCompletedEventDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutItemCompletedEventDto _self;
+  final $Res Function(CodexRolloutItemCompletedEventDto) _then;
+
+/// Create a copy of CodexRolloutEventDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? threadId = null,Object? turnId = null,Object? item = null,}) {
+  return _then(CodexRolloutItemCompletedEventDto(
+threadId: null == threadId ? _self.threadId : threadId // ignore: cast_nullable_to_non_nullable
+as String,turnId: null == turnId ? _self.turnId : turnId // ignore: cast_nullable_to_non_nullable
+as String,item: null == item ? _self.item : item // ignore: cast_nullable_to_non_nullable
+as CodexRolloutCompletedItemDto,
+  ));
+}
+
+/// Create a copy of CodexRolloutEventDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexRolloutCompletedItemDtoCopyWith<$Res> get item {
+  
+  return $CodexRolloutCompletedItemDtoCopyWith<$Res>(_self.item, (value) {
+    return _then(_self.copyWith(item: value));
+  });
+}
 }
 
 /// @nodoc
@@ -1244,6 +1416,295 @@ int get hashCode => runtimeType.hashCode;
 @override
 String toString() {
   return 'CodexRolloutEventDto.unknown()';
+}
+
+
+}
+
+
+
+
+
+/// @nodoc
+mixin _$CodexRolloutInterAgentCommunicationMetadataDto {
+
+@JsonKey(name: "trigger_turn") bool get triggerTurn;
+/// Create a copy of CodexRolloutInterAgentCommunicationMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutInterAgentCommunicationMetadataDtoCopyWith<CodexRolloutInterAgentCommunicationMetadataDto> get copyWith => _$CodexRolloutInterAgentCommunicationMetadataDtoCopyWithImpl<CodexRolloutInterAgentCommunicationMetadataDto>(this as CodexRolloutInterAgentCommunicationMetadataDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutInterAgentCommunicationMetadataDto&&(identical(other.triggerTurn, triggerTurn) || other.triggerTurn == triggerTurn));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,triggerTurn);
+
+@override
+String toString() {
+  return 'CodexRolloutInterAgentCommunicationMetadataDto(triggerTurn: $triggerTurn)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutInterAgentCommunicationMetadataDtoCopyWith<$Res>  {
+  factory $CodexRolloutInterAgentCommunicationMetadataDtoCopyWith(CodexRolloutInterAgentCommunicationMetadataDto value, $Res Function(CodexRolloutInterAgentCommunicationMetadataDto) _then) = _$CodexRolloutInterAgentCommunicationMetadataDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "trigger_turn") bool triggerTurn
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutInterAgentCommunicationMetadataDtoCopyWithImpl<$Res>
+    implements $CodexRolloutInterAgentCommunicationMetadataDtoCopyWith<$Res> {
+  _$CodexRolloutInterAgentCommunicationMetadataDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutInterAgentCommunicationMetadataDto _self;
+  final $Res Function(CodexRolloutInterAgentCommunicationMetadataDto) _then;
+
+/// Create a copy of CodexRolloutInterAgentCommunicationMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? triggerTurn = null,}) {
+  return _then(CodexRolloutInterAgentCommunicationMetadataDto(
+triggerTurn: null == triggerTurn ? _self.triggerTurn : triggerTurn // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CodexRolloutInterAgentCommunicationMetadataDto implements CodexRolloutInterAgentCommunicationMetadataDto {
+  const _CodexRolloutInterAgentCommunicationMetadataDto({@JsonKey(name: "trigger_turn") required this.triggerTurn});
+  factory _CodexRolloutInterAgentCommunicationMetadataDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutInterAgentCommunicationMetadataDtoFromJson(json);
+
+@override@JsonKey(name: "trigger_turn") final  bool triggerTurn;
+
+/// Create a copy of CodexRolloutInterAgentCommunicationMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CodexRolloutInterAgentCommunicationMetadataDtoCopyWith<_CodexRolloutInterAgentCommunicationMetadataDto> get copyWith => __$CodexRolloutInterAgentCommunicationMetadataDtoCopyWithImpl<_CodexRolloutInterAgentCommunicationMetadataDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _CodexRolloutInterAgentCommunicationMetadataDto&&(identical(other.triggerTurn, triggerTurn) || other.triggerTurn == triggerTurn));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,triggerTurn);
+
+@override
+String toString() {
+  return 'CodexRolloutInterAgentCommunicationMetadataDto(triggerTurn: $triggerTurn)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CodexRolloutInterAgentCommunicationMetadataDtoCopyWith<$Res> implements $CodexRolloutInterAgentCommunicationMetadataDtoCopyWith<$Res> {
+  factory _$CodexRolloutInterAgentCommunicationMetadataDtoCopyWith(_CodexRolloutInterAgentCommunicationMetadataDto value, $Res Function(_CodexRolloutInterAgentCommunicationMetadataDto) _then) = __$CodexRolloutInterAgentCommunicationMetadataDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: "trigger_turn") bool triggerTurn
+});
+
+
+
+
+}
+/// @nodoc
+class __$CodexRolloutInterAgentCommunicationMetadataDtoCopyWithImpl<$Res>
+    implements _$CodexRolloutInterAgentCommunicationMetadataDtoCopyWith<$Res> {
+  __$CodexRolloutInterAgentCommunicationMetadataDtoCopyWithImpl(this._self, this._then);
+
+  final _CodexRolloutInterAgentCommunicationMetadataDto _self;
+  final $Res Function(_CodexRolloutInterAgentCommunicationMetadataDto) _then;
+
+/// Create a copy of CodexRolloutInterAgentCommunicationMetadataDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? triggerTurn = null,}) {
+  return _then(_CodexRolloutInterAgentCommunicationMetadataDto(
+triggerTurn: null == triggerTurn ? _self.triggerTurn : triggerTurn // ignore: cast_nullable_to_non_nullable
+as bool,
+  ));
+}
+
+
+}
+
+CodexRolloutCompletedItemDto _$CodexRolloutCompletedItemDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'SubAgentActivity':
+          return CodexRolloutCompletedSubAgentActivityDto.fromJson(
+            json
+          );
+        
+          default:
+            return CodexRolloutUnknownCompletedItemDto.fromJson(
+  json
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$CodexRolloutCompletedItemDto {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutCompletedItemDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexRolloutCompletedItemDto()';
+}
+
+
+}
+
+/// @nodoc
+class $CodexRolloutCompletedItemDtoCopyWith<$Res>  {
+$CodexRolloutCompletedItemDtoCopyWith(CodexRolloutCompletedItemDto _, $Res Function(CodexRolloutCompletedItemDto) __);
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutCompletedSubAgentActivityDto implements CodexRolloutCompletedItemDto {
+  const CodexRolloutCompletedSubAgentActivityDto({required this.id, @JsonKey(unknownEnumValue: CodexSubAgentActivityKind.unknown) required this.kind, @JsonKey(name: "agent_thread_id") required this.agentThreadId, @JsonKey(name: "agent_path") required this.agentPath,  String? $type}): $type = $type ?? 'SubAgentActivity';
+  factory CodexRolloutCompletedSubAgentActivityDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutCompletedSubAgentActivityDtoFromJson(json);
+
+ final  String id;
+@JsonKey(unknownEnumValue: CodexSubAgentActivityKind.unknown) final  CodexSubAgentActivityKind kind;
+@JsonKey(name: "agent_thread_id") final  String agentThreadId;
+@JsonKey(name: "agent_path") final  String agentPath;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutCompletedItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutCompletedSubAgentActivityDtoCopyWith<CodexRolloutCompletedSubAgentActivityDto> get copyWith => _$CodexRolloutCompletedSubAgentActivityDtoCopyWithImpl<CodexRolloutCompletedSubAgentActivityDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutCompletedSubAgentActivityDto&&(identical(other.id, id) || other.id == id)&&(identical(other.kind, kind) || other.kind == kind)&&(identical(other.agentThreadId, agentThreadId) || other.agentThreadId == agentThreadId)&&(identical(other.agentPath, agentPath) || other.agentPath == agentPath));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,kind,agentThreadId,agentPath);
+
+@override
+String toString() {
+  return 'CodexRolloutCompletedItemDto.subAgentActivity(id: $id, kind: $kind, agentThreadId: $agentThreadId, agentPath: $agentPath)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutCompletedSubAgentActivityDtoCopyWith<$Res> implements $CodexRolloutCompletedItemDtoCopyWith<$Res> {
+  factory $CodexRolloutCompletedSubAgentActivityDtoCopyWith(CodexRolloutCompletedSubAgentActivityDto value, $Res Function(CodexRolloutCompletedSubAgentActivityDto) _then) = _$CodexRolloutCompletedSubAgentActivityDtoCopyWithImpl;
+@useResult
+$Res call({
+ String id,@JsonKey(unknownEnumValue: CodexSubAgentActivityKind.unknown) CodexSubAgentActivityKind kind,@JsonKey(name: "agent_thread_id") String agentThreadId,@JsonKey(name: "agent_path") String agentPath
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutCompletedSubAgentActivityDtoCopyWithImpl<$Res>
+    implements $CodexRolloutCompletedSubAgentActivityDtoCopyWith<$Res> {
+  _$CodexRolloutCompletedSubAgentActivityDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutCompletedSubAgentActivityDto _self;
+  final $Res Function(CodexRolloutCompletedSubAgentActivityDto) _then;
+
+/// Create a copy of CodexRolloutCompletedItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = null,Object? kind = null,Object? agentThreadId = null,Object? agentPath = null,}) {
+  return _then(CodexRolloutCompletedSubAgentActivityDto(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,kind: null == kind ? _self.kind : kind // ignore: cast_nullable_to_non_nullable
+as CodexSubAgentActivityKind,agentThreadId: null == agentThreadId ? _self.agentThreadId : agentThreadId // ignore: cast_nullable_to_non_nullable
+as String,agentPath: null == agentPath ? _self.agentPath : agentPath // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutUnknownCompletedItemDto implements CodexRolloutCompletedItemDto {
+  const CodexRolloutUnknownCompletedItemDto({ String? $type}): $type = $type ?? 'unknown';
+  factory CodexRolloutUnknownCompletedItemDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutUnknownCompletedItemDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutUnknownCompletedItemDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexRolloutCompletedItemDto.unknown()';
 }
 
 
@@ -1807,6 +2268,10 @@ CodexRolloutResponseItemDto _$CodexRolloutResponseItemDtoFromJson(
           return CodexRolloutReasoningDto.fromJson(
             json
           );
+                case 'agent_message':
+          return CodexRolloutAgentMessageDto.fromJson(
+            json
+          );
                 case 'function_call':
           return CodexRolloutFunctionCallDto.fromJson(
             json
@@ -2027,6 +2492,102 @@ as List<CodexRolloutContentDto>,
 }
 
 
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutAgentMessageDto implements CodexRolloutResponseItemDto {
+  const CodexRolloutAgentMessageDto({required this.id, required this.author, required this.recipient, @CodexRolloutAgentMessageContentListConverter() required  List<CodexRolloutAgentMessageContentDto> content, @JsonKey(name: "internal_chat_message_metadata_passthrough") required this.metadata,  String? $type}): _content = content,$type = $type ?? 'agent_message';
+  factory CodexRolloutAgentMessageDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutAgentMessageDtoFromJson(json);
+
+ final  String? id;
+ final  String author;
+ final  String recipient;
+ final  List<CodexRolloutAgentMessageContentDto> _content;
+@CodexRolloutAgentMessageContentListConverter() List<CodexRolloutAgentMessageContentDto> get content {
+  if (_content is EqualUnmodifiableListView) return _content;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_content);
+}
+
+@JsonKey(name: "internal_chat_message_metadata_passthrough") final  CodexRolloutItemMetadataDto? metadata;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutAgentMessageDtoCopyWith<CodexRolloutAgentMessageDto> get copyWith => _$CodexRolloutAgentMessageDtoCopyWithImpl<CodexRolloutAgentMessageDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutAgentMessageDto&&(identical(other.id, id) || other.id == id)&&(identical(other.author, author) || other.author == author)&&(identical(other.recipient, recipient) || other.recipient == recipient)&&const DeepCollectionEquality().equals(other._content, _content)&&(identical(other.metadata, metadata) || other.metadata == metadata));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,author,recipient,const DeepCollectionEquality().hash(_content),metadata);
+
+@override
+String toString() {
+  return 'CodexRolloutResponseItemDto.agentMessage(id: $id, author: $author, recipient: $recipient, content: $content, metadata: $metadata)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutAgentMessageDtoCopyWith<$Res> implements $CodexRolloutResponseItemDtoCopyWith<$Res> {
+  factory $CodexRolloutAgentMessageDtoCopyWith(CodexRolloutAgentMessageDto value, $Res Function(CodexRolloutAgentMessageDto) _then) = _$CodexRolloutAgentMessageDtoCopyWithImpl;
+@useResult
+$Res call({
+ String? id, String author, String recipient,@CodexRolloutAgentMessageContentListConverter() List<CodexRolloutAgentMessageContentDto> content,@JsonKey(name: "internal_chat_message_metadata_passthrough") CodexRolloutItemMetadataDto? metadata
+});
+
+
+$CodexRolloutItemMetadataDtoCopyWith<$Res>? get metadata;
+
+}
+/// @nodoc
+class _$CodexRolloutAgentMessageDtoCopyWithImpl<$Res>
+    implements $CodexRolloutAgentMessageDtoCopyWith<$Res> {
+  _$CodexRolloutAgentMessageDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutAgentMessageDto _self;
+  final $Res Function(CodexRolloutAgentMessageDto) _then;
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? id = freezed,Object? author = null,Object? recipient = null,Object? content = null,Object? metadata = freezed,}) {
+  return _then(CodexRolloutAgentMessageDto(
+id: freezed == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String?,author: null == author ? _self.author : author // ignore: cast_nullable_to_non_nullable
+as String,recipient: null == recipient ? _self.recipient : recipient // ignore: cast_nullable_to_non_nullable
+as String,content: null == content ? _self._content : content // ignore: cast_nullable_to_non_nullable
+as List<CodexRolloutAgentMessageContentDto>,metadata: freezed == metadata ? _self.metadata : metadata // ignore: cast_nullable_to_non_nullable
+as CodexRolloutItemMetadataDto?,
+  ));
+}
+
+/// Create a copy of CodexRolloutResponseItemDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CodexRolloutItemMetadataDtoCopyWith<$Res>? get metadata {
+    if (_self.metadata == null) {
+    return null;
+  }
+
+  return $CodexRolloutItemMetadataDtoCopyWith<$Res>(_self.metadata!, (value) {
+    return _then(_self.copyWith(metadata: value));
+  });
+}
 }
 
 /// @nodoc
@@ -2551,6 +3112,234 @@ int get hashCode => runtimeType.hashCode;
 @override
 String toString() {
   return 'CodexRolloutResponseItemDto.unknown()';
+}
+
+
+}
+
+
+
+
+CodexRolloutAgentMessageContentDto _$CodexRolloutAgentMessageContentDtoFromJson(
+  Map<String, dynamic> json
+) {
+        switch (json['type']) {
+                  case 'input_text':
+          return CodexRolloutAgentMessageInputTextDto.fromJson(
+            json
+          );
+                case 'encrypted_content':
+          return CodexRolloutAgentMessageEncryptedContentDto.fromJson(
+            json
+          );
+        
+          default:
+            return CodexRolloutUnknownAgentMessageContentDto.fromJson(
+  json
+);
+        }
+      
+}
+
+/// @nodoc
+mixin _$CodexRolloutAgentMessageContentDto {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutAgentMessageContentDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexRolloutAgentMessageContentDto()';
+}
+
+
+}
+
+/// @nodoc
+class $CodexRolloutAgentMessageContentDtoCopyWith<$Res>  {
+$CodexRolloutAgentMessageContentDtoCopyWith(CodexRolloutAgentMessageContentDto _, $Res Function(CodexRolloutAgentMessageContentDto) __);
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutAgentMessageInputTextDto implements CodexRolloutAgentMessageContentDto {
+  const CodexRolloutAgentMessageInputTextDto({required this.text,  String? $type}): $type = $type ?? 'input_text';
+  factory CodexRolloutAgentMessageInputTextDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutAgentMessageInputTextDtoFromJson(json);
+
+ final  String text;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutAgentMessageContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutAgentMessageInputTextDtoCopyWith<CodexRolloutAgentMessageInputTextDto> get copyWith => _$CodexRolloutAgentMessageInputTextDtoCopyWithImpl<CodexRolloutAgentMessageInputTextDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutAgentMessageInputTextDto&&(identical(other.text, text) || other.text == text));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,text);
+
+@override
+String toString() {
+  return 'CodexRolloutAgentMessageContentDto.inputText(text: $text)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutAgentMessageInputTextDtoCopyWith<$Res> implements $CodexRolloutAgentMessageContentDtoCopyWith<$Res> {
+  factory $CodexRolloutAgentMessageInputTextDtoCopyWith(CodexRolloutAgentMessageInputTextDto value, $Res Function(CodexRolloutAgentMessageInputTextDto) _then) = _$CodexRolloutAgentMessageInputTextDtoCopyWithImpl;
+@useResult
+$Res call({
+ String text
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutAgentMessageInputTextDtoCopyWithImpl<$Res>
+    implements $CodexRolloutAgentMessageInputTextDtoCopyWith<$Res> {
+  _$CodexRolloutAgentMessageInputTextDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutAgentMessageInputTextDto _self;
+  final $Res Function(CodexRolloutAgentMessageInputTextDto) _then;
+
+/// Create a copy of CodexRolloutAgentMessageContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? text = null,}) {
+  return _then(CodexRolloutAgentMessageInputTextDto(
+text: null == text ? _self.text : text // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutAgentMessageEncryptedContentDto implements CodexRolloutAgentMessageContentDto {
+  const CodexRolloutAgentMessageEncryptedContentDto({@JsonKey(name: "encrypted_content") required this.encryptedContent,  String? $type}): $type = $type ?? 'encrypted_content';
+  factory CodexRolloutAgentMessageEncryptedContentDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutAgentMessageEncryptedContentDtoFromJson(json);
+
+@JsonKey(name: "encrypted_content") final  String encryptedContent;
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+/// Create a copy of CodexRolloutAgentMessageContentDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CodexRolloutAgentMessageEncryptedContentDtoCopyWith<CodexRolloutAgentMessageEncryptedContentDto> get copyWith => _$CodexRolloutAgentMessageEncryptedContentDtoCopyWithImpl<CodexRolloutAgentMessageEncryptedContentDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutAgentMessageEncryptedContentDto&&(identical(other.encryptedContent, encryptedContent) || other.encryptedContent == encryptedContent));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,encryptedContent);
+
+@override
+String toString() {
+  return 'CodexRolloutAgentMessageContentDto.encrypted(encryptedContent: $encryptedContent)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CodexRolloutAgentMessageEncryptedContentDtoCopyWith<$Res> implements $CodexRolloutAgentMessageContentDtoCopyWith<$Res> {
+  factory $CodexRolloutAgentMessageEncryptedContentDtoCopyWith(CodexRolloutAgentMessageEncryptedContentDto value, $Res Function(CodexRolloutAgentMessageEncryptedContentDto) _then) = _$CodexRolloutAgentMessageEncryptedContentDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "encrypted_content") String encryptedContent
+});
+
+
+
+
+}
+/// @nodoc
+class _$CodexRolloutAgentMessageEncryptedContentDtoCopyWithImpl<$Res>
+    implements $CodexRolloutAgentMessageEncryptedContentDtoCopyWith<$Res> {
+  _$CodexRolloutAgentMessageEncryptedContentDtoCopyWithImpl(this._self, this._then);
+
+  final CodexRolloutAgentMessageEncryptedContentDto _self;
+  final $Res Function(CodexRolloutAgentMessageEncryptedContentDto) _then;
+
+/// Create a copy of CodexRolloutAgentMessageContentDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? encryptedContent = null,}) {
+  return _then(CodexRolloutAgentMessageEncryptedContentDto(
+encryptedContent: null == encryptedContent ? _self.encryptedContent : encryptedContent // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class CodexRolloutUnknownAgentMessageContentDto implements CodexRolloutAgentMessageContentDto {
+  const CodexRolloutUnknownAgentMessageContentDto({ String? $type}): $type = $type ?? 'unknown';
+  factory CodexRolloutUnknownAgentMessageContentDto.fromJson(Map<String, dynamic> json) => _$CodexRolloutUnknownAgentMessageContentDtoFromJson(json);
+
+
+
+@JsonKey(name: 'type')
+final String $type;
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CodexRolloutUnknownAgentMessageContentDto);
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CodexRolloutAgentMessageContentDto.unknown()';
 }
 
 

--- a/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
+++ b/bridge/sesori_plugin_codex/lib/src/api/models/codex_rollout_dto.g.dart
@@ -53,6 +53,16 @@ CodexRolloutEventMessageLineDto _$CodexRolloutEventMessageLineDtoFromJson(
   $type: json['type'] as String?,
 );
 
+CodexRolloutInterAgentCommunicationMetadataLineDto
+_$CodexRolloutInterAgentCommunicationMetadataLineDtoFromJson(Map json) =>
+    CodexRolloutInterAgentCommunicationMetadataLineDto(
+      timestamp: json['timestamp'] as String?,
+      payload: CodexRolloutInterAgentCommunicationMetadataDto.fromJson(
+        Map<String, dynamic>.from(json['payload'] as Map),
+      ),
+      $type: json['type'] as String?,
+    );
+
 CodexRolloutCompactedLineDto _$CodexRolloutCompactedLineDtoFromJson(Map json) =>
     CodexRolloutCompactedLineDto(
       timestamp: json['timestamp'] as String?,
@@ -69,6 +79,17 @@ CodexRolloutUserMessageEventDto _$CodexRolloutUserMessageEventDtoFromJson(
   Map json,
 ) => CodexRolloutUserMessageEventDto(
   message: json['message'] as String,
+  $type: json['type'] as String?,
+);
+
+CodexRolloutItemCompletedEventDto _$CodexRolloutItemCompletedEventDtoFromJson(
+  Map json,
+) => CodexRolloutItemCompletedEventDto(
+  threadId: json['thread_id'] as String,
+  turnId: json['turn_id'] as String,
+  item: CodexRolloutCompletedItemDto.fromJson(
+    Map<String, dynamic>.from(json['item'] as Map),
+  ),
   $type: json['type'] as String?,
 );
 
@@ -129,6 +150,38 @@ _$CodexRolloutThreadRolledBackEventDtoFromJson(Map json) =>
 
 CodexRolloutUnknownEventDto _$CodexRolloutUnknownEventDtoFromJson(Map json) =>
     CodexRolloutUnknownEventDto($type: json['type'] as String?);
+
+_CodexRolloutInterAgentCommunicationMetadataDto
+_$CodexRolloutInterAgentCommunicationMetadataDtoFromJson(Map json) =>
+    _CodexRolloutInterAgentCommunicationMetadataDto(
+      triggerTurn: json['trigger_turn'] as bool,
+    );
+
+CodexRolloutCompletedSubAgentActivityDto
+_$CodexRolloutCompletedSubAgentActivityDtoFromJson(Map json) =>
+    CodexRolloutCompletedSubAgentActivityDto(
+      id: json['id'] as String,
+      kind: $enumDecode(
+        _$CodexSubAgentActivityKindEnumMap,
+        json['kind'],
+        unknownValue: CodexSubAgentActivityKind.unknown,
+      ),
+      agentThreadId: json['agent_thread_id'] as String,
+      agentPath: json['agent_path'] as String,
+      $type: json['type'] as String?,
+    );
+
+const _$CodexSubAgentActivityKindEnumMap = {
+  CodexSubAgentActivityKind.started: 'started',
+  CodexSubAgentActivityKind.interacted: 'interacted',
+  CodexSubAgentActivityKind.interrupted: 'interrupted',
+  CodexSubAgentActivityKind.completed: 'completed',
+  CodexSubAgentActivityKind.unknown: 'unknown',
+};
+
+CodexRolloutUnknownCompletedItemDto
+_$CodexRolloutUnknownCompletedItemDtoFromJson(Map json) =>
+    CodexRolloutUnknownCompletedItemDto($type: json['type'] as String?);
 
 _CodexRolloutErrorDto _$CodexRolloutErrorDtoFromJson(Map json) =>
     _CodexRolloutErrorDto(message: json['message'] as String);
@@ -192,6 +245,24 @@ CodexRolloutReasoningDto _$CodexRolloutReasoningDtoFromJson(Map json) =>
       summary: const CodexRolloutContentListConverter().fromJson(
         json['summary'],
       ),
+      $type: json['type'] as String?,
+    );
+
+CodexRolloutAgentMessageDto _$CodexRolloutAgentMessageDtoFromJson(Map json) =>
+    CodexRolloutAgentMessageDto(
+      id: json['id'] as String?,
+      author: json['author'] as String,
+      recipient: json['recipient'] as String,
+      content: const CodexRolloutAgentMessageContentListConverter().fromJson(
+        json['content'],
+      ),
+      metadata: json['internal_chat_message_metadata_passthrough'] == null
+          ? null
+          : CodexRolloutItemMetadataDto.fromJson(
+              Map<String, dynamic>.from(
+                json['internal_chat_message_metadata_passthrough'] as Map,
+              ),
+            ),
       $type: json['type'] as String?,
     );
 
@@ -271,6 +342,24 @@ CodexRolloutImageGenerationDto _$CodexRolloutImageGenerationDtoFromJson(
 CodexRolloutUnknownResponseItemDto _$CodexRolloutUnknownResponseItemDtoFromJson(
   Map json,
 ) => CodexRolloutUnknownResponseItemDto($type: json['type'] as String?);
+
+CodexRolloutAgentMessageInputTextDto
+_$CodexRolloutAgentMessageInputTextDtoFromJson(Map json) =>
+    CodexRolloutAgentMessageInputTextDto(
+      text: json['text'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexRolloutAgentMessageEncryptedContentDto
+_$CodexRolloutAgentMessageEncryptedContentDtoFromJson(Map json) =>
+    CodexRolloutAgentMessageEncryptedContentDto(
+      encryptedContent: json['encrypted_content'] as String,
+      $type: json['type'] as String?,
+    );
+
+CodexRolloutUnknownAgentMessageContentDto
+_$CodexRolloutUnknownAgentMessageContentDtoFromJson(Map json) =>
+    CodexRolloutUnknownAgentMessageContentDto($type: json['type'] as String?);
 
 CodexRolloutInputTextDto _$CodexRolloutInputTextDtoFromJson(Map json) =>
     CodexRolloutInputTextDto(

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_catalog_repository.dart
@@ -324,6 +324,7 @@ class CodexCatalogRepository({required final CodexRolloutApi _rolloutApi}) {
           if (candidate != null && candidate.isNotEmpty) model = candidate;
         case CodexRolloutResponseItemLineDto() ||
             CodexRolloutEventMessageLineDto() ||
+            CodexRolloutInterAgentCommunicationMetadataLineDto() ||
             CodexRolloutCompactedLineDto() ||
             CodexRolloutUnknownLineDto():
           break;

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_message_repository.dart
@@ -2,6 +2,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../api/codex_rollout_api.dart";
 import "../api/models/codex_rollout_dto.dart";
+import "../api/models/codex_sub_agent_item_dto.dart";
 import "../codex_config_reader.dart";
 import "../models/codex_replay_tool_disposition.dart";
 import "codex_tool_lifecycle_tracker.dart";
@@ -9,6 +10,7 @@ import "mappers/codex_rollout_tool_mapper.dart";
 import "mappers/codex_tool_part_mapper.dart";
 import "mappers/codex_user_content_mapper.dart";
 import "models/codex_projected_tool.dart";
+import "models/codex_sub_agent_rollout_fact.dart";
 import "models/codex_thread_record.dart";
 
 final class CodexPreparedMessageRead({required Iterable<CodexRolloutLineDto> lines}) {
@@ -148,6 +150,7 @@ class CodexMessageRepository({
             CodexRolloutTurnContextLineDto() ||
             CodexRolloutResponseItemLineDto() ||
             CodexRolloutEventMessageLineDto() ||
+            CodexRolloutInterAgentCommunicationMetadataLineDto() ||
             CodexRolloutCompactedLineDto() ||
             CodexRolloutUnknownLineDto():
           break;
@@ -196,6 +199,7 @@ class CodexMessageRepository({
               CodexRolloutThreadRolledBackEventDto():
             openTurn = false;
           case CodexRolloutUserMessageEventDto() ||
+              CodexRolloutItemCompletedEventDto() ||
               CodexRolloutImageGenerationEndEventDto() ||
               CodexRolloutUnknownEventDto():
             break;
@@ -204,6 +208,86 @@ class CodexMessageRepository({
     }
     return lines;
   }
+
+  /// Projects only provenance-safe sub-agent facts from current Codex rollout
+  /// records. [previousLine] proves native communication-marker adjacency.
+  CodexSubAgentRolloutFact? subAgentRolloutFact({
+    required CodexRolloutLineDto line,
+    required CodexRolloutLineDto? previousLine,
+  }) {
+    if (line case CodexRolloutResponseItemLineDto(:final payload)) {
+      final spawn = _rolloutToolMapper.mapSubAgentSpawn(payload: payload);
+      if (spawn != null) return spawn;
+      if (payload case CodexRolloutAgentMessageDto()) {
+        return _initialChildInputFact(message: payload, previousLine: previousLine);
+      }
+    }
+    if (line case CodexRolloutEventMessageLineDto(
+      payload: CodexRolloutItemCompletedEventDto(
+        item: CodexRolloutCompletedSubAgentActivityDto(
+          kind: CodexSubAgentActivityKind.started,
+          :final id,
+          :final agentThreadId,
+          :final agentPath,
+        ),
+      ),
+    )) {
+      return CodexSubAgentStartedActivityFact(
+        callId: id,
+        childThreadId: agentThreadId,
+        agentPath: agentPath,
+      );
+    }
+    return null;
+  }
+
+  CodexSubAgentInitialInputFact? _initialChildInputFact({
+    required CodexRolloutAgentMessageDto message,
+    required CodexRolloutLineDto? previousLine,
+  }) {
+    if (previousLine case CodexRolloutInterAgentCommunicationMetadataLineDto(
+      payload: CodexRolloutInterAgentCommunicationMetadataDto(triggerTurn: true),
+    )) {
+      final turnId = _exactNonBlank(message.metadata?.turnId);
+      if (turnId == null) return null;
+      if (message.content.any((content) => content is CodexRolloutAgentMessageEncryptedContentDto)) {
+        return CodexSubAgentInitialInputFact(
+          turnId: turnId,
+          input: const CodexSubAgentEncryptedInput(),
+        );
+      }
+      if (message.content.any((content) => content is! CodexRolloutAgentMessageInputTextDto)) return null;
+      final plaintext = message.content
+          .whereType<CodexRolloutAgentMessageInputTextDto>()
+          .map((content) => content.text)
+          .join("\n");
+      final payload = _parsePlaintextNewTask(
+        text: plaintext,
+        author: message.author,
+        recipient: message.recipient,
+      );
+      if (payload == null) return null;
+      return CodexSubAgentInitialInputFact(
+        turnId: turnId,
+        input: CodexSubAgentPlaintextInput(message: payload),
+      );
+    }
+    return null;
+  }
+
+  String? _parsePlaintextNewTask({
+    required String text,
+    required String author,
+    required String recipient,
+  }) {
+    final match = RegExp(
+      r"^Message Type: NEW_TASK\nTask name: ([^\n]+)\nSender: ([^\n]+)\nPayload:\n([\s\S]*)$",
+    ).firstMatch(text);
+    if (match == null || match.group(1) != recipient || match.group(2) != author) return null;
+    return _exactNonBlank(match.group(3));
+  }
+
+  String? _exactNonBlank(String? value) => value == null || value.trim().isEmpty ? null : value;
 
   List<PluginMessageWithParts> projectMessages({
     required CodexPreparedMessageRead read,
@@ -402,7 +486,7 @@ class CodexMessageRepository({
             ),
           );
           continue;
-        case CodexRolloutEventMessageLineDto():
+        case CodexRolloutEventMessageLineDto() || CodexRolloutInterAgentCommunicationMetadataLineDto():
           continue;
         case CodexRolloutResponseItemLineDto(
           payload: final responseItem,
@@ -466,6 +550,8 @@ class CodexMessageRepository({
               attachments: generation.attachments,
             ),
           );
+        case CodexRolloutAgentMessageDto():
+          continue;
         case CodexRolloutReasoningDto(:final id, :final summary):
           final reasoning = [
             for (final item in summary)
@@ -588,6 +674,7 @@ class CodexMessageRepository({
       CodexRolloutTurnContextLineDto(:final timestamp) ||
       CodexRolloutResponseItemLineDto(:final timestamp) ||
       CodexRolloutEventMessageLineDto(:final timestamp) ||
+      CodexRolloutInterAgentCommunicationMetadataLineDto(:final timestamp) ||
       CodexRolloutCompactedLineDto(:final timestamp) ||
       CodexRolloutUnknownLineDto(:final timestamp) => timestamp,
     };

--- a/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/codex_tool_lifecycle_tracker.dart
@@ -72,6 +72,7 @@ class CodexToolLifecycleTracker({
       ),
       CodexRolloutSessionMetadataLineDto() ||
       CodexRolloutTurnContextLineDto() ||
+      CodexRolloutInterAgentCommunicationMetadataLineDto() ||
       CodexRolloutCompactedLineDto() ||
       CodexRolloutUnknownLineDto() => const [],
     };
@@ -553,6 +554,7 @@ class CodexToolLifecycleTracker({
         turnId: turnId ?? thread.activeTurnId,
         status: PluginToolStatus.error,
       ),
+      CodexRolloutItemCompletedEventDto() => const [],
       CodexRolloutImageGenerationEndEventDto() => _observeImageGenerationEnd(
         thread: thread,
         event: event,

--- a/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/mappers/codex_rollout_tool_mapper.dart
@@ -6,6 +6,7 @@ import "package:sesori_shared/sesori_shared.dart" show jsonDecodeMap;
 import "../../api/models/codex_image_bearing_item_dto.dart";
 import "../../api/models/codex_rollout_dto.dart";
 import "../models/codex_projected_tool.dart";
+import "../models/codex_sub_agent_rollout_fact.dart";
 import "codex_image_attachment_mapper.dart";
 
 class const CodexRolloutToolCall({
@@ -83,6 +84,7 @@ class const CodexRolloutToolMapper({
     return switch (payload) {
       CodexRolloutFunctionCallDto(:final name) => name.toLowerCase() == "exec_command",
       CodexRolloutMessageDto() ||
+      CodexRolloutAgentMessageDto() ||
       CodexRolloutReasoningDto() ||
       CodexRolloutFunctionCallOutputDto() ||
       CodexRolloutCustomToolCallDto() ||
@@ -252,6 +254,7 @@ class const CodexRolloutToolMapper({
           input: input,
         ),
       CodexRolloutMessageDto() ||
+      CodexRolloutAgentMessageDto() ||
       CodexRolloutReasoningDto() ||
       CodexRolloutFunctionCallOutputDto() ||
       CodexRolloutCustomToolCallOutputDto() ||
@@ -274,6 +277,7 @@ class const CodexRolloutToolMapper({
       CodexRolloutCustomToolCallDto(:final name, :final input) =>
         name.toLowerCase() == "exec" && _isGeneratedImageInvocation(input),
       CodexRolloutMessageDto() ||
+      CodexRolloutAgentMessageDto() ||
       CodexRolloutReasoningDto() ||
       CodexRolloutFunctionCallOutputDto() ||
       CodexRolloutCustomToolCallOutputDto() ||
@@ -281,6 +285,25 @@ class const CodexRolloutToolMapper({
       CodexRolloutImageGenerationDto() ||
       CodexRolloutUnknownResponseItemDto() => false,
     };
+  }
+
+  CodexSubAgentSpawnFact? mapSubAgentSpawn({
+    required CodexRolloutResponseItemDto payload,
+  }) {
+    if (payload case CodexRolloutFunctionCallDto(:final callId, :final name, :final arguments)
+        when name == "spawn_agent") {
+      final decoded = _tryDecodeToolArguments(raw: arguments);
+      final usefulCallId = _usefulText(callId);
+      final exactMessage = _exactNonBlank(decoded?.message);
+      if (usefulCallId != null && exactMessage != null) {
+        return CodexSubAgentSpawnFact(
+          callId: usefulCallId,
+          agent: _usefulText(decoded?.agentType) ?? "codex",
+          message: exactMessage,
+        );
+      }
+    }
+    return null;
   }
 
   CodexRolloutWaitCall? mapWaitCall({
@@ -315,6 +338,7 @@ class const CodexRolloutToolMapper({
     return switch (payload) {
       CodexRolloutFunctionCallDto(:final callId) || CodexRolloutCustomToolCallDto(:final callId) => _usefulText(callId),
       CodexRolloutMessageDto() ||
+      CodexRolloutAgentMessageDto() ||
       CodexRolloutReasoningDto() ||
       CodexRolloutFunctionCallOutputDto() ||
       CodexRolloutCustomToolCallOutputDto() ||
@@ -386,6 +410,7 @@ class const CodexRolloutToolMapper({
       CodexRolloutFunctionCallOutputDto(:final callId, :final output) ||
       CodexRolloutCustomToolCallOutputDto(:final callId, :final output) => (callId: callId, content: output),
       CodexRolloutMessageDto() ||
+      CodexRolloutAgentMessageDto() ||
       CodexRolloutReasoningDto() ||
       CodexRolloutFunctionCallDto() ||
       CodexRolloutCustomToolCallDto() ||
@@ -645,6 +670,8 @@ class const CodexRolloutToolMapper({
     final trimmed = value?.trim();
     return trimmed == null || trimmed.isEmpty ? null : trimmed;
   }
+
+  String? _exactNonBlank(String? value) => value == null || value.trim().isEmpty ? null : value;
 }
 
 final RegExp _generatedImageInvocationPrefixPattern = RegExp(

--- a/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_sub_agent_rollout_fact.dart
+++ b/bridge/sesori_plugin_codex/lib/src/repositories/models/codex_sub_agent_rollout_fact.dart
@@ -1,0 +1,30 @@
+/// Repository-owned facts projected from Codex rollout records.
+sealed class const CodexSubAgentRolloutFact();
+
+/// Exact delegated input from one parent-local `spawn_agent` call.
+final class const CodexSubAgentSpawnFact({
+  required final String callId,
+  required final String agent,
+  required final String message,
+}) extends CodexSubAgentRolloutFact;
+
+/// Persisted child identity for a completed `SubAgentActivity` start item.
+final class const CodexSubAgentStartedActivityFact({
+  required final String callId,
+  required final String childThreadId,
+  required final String agentPath,
+}) extends CodexSubAgentRolloutFact;
+
+/// Initial child input associated with its owning child turn.
+final class const CodexSubAgentInitialInputFact({
+  required final String turnId,
+  required final CodexSubAgentInitialInput input,
+}) extends CodexSubAgentRolloutFact;
+
+sealed class const CodexSubAgentInitialInput();
+
+/// Genuine child-owned plaintext from a complete native `NEW_TASK` envelope.
+final class const CodexSubAgentPlaintextInput({required final String message}) extends CodexSubAgentInitialInput;
+
+/// Native input contains opaque encrypted content and cannot be projected.
+final class const CodexSubAgentEncryptedInput() extends CodexSubAgentInitialInput;

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_metadata_dto_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_metadata_dto_test.dart
@@ -1,4 +1,5 @@
 import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
+import "package:codex_plugin/src/api/models/codex_sub_agent_item_dto.dart";
 import "package:codex_plugin/src/api/models/codex_thread_dto.dart";
 import "package:test/test.dart";
 
@@ -57,6 +58,92 @@ void main() {
       expect(envelope.thread?.id, "root-1");
       expect(envelope.thread?.parentThreadId, isNull);
       expect(envelope.thread?.threadSource, isNull);
+    });
+  });
+
+  group("Codex rollout 0.153.4 sub-agent records", () {
+    test("decodes nested completed SubAgentActivity", () {
+      final line = CodexRolloutLineDto.fromJson(const {
+        "timestamp": "2026-09-05T12:00:00Z",
+        "type": "event_msg",
+        "payload": {
+          "type": "item_completed",
+          "thread_id": "root-1",
+          "turn_id": "turn-1",
+          "item": {
+            "type": "SubAgentActivity",
+            "id": "call-spawn",
+            "kind": "started",
+            "agent_thread_id": "child-1",
+            "agent_path": "/root/worker",
+          },
+          "started_at_ms": 1,
+          "completed_at_ms": 2,
+        },
+      });
+
+      final event = (line as CodexRolloutEventMessageLineDto).payload as CodexRolloutItemCompletedEventDto;
+      final item = event.item as CodexRolloutCompletedSubAgentActivityDto;
+      expect(event.threadId, "root-1");
+      expect(event.turnId, "turn-1");
+      expect(item.id, "call-spawn");
+      expect(item.kind, CodexSubAgentActivityKind.started);
+      expect(item.agentThreadId, "child-1");
+      expect(item.agentPath, "/root/worker");
+    });
+
+    test("decodes communication marker and plaintext plus encrypted agent content", () {
+      final marker = CodexRolloutLineDto.fromJson(const {
+        "type": "inter_agent_communication_metadata",
+        "payload": {"trigger_turn": true},
+      });
+      expect(
+        (marker as CodexRolloutInterAgentCommunicationMetadataLineDto).payload.triggerTurn,
+        isTrue,
+      );
+
+      final message = CodexRolloutLineDto.fromJson(const {
+        "type": "response_item",
+        "payload": {
+          "type": "agent_message",
+          "id": "amsg-1",
+          "author": "/root",
+          "recipient": "/root/worker",
+          "content": [
+            {"type": "input_text", "text": "header"},
+            {"type": "encrypted_content", "encrypted_content": "opaque"},
+          ],
+          "internal_chat_message_metadata_passthrough": {"turn_id": "turn-1"},
+        },
+      });
+      final payload = (message as CodexRolloutResponseItemLineDto).payload as CodexRolloutAgentMessageDto;
+      expect(payload.author, "/root");
+      expect(payload.recipient, "/root/worker");
+      expect(payload.metadata?.turnId, "turn-1");
+      expect(payload.content.first, isA<CodexRolloutAgentMessageInputTextDto>());
+      expect(payload.content.last, isA<CodexRolloutAgentMessageEncryptedContentDto>());
+    });
+
+    test("unknown nested items and agent content stay typed unknown", () {
+      final event = CodexRolloutEventDto.fromJson(const {
+        "type": "item_completed",
+        "thread_id": "root-1",
+        "turn_id": "turn-1",
+        "item": {"type": "FutureItem", "value": true},
+      }) as CodexRolloutItemCompletedEventDto;
+      expect(event.item, isA<CodexRolloutUnknownCompletedItemDto>());
+
+      final response = CodexRolloutResponseItemDto.fromJson(const {
+        "type": "agent_message",
+        "id": "amsg-1",
+        "author": "/root",
+        "recipient": "/root/worker",
+        "content": [
+          {"type": "future_content", "value": true},
+        ],
+        "internal_chat_message_metadata_passthrough": {"turn_id": "turn-1"},
+      }) as CodexRolloutAgentMessageDto;
+      expect(response.content.single, isA<CodexRolloutUnknownAgentMessageContentDto>());
     });
   });
 

--- a/bridge/sesori_plugin_codex/test/codex_sub_agent_rollout_fact_test.dart
+++ b/bridge/sesori_plugin_codex/test/codex_sub_agent_rollout_fact_test.dart
@@ -1,0 +1,149 @@
+import "dart:convert";
+
+import "package:codex_plugin/src/api/codex_rollout_api.dart";
+import "package:codex_plugin/src/api/models/codex_rollout_dto.dart";
+import "package:codex_plugin/src/repositories/codex_message_repository.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_image_attachment_mapper.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_rollout_tool_mapper.dart";
+import "package:codex_plugin/src/repositories/mappers/codex_user_content_mapper.dart";
+import "package:codex_plugin/src/repositories/models/codex_sub_agent_rollout_fact.dart";
+import "package:test/test.dart";
+
+void main() {
+  final repository = CodexMessageRepository(
+    rolloutApi: CodexRolloutApi(environment: const {}),
+    rolloutToolMapper: const CodexRolloutToolMapper(
+      imageAttachmentMapper: CodexImageAttachmentMapper(),
+    ),
+    userContentMapper: const CodexUserContentMapper(),
+  );
+
+  test("projects exact spawn and nested started-activity facts", () {
+    final spawn = repository.subAgentRolloutFact(
+      line: _line(
+        type: "response_item",
+        payload: {
+          "type": "function_call",
+          "call_id": "call-spawn",
+          "name": "spawn_agent",
+          "arguments": jsonEncode({
+            "agent_type": "worker",
+            "message": "  preserve delegated text  ",
+          }),
+        },
+      ),
+      previousLine: null,
+    );
+    expect(spawn, isA<CodexSubAgentSpawnFact>());
+    final spawnFact = spawn! as CodexSubAgentSpawnFact;
+    expect(spawnFact.callId, "call-spawn");
+    expect(spawnFact.agent, "worker");
+    expect(spawnFact.message, "  preserve delegated text  ");
+
+    final started = repository.subAgentRolloutFact(
+      line: _line(
+        type: "event_msg",
+        payload: const {
+          "type": "item_completed",
+          "thread_id": "parent-1",
+          "turn_id": "turn-1",
+          "item": {
+            "type": "SubAgentActivity",
+            "id": "call-spawn",
+            "kind": "started",
+            "agent_thread_id": "child-1",
+            "agent_path": "/root/worker",
+          },
+        },
+      ),
+      previousLine: null,
+    );
+    expect(started, isA<CodexSubAgentStartedActivityFact>());
+    final startedFact = started! as CodexSubAgentStartedActivityFact;
+    expect(startedFact.callId, "call-spawn");
+    expect(startedFact.childThreadId, "child-1");
+    expect(startedFact.agentPath, "/root/worker");
+  });
+
+  test("keeps encrypted input opaque and accepts complete plaintext NEW_TASK", () {
+    final marker = _line(
+      type: "inter_agent_communication_metadata",
+      payload: const {"trigger_turn": true},
+    );
+    final encrypted = repository.subAgentRolloutFact(
+      line: _agentMessage(
+        content: const [
+          {"type": "input_text", "text": "envelope only"},
+          {"type": "encrypted_content", "encrypted_content": "opaque"},
+        ],
+      ),
+      previousLine: marker,
+    );
+    expect(
+      (encrypted! as CodexSubAgentInitialInputFact).input,
+      isA<CodexSubAgentEncryptedInput>(),
+    );
+
+    final plaintext = repository.subAgentRolloutFact(
+      line: _agentMessage(
+        content: const [
+          {
+            "type": "input_text",
+            "text": "Message Type: NEW_TASK\nTask name: /root/worker\nSender: /root\nPayload:\nchild task",
+          },
+        ],
+      ),
+      previousLine: marker,
+    );
+    expect(plaintext, isA<CodexSubAgentInitialInputFact>());
+    final plaintextFact = plaintext! as CodexSubAgentInitialInputFact;
+    expect(plaintextFact.turnId, "child-turn-1");
+    expect(
+      (plaintextFact.input as CodexSubAgentPlaintextInput).message,
+      "child task",
+    );
+  });
+
+  test("rejects input without adjacent marker or valid native envelope", () {
+    final message = _agentMessage(
+      content: const [
+        {"type": "input_text", "text": "child task"},
+      ],
+    );
+    expect(
+      repository.subAgentRolloutFact(line: message, previousLine: null),
+      isNull,
+    );
+    expect(
+      repository.subAgentRolloutFact(
+        line: message,
+        previousLine: _line(
+          type: "inter_agent_communication_metadata",
+          payload: const {"trigger_turn": true},
+        ),
+      ),
+      isNull,
+    );
+  });
+}
+
+CodexRolloutLineDto _agentMessage({
+  required List<Map<String, Object>> content,
+}) => _line(
+  type: "response_item",
+  payload: {
+    "type": "agent_message",
+    "id": "message-1",
+    "author": "/root",
+    "recipient": "/root/worker",
+    "content": content,
+    "internal_chat_message_metadata_passthrough": const {
+      "turn_id": "child-turn-1",
+    },
+  },
+);
+
+CodexRolloutLineDto _line({
+  required String type,
+  required Map<String, Object> payload,
+}) => CodexRolloutLineDto.fromJson({"type": type, "payload": payload});


### PR DESCRIPTION
## Complexity
⚙️ Moderate: typed native rollout variants, generated serializers, and repository-owned projections, without activating tile behavior.

## What
- Parse Codex 0.153.4 nested `item_completed/SubAgentActivity`, communication metadata, and `agent_message` records.
- Project repository-owned spawn, child-activity, and initial-input facts.
- Keep encrypted content opaque; recognize only validated plaintext `NEW_TASK` payloads.
- Add native-shaped DTO/projection tests and update the nine-step series.

## Why
Real managed-runtime probes established these persisted shapes. Normal child input is encrypted and absent from `thread/read`; future tiles use the approved exact matching spawn-call message rather than copied parent history or envelope text.

This is the first slice of the independently reviewed complete implementation. Step 6/9 integrates live/replay tiles; step 7/9 adds expanded lifecycle coverage/documentation. Scoped stop and final coverage remain steps 8/9 and 9/9.

## Risk and test focus
No user-visible or database impact. This PR adds dormant native parsing/projection only; it does not activate new tile behavior. Focus on case-sensitive native variants, unknown-variant tolerance, marker adjacency, exact identifiers, valid plaintext envelopes, and opaque encrypted payloads. No runtime-pin, native-adapter, client, or shared-wire changes. Removed #1387 cache remains absent.

## Expected result
The subsequent tile integration can consume typed repository facts without passing API DTOs into services. Existing session behavior remains unchanged.

## Verification
- Full Codex package: 445 tests passed; fatal-info analysis clean.
- Focused native DTO/fact tests: 11 passed.
- Generated serializers produced through workspace codegen; whitespace checks passed.
- Full implementation architecture and correctness reviews approved; independent split review confirmed cumulative production equivalence and independent predecessor coherence.
- Split review's documentation scope mismatch corrected before publication; unchanged production suites were not rerun for that docs-only correction.
- Actual-plugin authenticated live QA remains outstanding; native probe evidence is not represented as live tile QA.
