### PR TITLE
⚙️ Share session detail visibility and activity ownership

### DIFF
--- a/client/app/lib/features/session_detail/session_detail_screen.dart
+++ b/client/app/lib/features/session_detail/session_detail_screen.dart
@@ -1,5 +1,3 @@
-import "dart:async";
-
 import "package:flutter/foundation.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:go_router/go_router.dart";
@@ -37,8 +35,11 @@ class const SessionDetailScreen({
           ),
         ),
       ],
-      child: _SessionActivityAnalyticsOwner(
-        auditView: auditView,
+      child: SessionDetailActivityOwner(
+        routeSource: getIt<RouteSource>(),
+        lifecycleSource: getIt<LifecycleSource>(),
+        productAnalyticsService: getIt<ProductAnalyticsService>(),
+        expectedDetailRoute: auditView ? AppRouteDef.archivedSessionDetail : AppRouteDef.sessionDetail,
         child: _MobileSessionDetailBody(
           auditView: auditView,
           onBack: onBack,
@@ -138,59 +139,4 @@ class const _MobileSessionDetailBody({
       ),
     );
   }
-}
-
-class const _SessionActivityAnalyticsOwner({
-  required final bool auditView,
-  required final Widget child,
-}) extends StatefulWidget {
-  @override
-  State<_SessionActivityAnalyticsOwner> createState() => _SessionActivityAnalyticsOwnerState();
-}
-
-class _SessionActivityAnalyticsOwnerState() extends State<_SessionActivityAnalyticsOwner> {
-  SessionActivityAnalyticsListener? _listener;
-  StreamSubscription<AppRouteDef?>? _routeSubscription;
-  bool? _wasRouteVisible;
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _routeSubscription ??= getIt<RouteSource>().currentRouteStream.listen((_) => _updateRouteVisibility());
-    _updateRouteVisibility();
-  }
-
-  void _updateRouteVisibility() {
-    // The root archive modal covers a live detail without changing the nested
-    // pane route's isCurrent flag. Covered content must not mark new output seen.
-    final topRoute = getIt<RouteSource>().currentRoute;
-    final archiveIsOpen = topRoute == AppRouteDef.archivedSessions || topRoute == AppRouteDef.archivedSessionDetail;
-    final isRouteVisible = (ModalRoute.of(context)?.isCurrent ?? false) && (widget.auditView || !archiveIsOpen);
-    if (_wasRouteVisible != isRouteVisible) {
-      context.read<SessionDetailCubit>().setRouteVisible(isVisible: isRouteVisible);
-    }
-    _wasRouteVisible = isRouteVisible;
-    final listener = _listener;
-    if (listener == null) {
-      _listener = SessionActivityAnalyticsListener(
-        sessionDetailCubit: context.read<SessionDetailCubit>(),
-        lifecycleSource: getIt<LifecycleSource>(),
-        productAnalyticsService: getIt<ProductAnalyticsService>(),
-        initialRouteVisible: isRouteVisible,
-      );
-    } else {
-      listener.setRouteVisible(isVisible: isRouteVisible);
-    }
-  }
-
-  @override
-  void dispose() {
-    final listener = _listener;
-    if (listener != null) unawaited(listener.dispose());
-    unawaited(_routeSubscription?.cancel());
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) => widget.child;
 }

