### PR TITLE
🌿 Honor authentication deadlines during Antigravity preflight

### DIFF
--- a/bridge/app/test/runtime/browser_noop_test.dart
+++ b/bridge/app/test/runtime/browser_noop_test.dart
@@ -1,6 +1,12 @@
 import 'dart:io';
 
+import 'package:antigravity_plugin/antigravity_plugin.dart';
+import 'package:sesori_bridge/src/foundation/process_runner.dart';
+import 'package:sesori_bridge/src/server/api/system_process_api.dart';
+import 'package:sesori_bridge/src/server/host/bridge_host_process_service.dart';
+import 'package:sesori_bridge/src/server/repositories/process_repository.dart';
 import 'package:sesori_bridge_foundation/sesori_bridge_foundation.dart';
+import 'package:sesori_plugin_interface/sesori_plugin_interface.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -14,9 +20,55 @@ void main() {
     test('actual source entrypoint exits silently with explicit packages: $explicitPackages', () async {
       final temp = Directory.systemTemp.createTempSync('browser-noop-test-');
       addTearDown(() => temp.deleteSync(recursive: true));
-      final result = await Process.run(
-        Platform.resolvedExecutable,
-        [
+      const clock = ServerClock();
+      final storage = AntigravityProfileStorage(
+        geminiHome: temp.path,
+        settingsStore: const _UnusedProfileStore(),
+        commands: HostProcessCommandExecutor(
+          processes: BridgeHostProcessService(
+            processStarter:
+                (
+                  executable,
+                  arguments, {
+                  environment,
+                  workingDirectory,
+                  runInShell = false,
+                  required includeParentEnvironment,
+                }) => Process.start(
+                  executable,
+                  arguments,
+                  environment: environment,
+                  workingDirectory: temp.path,
+                  runInShell: runInShell,
+                  includeParentEnvironment: includeParentEnvironment,
+                ),
+            processRepository: ProcessRepository(
+              api: SystemProcessApi(
+                processRunner: ProcessRunner(),
+                clock: clock,
+                isWindows: Platform.isWindows,
+                platform: Platform.operatingSystem,
+              ),
+              currentUser: null,
+            ),
+            clock: clock,
+            currentUser: null,
+            isWindows: Platform.isWindows,
+            platform: Platform.operatingSystem,
+          ),
+          runInShell: false,
+          includeParentEnvironment: false,
+          maxCapturedOutputCharactersPerStream: 4096,
+        ),
+        target: PlatformTarget.current(),
+      );
+      final result = await storage.runBrowserPreflight(
+        budget: AntigravityAuthenticationBudget(
+          timeout: const Duration(minutes: 2),
+          abortSignal: StartAbortSignal.never,
+        ),
+        executable: Platform.resolvedExecutable,
+        arguments: [
           if (explicitPackages) '--packages=${File('../.dart_tool/package_config.json').absolute.path}',
           File('bin/bridge.dart').absolute.path,
           BrowserNoop.argument,
@@ -24,13 +76,16 @@ void main() {
           '--deliberately-invalid-option',
         ],
         environment: {'HOME': temp.path, 'USERPROFILE': temp.path},
-        includeParentEnvironment: false,
-        workingDirectory: temp.path,
-      ).timeout(const Duration(seconds: 45));
+      );
       expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
       expect(result.stdout, isEmpty);
       expect(result.stderr, isEmpty);
       expect(temp.listSync(), isEmpty);
-    });
+    }, timeout: const Timeout(Duration(minutes: 3)));
   }
+}
+
+class const _UnusedProfileStore() implements HostJsonStore {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/bridge/sesori_plugin_antigravity/lib/src/storage/antigravity_profile_storage.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/storage/antigravity_profile_storage.dart
@@ -52,13 +52,13 @@ class AntigravityProfileStorage({
     required List<String> arguments,
     required Map<String, String> environment,
   }) {
-    final remaining = budget.remaining;
-    const preflightLimit = Duration(seconds: 5);
+    // Source-mode helpers compile the bridge before reaching the silent no-op.
+    // Keep them within the operation deadline, not a native-startup-sized cap.
     return _commands.run(
       executable,
       arguments,
       environment: environment,
-      timeout: remaining < preflightLimit ? remaining : preflightLimit,
+      timeout: budget.remaining,
     );
   }
 }

