### PR TITLE
🌱 Group stopping harnesses with disabled

### DIFF
--- a/client/module_app_ui/lib/src/features/settings/harness_settings_presentation.dart
+++ b/client/module_app_ui/lib/src/features/settings/harness_settings_presentation.dart
@@ -9,7 +9,11 @@ enum _HarnessGroup() {
 
 _HarnessGroup _group({required PluginManagementMetadata plugin, required PluginInstallState? install}) {
   if (install is PluginInstallInProgress) return _HarnessGroup.notInstalled;
-  if (plugin.runtimeState == PluginRuntimeState.disabled) return _HarnessGroup.disabled;
+  // A stopping harness is winding down, not asking for attention. Group it with
+  // disabled harnesses so a toggled-off harness lands where it will settle.
+  if (plugin.runtimeState == PluginRuntimeState.disabled || plugin.runtimeState == PluginRuntimeState.stopping) {
+    return _HarnessGroup.disabled;
+  }
   if (plugin.setup.state == PluginSetupState.runtimeMissing) return _HarnessGroup.notInstalled;
   if (plugin.setup.state == PluginSetupState.ready &&
       (plugin.runtimeState == PluginRuntimeState.dormant ||
@@ -32,7 +36,9 @@ bool _canInstall({required PluginManagementMetadata plugin}) =>
     (plugin.setup.state == PluginSetupState.runtimeMissing || plugin.setup.state == PluginSetupState.unavailable);
 
 bool _showOverviewStatus({required PluginManagementMetadata plugin, required PluginInstallState? install}) {
-  if (_group(plugin: plugin, install: install) == _HarnessGroup.disabled) return false;
+  if (_group(plugin: plugin, install: install) == _HarnessGroup.disabled) {
+    return plugin.runtimeState == PluginRuntimeState.stopping;
+  }
   if (install != null || plugin.setup.state != PluginSetupState.ready) return true;
   return plugin.runtimeState != PluginRuntimeState.dormant &&
       (plugin.runtimeState != PluginRuntimeState.active || plugin.workState != PluginManagementWorkState.idle);

--- a/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
+++ b/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
@@ -156,6 +156,31 @@ void main() {
     }
   }
 
+  testWidgets("stopping harness sits in the disabled group and keeps its status", (tester) async {
+    phone(tester: tester);
+    publish(
+      plugins: [
+        _plugin(id: "stopping", runtime: PluginRuntimeState.stopping, setup: PluginSetupState.ready),
+        _ready,
+      ],
+    );
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+    final ids = tester
+        .widgetList<PregoGroupedRow>(find.byType(PregoGroupedRow))
+        .map((row) => row.key)
+        .whereType<Key>()
+        .toList();
+    expect(ids, [
+      const Key("harnesses_card_ready"),
+      const Key("harnesses_card_stopping"),
+      const Key("harness_management_default_timeout"),
+    ]);
+    expect(find.text("Needs attention"), findsNothing);
+    expect(find.text("Disabled"), findsOneWidget);
+    expect(find.text("Stopping"), findsOneWidget);
+  });
+
   testWidgets("overview groups honest states in design order and preserves registry order", (tester) async {
     phone(tester: tester);
     publish(

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -269,6 +269,8 @@ idle suspension, the management snapshot, and lifecycle commands.
   retained within groups; empty groups disappear. Installing entries belong to Not installed;
   genuinely disabled entries belong to Disabled; only ready dormant/starting/active entries
   are Enabled. Degraded remains attention even though its separate scan capability is routable.
+  A stopping harness belongs to Disabled — where a toggled-off harness settles — and keeps its
+  `Stopping` status there instead of jumping through Needs attention while it drains.
 - Harness names and the separate download target open details without starting installation;
   setup guidance stays visible before the explicit detail installation button. Switches send
   actual enable/disable intent and retain the bridge's


### PR DESCRIPTION
## Complexity

🌱 Trivial: two lines in the harness settings grouping helper, one widget test, one regression-doc line.

## What

A harness in `PluginRuntimeState.stopping` now groups under **Disabled** in the harness
settings overview instead of **Needs attention**, and keeps showing its `Stopping` status
there while it drains.

## Why

Toggling a harness off makes the bridge publish `stopping` while it drains
(`accessGate == draining`), so the row jumped into **Needs attention** for the duration of
the disable and then landed in **Disabled**. Nothing needs attention — the harness is
winding down toward exactly where the grouping now puts it immediately.

`stopping` is also published for non-disable reasons (restart/stop of a generation, crash
retirement before `failed`, auth-loss cleanup). The client payload carries no transition
reason, so all of those are grouped the same way. That is honest for each of them: the
harness is not running, and none of them asks the user to act. Crash retirement passes
through `stopping` briefly before `failed`, which lands back in Needs attention on its own.

## Risk and test focus

No database impact and no wire-contract change — client-side presentation only. User-visible
impact is limited to which section a stopping harness renders in and that its status line
stays visible there.

Focus: disable a running harness with active work so the drain is observable, and confirm the
row stays in Disabled with a `Stopping` status and the in-place switch indicator.

## Verification

- `flutter test test/features/settings/harnesses_settings_view_test.dart` (module_app_ui) — passed, includes the new grouping test.
- `flutter test test/features/settings/harnesses_settings_screen_test.dart` (client/app) — passed.
- `flutter analyze` on `client/module_app_ui` — clean.

## Expected result

Toggling a harness off moves it straight into the **Disabled** section, showing `Stopping`
until it settles to `Disabled`. No pass through **Needs attention**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grouping harnesses in `PluginRuntimeState.stopping` under **Disabled** instead of **Needs attention**, so a toggled-off harness lands where it settles and keeps showing its `Stopping` status while it drains. Behavior is client-side only; no database or wire-contract impact.

<sup>Written for commit bc2db88d664f6615187b4b578352acfedb1d258a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1404?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

