### PR TITLE
🌿 Fix Antigravity source login and install status

### DIFF
--- a/bridge/app/lib/src/services/plugin_lifecycle_service.dart
+++ b/bridge/app/lib/src/services/plugin_lifecycle_service.dart
@@ -671,18 +671,16 @@ class PluginLifecycleService({
                 );
               }
           }
-          // The binary is installed, but setup can still be blocked (most
-          // often authentication). Report completed only when the harness
-          // actually became usable; otherwise the phone would show success
-          // while the card stays blocked.
+          // Authentication is a separate setup step, not an installation
+          // failure. Keep the login-required card blocked without telling the
+          // client to reinstall a runtime that was successfully provisioned.
           final setup = _requireSetupById()[pluginId];
+          final installed = setup is PluginSetupReady || setup is PluginSetupAuthenticationRequired;
           _emitInstallProgress(
             pluginId: pluginId,
-            phase: setup is PluginSetupReady ? PluginInstallPhase.completed : PluginInstallPhase.failed,
+            phase: installed ? PluginInstallPhase.completed : PluginInstallPhase.failed,
             percent: null,
-            message: setup is PluginSetupReady
-                ? null
-                : "The runtime installed, but the harness still needs setup. Check its status.",
+            message: installed ? null : "The runtime installed, but the harness still needs setup. Check its status.",
           );
         case ProvisionFailed():
           // Descriptor failure text is not a trusted wire payload; the phone

--- a/bridge/app/test/runtime/browser_noop_test.dart
+++ b/bridge/app/test/runtime/browser_noop_test.dart
@@ -10,24 +10,27 @@ void main() {
     expect(BrowserNoop.matches(arguments: [BrowserNoop.argument]), isTrue);
   });
 
-  test('actual source entrypoint exits silently before config, DI or URL handling', () async {
-    final temp = Directory.systemTemp.createTempSync('browser-noop-test-');
-    addTearDown(() => temp.deleteSync(recursive: true));
-    final result = await Process.run(
-      Platform.resolvedExecutable,
-      [
-        '--packages=${File('../.dart_tool/package_config.json').absolute.path}',
-        File('bin/bridge.dart').absolute.path,
-        BrowserNoop.argument,
-        'https://example.invalid/synthetic?code=not-a-credential',
-        '--deliberately-invalid-option',
-      ],
-      environment: {'HOME': temp.path, 'USERPROFILE': temp.path},
-      workingDirectory: temp.path,
-    ).timeout(const Duration(seconds: 45));
-    expect(result.exitCode, 0);
-    expect(result.stdout, isEmpty);
-    expect(result.stderr, isEmpty);
-    expect(temp.listSync(), isEmpty);
-  });
+  for (final explicitPackages in [false, true]) {
+    test('actual source entrypoint exits silently with explicit packages: $explicitPackages', () async {
+      final temp = Directory.systemTemp.createTempSync('browser-noop-test-');
+      addTearDown(() => temp.deleteSync(recursive: true));
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        [
+          if (explicitPackages) '--packages=${File('../.dart_tool/package_config.json').absolute.path}',
+          File('bin/bridge.dart').absolute.path,
+          BrowserNoop.argument,
+          'https://example.invalid/synthetic?code=not-a-credential',
+          '--deliberately-invalid-option',
+        ],
+        environment: {'HOME': temp.path, 'USERPROFILE': temp.path},
+        includeParentEnvironment: false,
+        workingDirectory: temp.path,
+      ).timeout(const Duration(seconds: 45));
+      expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+      expect(result.stdout, isEmpty);
+      expect(result.stderr, isEmpty);
+      expect(temp.listSync(), isEmpty);
+    });
+  }
 }

--- a/bridge/app/test/services/plugin_lifecycle_service_test.dart
+++ b/bridge/app/test/services/plugin_lifecycle_service_test.dart
@@ -1994,7 +1994,7 @@ void main() {
     expect(settingsRepository.settings.plugins.isDisabled(pluginId: "one"), isTrue);
   });
 