--- a/client/app/test/features/session_detail/session_detail_activity_navigation_test.dart
+++ b/client/app/test/features/session_detail/session_detail_activity_navigation_test.dart
@@ -1,0 +1,153 @@
+import "dart:async";
+
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:get_it/get_it.dart";
+import "package:go_router/go_router.dart";
+import "package:material_ui/material_ui.dart";
+import "package:mocktail/mocktail.dart";
+import "package:sesori_app_ui/sesori_app_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+
+import "../../core/routing/adaptive_session_router_test_harness.dart";
+import "../../helpers/test_helpers.dart";
+
+void main() {
+  setUpAll(registerAllFallbackValues);
+
+  Future<AdaptiveSessionRouterTestHarness> setUpRouter({
+    required WidgetTester tester,
+    required String location,
+  }) async {
+    final harness = AdaptiveSessionRouterTestHarness();
+    await tester.binding.setSurfaceSize(const Size(1024, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    addTearDown(harness.tearDown);
+    await harness.setUp(
+      initialLocation: location,
+      currentRouteDef: AppRouteDef.sessionDetail,
+      sessionsByProject: const {"p1": []},
+      extraRoutes: [
+        for (final route in [AppRouteDef.settings, AppRouteDef.settingsHarnesses])
+          GoRoute(
+            path: route.path,
+            builder: (_, _) => const Scaffold(body: Text("Root cover")),
+          ),
+      ],
+    );
+    final routeSource = GoRouterRouteSource(router: harness.router);
+    await GetIt.instance.unregister<RouteSource>();
+    GetIt.instance.registerSingleton<RouteSource>(routeSource, dispose: (_) => routeSource.dispose());
+    return harness;
+  }
+
+  SessionDetailCubit detailCubit({required WidgetTester tester}) =>
+      tester.element(find.byType(SessionDetailBody)).read<SessionDetailCubit>();
+
+  for (final detailPath in ["sessions", "archived-sessions"]) {
+    testWidgets("$detailPath same-kind child suppresses parent and pop retains loaded draft", (tester) async {
+      final harness = await setUpRouter(tester: tester, location: "/projects/p1/$detailPath/parent");
+      await tester.pumpWidget(harness.buildApp());
+      await tester.pumpAndSettle();
+      final parent = detailCubit(tester: tester);
+      final loadedState = parent.state;
+      expect(loadedState, isA<SessionDetailLoaded>());
+      expect(parent.isRouteVisible, isTrue);
+      final draft = ComposerDraft.typed(text: "Retained draft");
+      parent.saveComposerDraft(draft: draft);
+      final viewing = GetIt.instance<SessionViewingService>() as MockSessionViewingService;
+      clearInteractions(viewing);
+
+      unawaited(harness.router.push<void>("/projects/p1/$detailPath/child"));
+      await tester.pumpAndSettle();
+      final child = detailCubit(tester: tester);
+      expect(child, isNot(same(parent)));
+      expect(parent.isRouteVisible, isFalse);
+      expect(child.isRouteVisible, isTrue);
+      verify(() => viewing.clearViewingSession("parent")).called(1);
+      clearInteractions(viewing);
+
+      harness.router.pop();
+      await tester.pumpAndSettle();
+      expect(detailCubit(tester: tester), same(parent));
+      expect(parent.state, same(loadedState));
+      expect(parent.composerDraft, draft);
+      expect(parent.isRouteVisible, isTrue);
+      expect(child.isClosed, isTrue);
+      verify(() => viewing.setViewingSession("parent")).called(1);
+    });
+  }
+
+  for (final cover in [
+    "/settings",
+    "/settings/harnesses",
+    "/projects/p1/archived-sessions",
+    "/projects/p1/archived-sessions/audit",
+    "/projects/p1/sessions/parent/diffs",
+  ]) {
+    testWidgets("$cover suppresses refresh declarations and restores retained detail", (tester) async {
+      final harness = await setUpRouter(tester: tester, location: "/projects/p1/sessions/parent");
+      await tester.pumpWidget(harness.buildApp());
+      await tester.pumpAndSettle();
+      final parent = detailCubit(tester: tester);
+      final draft = ComposerDraft.typed(text: "Keep while covered");
+      parent.saveComposerDraft(draft: draft);
+      final viewing = GetIt.instance<SessionViewingService>() as MockSessionViewingService;
+      clearInteractions(viewing);
+
+      unawaited(harness.router.push<void>(cover));
+      await tester.pumpAndSettle();
+      expect(parent.isRouteVisible, isFalse);
+      verify(() => viewing.clearViewingSession("parent")).called(1);
+      clearInteractions(viewing);
+      await parent.reload();
+      await tester.pumpAndSettle();
+      verifyNever(() => viewing.setViewingSession("parent"));
+
+      harness.router.pop();
+      await tester.pumpAndSettle();
+      expect(detailCubit(tester: tester), same(parent));
+      expect(parent.state, isA<SessionDetailLoaded>());
+      expect(parent.composerDraft, draft);
+      expect(parent.isRouteVisible, isTrue);
+      verify(() => viewing.setViewingSession("parent")).called(1);
+    });
+  }
+
+  testWidgets("load completing under root Settings waits for return before viewed or analytics", (tester) async {
+    final harness = await setUpRouter(tester: tester, location: "/projects/p1/sessions/parent");
+    final result = Completer<SessionDetailMetadataLoadResult>();
+    when(() => harness.sessionDetailLoadService.loadMetadata(sessionId: "parent")).thenAnswer((_) => result.future);
+    await tester.pumpWidget(harness.buildApp());
+    await tester.pump();
+    final parent = detailCubit(tester: tester);
+    unawaited(harness.router.push<void>("/settings"));
+    await tester.pumpAndSettle();
+    expect(parent.isRouteVisible, isFalse);
+    final viewing = GetIt.instance<SessionViewingService>() as MockSessionViewingService;
+    final analytics = GetIt.instance<ProductAnalyticsService>() as MockProductAnalyticsService;
+    clearInteractions(viewing);
+    clearInteractions(analytics);
+    result.complete(SessionDetailMetadataLoadResult.found(session: testSession(id: "parent")));
+    await tester.pumpAndSettle();
+    expect(parent.state, isA<SessionDetailLoaded>());
+    verifyNever(() => viewing.setViewingSession("parent"));
+    verifyNever(
+      () => analytics.logEvent(
+        event: any(named: "event"),
+        occurredAtUtc: any(named: "occurredAtUtc"),
+      ),
+    );
+
+    harness.router.pop();
+    await tester.pumpAndSettle();
+    expect(detailCubit(tester: tester), same(parent));
+    verify(() => viewing.setViewingSession("parent")).called(1);
+    verify(
+      () => analytics.logEvent(
+        event: const ProductAnalyticsEvent.sessionActivityViewed(activityState: AnalyticsActivityState.empty),
+        occurredAtUtc: any(named: "occurredAtUtc"),
+      ),
+    ).called(1);
+  });
+}

--- a/client/desktop/lib/features/sessions/desktop_session_detail_screen.dart
+++ b/client/desktop/lib/features/sessions/desktop_session_detail_screen.dart
@@ -1,5 +1,3 @@
-import "dart:async";
-
 import "package:flutter/foundation.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:material_ui/material_ui.dart";
@@ -28,7 +26,11 @@ class const DesktopSessionDetailScreen({
       create: (_) =>
           createSessionDetailCubit(claimProjectView: true, locator: getIt, sessionId: sessionId, projectId: projectId),
       child: DesktopComposerPresentationScope(
-        child: _SessionActivityAnalyticsOwner(
+        child: SessionDetailActivityOwner(
+          routeSource: getIt<RouteSource>(),
+          lifecycleSource: getIt<LifecycleSource>(),
+          productAnalyticsService: getIt<ProductAnalyticsService>(),
+          expectedDetailRoute: AppRouteDef.sessionDetail,
           child: DesktopSessionDetailView(
             projectId: projectId,
             sessionId: sessionId,
@@ -95,82 +97,4 @@ class const DesktopSessionDetailView({
       ),
     );
   }
-}
-
-class const _SessionActivityAnalyticsOwner({required final Widget child}) extends StatefulWidget {
-  @override
-  State<_SessionActivityAnalyticsOwner> createState() => _SessionActivityAnalyticsOwnerState();
-}
-
-class _SessionActivityAnalyticsOwnerState() extends State<_SessionActivityAnalyticsOwner> {
-  SessionActivityAnalyticsListener? _listener;
-  StreamSubscription<AppRouteDef?>? _routeSubscription;
-  AppRouteDef? _topRoute;
-  bool? _wasRouteVisible;
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (_routeSubscription == null) {
-      final routeSource = getIt<RouteSource>();
-      _topRoute = routeSource.currentRoute;
-      _routeSubscription = routeSource.currentRouteStream.listen((route) {
-        _topRoute = route;
-        _updateRouteVisibility();
-      });
-    }
-    _updateRouteVisibility();
-  }
-
-  void _updateRouteVisibility() {
-    final isRouteVisible = (ModalRoute.of(context)?.isCurrent ?? false) && !_isCoveredBySettings;
-    final cubit = context.read<SessionDetailCubit>();
-    if (_wasRouteVisible != isRouteVisible) {
-      cubit.setRouteVisible(isVisible: isRouteVisible);
-    }
-    _wasRouteVisible = isRouteVisible;
-    final listener = _listener;
-    if (listener == null) {
-      _listener = SessionActivityAnalyticsListener(
-        sessionDetailCubit: cubit,
-        lifecycleSource: getIt<LifecycleSource>(),
-        productAnalyticsService: getIt<ProductAnalyticsService>(),
-        initialRouteVisible: isRouteVisible,
-      );
-    } else {
-      listener.setRouteVisible(isVisible: isRouteVisible);
-    }
-  }
-
-  bool get _isCoveredBySettings {
-    return switch (_topRoute) {
-      AppRouteDef.archivedSessions ||
-      AppRouteDef.archivedSessionDetail ||
-      AppRouteDef.settings ||
-      AppRouteDef.settingsNotifications ||
-      AppRouteDef.settingsDefaultInput ||
-      AppRouteDef.settingsProfile ||
-      AppRouteDef.settingsHarnesses ||
-      AppRouteDef.settingsHarnessDetail => true,
-      null ||
-      AppRouteDef.splash ||
-      AppRouteDef.login ||
-      AppRouteDef.projects ||
-      AppRouteDef.sessions ||
-      AppRouteDef.newSession ||
-      AppRouteDef.sessionDetail ||
-      AppRouteDef.sessionDiffs => false,
-    };
-  }
-
-  @override
-  void dispose() {
-    final listener = _listener;
-    if (listener != null) unawaited(listener.dispose());
-    unawaited(_routeSubscription?.cancel());
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) => widget.child;
 }

--- a/client/module_app_ui/lib/sesori_app_ui.dart
+++ b/client/module_app_ui/lib/sesori_app_ui.dart
@@ -14,6 +14,7 @@ export "src/features/project_list/project_list_view.dart";
 export "src/features/project_list/rename_project_dialog.dart";
 export "src/features/project_list/widgets/project_tile.dart";
 export "src/features/session_detail/composer_presentation_scope.dart";
+export "src/features/session_detail/session_detail_activity_owner.dart";
 export "src/features/session_detail/session_detail_presentation_scope.dart";
 export "src/features/session_detail/widgets/agent_model_buttons.dart";
 export "src/features/session_detail/widgets/agent_part_widget.dart";

--- a/client/module_app_ui/lib/src/features/session_detail/session_detail_activity_owner.dart
+++ b/client/module_app_ui/lib/src/features/session_detail/session_detail_activity_owner.dart
@@ -1,0 +1,63 @@
+import "dart:async";
+
+import "package:flutter/widgets.dart";
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+
+/// Owns visibility and activity analytics for the inherited [SessionDetailCubit].
+///
+/// The shell constructs and owns the cubit above this widget. The top route
+/// identifies the detail kind; the nearest page distinguishes retained details
+/// when another detail of the same kind is pushed in the nested navigator.
+class const SessionDetailActivityOwner({
+  super.key,
+  required final RouteSource routeSource,
+  required final LifecycleSource lifecycleSource,
+  required final ProductAnalyticsService productAnalyticsService,
+  required final AppRouteDef expectedDetailRoute,
+  required final Widget child,
+}) extends StatefulWidget {
+  @override
+  State<SessionDetailActivityOwner> createState() => _SessionDetailActivityOwnerState();
+}
+
+class _SessionDetailActivityOwnerState() extends State<SessionDetailActivityOwner> {
+  SessionActivityAnalyticsListener? _listener;
+  StreamSubscription<AppRouteDef?>? _routeSubscription;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _routeSubscription ??= widget.routeSource.currentRouteStream.listen((_) => _updateRouteVisibility());
+    _updateRouteVisibility();
+  }
+
+  void _updateRouteVisibility() {
+    final isPageCurrent = ModalRoute.of(context)?.isCurrent ?? false;
+    final isRouteVisible = widget.routeSource.currentRoute == widget.expectedDetailRoute && isPageCurrent;
+    final cubit = context.read<SessionDetailCubit>();
+    cubit.setRouteVisible(isVisible: isRouteVisible);
+    final listener = _listener;
+    if (listener == null) {
+      _listener = SessionActivityAnalyticsListener(
+        sessionDetailCubit: cubit,
+        lifecycleSource: widget.lifecycleSource,
+        productAnalyticsService: widget.productAnalyticsService,
+        initialRouteVisible: isRouteVisible,
+      );
+    } else {
+      listener.setRouteVisible(isVisible: isRouteVisible);
+    }
+  }
+
+  @override
+  void dispose() {
+    final listener = _listener;
+    if (listener != null) unawaited(listener.dispose());
+    unawaited(_routeSubscription?.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/client/module_app_ui/test/features/session_detail/session_detail_activity_owner_test.dart
+++ b/client/module_app_ui/test/features/session_detail/session_detail_activity_owner_test.dart
@@ -1,0 +1,154 @@
+import "dart:async";
+
+import "package:flutter_bloc/flutter_bloc.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:mocktail/mocktail.dart";
+import "package:rxdart/rxdart.dart";
+import "package:sesori_app_ui/sesori_app_ui.dart";
+import "package:sesori_dart_core/sesori_dart_core.dart";
+import "package:sesori_dart_core/src/repositories/models/analytics_delivery_result.dart";
+import "package:sesori_shared/sesori_shared.dart";
+
+class _MockSessionDetailCubit() extends Mock implements SessionDetailCubit;
+
+class _MockRouteSource() extends Mock implements RouteSource;
+
+class _MockLifecycleSource() extends Mock implements LifecycleSource;
+
+class _MockProductAnalyticsService() extends Mock implements ProductAnalyticsService;
+
+const _loaded = SessionDetailState.loaded(
+  interaction: SessionInteractionState.available(refreshError: null),
+  messages: [],
+  olderMessagesCursor: null,
+  streamingText: {},
+  sessionStatus: SessionStatus.idle(),
+  pendingQuestions: [],
+  pendingPermissions: [],
+  sessionTitle: null,
+  pluginId: "opencode",
+  supportsPromptAttachments: false,
+  agent: null,
+  assistantAgentModel: null,
+  children: [],
+  childStatuses: {},
+  isRootSession: true,
+  isArchived: false,
+  queuedMessages: [],
+  sendingSubmission: null,
+  availableAgents: [],
+  availableProviders: [],
+  availableCommands: [],
+  selectedAgent: "build",
+  selectedAgentModel: null,
+  stagedCommand: null,
+  isRefreshing: false,
+);
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      const ProductAnalyticsEvent.sessionActivityViewed(activityState: AnalyticsActivityState.empty),
+    );
+    registerFallbackValue(DateTime.utc(2026));
+  });
+
+  for (final expectedRoute in [AppRouteDef.sessionDetail, AppRouteDef.archivedSessionDetail]) {
+    testWidgets("$expectedRoute gates cubit and analytics together and disposes only its listeners", (tester) async {
+      final cubit = _MockSessionDetailCubit();
+      final routeSource = _MockRouteSource();
+      final lifecycleSource = _MockLifecycleSource();
+      final analytics = _MockProductAnalyticsService();
+      final routes = BehaviorSubject<AppRouteDef?>.seeded(
+        expectedRoute == AppRouteDef.sessionDetail ? AppRouteDef.archivedSessionDetail : AppRouteDef.sessionDetail,
+      );
+      final lifecycle = BehaviorSubject.seeded(LifecycleState.resumed);
+      final states = StreamController<SessionDetailState>.broadcast();
+      final analyticsStates = BehaviorSubject.seeded(ProductAnalyticsState.initial);
+      addTearDown(routes.close);
+      addTearDown(lifecycle.close);
+      addTearDown(states.close);
+      addTearDown(analyticsStates.close);
+      when(() => cubit.state).thenReturn(_loaded);
+      when(() => cubit.stream).thenAnswer((_) => states.stream);
+      when(() => routeSource.currentRouteStream).thenAnswer((_) => routes.stream);
+      when(() => lifecycleSource.lifecycleStateStream).thenAnswer((_) => lifecycle.stream);
+      when(() => analytics.state).thenAnswer((_) => analyticsStates.value);
+      when(() => analytics.stateStream).thenAnswer((_) => analyticsStates.stream);
+      var events = 0;
+      when(
+        () => analytics.logEvent(
+          event: any(named: "event"),
+          occurredAtUtc: any(named: "occurredAtUtc"),
+        ),
+      ).thenAnswer((_) async {
+        events++;
+        return AnalyticsDeliveryResult.acceptedBySdk;
+      });
+      final visibility = <bool>[];
+      when(() => cubit.setRouteVisible(isVisible: any(named: "isVisible"))).thenAnswer((invocation) {
+        visibility.add(invocation.namedArguments[#isVisible]! as bool);
+      });
+
+      await tester.pumpWidget(
+        BlocProvider<SessionDetailCubit>.value(
+          value: cubit,
+          child: MaterialApp(
+            home: SessionDetailActivityOwner(
+              routeSource: routeSource,
+              lifecycleSource: lifecycleSource,
+              productAnalyticsService: analytics,
+              expectedDetailRoute: expectedRoute,
+              child: const SizedBox(),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(visibility.last, isFalse);
+      expect(events, 0);
+      expect(routes.hasListener, isTrue);
+      expect(states.hasListener, isTrue);
+      expect(lifecycle.hasListener, isTrue);
+      expect(analyticsStates.hasListener, isTrue);
+
+      // App lifecycle remains the analytics listener's concern, not a second
+      // visibility calculation in the Flutter owner.
+      lifecycle.add(LifecycleState.hidden);
+      routes.add(expectedRoute);
+      await tester.pumpAndSettle();
+      expect(visibility.last, isTrue);
+      expect(events, 0);
+      visibility.clear();
+      lifecycle.add(LifecycleState.resumed);
+      await tester.pumpAndSettle();
+      expect(visibility, isEmpty);
+      expect(events, 1);
+
+      routes.add(AppRouteDef.settings);
+      await tester.pumpAndSettle();
+      expect(visibility.last, isFalse);
+      routes.add(expectedRoute);
+      await tester.pumpAndSettle();
+      expect(visibility.last, isTrue);
+      expect(events, 1); // Existing analytics deduplication survives cover/return.
+
+      await tester.pumpWidget(const SizedBox());
+      await tester.pumpAndSettle();
+      expect(routes.hasListener, isFalse);
+      expect(states.hasListener, isFalse);
+      expect(lifecycle.hasListener, isFalse);
+      expect(analyticsStates.hasListener, isFalse);
+      verifyNever(cubit.close); // The shell/provider still owns the cubit.
+      visibility.clear();
+      routes.add(AppRouteDef.settings);
+      lifecycle.add(LifecycleState.resumed);
+      states.add(_loaded);
+      analyticsStates.add(ProductAnalyticsState.initial);
+      await tester.pumpAndSettle();
+      expect(visibility, isEmpty);
+      expect(events, 1);
+    });
+  }
+}

--- a/docs/regression/session-archiving-and-deletion.md
+++ b/docs/regression/session-archiving-and-deletion.md
@@ -84,6 +84,14 @@ entirely along with its transcript and, optionally, its worktree.
   stays unread; closing the modal reasserts the retained loaded detail. Incoming
   questions, permissions and notices from the covered detail do not interrupt
   archive browsing.
+- Mobile and desktop detail activity share one visibility rule: the top route
+  must match the expected normal or archived detail kind and the nearest detail
+  page must be current. A pushed same-kind child, root Settings/Harness settings,
+  archive flow, or diffs suppresses the retained detail's viewed declaration and
+  activity analytics. Late loads and refreshes while covered do not mark output
+  seen. Returning reasserts only a loaded retained detail, preserving its draft;
+  app background/resume handling remains owned by the existing cubit and analytics
+  listener. Disposing the detail releases the owner's route and analytics listeners.
 - Deletion completed in the archive flow returns to its archive list only when
   the currently open audit record matches both project and session. Stale or
   unrelated completions leave navigation unchanged; X still restores the opener.
@@ -128,6 +136,9 @@ restart before explicit re-import.
   the modal, loses the opener on X, or navigates out of the modal on detail Back.
 - Opening or closing an audit record consumes the underlying live project's
   claim, preventing its declaration from returning when the opener is visible.
+- A covered detail marks late output seen, reports activity, or presents a
+  question, permission or notice over another page; child Back or cover dismissal
+  loses the retained detail/draft or fails to restore its loaded viewed state.
 
 - An archived session accepts a prohibited non-deletion mutation, or becomes
   unarchived by any path.
@@ -185,4 +196,6 @@ Bridge session lifecycle, deletion, archived-validator, and mutation dispatch
 services; chat-history export and purge; archived-record completeness model;
 worktree service; shared cleanup rejection model; OMP cleanup service; shared
 ACP tombstone behavior used by Antigravity, Copilot and Grok; Antigravity composed deletion tests; Grok package deletion
-tests; client list/detail surfaces.
+tests; client list/detail surfaces; shared `session_detail_activity_owner_test`,
+mobile `session_detail_activity_navigation_test` and
+`archived_sessions_navigation_test`, desktop `desktop_session_detail_screen_test`.


### PR DESCRIPTION
## Complexity
⚙️ Moderate: consolidate detail route/lifecycle ownership across two shells, with focused nested-navigation coverage. Four production files change; no session-state or routing-stack rewrite.

## What
- Introduce shared `SessionDetailActivityOwner` in `module_app_ui`, consumed by mobile and desktop.
- Feed one visibility decision to the detail cubit and activity analytics: the top route must match the expected detail kind and the nearest detail page must be current.
- Remove both private owners, route-cover blacklists, and redundant visibility caches.
- Add 10 focused lifecycle/navigation tests and update the archive regression document.

## Why
Follow-up to #1400. Mobile and desktop duplicated this ownership and already differed when Settings covered detail. One shared owner handles normal and archived detail consistently without adding a shared inventory store or changing modal cubit lifetimes.

## Risk and test focus
- Moderate behavioral risk around initial loading, same-kind child push/pop, root Settings/Harness/archive/diffs cover-and-return, and listener disposal.
- User-visible effect: covered detail no longer counts as viewed or reports activity; returning preserves the existing detail and draft.
- No database, bridge, transport, analytics-event-contract, or visual-design impact. Existing project claims, audit claim exclusion, core factories, Back/X navigation, and transient-presentation guards remain unchanged.
- iPhone 17 Pro Max simulator QA passed for signed-in upgrade, empty/populated archives, a real read-only Pi transcript, archive Back/X, File Changes and background/resume draft retention, and archive → Harness Settings → Back/X restoration. App remains running in portrait/dark; no prompts were sent or harness settings changed.
- Landscape was visually exercised, but inconsistent automation coordinates prevent claiming a landscape-interaction pass. Hidden viewed-declaration/analytics suppression and same-kind child navigation remain covered by automated tests rather than direct device instrumentation. No new desktop device run or dedicated desktop nested-router fixture.

## Expected result
Normal and archived details share one consistent visibility owner. Covered or superseded details stop declaring themselves viewed and reporting activity, including when loading completes while covered. Returning reactivates the loaded retained detail without losing its draft.

## Verification
- **196 relevant tests passed**, including 10 new tests: 134 mobile, 2 shared owner, 2 desktop, and 58 core.
- `dart analyze` clean for `module_app_ui`, `app`, and `desktop`.
- Formatting and staged diff whitespace checks passed.
- Architecture plan and implementation reviews approved without findings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates mobile and desktop session-detail visibility and activity ownership into a single shared `SessionDetailActivityOwner`, replacing the two private owners that had drifted apart.

**What changed**

- The shared owner applies one rule: the top route must match the expected detail kind and the nearest detail page must be current.
- Covered or superseded detail pages no longer mark themselves viewed or report activity, including late loads and refreshes.
- Returning to a retained detail restores viewed state and preserves its draft.
- Removes route-cover blacklists, redundant visibility caches, and listener duplication.
- Adds 10 tests covering nested navigation, cover/return, and disposal.

<sup>Written for commit 77659c1b3309a91e308782686f88f9192240ef2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


### Simulator verification
- Built and installed commit `77659c1b3` on iPhone 17 Pro Max without erasing app data.
- Verified a temporary unsent draft survived navigation/background/rotation, then cleared it and verified the empty field.
- Real archived Pi history loaded read-only. Disabled Cursor history showed its expected limitation; its Harness Settings flow returned correctly without enabling the harness.
- Same app process remained running during QA; private screenshots and detailed coverage notes are saved locally in `client/app/build/pr-1402-qa/`.