--- a/bridge/sesori_plugin_antigravity/test/antigravity_profile_service_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_profile_service_test.dart
@@ -33,7 +33,8 @@ class _Commands({required final List<String> events}) implements CommandExecutor
   bool timeoutPreflight = false;
   TimeoutException? timeoutFailure;
   StartAbortController? abortAfterPreflight;
-  final List<({String executable, List<String> arguments, Map<String, String>? environment})> calls = [];
+  final List<({String executable, List<String> arguments, Map<String, String>? environment, Duration? timeout})> calls =
+      [];
 
   @override
   Future<CommandResult> run(
@@ -43,7 +44,7 @@ class _Commands({required final List<String> events}) implements CommandExecutor
     Map<String, String>? environment,
     Duration? timeout,
   }) async {
-    calls.add((executable: executable, arguments: arguments, environment: environment));
+    calls.add((executable: executable, arguments: arguments, environment: environment, timeout: timeout));
     if (executable == "chmod") {
       events.add("chmod");
       expect(arguments.first, "700");
@@ -62,7 +63,7 @@ class _Commands({required final List<String> events}) implements CommandExecutor
     }
     events.add("preflight");
     expect(timeout, isNotNull);
-    expect(timeout! <= const Duration(seconds: 5), isTrue);
+    expect(timeout, greaterThan(Duration.zero));
     expect(arguments.last, AntigravityProfileService.browserPreflightUrl);
     if (timeoutPreflight) throw const ProcessException("synthetic", [], "timed out");
     if (timeoutFailure case final failure?) throw failure;
@@ -137,6 +138,29 @@ void main() {
     commands = _Commands(events: events);
   });
   tearDown(() => temp.deleteSync(recursive: true));
+
+  for (final timeout in [const Duration(seconds: 3), const Duration(minutes: 2)]) {
+    test("preflight uses the remaining $timeout operation budget without a separate cutoff", () async {
+      final operationBudget = AntigravityAuthenticationBudget(timeout: timeout, abortSignal: StartAbortSignal.never);
+      final storage = AntigravityProfileStorage(
+        geminiHome: home,
+        settingsStore: store,
+        commands: commands,
+        target: mac,
+      );
+      final before = operationBudget.remaining;
+      await storage.runBrowserPreflight(
+        budget: operationBudget,
+        executable: "/bridge",
+        arguments: [BrowserNoop.argument, AntigravityProfileService.browserPreflightUrl],
+        environment: {},
+      );
+      expect(commands.calls.single.timeout, lessThanOrEqualTo(before));
+      expect(commands.calls.single.timeout, greaterThanOrEqualTo(operationBudget.remaining));
+      expect(events, ["preflight"]);
+      expect(temp.listSync(), isEmpty);
+    });
+  }
 
   test("expired preparation does not dispatch and executor timeouts preserve identity", () async {
     final expired = AntigravityAuthenticationBudget(timeout: Duration.zero, abortSignal: StartAbortSignal.never);

--- a/client/module_core/lib/src/api/plugin_api.dart
+++ b/client/module_core/lib/src/api/plugin_api.dart
@@ -40,6 +40,9 @@ class PluginApi({required final RelayHttpApiClient _client}) {
       "/plugin/${Uri.encodeComponent(pluginId)}/authentication",
       body: const SuccessEmptyResponse().toJson(),
       fromJson: PluginAuthenticationChallengeResponse.fromJson,
+      // Preparing a source-mode bridge helper and starting the backend happen
+      // before the challenge; do not truncate the bridge's two-minute budget.
+      timeout: const Duration(minutes: 2),
     );
   }
 

--- a/client/module_core/lib/src/api/plugin_api.dart
+++ b/client/module_core/lib/src/api/plugin_api.dart
@@ -40,9 +40,9 @@ class PluginApi({required final RelayHttpApiClient _client}) {
       "/plugin/${Uri.encodeComponent(pluginId)}/authentication",
       body: const SuccessEmptyResponse().toJson(),
       fromJson: PluginAuthenticationChallengeResponse.fromJson,
-      // Preparing a source-mode bridge helper and starting the backend happen
-      // before the challenge; do not truncate the bridge's two-minute budget.
-      timeout: const Duration(minutes: 2),
+      // Preparation and backend startup can consume the two-minute operation
+      // budget. Leave relay headroom because this timer starts before the bridge's.
+      timeout: const Duration(minutes: 2, seconds: 30),
     );
   }
 

