### PR TITLE
🌿 Fix rounded inline-alert edges under Impeller

### DIFF
--- a/client/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
+++ b/client/module_prego/lib/components/alerts/prego_inline_alerts_notifications.dart
@@ -130,23 +130,25 @@ class const PregoInlineAlertsNotifications({
 
     return Padding(
       padding: const EdgeInsets.all(PregoSpacing.xl),
-      // Material supplies text defaults outside a Scaffold and clips both the
-      // accent and action ink to the card, with its border in the foreground.
-      child: Material(
-        color: colors.bgSurface5,
-        shape: RoundedRectangleBorder(
+      // Paint the rounded surface directly, outside the content clip. Clipping
+      // a rectangular gradient and the foreground border together truncates
+      // their edge coverage on Impeller, leaving uneven rounded corners.
+      child: DecoratedBox(
+        decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(PregoRadius.x2l),
-          side: BorderSide(color: colors.borderPrimary),
+          border: Border.all(color: colors.borderPrimary),
+          gradient: _accentGradient(colors),
         ),
-        clipBehavior: Clip.antiAlias,
-        child: Stack(
-          children: [
-            Positioned.fill(child: IgnorePointer(child: _accentGradient(colors))),
-            Padding(
-              padding: const EdgeInsets.all(PregoSpacing.xl),
-              child: _buildBody(prego, brightness: Theme.of(context).brightness),
-            ),
-          ],
+        // Keep text defaults and clipped action ink without clipping the
+        // surface's antialiased fill or border a second time.
+        child: Material(
+          type: MaterialType.transparency,
+          borderRadius: BorderRadius.circular(PregoRadius.x2l),
+          clipBehavior: Clip.antiAlias,
+          child: Padding(
+            padding: const EdgeInsets.all(PregoSpacing.xl),
+            child: _buildBody(prego, brightness: Theme.of(context).brightness),
+          ),
         ),
       ),
     );
@@ -275,7 +277,7 @@ class const PregoInlineAlertsNotifications({
     );
   }
 
-  Widget _accentGradient(PregoColors colors) {
+  RadialGradient _accentGradient(PregoColors colors) {
     final rim = switch (type) {
       PregoInlineAlertsNotificationsType.info || PregoInlineAlertsNotificationsType.loading => colors.bgSurface5,
       PregoInlineAlertsNotificationsType.success => colors.bgSuccessSecondary,
@@ -283,18 +285,14 @@ class const PregoInlineAlertsNotifications({
       PregoInlineAlertsNotificationsType.error => colors.bgErrorSecondary,
     };
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        gradient: RadialGradient(
-          center: Alignment.topCenter,
-          radius: 1,
-          transform: const _WideEllipseGradientTransform(),
-          // Figma holds the surface colour through 60% of the ellipse, then
-          // fades to the status tint, with 20% opacity over the whole gradient.
-          stops: const [0.6, 1],
-          colors: [colors.bgSurface5.withValues(alpha: 0.20), rim.withValues(alpha: 0.20)],
-        ),
-      ),
+    return RadialGradient(
+      center: Alignment.topCenter,
+      radius: 1,
+      transform: const _WideEllipseGradientTransform(),
+      // Flatten Figma's 20%-opacity tint onto the surface so the rounded
+      // background is painted once, rather than as overlapping clipped fills.
+      stops: const [0.6, 1],
+      colors: [colors.bgSurface5, Color.alphaBlend(rim.withValues(alpha: 0.20), colors.bgSurface5)],
     );
   }
 

--- a/client/module_prego/test/components/prego_inline_alerts_notifications_test.dart
+++ b/client/module_prego/test/components/prego_inline_alerts_notifications_test.dart
@@ -18,6 +18,13 @@ void main() {
       )
       .first;
 
+  Finder surface() => find
+      .descendant(
+        of: find.byType(PregoInlineAlertsNotifications),
+        matching: find.byType(DecoratedBox),
+      )
+      .first;
+
   for (final brightness in Brightness.values) {
     final design = brightness == Brightness.dark ? PregoDesignSystem.dark : PregoDesignSystem.light;
 
@@ -38,13 +45,17 @@ void main() {
         expect(bounds.right, 440 - PregoSpacing.xl);
         expect(bounds.top, PregoSpacing.xl);
         expect(tester.getRect(find.byType(PregoInlineAlertsNotifications)).bottom - bounds.bottom, PregoSpacing.xl);
-        final surface = tester.widget<Material>(card());
-        expect(surface.color, design.colors.bgSurface5);
-        expect(surface.clipBehavior, Clip.antiAlias);
-        final shape = surface.shape! as RoundedRectangleBorder;
-        expect(shape.borderRadius, BorderRadius.circular(PregoRadius.x2l));
-        expect(shape.side.color, design.colors.borderPrimary);
-        expect(shape.side.width, 1);
+        final material = tester.widget<Material>(card());
+        expect(material.type, MaterialType.transparency);
+        expect(material.clipBehavior, Clip.antiAlias);
+        expect(material.borderRadius, BorderRadius.circular(PregoRadius.x2l));
+        expect(material.shape, isNull);
+        final decoration = tester.widget<DecoratedBox>(surface()).decoration as BoxDecoration;
+        expect(decoration.borderRadius, BorderRadius.circular(PregoRadius.x2l));
+        expect(decoration.border, Border.all(color: design.colors.borderPrimary));
+        final gradient = decoration.gradient! as RadialGradient;
+        expect(gradient.colors.first, design.colors.bgSurface5);
+        expect(gradient.colors.every((color) => color.a == 1), isTrue);
         final title = tester.widget<Text>(find.text("Bridge disconnected"));
         expect(title.style?.color, design.colors.textPrimary);
         expect(title.style?.fontWeight, FontWeight.w500);
@@ -70,17 +81,15 @@ void main() {
       expect(icon.left - bounds.left, PregoSpacing.xl);
       expect(icon.top - bounds.top, PregoSpacing.xl);
       expect(tester.getTopLeft(find.text("Bridge disconnected")).dx - icon.right, PregoSpacing.sm);
-      final decoration =
-          tester
-                  .widget<DecoratedBox>(
-                    find.descendant(of: card(), matching: find.byType(DecoratedBox)).first,
-                  )
-                  .decoration
-              as BoxDecoration;
+      final decoration = tester.widget<DecoratedBox>(surface()).decoration as BoxDecoration;
+      // The rounded fill and border live outside the ink/content clip. Keeping
+      // the gradient inside Material reintroduces clipped-edge artifacts.
+      expect(find.descendant(of: card(), matching: surface()), findsNothing);
+      expect(tester.getRect(surface()), bounds);
       final gradient = decoration.gradient! as RadialGradient;
       expect(gradient.colors, [
-        design.colors.bgSurface5.withValues(alpha: 0.2),
-        design.colors.bgWarningSecondary.withValues(alpha: 0.2),
+        design.colors.bgSurface5,
+        Color.alphaBlend(design.colors.bgWarningSecondary.withValues(alpha: 0.2), design.colors.bgSurface5),
       ]);
       expect(gradient.stops, [0.6, 1.0]);
     });

--- a/docs/regression/bridge-connectivity.md
+++ b/docs/regression/bridge-connectivity.md
@@ -58,6 +58,10 @@ explicit restart, and the connection states the app presents.
   broadcast-off icon and live-region announcement. Its entire padded height
   participates in the navigation's show/hide animation so the bar and content
   stay clear of the card and return to their original positions on recovery.
+  The rounded fill, tint, and border paint outside the action/content clip so
+  their antialiased edges remain smooth on Impeller and Skia; action ink still
+  clips to the card. Check light/dark themes at 1x and Retina scale, including
+  macOS Impeller, without disabling Impeller or adding a saveLayer.
 - The client relay socket pings on an interval, so a silently dead network path
   (Wi-Fi drop, VPN toggle, sleep/wake) surfaces as a socket close and enters
   reconnect within roughly two ping intervals instead of waiting on request
@@ -165,8 +169,9 @@ the bridge starts, how many clients are present, and whether restart is explicit
   startup never establishes the desktop relay client.
 - A dead network path leaving the app claiming connected for minutes, or the
   reconnecting banner flashing on every routine foreground resume.
-- An inline connection alert touching the screen edges, losing its rounded
-  clipping or theme contrast, overlapping navigation/content, clipping the
+- An inline connection alert touching the screen edges, showing jagged or
+  uneven rounded borders, losing its content clipping or theme contrast,
+  overlapping navigation/content, clipping the
   disconnected title at standard phone text size, or leaving space after recovery.
 - GUI shutdown unregistering the bridge, emitting login-needed, or exiting with the
   auth-required sentinel because teardown cancelled the bootstrap token request.


### PR DESCRIPTION
## Complexity
🌿 Straightforward: localized shared-widget paint/composition change; no new abstractions.

## What
- Paint inline alerts' rounded gradient and border directly with `BoxDecoration`, outside the content/ink clip.
- Flatten the translucent status tint onto the existing surface color instead of stacking separately clipped fills.
- Retain transparent Material for text defaults and clipped action ink.
- Update component tests and bridge-connectivity regression coverage.

## Why
The reported bridge-disconnected banner painted a rectangular gradient and its foreground border inside a shaped Material clip. That composition subjects the rounded surface edges to clipping as well as antialiasing. Painting the rounded decoration outside the content clip avoids truncating its edge coverage.

## Risk and test focus
Low, localized visual change shared by mobile and desktop. Check corner smoothness, tint/contrast, spacing, and action behavior in both themes and at normal/Retina scales. Impeller remains enabled; no platform checks or extra saveLayer. This fixes the demonstrated inline-alert composition, not every possible engine-level rounded-shape issue.

No database, protocol, authentication, or persisted-state impact.

## Expected result
User-visible: smoother, more consistent rounded edges on inline connection alerts while retaining their existing layout, status tint, and working actions across surfaces.

## Verification
- `client`: `flutter pub get` passed.
- `client/module_prego`: `dart analyze --fatal-infos` passed; inline-alert widget suite: 8 tests passed.
- `client/app`: connection-banner suite: 7 tests passed, including navigation show/hide and retry behavior.
- `git diff --check` passed.
- Built a temporary synthetic entrypoint in the existing desktop runner and launched its exact executable with `--enable-impeller`; native log confirmed **Impeller (MetalSDF)**. Captured light/dark alert scenes at 1x, 1.5x, and 2x; inspected light 1x and dark 2x output and magnified before/after corner crops. No real auth, relay, or bridge initialization; probe source removed before commit.
- Host: macOS 26.6.2, Xcode 26.6, Flutter 3.47.2 / Dart 3.13.2, debug build.
- Native on-screen confirmation remains blocked: Mac is locked (`loginwindow`). Offscreen render captures are not a claim of interactive on-screen verification. Other physical platforms not exercised locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inline connection alerts rendering jagged rounded edges under Impeller by painting the rounded gradient and border outside the content clip.

- Moves the rounded surface decoration out of the clipped `Material` so antialiased edges aren't truncated a second time.
- Flattens the translucent status tint onto the surface color instead of stacking separate clipped fills.
- Keeps action ink and text defaults clipped to the card as before.
- Updates widget tests to assert the new composition and expands the bridge-connectivity regression checklist.
- No change to layout, status tint, action behavior, or Impeller settings.

<sup>Written for commit d7472a5141d15d8c901d8e5d7e3214def3a706bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1409?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

