### PR TITLE
🌿 Fix catalog scan icon and title alignment across states

### DIFF
--- a/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
+++ b/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
@@ -16,6 +16,8 @@ const Curve _revealEaseOut = Cubic(0.23, 1, 0.32, 1);
 // with just enough blur to connect the card to the pull without looking glassy.
 const double _entranceScaleFrom = 0.97;
 const double _entranceBlurSigma = 2;
+// Keep the leading footprint identical when loading becomes a result.
+const double _scanMarkSize = 20;
 
 /// The catalog scan reported as one quiet row above a list.
 ///
@@ -355,7 +357,6 @@ class const _RowContent({
 /// The Figma result card: leading mark, two fixed lines, one tinted action.
 class const _ScanCard({required final _RowContent content}) extends StatelessWidget {
   static const double _minHeight = 69;
-  static const double _markSize = 22;
   // Figma's radial is 483.76px wide for a 69px vertical radius.
   static const double _glowScaleX = 7.011014492753623;
 
@@ -389,35 +390,29 @@ class const _ScanCard({required final _RowContent content}) extends StatelessWid
         colors.textErrorPrimary,
       ),
     };
-    final textBlock = Padding(
-      padding: const EdgeInsetsDirectional.only(top: 1),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            content.title,
-            maxLines: wrapsText ? null : 1,
-            overflow: wrapsText ? null : TextOverflow.ellipsis,
-            style: prego.textTheme.textSm.medium.copyWith(color: colors.textPrimary),
-          ),
-          const SizedBox(height: PregoSpacing.xxs),
-          Text(
-            content.detail,
-            maxLines: wrapsText ? null : 1,
-            overflow: wrapsText ? null : TextOverflow.ellipsis,
-            style: prego.textTheme.textSm.medium.copyWith(color: colors.textSecondary),
-          ),
-        ],
-      ),
+    final textBlock = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          content.title,
+          maxLines: wrapsText ? null : 1,
+          overflow: wrapsText ? null : TextOverflow.ellipsis,
+          style: prego.textTheme.textSm.medium.copyWith(color: colors.textPrimary),
+        ),
+        const SizedBox(height: PregoSpacing.xxs),
+        Text(
+          content.detail,
+          maxLines: wrapsText ? null : 1,
+          overflow: wrapsText ? null : TextOverflow.ellipsis,
+          style: prego.textTheme.textSm.medium.copyWith(color: colors.textSecondary),
+        ),
+      ],
     );
-    final action = Padding(
-      padding: const EdgeInsetsDirectional.only(top: PregoSpacing.xs),
-      child: _ScanDismissButton(
-        label: content.actionLabel,
-        color: actionColor,
-        onPressed: content.onAction,
-      ),
+    final action = _ScanDismissButton(
+      label: content.actionLabel,
+      color: actionColor,
+      onPressed: content.onAction,
     );
 
     return Column(
@@ -454,12 +449,12 @@ class const _ScanCard({required final _RowContent content}) extends StatelessWid
                   vertical: PregoSpacing.lg,
                 ),
                 child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                  crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     SizedBox.square(
                       key: const ValueKey("catalog-scan-terminal-icon"),
-                      dimension: _markSize,
-                      child: Icon(icon, size: _markSize, color: markColor),
+                      dimension: _scanMarkSize,
+                      child: Icon(icon, size: _scanMarkSize, color: markColor),
                     ),
                     const SizedBox(width: PregoSpacing.sm),
                     Expanded(
@@ -473,7 +468,7 @@ class const _ScanCard({required final _RowContent content}) extends StatelessWid
                               ],
                             )
                           : Row(
-                              crossAxisAlignment: CrossAxisAlignment.start,
+                              crossAxisAlignment: CrossAxisAlignment.center,
                               children: [
                                 Expanded(child: textBlock),
                                 const SizedBox(width: PregoSpacing.xs),
@@ -602,7 +597,7 @@ class _ScanLoadingCardState()
                         key: const ValueKey("prego-deep-scan-loader"),
                         turns: _loaderTurns,
                         child: PregoAiLoader(
-                          size: 20,
+                          size: _scanMarkSize,
                           animate: false,
                           fillMode: .outline,
                           color: colors.textPrimary,

--- a/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
+++ b/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
@@ -464,6 +464,7 @@ class const _ScanCard({required final _RowContent content}) extends StatelessWid
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 textBlock,
+                                const SizedBox(height: PregoSpacing.xs),
                                 Align(alignment: AlignmentDirectional.centerEnd, child: action),
                               ],
                             )

--- a/client/module_app_ui/test/widgets/catalog_scan_row_test.dart
+++ b/client/module_app_ui/test/widgets/catalog_scan_row_test.dart
@@ -185,6 +185,10 @@ void main() {
           if (textScale == 1) {
             expect(markRect, initialMark);
             expect(titleOffset, initialTitle);
+          } else if (!scan.isLive) {
+            final textBlock = find.ancestor(of: find.text(title), matching: find.byType(Column)).first;
+            final action = find.byKey(const ValueKey("catalog-scan-dismiss-action"));
+            expect(tester.getTopLeft(action).dy - tester.getBottomLeft(textBlock).dy, PregoSpacing.xs);
           }
           expect(tester.takeException(), isNull);
         }

--- a/client/module_app_ui/test/widgets/catalog_scan_row_test.dart
+++ b/client/module_app_ui/test/widgets/catalog_scan_row_test.dart
@@ -147,6 +147,50 @@ void main() {
       expect(running, starting);
     });
 