-  test("an installed runtime that is still setup-blocked does not report completed", () async {
+  test("an installed runtime needing login reports completed without starting the harness", () async {
     final repository = _CommandLifecycleRepository(
       inspectionResult: const PluginSetupAuthenticationRequired(actionHint: "Log in"),
       inspectionGate: null,
@@ -2020,9 +2020,12 @@ void main() {
 
     expect(progress.map((update) => update.phase).toList(), const [
       PluginInstallPhase.finalizing,
-      PluginInstallPhase.failed,
+      PluginInstallPhase.completed,
     ]);
+    expect(progress.last.message, isNull);
     expect(repository.startCalls, isZero);
+    expect(service.managementSnapshot.plugins.single.setup.state, PluginSetupState.authenticationRequired);
+    expect(service.managementSnapshot.plugins.single.runtimeState, shared.PluginRuntimeState.blocked);
   });
 
   test("a duplicate install joins and a different command conflicts while installing", () async {

--- a/bridge/sesori_plugin_antigravity/lib/src/authentication/antigravity_authentication_operation.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/authentication/antigravity_authentication_operation.dart
@@ -5,6 +5,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../foundation/antigravity_authentication_budget.dart";
 import "../models/antigravity_authentication.dart";
+import "../models/antigravity_profile.dart";
 import "../models/antigravity_runtime_resolution.dart";
 import "../services/antigravity_authentication_service.dart";
 import "../services/antigravity_profile_service.dart";
@@ -112,6 +113,11 @@ class AntigravityAuthenticationOperation({
       if (redirect case _RedirectSubmitted(:final settled)) await settled;
       _budget.remaining;
     } on Object catch (error, stackTrace) {
+      // Profile exceptions keep output out of their presentation. Preserve the
+      // underlying bounded preflight/storage diagnostics in the local log.
+      if (error case AntigravityProfileException(:final cause?)) {
+        Log.w("[antigravity] authentication profile preparation failed", cause, stackTrace);
+      }
       _fail(error: error, stackTrace: stackTrace);
     } finally {
       final redirect = _redirect;

--- a/bridge/sesori_plugin_antigravity/lib/src/runtime/antigravity_plugin_descriptor.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/runtime/antigravity_plugin_descriptor.dart
@@ -112,11 +112,16 @@ class const AntigravityPluginDescriptor({
     }
     final packageConfig = Platform.packageConfig;
     final packageConfigPath = packageConfig == null ? null : Uri.parse(packageConfig).toFilePath();
+    // Package discovery may be implicit in Dart-hosted source/snapshot runs.
+    // Native bundles use their invoked executable as the script, including
+    // relative/PATH invocations; do not compare with the resolved symlink path.
+    final executableScript = Uri.base.resolveUri(Uri.file(Platform.executable));
     return (
       executable: Platform.resolvedExecutable,
-      arguments: packageConfigPath == null
-          ? const []
-          : List.unmodifiable(["--packages=$packageConfigPath", Platform.script.toFilePath()]),
+      arguments: List.unmodifiable([
+        if (packageConfigPath != null) "--packages=$packageConfigPath",
+        if (Platform.script != executableScript) Platform.script.toFilePath(),
+      ]),
     );
   }
 

--- a/bridge/sesori_plugin_antigravity/test/antigravity_authentication_operation_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_authentication_operation_test.dart
@@ -1,7 +1,9 @@
 import "dart:async";
+import "dart:io";
 
 import "package:antigravity_plugin/antigravity_plugin.dart";
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -24,6 +26,7 @@ class _Profile() implements AntigravityProfileService {
   AntigravityAuthenticationBudget? budget;
   final started = Completer<void>();
   Completer<void>? gate;
+  AntigravityProfileException? failure;
   @override
   Future<AntigravityPreparedProfile> prepare({
     required AntigravityAuthenticationBudget budget,
@@ -33,6 +36,7 @@ class _Profile() implements AntigravityProfileService {
     started.complete();
     await gate?.future;
     budget.remaining;
+    if (failure case final error?) throw error;
     return prepared;
   }
 
@@ -169,6 +173,36 @@ class _Attempt({final Duration timeout = const Duration(seconds: 2)}) {
 }
 
 void main() {
+  test("profile failures retain bounded local diagnostics without starting runtime or login", () async {
+    const diagnostics = CommandResult(
+      exitCode: 255,
+      stdout: "",
+      stderr: "Setting VM flags failed: Unrecognized flags: internal_browser_noop",
+    );
+    const failure = AntigravityProfileException(message: "Browser suppression preflight failed", cause: diagnostics);
+    final attempt = _Attempt();
+    attempt.profile.failure = failure;
+    final logs = BufferingStdout();
+    final previousLevel = Log.level;
+    try {
+      Log.level = LogLevel.debug;
+      await IOOverrides.runZoned(() async {
+        attempt.start();
+        await attempt.done.future;
+      }, stderr: () => logs);
+    } finally {
+      Log.level = previousLevel;
+    }
+    expect(attempt.errors.single.error, same(failure));
+    expect(failure.toString(), isNot(contains(diagnostics.stderr)));
+    expect(logs.text, contains(diagnostics.stderr));
+    expect(logs.text, contains("255"));
+    expect(logs.text, contains("antigravity_authentication_operation.dart"));
+    expect(attempt.runtime.calls, 0);
+    expect(attempt.authentication.started.isCompleted, isFalse);
+    expect(attempt.authentication.disposed, isTrue);
+  });
+
   test("prepares then probes then authenticates with one environment and budget; no challenge is required", () async {
     final attempt = _Attempt()..start();
     await attempt.authentication.started.future;

--- a/bridge/sesori_plugin_antigravity/test/antigravity_browser_invocation_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_browser_invocation_test.dart
@@ -1,0 +1,47 @@
+import "dart:io";
+
+import "package:path/path.dart" as p;
+import "package:test/test.dart";
+
+void main() {
+  final fixture = File("test/fixtures/browser_invocation.dart").absolute.path;
+  final packageConfig = File("../.dart_tool/package_config.json").absolute.path;
+
+  for (final explicitPackages in [false, true]) {
+    test("descriptor source browser helper works with explicit packages: $explicitPackages", () async {
+      final result = await Process.run(Platform.resolvedExecutable, [
+        if (explicitPackages) "--packages=$packageConfig",
+        fixture,
+        explicitPackages ? "explicit" : "implicit",
+      ]).timeout(const Duration(seconds: 60));
+      expect(result.exitCode, 0, reason: "${result.stdout}\n${result.stderr}");
+      expect(result.stdout, isEmpty);
+      expect(result.stderr, isEmpty);
+    }, timeout: const Timeout(Duration(seconds: 75)));
+  }
+
+  test("descriptor native browser helper works through absolute and PATH launches", () async {
+    final output = await Directory.systemTemp.createTemp("antigravity-native-browser-");
+    addTearDown(() => output.delete(recursive: true));
+    final binary = p.join(output.path, Platform.isWindows ? "browser-fixture.exe" : "browser-fixture");
+    final compiled = await Process.run(Platform.resolvedExecutable, [
+      "compile",
+      "exe",
+      fixture,
+      "-o",
+      binary,
+    ]).timeout(const Duration(minutes: 2));
+    expect(compiled.exitCode, 0, reason: "${compiled.stdout}\n${compiled.stderr}");
+
+    for (final executable in [binary, if (!Platform.isWindows) p.basename(binary)]) {
+      final result = await Process.run(
+        executable,
+        ["implicit"],
+        environment: {"PATH": output.path},
+      ).timeout(const Duration(seconds: 30));
+      expect(result.exitCode, 0, reason: "${result.stdout}\n${result.stderr}");
+      expect(result.stdout, isEmpty);
+      expect(result.stderr, isEmpty);
+    }
+  }, timeout: const Timeout(Duration(minutes: 3)));
+}

--- a/bridge/sesori_plugin_antigravity/test/antigravity_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_plugin_descriptor_test.dart
@@ -645,9 +645,10 @@ void main() {
       aborted: StartAbortSignal.never,
     );
     expect(await operation.events.toList(), [isA<PluginAuthenticationCompleted>()]);
-    final expectedPrefix = Platform.packageConfig == null
-        ? const <String>[]
-        : ["--packages=${Uri.parse(Platform.packageConfig!).toFilePath()}", Platform.script.toFilePath()];
+    final expectedPrefix = [
+      if (Platform.packageConfig case final config?) "--packages=${Uri.parse(config).toFilePath()}",
+      Platform.script.toFilePath(),
+    ];
     expect(processes.launches.first.executable, Platform.resolvedExecutable);
     expect(processes.launches.first.arguments, [
       ...expectedPrefix,

--- a/bridge/sesori_plugin_antigravity/test/fixtures/browser_invocation.dart
+++ b/bridge/sesori_plugin_antigravity/test/fixtures/browser_invocation.dart
@@ -1,0 +1,84 @@
+import "dart:io";
+
+import "package:antigravity_plugin/antigravity_plugin.dart";
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+/// Exercises the descriptor's actual process metadata, not injected prefixes.
+/// The capture aborts before profile writes or any Google runtime/network use.
+Future<void> main(List<String> arguments) async {
+  if (BrowserNoop.matches(arguments: arguments)) return;
+  final expectsExplicitPackages = arguments.single == "explicit";
+  if ((Platform.packageConfig != null) != expectsExplicitPackages) {
+    throw StateError("Fixture package discovery did not match its launch mode");
+  }
+  Log.level = LogLevel.error;
+  final state = await Directory.systemTemp.createTemp("antigravity-browser-invocation-");
+  try {
+    final processes = _CaptureProcesses();
+    final descriptor = AntigravityPluginDescriptor(
+      callbackHttpClientFactory: HttpClient.new,
+      runtimeDownloadHttpClientFactory: () => throw StateError("No runtime download is allowed"),
+    );
+    final operation = descriptor.authenticate(
+      config: const PluginConfig(values: {AntigravityPluginDescriptor.binOption: null}),
+      processes: processes,
+      environment: const {},
+      stateDirectory: state.path,
+      store: const _Store(),
+      aborted: StartAbortSignal.never,
+    );
+    try {
+      await operation.events.drain<void>();
+      throw StateError("The capture must stop before profile preparation");
+    } on AntigravityProfileException catch (error) {
+      if (!identical(error.cause, processes.stop)) rethrow;
+    }
+
+    final invocation = processes.invocation;
+    final result = await Process.run(
+      invocation.executable,
+      invocation.arguments,
+      environment: invocation.environment,
+      includeParentEnvironment: false,
+      runInShell: false,
+      workingDirectory: state.path,
+    ).timeout(const Duration(seconds: 45));
+    if (result.exitCode != 0 || result.stdout != "" || result.stderr != "") {
+      throw StateError("Helper failed: exit=${result.exitCode}, stdout=${result.stdout}, stderr=${result.stderr}");
+    }
+    if (state.listSync().isNotEmpty) throw StateError("Browser preflight wrote profile state");
+  } finally {
+    await state.delete(recursive: true);
+  }
+}
+
+class _CaptureProcesses() implements HostProcessService {
+  final stop = StateError("Stop before profile preparation");
+  late final ({String executable, List<String> arguments, Map<String, String>? environment}) invocation;
+
+  @override
+  Future<SpawnedProcess> spawn({
+    required String executable,
+    required List<String> arguments,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+    required bool runInShell,
+    required bool includeParentEnvironment,
+  }) async {
+    if (runInShell || includeParentEnvironment) throw StateError("Browser preflight must not inherit or use a shell");
+    invocation = (executable: executable, arguments: arguments, environment: environment);
+    throw stop;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class const _Store() implements HostJsonStore {
+  @override
+  HostJsonStore scope({required String directoryName}) => this;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/client/module_core/lib/src/services/plugin_management_service.dart
+++ b/client/module_core/lib/src/services/plugin_management_service.dart
@@ -723,7 +723,10 @@ class PluginManagementService({
         _activeBridgeId = response.bridgeId;
         final installs = Map<String, PluginInstallState>.from(_installStates.value);
         for (final plugin in response.plugins) {
-          if (plugin.setup.state == PluginSetupState.ready && installs[plugin.setup.id] is PluginInstallFailed) {
+          final runtimeInstalled =
+              plugin.setup.state == PluginSetupState.ready ||
+              plugin.setup.state == PluginSetupState.authenticationRequired;
+          if (runtimeInstalled && installs[plugin.setup.id] is PluginInstallFailed) {
             installs.remove(plugin.setup.id);
           }
         }

--- a/client/module_core/test/services/plugin_management_service_test.dart
+++ b/client/module_core/test/services/plugin_management_service_test.dart
@@ -1225,6 +1225,37 @@ void main() {
       expect(reportedEvents, isEmpty);
     });
 
+    test("authentication-required setup clears a stale install failure without starting login", () async {
+      final missing = _conflict([]).current
+          .copyWith(setup: _conflict([]).current.setup.copyWith(state: PluginSetupState.runtimeMissing));
+      final loginRequired = missing.copyWith(
+        setup: missing.setup.copyWith(state: PluginSetupState.authenticationRequired),
+      );
+      final repository = _FakePluginRepository()
+        ..queueLoad(_supported(_response(token: "one").copyWith(plugins: [missing])))
+        ..queueLoad(_supported(_response(token: "two").copyWith(plugins: [loginRequired])));
+      final connection = _FakeConnectionService(initialStatus: _connected);
+      final service = PluginManagementService(
+        pluginRepository: repository,
+        connectionService: connection,
+        productAnalyticsService: analytics,
+      );
+      addTearDown(() async {
+        await service.onDispose();
+        await connection.dispose();
+      });
+      await _waitFor(() => service.snapshots.hasValue);
+      connection.emitInstallProgress(pluginId: "one", phase: PluginInstallPhase.failed);
+      await _pump();
+      expect(service.installStates.value["one"], const PluginInstallState.failed());
+
+      await service.refresh();
+      await _pump();
+      expect(service.installStates.value, isEmpty);
+      expect(service.authenticationChallenges.value, isEmpty);
+      expect(reportedEvents, isEmpty);
+    });
+
     test("failed installs replay, survive missing snapshots, recover, and reset on disconnect", () async {
       final missing = _conflict([]).current
           .copyWith(setup: _conflict([]).current.setup.copyWith(state: PluginSetupState.runtimeMissing));

--- a/docs/regression/antigravity-isolated-profiles.md
+++ b/docs/regression/antigravity-isolated-profiles.md
@@ -26,11 +26,14 @@ callback policy and shared preparation/authentication budget.
   and directory commands cannot restore ambient credentials. Existing other-plugin executors retain inheritance.
 - The backend-neutral `--internal-browser-noop` mode returns before CLI/config/DI/logging. It does not inspect,
   open, fetch, or print its URL argument. It exits successfully with empty stdout/stderr, including after cancellation.
-  The plugin requires an exact injected native or source invocation, quotes it for Python shlex (not a shell),
+  The plugin reconstructs the current native or Dart-hosted source/snapshot invocation, including the entrypoint when
+  package discovery is implicit and `Platform.packageConfig` is null. Native relative/PATH launches stay native;
+  symlink resolution does not add the binary as a script argument. It quotes the invocation for Python shlex (not a shell),
   rejects path-separator/control/placeholder ambiguity and preflights exit/output before preparing the profile.
   The repository maps exit/output facts; the service alone decides that success requires zero exit and no output.
   Rejected preflights retain the original command result as the exception cause, while the safe presentation
-  identifies the executable and exit code without echoing captured output.
+  identifies the executable and exit code without echoing captured output. Authentication logs retain the bounded
+  original preflight/storage diagnostics and stack locally rather than only the wrapper's safe message.
 - Every composed Antigravity stderr interceptor uses the plugin mapper before logging: OAuth authorization/token
   endpoint URLs with queries, callback query URLs, state/code/token/PKCE/secret assignments and bearer values are consumed.
   Bare endpoint mentions and DNS/TLS/proxy/HTTP errors without payloads remain visible, alongside paths, stack frames,
@@ -52,7 +55,12 @@ callback policy and shared preparation/authentication budget.
   Its real host-executor composition test verifies preflight and directory calls disable parent inheritance.
 - `antigravity_stderr_mapper_test.dart`: selective OAuth consumption, retained diagnostics, byte-split CRLF/EOF,
   sanitized bounds. `antigravity_acp_api_test.dart` exercises the injected scratch-process interceptor composition.
-- `browser_noop_test.dart`: actual source entrypoint subprocess, synthetic HOME, empty output and no created files.
+- `antigravity_browser_invocation_test.dart`: actual descriptor-derived helper invocation with implicit/explicit package
+  discovery, plus a compiled native fixture launched directly and through POSIX PATH; no runtime/login is started.
+- `browser_noop_test.dart`: actual source entrypoint subprocess with implicit/explicit package discovery, synthetic HOME,
+  false parent inheritance, empty output and no created files.
+- `antigravity_authentication_operation_test.dart`: a failed preflight retains its original result/stack in local logs,
+  leaves the safe exception presentation unchanged, and starts neither the runtime nor authentication.
 - Existing `bridge_host_json_store_test.dart`: real nested child stores, interrupted atomic update, shared exclusion.
 - Native proof on macOS arm64, 2026-09-05: `cd bridge/app && dart build cli -o /tmp/step6b-native-build`;
   the resulting `bundle/bin/bridge --internal-browser-noop https://example.invalid/sesori-browser-preflight`

--- a/docs/regression/plugin-runtime-installation.md
+++ b/docs/regression/plugin-runtime-installation.md
@@ -62,9 +62,10 @@ bridge start when Sesori already manages an older version.
   progress reports phases with an optional download percentage. Completion re-inspects setup;
   a setup snapshot alone is not evidence of a historical installation failure.
 - Success then implies enable: the harness is persisted enabled, setup is re-inspected,
-  and the post-install enable phase starts it when ready. A still-blocked setup is
-  reported honestly, and failure text sent to the client is sanitized while paths and
-  command output stay in the log.
+  and the post-install enable phase starts it when ready. Authentication-required after successful provisioning reports
+  installation completed, while setup remains blocked and offers login; it is not a reason to reinstall. Other unresolved
+  runtime/setup failures remain failures. Failure text sent to the client is sanitized while paths and command output
+  stay in the log.
 - A duplicate request joins the running install, another command for the same harness
   conflicts, and a shutdown mid-install ends it as interrupted so a retry redoes it.
 - A bridge start upgrades every eligible harness that still has a Sesori-managed version
@@ -102,7 +103,8 @@ bridge start when Sesori already manages an older version.
 - Failed terminal SSE is retained in connection-scoped client memory and replayed across
   overview/detail navigation and cubit recreation. Retry starts immediately and clears it;
   observed progress from another surface replaces it. An unchanged missing/unavailable
-  snapshot preserves failure; a newly applied ready snapshot or completed SSE clears it.
+  snapshot preserves failure; a newly applied ready or authentication-required snapshot, or completed SSE, clears it.
+  Login-required reconciliation removes stale installation failure without starting authentication or claiming readiness.
   Connection/bridge invalidation clears all retained installation state.
 - Failure detail offers Restart installation where install remains eligible. Status still
   follows actual setup: a missing runtime is Not installed, unavailable remains Unavailable,


### PR DESCRIPTION
## Complexity

🌿 Straightforward, localized method-logic fixes with subprocess regression coverage. No new production classes, wire shapes, dependency ownership or lifecycle machinery.

## What

- Preserve the bridge entrypoint when reconstructing a Dart-hosted browser-suppression command, even when package discovery is implicit. Native absolute, relative and PATH invocations remain native; resolved symlinks are not used to infer launch mode.
- Retain bounded profile/preflight diagnostics and their stack in local authentication logs without changing the privacy-safe exception presentation.
- Report successful runtime installation as completed when authentication is the remaining setup step. Keep that harness blocked for login; do not start it or ask users to reinstall.
- Clear stale client installation failures after authoritative ready or authentication-required setup, without starting login.
- Update focused regression contracts and add real source/native helper tests.

## Why

The reported source-mode failure is reproducible: `Platform.packageConfig` is null during implicit package discovery, but the previous implementation treated null as native execution. It therefore launched `dart --internal-browser-noop ...`, which exits 255 with `Setting VM flags failed: Unrecognized flags: internal_browser_noop`.

Separately, the shared bridge install flow mapped a successful install followed by authentication-required setup to `failed`. The client retained that failure until fully ready, producing the contradictory “Authentication required” / “Installation failed” card.

## Risk and test focus

Authentication startup is security-sensitive. Browser suppression remains mandatory and preflight still requires exit zero with empty output before profile preparation. Environment isolation, deadlines, callback validation, credential handling and runtime installation checks are unchanged. Installation completion does not grant readiness or start authentication.

User-visible impact: source-mode login can pass the helper preflight, useful failure diagnostics remain local, and installed-but-login-required harnesses no longer show a false installation failure. No database impact. Existing shared enum variants are reused; no transport migration or compatibility shim.

No real Google OAuth, browser launch, token inspection, Google session creation or user-profile mutation was performed. These checks do not claim authenticated end-to-end verification.

## Expected result

After restarting the updated source bridge, Antigravity login no longer fails because its internal helper flag was sent to the Dart VM. The installed runtime needs login, not reinstallation. The updated client clears previously retained false install failures on setup refresh.

## Verification

Fresh branch `fix/antigravity-login-and-install-status` starts directly from the latest fetched main at creation, `617b780d24e7fdc4e89734e5860b802f380adb42`; no prior plan branch history is included.

- **251 distinct tests pass:** Antigravity focused suites 49; bridge lifecycle and actual CLI no-op 64; client management service 57; shared settings UI 26; mobile settings 50; desktop settings 5.
- Antigravity, bridge app and client core analyzers pass with `--fatal-infos`.
- Real descriptor-derived source helpers pass with implicit and explicit packages; compiled-native fixture passes directly and through POSIX PATH. Actual bridge source entrypoint remains silent with both package-discovery modes and false parent inheritance.
- Original exit-255 argv reproduced with a harmless standalone SDK probe. An initial regression-fixture run omitted its required `bin` config declaration; corrected that fixture and reran only its three affected cases. Earlier passing cases are not double-counted.
- Formatting and whitespace checks pass. Scope: 13 files, +269/−44 = 313 changed lines.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Antigravity source-mode login failing when package discovery is implicit, and reports installation as completed when the runtime is installed but still needs login.

**Bug Fixes**
- Source-mode browser suppression now preserves the bridge entrypoint when `Platform.packageConfig` is null, so `--internal-browser-noop` is no longer passed to the Dart VM (which exited 255).
- Native absolute, relative, and PATH launches remain native; resolved symlinks are not used to infer launch mode.
- An installed runtime that only needs authentication now reports installation completed instead of failed, and stays blocked without starting the harness.
- The client clears stale installation failures once setup is ready or authentication-required.
- Authentication logs retain the bounded preflight/storage diagnostics and stack locally while the safe exception presentation stays unchanged.

<sup>Written for commit 1b6cd002ed9aa74297f1fd71abcee7f3b476823e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

