### PR TITLE
🌿 Animate harness list group moves

### DIFF
--- a/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
+++ b/client/module_app_ui/lib/src/features/settings/harnesses_settings_view.dart
@@ -134,38 +134,53 @@ class const _ReadyView({
             title: Text(loc.harnessesEmptyTitle),
             subtitle: Text(loc.harnessesEmptyDescription),
           ),
-        for (final group in _HarnessGroup.values)
-          if (response.plugins.any(
-            (plugin) => _group(plugin: plugin, install: state.installs[plugin.setup.id]) == group,
-          )) ...[
-            SettingsSection(
+        // Harnesses change group as they are toggled, installed or stopped, so
+        // a row that leaves closes in its old section while a copy opens in the
+        // new one, and a section that empties or appears follows its rows.
+        PregoAnimatedList<_HarnessGroup>(
+          items: [
+            for (final group in _HarnessGroup.values)
+              if (response.plugins.any(
+                (plugin) => _group(plugin: plugin, install: state.installs[plugin.setup.id]) == group,
+              ))
+                group,
+          ],
+          itemKey: ValueKey<_HarnessGroup>.new,
+          itemBuilder: (context, index, group) => Padding(
+            padding: const EdgeInsetsDirectional.only(bottom: PregoSpacing.xl),
+            child: SettingsSection(
               title: _groupTitle(context: context, group: group),
               child: PregoGroupedRows(
                 color: context.prego.colors.bgSurface2,
                 showDividers: false,
                 children: [
-                  for (final plugin in response.plugins)
-                    if (_group(plugin: plugin, install: state.installs[plugin.setup.id]) == group)
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          _HarnessOverviewRow(
-                            plugin: plugin,
-                            state: state,
-                            onOpen: () => onOpenHarness(pluginId: plugin.setup.id),
-                          ),
-                          _HarnessActionFeedback(
-                            state: state,
-                            target: PluginManagementActionTarget.harness(pluginId: plugin.setup.id),
-                            groupForceReview: false,
-                          ),
-                        ],
-                      ),
+                  PregoAnimatedList<PluginManagementMetadata>(
+                    items: [
+                      for (final plugin in response.plugins)
+                        if (_group(plugin: plugin, install: state.installs[plugin.setup.id]) == group) plugin,
+                    ],
+                    itemKey: (plugin) => ValueKey(plugin.setup.id),
+                    itemBuilder: (context, index, plugin) => Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        _HarnessOverviewRow(
+                          plugin: plugin,
+                          state: state,
+                          onOpen: () => onOpenHarness(pluginId: plugin.setup.id),
+                        ),
+                        _HarnessActionFeedback(
+                          state: state,
+                          target: PluginManagementActionTarget.harness(pluginId: plugin.setup.id),
+                          groupForceReview: false,
+                        ),
+                      ],
+                    ),
+                  ),
                 ],
               ),
             ),
-            const SizedBox(height: PregoSpacing.xl),
-          ],
+          ),
+        ),
         if (response.plugins.any(_supportsOperationalTimeout))
           SettingsSection(
             title: loc.harnessManagementDefaultsSection,

--- a/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
+++ b/client/module_app_ui/test/features/settings/harnesses_settings_view_test.dart
@@ -156,6 +156,27 @@ void main() {
     }
   }
 