--- a/client/module_core/test/api/plugin_api_test.dart
+++ b/client/module_core/test/api/plugin_api_test.dart
@@ -3,6 +3,7 @@ import "package:sesori_auth/sesori_auth.dart";
 import "package:sesori_dart_core/src/api/plugin_api.dart";
 import "package:sesori_shared/sesori_shared.dart";
 import "package:test/test.dart";
+
 import "../helpers/test_helpers.dart";
 
 void main() {
@@ -147,6 +148,7 @@ void main() {
         any(),
         body: any(named: "body"),
         fromJson: any(named: "fromJson"),
+        timeout: const Duration(minutes: 2),
       ),
     ).thenAnswer((invocation) async {
       final fromJson =
@@ -160,7 +162,11 @@ void main() {
       );
     });
     when(
-      () => client.post<SuccessEmptyResponse>(any(), body: any(named: "body"), fromJson: any(named: "fromJson")),
+      () => client.post<SuccessEmptyResponse>(
+        any(),
+        body: any(named: "body"),
+        fromJson: any(named: "fromJson"),
+      ),
     ).thenAnswer((_) async => ApiResponse.success(const SuccessEmptyResponse()));
     when(
       () => client.delete<SuccessEmptyResponse>(any(), fromJson: any(named: "fromJson")),
@@ -183,6 +189,7 @@ void main() {
         captureAny(),
         body: captureAny(named: "body"),
         fromJson: any(named: "fromJson"),
+        timeout: const Duration(minutes: 2),
       ),
     ).captured;
     expect(start[0], "/plugin/codex%2Fdev/authentication");