+    for (final textScale in [1.0, 2.0]) {
+      testWidgets("keeps scan marks and text in place across states at ${textScale}x text", (tester) async {
+        final loc = await AppLocalizations.delegate.load(const Locale("en"));
+        final states = [
+          (const CatalogRescanState.starting(pluginIds: {"codex"}), loc.catalogScanRunningTitle),
+          (
+            const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
+            loc.catalogScanRunningTitle,
+          ),
+          (
+            const CatalogRescanState.succeeded(
+              harnessCount: 1,
+              counts: CatalogRescanCounts.delta(newProjects: 0, newSessions: 3),
+            ),
+            loc.catalogScanCompleteTitle,
+          ),
+          (const CatalogRescanState.partlyFailed(succeededCount: 1, failedCount: 1), loc.catalogScanPartlyFailedTitle),
+          (const CatalogRescanState.failed(harnessCount: 1), loc.catalogScanFailedTitle),
+          (const CatalogRescanState.unsupported(), loc.catalogScanUnsupportedTitle),
+          (const CatalogRescanState.noHarness(), loc.catalogScanNoHarnessTitle),
+        ];
+        Rect? initialMark;
+        Offset? initialTitle;
+        for (final (scan, title) in states) {
+          await pumpRow(tester, scan, width: 402, textScaler: TextScaler.linear(textScale), reducedMotion: true);
+          final card = find.byKey(ValueKey(scan.isLive ? "prego-deep-scan-card" : "catalog-scan-terminal-card"));
+          final mark = find.byKey(ValueKey(scan.isLive ? "prego-deep-scan-loader" : "catalog-scan-terminal-icon"));
+          final markRect = tester.getRect(mark);
+          final titleOffset = tester.getTopLeft(find.text(title));
+          initialMark ??= markRect;
+          initialTitle ??= titleOffset;
+          expect(markRect.size, const Size.square(20));
+          expect(markRect.left, initialMark.left);
+          expect(markRect.center.dy, tester.getCenter(card).dy);
+          expect(titleOffset.dx, initialTitle.dx);
+          if (textScale == 1) {
+            expect(markRect, initialMark);
+            expect(titleOffset, initialTitle);
+          }
+          expect(tester.takeException(), isNull);
+        }
+      });
+    }
+
     testWidgets("reports the scan before any harness has reported progress", (tester) async {
       await pumpRow(tester, const CatalogRescanState.starting(pluginIds: {"codex"}));
 
@@ -396,7 +440,7 @@ void main() {
       expect(tester.getSize(row), const Size(402, 101));
       expect(tester.getSize(card), const Size(370, 69));
       expect(tester.getTopLeft(card) - tester.getTopLeft(row), const Offset(16, 16));
-      expect(tester.getSize(mark), const Size.square(22));
+      expect(tester.getSize(mark), const Size.square(20));
       expect(tester.getSize(action), const Size(76, 36));
 
       final container = tester.widget<Container>(card);

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -87,7 +87,11 @@ state.
   gentle opacity transition. Finished outcomes use the shared PREGO result-card
   geometry, expanding rather than clipping at accessibility text sizes: a
   success, warning, or error glow rises from the lower edge and the matching
-  tinted Dismiss action remains available until the result clears.
+  tinted Dismiss action remains available until the result clears. Loading and
+  every result state use a vertically centered 20px leading mark with identical
+  edge inset and icon-to-text gap. Titles do not shift horizontally between
+  states; at standard text size, icon and title positions stay fixed vertically
+  too. Enlarged text may grow the card without changing those horizontal insets.
 - A scan the pull started is reported by that row alone: the pull raises no
   confirmation of its own, having run no ordinary refresh. A scan started from
   harness settings is the exception, because that surface has no row — it


### PR DESCRIPTION
## Complexity
🌿 Straightforward: localized shared-widget layout correction.

## What
- Center result icons like the loading indicator and share their 20px size.
- Remove result-only top offsets so titles and actions align consistently.
- Add geometry checks across all seven visible states at normal and enlarged text sizes.
- Update the projects/sessions regression contract.

## Why
Completing a deep-pull catalog scan moved the icon upward and shifted the title 2px right because result icons were top-aligned and 22px rather than 20px.

## Risk and test focus
Low-risk presentation-only change shared by scan list surfaces. Check stable icon/text positions, unchanged normal card height, and accessibility expansion. No database, transport, or scan-lifecycle impact.

## Expected result
Loading transitions into success or any other result without icon-size or horizontal title jumps. Icons stay vertically centered; enlarged text can still expand the card.

## Verification
- `flutter test test/widgets/catalog_scan_row_test.dart` — 36 tests passed.
- `dart analyze` in `client/module_app_ui` — no issues.
- `git diff --check` — passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes catalog scan row alignment so loading and result states share the same vertically centered 20px leading mark, removing the icon shift and 2px title jump that happened when a scan finished. Also preserves the dismiss action's spacing below the text in the enlarged-text layout. Presentation-only change; scan lifecycle, data, and card height are unaffected.

<sup>Written for commit f2e2ee78a306ac1fb7baaff42e9624c2bc28aea5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