+  testWidgets("a harness changing group animates out of the old section instead of jumping", (tester) async {
+    phone(tester: tester);
+    publish(plugins: [_ready]);
+    await tester.pumpWidget(app());
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key("harnesses_card_ready")), findsOneWidget);
+
+    publish(plugins: [_ready.copyWith(runtimeState: PluginRuntimeState.disabled)]);
+    await tester.runAsync(() => Future<void>.delayed(Duration.zero));
+    await tester.pump();
+    // The outgoing snapshot closes with the section it left while the row opens
+    // in the one it moved to.
+    expect(find.byKey(const Key("harnesses_card_ready")), findsNWidgets(2));
+    expect(find.text("Enabled"), findsOneWidget);
+
+    await tester.pumpAndSettle();
+    expect(find.byKey(const Key("harnesses_card_ready")), findsOneWidget);
+    expect(find.text("Enabled"), findsNothing);
+    expect(find.text("Disabled"), findsOneWidget);
+  });
+
   testWidgets("overview groups honest states in design order and preserves registry order", (tester) async {
     phone(tester: tester);
     publish(
@@ -335,6 +356,9 @@ void main() {
       );
       await tester.runAsync(() => Future<void>.delayed(Duration.zero));
       await tester.pump();
+      // The overview harness just changed group, so let it finish moving before
+      // asserting that a single pending switch slot survived the move.
+      await tester.pump(const Duration(milliseconds: 300));
       expect(find.bySemanticsLabel("Loading harnesses"), findsNothing);
       expect(find.byKey(const Key("harness_management_enabled_progress_ready")), findsOneWidget);
       result.complete(

--- a/client/module_prego/lib/components/lists/prego_animated_list.dart
+++ b/client/module_prego/lib/components/lists/prego_animated_list.dart
@@ -1,0 +1,35 @@
+import "package:material_ui/material_ui.dart";
+
+import "prego_animated_sliver_list.dart";
+
+/// The box-layout form of [PregoAnimatedSliverList], for keyed rows that live
+/// inside a column rather than a scroll view's sliver list.
+///
+/// The list sizes itself to its rows and never scrolls on its own; the
+/// surrounding page owns scrolling.
+class const PregoAnimatedList<T>({
+  super.key,
+
+  /// The items currently present in the source list.
+  required final List<T> items,
+
+  /// Returns the stable, unique identity of an item across list updates.
+  required final Key Function(T item) itemKey,
+
+  /// Builds an item at its current index.
+  required final Widget Function(BuildContext context, int index, T item) itemBuilder,
+}) extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // ponytail: a shrink-wrapped scroll view reuses the sliver list's
+    // reconciliation instead of restating it for box layout. Build a real
+    // AnimatedList-based twin if a caller ever needs a long or lazy list.
+    return CustomScrollView(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      slivers: [
+        PregoAnimatedSliverList<T>(items: items, itemKey: itemKey, itemBuilder: itemBuilder),
+      ],
+    );
+  }
+}

--- a/client/module_prego/lib/components/lists/prego_animated_list.dart
+++ b/client/module_prego/lib/components/lists/prego_animated_list.dart
@@ -26,6 +26,9 @@ class const PregoAnimatedList<T>({
     // AnimatedList-based twin if a caller ever needs a long or lazy list.
     return CustomScrollView(
       shrinkWrap: true,
+      // The page owns the primary scroll position; this list never scrolls and
+      // must not attach a second position to that controller.
+      primary: false,
       physics: const NeverScrollableScrollPhysics(),
       slivers: [
         PregoAnimatedSliverList<T>(items: items, itemKey: itemKey, itemBuilder: itemBuilder),

--- a/client/module_prego/lib/module_prego.dart
+++ b/client/module_prego/lib/module_prego.dart
@@ -12,6 +12,7 @@ export 'components/icons/prego_avatar_user.dart';
 export 'components/icons/prego_brand_logo.dart';
 export 'components/inputs/prego_input_field.dart';
 export 'components/inputs/prego_voice_waveform.dart';
+export 'components/lists/prego_animated_list.dart';
 export 'components/lists/prego_animated_sliver_list.dart';
 export 'components/loaders/prego_activity_indicator.dart';
 export 'components/loaders/prego_ai_loader.dart';

--- a/client/module_prego/test/components/prego_animated_list_test.dart
+++ b/client/module_prego/test/components/prego_animated_list_test.dart
@@ -1,0 +1,40 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:theme_prego/module_prego.dart";
+
+const double _rowHeight = 80;
+
+Widget _harness(List<String> items) {
+  return MaterialApp(
+    home: Column(
+      children: [
+        PregoAnimatedList<String>(
+          items: items,
+          itemKey: ValueKey<String>.new,
+          itemBuilder: (context, index, item) => SizedBox(
+            key: ValueKey("row-$item"),
+            height: _rowHeight,
+            child: Text(item),
+          ),
+        ),
+      ],
+    ),
+  );
+}
+
+void main() {
+  testWidgets("rows size the column and a removed row closes in place", (tester) async {
+    await tester.pumpWidget(_harness(["A", "B"]));
+    expect(tester.getSize(find.byType(PregoAnimatedList<String>)).height, _rowHeight * 2);
+
+    await tester.pumpWidget(_harness(["B"]));
+    expect(find.text("A"), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 130));
+    expect(tester.getSize(find.byType(PregoAnimatedList<String>)).height, inExclusiveRange(_rowHeight, _rowHeight * 2));
+
+    await tester.pumpAndSettle();
+    expect(find.text("A"), findsNothing);
+    expect(tester.getSize(find.byType(PregoAnimatedList<String>)).height, _rowHeight);
+  });
+}

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -269,6 +269,9 @@ idle suspension, the management snapshot, and lifecycle commands.
   retained within groups; empty groups disappear. Installing entries belong to Not installed;
   genuinely disabled entries belong to Disabled; only ready dormant/starting/active entries
   are Enabled. Degraded remains attention even though its separate scan capability is routable.
+  A harness that changes group closes in the section it left while opening in the section it
+  joined, and an emptied section closes with its last row rather than disappearing under it;
+  reduced motion keeps the same result without the transition.
 - Harness names and the separate download target open details without starting installation;
   setup guidance stays visible before the explicit detail installation button. Switches send
   actual enable/disable intent and retain the bridge's


### PR DESCRIPTION
## Complexity

🌿 Straightforward: a box-layout wrapper around the existing animated sliver list plus its use
in the harness overview.

## What

The harness settings overview now animates group changes. A harness that moves between
**Needs attention / Enabled / Not installed / Disabled** closes in the section it left while
opening in the one it joined, and a section that empties closes with its last row instead of
vanishing under it.

`PregoAnimatedList` is the box-layout form of the existing `PregoAnimatedSliverList` (already
used by the session and project lists). It is a shrink-wrapped, non-scrolling `CustomScrollView`
around that same widget, so the keyed reconciliation, the reduced-motion behavior and the
inert outgoing snapshot are reused rather than restated for box layout.

## Why

Toggling a harness, finishing an install, or a harness stopping moves its row to a different
section. The row and its section previously appeared and disappeared between frames, so the
list jumped and it was easy to lose track of the harness you just acted on.

## Risk and test focus

No database impact and no wire-contract change — presentation only. User-visible impact is the
260 ms enter/exit transition on the harness overview; reduced motion still applies it instantly.

Focus: toggle a harness off and on with other harnesses present and with it as the only one in
its section, and install a harness, watching the list on both phone and desktop. The list is
nested inside the settings page's own scroll view, so also confirm the page still scrolls and
pull-to-refresh still works.

## Verification

- `flutter test test/features/settings/harnesses_settings_view_test.dart` (module_app_ui) — passed, including the new group-move test.
- `flutter test` (module_prego, 283 tests) — passed, including the new `PregoAnimatedList` test.
- `flutter test test/features/settings/harnesses_settings_screen_test.dart` (client/app) and `test/features/settings/desktop_settings_screens_test.dart` (client/desktop) — passed.
- `flutter analyze` on `client/module_prego` and `client/module_app_ui` — clean.

## Expected result

Harness rows glide between sections instead of jumping, on both mobile and desktop, with the
same final grouping as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Animates harness rows as they move between groups in the settings overview, so toggling, installing, or stopping a harness no longer makes the list jump between frames. A row now closes in the section it left while opening in the section it joined, and a section that empties closes with its last row. This is presentation-only, with no database or wire-contract changes; the transition runs for 260 ms and reduced motion applies it instantly.

**Refactors**
- Adds `PregoAnimatedList`, a shrink-wrapped, non-scrolling `CustomScrollView` wrapper around the existing `PregoAnimatedSliverList` that stays off the primary scroll controller, so the harness overview reuses its keyed reconciliation and outgoing snapshot logic without competing with the settings page's own scrolling.

<sup>Written for commit 30bf8cfc43bff4599b78b80b09e611212160f797. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