--- a/client/module_core/test/api/plugin_api_test.dart
+++ b/client/module_core/test/api/plugin_api_test.dart
@@ -148,7 +148,7 @@ void main() {
         any(),
         body: any(named: "body"),
         fromJson: any(named: "fromJson"),
-        timeout: const Duration(minutes: 2),
+        timeout: const Duration(minutes: 2, seconds: 30),
       ),
     ).thenAnswer((invocation) async {
       final fromJson =
@@ -189,7 +189,7 @@ void main() {
         captureAny(),
         body: captureAny(named: "body"),
         fromJson: any(named: "fromJson"),
-        timeout: const Duration(minutes: 2),
+        timeout: const Duration(minutes: 2, seconds: 30),
       ),
     ).captured;
     expect(start[0], "/plugin/codex%2Fdev/authentication");

--- a/docs/regression/antigravity-isolated-profiles.md
+++ b/docs/regression/antigravity-isolated-profiles.md
@@ -30,6 +30,8 @@ callback policy and shared preparation/authentication budget.
   package discovery is implicit and `Platform.packageConfig` is null. Native relative/PATH launches stay native;
   symlink resolution does not add the binary as a script argument. It quotes the invocation for Python shlex (not a shell),
   rejects path-separator/control/placeholder ambiguity and preflights exit/output before preparing the profile.
+  Source-mode compilation consumes the shared operation budget; preflight uses its remaining deadline rather than
+  a short native-startup cutoff. Expiry still blocks preparation and launch; a slow helper never bypasses validation.
   The repository maps exit/output facts; the service alone decides that success requires zero exit and no output.
   Rejected preflights retain the original command result as the exception cause, while the safe presentation
   identifies the executable and exit code without echoing captured output. Authentication logs retain the bounded
@@ -53,12 +55,14 @@ callback policy and shared preparation/authentication budget.
 - `antigravity_profile_service_test.dart`: inert token-presence inspection, mode/order, generated serialization,
   exact native/source/Windows invocation shapes, environment aliases, immutable outputs and surfaced failures.
   Its real host-executor composition test verifies preflight and directory calls disable parent inheritance.
+  Deterministic budget-forwarding cases cover short and full operation budgets without a separate preflight cutoff.
 - `antigravity_stderr_mapper_test.dart`: selective OAuth consumption, retained diagnostics, byte-split CRLF/EOF,
   sanitized bounds. `antigravity_acp_api_test.dart` exercises the injected scratch-process interceptor composition.
 - `antigravity_browser_invocation_test.dart`: actual descriptor-derived helper invocation with implicit/explicit package
   discovery, plus a compiled native fixture launched directly and through POSIX PATH; no runtime/login is started.
-- `browser_noop_test.dart`: actual source entrypoint subprocess with implicit/explicit package discovery, synthetic HOME,
-  false parent inheritance, empty output and no created files.
+- `browser_noop_test.dart`: actual source entrypoint through production profile storage, host command executor and
+  host process service, with implicit/explicit package discovery, synthetic HOME/cwd, false parent inheritance,
+  empty output and no created files. The subprocess uses the production preflight budget, not a test-only allowance.
 - `antigravity_authentication_operation_test.dart`: a failed preflight retains its original result/stack in local logs,
   leaves the safe exception presentation unchanged, and starts neither the runtime nor authentication.
 - Existing `bridge_host_json_store_test.dart`: real nested child stores, interrupted atomic update, shared exclusion.

--- a/docs/regression/antigravity-personal-authentication.md
+++ b/docs/regression/antigravity-personal-authentication.md
@@ -13,8 +13,9 @@ credentials/token contents.
   silent no-op. Check between mutations, await an in-flight filesystem/atomic-store write, then reject cancellation
   or expired-budget success. Cancellation is checked before and after the bounded preflight; it does not immediately
   interrupt the helper. No instant cancellation of uninterruptible filesystem work is promised.
-- The generic client login-start request allows two minutes for preparation and backend challenge creation rather
-  than the ordinary 30-second request timeout. Other plugin-management requests retain their existing deadlines.
+- The generic client login-start request allows two minutes for preparation/backend challenge creation plus 30 seconds
+  of relay headroom because its timer starts before the bridge's operation budget. This replaces the ordinary
+  30-second request timeout; other plugin-management requests retain their existing deadlines.
 - Scratch authentication validates the negotiated ACP version and selects only an advertised `oauth-personal`
   method before sending authentication. Incompatible protocols or other-only methods fail without auth dispatch.
   It uses the prepared environment with no
@@ -64,8 +65,8 @@ credentials/token contents.
   through real forced client closure. No Google endpoint is contacted.
 - `antigravity_profile_service_test.dart`: remaining-budget forwarding, executor timeout identity, no mutation after
   aborted preflight, and awaited atomic write before rejecting late success, in addition to the isolated-profile coverage.
-- Client `plugin_api_test.dart`: the generic login-start request forwards its explicit two-minute timeout and retains
-  typed challenge/redirect/cancel contracts.
+- Client `plugin_api_test.dart`: the generic login-start request forwards its explicit two-minute-plus-headroom timeout
+  and retains typed challenge/redirect/cancel contracts.
 - `antigravity_authentication_operation_test.dart`: shared environment/budget, one-shot continuation, same-host
   completion, runtime rejection, callback/authorization failure, timeout/process exit, cancellation while cleanup or
   callback work is in flight, and isolation from subsequent attempts.

--- a/docs/regression/antigravity-personal-authentication.md
+++ b/docs/regression/antigravity-personal-authentication.md
@@ -9,9 +9,12 @@ credentials/token contents.
 ## Required behavior
 
 - Profile preparation, runtime probing and authentication share one monotonic budget and abort signal. Browser
-  preflight retains a five-second sub-limit; chmod uses the remaining budget. Check between mutations, await an
-  in-flight filesystem/atomic-store write, then reject cancellation or expired-budget success. No instant cancellation
-  of uninterruptible filesystem work is promised.
+  preflight and chmod use the remaining budget, including source-mode compilation before the helper reaches its
+  silent no-op. Check between mutations, await an in-flight filesystem/atomic-store write, then reject cancellation
+  or expired-budget success. Cancellation is checked before and after the bounded preflight; it does not immediately
+  interrupt the helper. No instant cancellation of uninterruptible filesystem work is promised.
+- The generic client login-start request allows two minutes for preparation and backend challenge creation rather
+  than the ordinary 30-second request timeout. Other plugin-management requests retain their existing deadlines.
 - Scratch authentication validates the negotiated ACP version and selects only an advertised `oauth-personal`
   method before sending authentication. Incompatible protocols or other-only methods fail without auth dispatch.
   It uses the prepared environment with no
@@ -59,8 +62,10 @@ credentials/token contents.
   budget is still positive. The selected failure fences late connection completion; cleanup retains the original
   failure/stack. A local synthetic HTTP server proves dispatched requests settle
   through real forced client closure. No Google endpoint is contacted.
-- `antigravity_profile_service_test.dart`: executor timeout identity, no mutation after aborted preflight, and awaited
-  atomic write before rejecting late success, in addition to the isolated-profile coverage.
+- `antigravity_profile_service_test.dart`: remaining-budget forwarding, executor timeout identity, no mutation after
+  aborted preflight, and awaited atomic write before rejecting late success, in addition to the isolated-profile coverage.
+- Client `plugin_api_test.dart`: the generic login-start request forwards its explicit two-minute timeout and retains
+  typed challenge/redirect/cancel contracts.
 - `antigravity_authentication_operation_test.dart`: shared environment/budget, one-shot continuation, same-host
   completion, runtime rejection, callback/authorization failure, timeout/process exit, cancellation while cleanup or
   callback work is in flight, and isolation from subsequent attempts.


### PR DESCRIPTION
## Complexity
🌿 Straightforward: reuse existing deadlines, strengthen focused regression coverage, and update two regression contracts. Seven files, 141 additions + deletions; no new production classes or dependencies.

## What
- Run Antigravity browser-suppression preflight with the remaining authentication-operation budget instead of a separate five-second cap.
- Give the generic client login-start request two minutes for preparation/backend challenge creation plus 30 seconds of relay headroom; other management-request deadlines are unchanged.
- Exercise the actual bridge source entrypoint through production profile storage, host command execution, and host process spawning, with implicit and explicit package discovery.
- Add deterministic short/full budget-forwarding coverage and assert the client request timeout.

## Why
Follow-up to #1403. Correct source-mode argv exposed a second failure: production preflight killed the helper after five seconds, while earlier subprocess tests allowed 45 seconds. Source execution loads/compiles the bridge before reaching its silent no-op. The client also otherwise abandons challenge creation after its ordinary 30-second request timeout. Its timer starts before the bridge's, so the transport deadline must leave room for request and response delivery beyond the two-minute operation budget.

## Risk and test focus
- User-visible change: slow source-mode helper startup and challenge creation can use the existing bounded login window. Update both bridge and mobile/desktop client for the complete fix.
- Zero-exit/empty-output verification remains mandatory before profile writes or backend launch. No browser fallback, credential inheritance, or authentication bypass is added.
- Expired budgets and original timeout failures remain failures. Cancellation is checked before/after an in-flight preflight; immediate interruption is not promised.
- No database or wire-shape impact. No Google OAuth, credential/token-content access, or authenticated runtime session was executed.

## Expected result
A valid source-mode helper is no longer rejected solely for exceeding five seconds, and the updated client does not cut off login-start at 30 seconds. A failed, noisy, cancelled, or expired preflight still blocks preparation/launch. Real authenticated Google behavior remains unverified.

## Verification
- 135 distinct passing tests: Antigravity profile/descriptor/authentication operation/composer **49**; actual bridge browser-noop **3**; client API/repository/management service **83**.
- All three owning analyzers pass with `--fatal-infos`.
- Source subprocesses use isolated HOME/cwd, disabled parent inheritance, and the production preflight deadline; both exit silently without profile writes or backend/login activity.
- Formatting, diff whitespace, and changed regression-document link checks pass.
- An initial mocktail timeout-matcher setup error was corrected using the concrete expected duration; only that failed case was rerun. Passing cases were not double-counted.
- After the review correction adding transport headroom, the affected API case and core fatal-info analyzer passed again; the overlapping case is not an additional distinct test.
