### PR TITLE
🌿 Batch internal releases hourly and skip repeated attempts

### DIFF
--- a/.github/scripts/check_internal_release.sh
+++ b/.github/scripts/check_internal_release.sh
@@ -41,7 +41,7 @@ if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
       client/app/ client/module_core/ client/module_auth/ client/module_prego/ client/module_app_ui/ \
       client/pubspec.yaml client/pubspec.lock client/analysis_options.yaml client/Makefile \
       shared/ bridge/ .tool-versions tool/generate_release_notes.dart \
-      .github/scripts/check_internal_release.sh .github/workflows/release-all-platforms.yml \
+      .github/actions/ .github/scripts/check_internal_release.sh .github/workflows/release-all-platforms.yml \
       '.github/workflows/_reusable-*.yml'; then
       skip_release "No release-relevant changes since ${BASELINE}."
     else

--- a/.github/scripts/check_internal_release.sh
+++ b/.github/scripts/check_internal_release.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Run after a full checkout (including tags), inside release-all's concurrency
+# group. Only this workflow's main runs own the rolling attempt marker.
+set -euo pipefail
+
+ATTEMPT_TAG="internal-release-attempt"
+
+skip_release() {
+  echo "should_release=false" >> "$GITHUB_OUTPUT"
+  echo "Skipping internal release: $1"
+  echo "## Internal release skipped" >> "$GITHUB_STEP_SUMMARY"
+  echo "$1" >> "$GITHUB_STEP_SUMMARY"
+  exit 0
+}
+
+if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+  RELEASE_TAGS=$(git tag --points-at "$GITHUB_SHA" --list 'v[0-9]*')
+  if [[ -n "$RELEASE_TAGS" ]]; then
+    skip_release "Commit ${GITHUB_SHA} already has a release tag: ${RELEASE_TAGS//$'\n'/, }."
+  fi
+
+  BASELINE=$(git for-each-ref --format='%(objectname)' "refs/tags/${ATTEMPT_TAG}")
+  if [[ "$BASELINE" == "$GITHUB_SHA" ]]; then
+    skip_release "Commit ${GITHUB_SHA} was already attempted. Use Run workflow to retry manually."
+  fi
+
+  if [[ -z "$BASELINE" ]]; then
+    # Bootstrap from the nearest release on this history. --always returns an
+    # abbreviated SHA (not v*) when no release exists yet; that first run builds.
+    BASELINE=$(git describe --tags --match 'v[0-9]*' --abbrev=0 --always "$GITHUB_SHA")
+    if [[ "$BASELINE" != v* ]]; then
+      BASELINE=""
+    fi
+  fi
+
+  if [[ -n "$BASELINE" ]]; then
+    # Preserve mobile-product scoping: desktop-only and unrelated documentation
+    # changes must not spend a store upload. Compare the whole batch, not only the tip.
+    # Release automation fixes also qualify, so a fixed pipeline can try again.
+    if git diff --quiet "$BASELINE" "$GITHUB_SHA" -- \
+      client/app/ client/module_core/ client/module_auth/ client/module_prego/ client/module_app_ui/ \
+      client/pubspec.yaml client/pubspec.lock client/analysis_options.yaml client/Makefile \
+      shared/ bridge/ .tool-versions tool/generate_release_notes.dart \
+      .github/scripts/check_internal_release.sh .github/workflows/release-all-platforms.yml \
+      '.github/workflows/_reusable-*.yml'; then
+      skip_release "No release-relevant changes since ${BASELINE}."
+    else
+      STATUS=$?
+      if [[ "$STATUS" -ne 1 ]]; then
+        echo "::error::Could not compare release changes (git diff exited ${STATUS})." >&2
+        exit "$STATUS"
+      fi
+    fi
+  fi
+fi
+
+# Write BEFORE version checks, store queries or builds: failure/cancellation
+# needs no cleanup job, and inability to persist the marker prevents uploads.
+# Manual branch builds stay supported but cannot overwrite main's checkpoint.
+if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+  git push --force origin "${GITHUB_SHA}:refs/tags/${ATTEMPT_TAG}"
+fi
+
+echo "should_release=true" >> "$GITHUB_OUTPUT"
+{
+  echo "## Internal release attempt"
+  echo "Building commit ${GITHUB_SHA}. Manual runs bypass the scheduled skip checks."
+} >> "$GITHUB_STEP_SUMMARY"

--- a/.github/scripts/test_check_internal_release.py
+++ b/.github/scripts/test_check_internal_release.py
@@ -161,6 +161,8 @@ class InternalReleaseGateTest(unittest.TestCase):
         for path in [
             ".github/workflows/release-all-platforms.yml",
             ".github/workflows/_reusable-ios-testflight.yml",
+            ".github/actions/setup-flutter/action.yml",
+            ".github/actions/resolve-flutter-dart-version/action.yml",
             ".github/scripts/check_internal_release.sh",
             ".tool-versions",
             "tool/generate_release_notes.dart",

--- a/.github/scripts/test_check_internal_release.py
+++ b/.github/scripts/test_check_internal_release.py
@@ -1,0 +1,200 @@
+"""Exercise the release gate against local Git fixtures; never contact the stores."""
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GATE = ROOT / ".github/scripts/check_internal_release.sh"
+ATTEMPT_REF = "refs/tags/internal-release-attempt"
+
+
+class InternalReleaseGateTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # Keep all fixtures inside the caller's checkout, not another worktree.
+        fixture = tempfile.TemporaryDirectory(prefix=".release-gate-test-", dir=ROOT)
+        self.addCleanup(fixture.cleanup)
+        self.fixture = Path(fixture.name)
+        self.repo = self.fixture / "repo"
+        self.origin = self.fixture / "origin.git"
+        self.output = self.fixture / "output"
+        self.summary = self.fixture / "summary"
+        self.repo.mkdir()
+        self.git(args=["init", "--bare", str(self.origin)])
+        self.git(args=["init", "--initial-branch=main"])
+        self.git(args=["config", "user.name", "Release Gate Test"])
+        self.git(args=["config", "user.email", "release-gate@example.invalid"])
+        self.git(args=["config", "commit.gpgsign", "false"])
+        self.git(args=["config", "tag.gpgsign", "false"])
+        self.git(args=["remote", "add", "origin", str(self.origin)])
+        self.commit(path="client/app/lib/app.dart")
+
+    def git(self, *, args: list[str]) -> str:
+        return subprocess.run(
+            ["git", *args], cwd=self.repo, check=True, text=True, capture_output=True
+        ).stdout.strip()
+
+    def commit(self, *, path: str) -> str:
+        target = self.repo / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a") as file:
+            file.write("change\n")
+        self.git(args=["add", path])
+        self.git(args=["commit", "-m", f"Change {path}"])
+        return self.git(args=["rev-parse", "HEAD"])
+
+    def tag(self, *, name: str, annotated: bool = False) -> None:
+        args = ["tag", "-a", name, "-m", name] if annotated else ["tag", name]
+        self.git(args=args)
+        self.git(args=["push", "origin", f"refs/tags/{name}"])
+
+    def attempt_sha(self) -> str:
+        return self.git(
+            args=["--git-dir", str(self.origin), "for-each-ref", "--format=%(objectname)", ATTEMPT_REF]
+        )
+
+    def run_gate(
+        self, *, event: str = "schedule", ref: str = "refs/heads/main", succeeds: bool = True
+    ) -> tuple[str, str]:
+        # Model checkout@v6 fetch-depth: 0, refreshing the moving remote tag.
+        self.git(args=["fetch", "origin", "+refs/tags/*:refs/tags/*"])
+        self.output.write_text("")
+        self.summary.write_text("")
+        result = subprocess.run(
+            ["bash", str(GATE)],
+            cwd=self.repo,
+            env={
+                **os.environ,
+                "GITHUB_EVENT_NAME": event,
+                "GITHUB_REF": ref,
+                "GITHUB_SHA": self.git(args=["rev-parse", "HEAD"]),
+                "GITHUB_OUTPUT": str(self.output),
+                "GITHUB_STEP_SUMMARY": str(self.summary),
+            },
+            text=True,
+            capture_output=True,
+        )
+        if succeeds:
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        else:
+            self.assertNotEqual(result.returncode, 0)
+        return self.output.read_text(), self.summary.read_text()
+
+    def test_first_run_without_release_history_builds_and_records_attempt(self) -> None:
+        output, _ = self.run_gate()
+        self.assertEqual(output, "should_release=true\n")
+        self.assertEqual(self.attempt_sha(), self.git(args=["rev-parse", "HEAD"]))
+        self.assertEqual(self.git(args=["tag", "--list", "v*"]), "")
+
+    def test_failed_or_cancelled_attempt_is_not_retried(self) -> None:
+        self.run_gate()
+        # No success tag: simulate a version/store/build failure or cancellation.
+        output, summary = self.run_gate()
+        self.assertEqual(output, "should_release=false\n")
+        self.assertIn("already attempted", summary)
+        self.assertIn("Run workflow", summary)
+
+    def test_annotated_internal_release_on_head_is_skipped(self) -> None:
+        self.tag(name="v1.2.3-internal.42", annotated=True)
+        output, _ = self.run_gate()
+        self.assertEqual(output, "should_release=false\n")
+        self.assertEqual(self.attempt_sha(), "")
+
+    def test_stable_release_on_head_is_skipped(self) -> None:
+        self.tag(name="v1.2.3")
+        output, _ = self.run_gate()
+        self.assertEqual(output, "should_release=false\n")
+
+    def test_unrelated_tag_does_not_block_a_build(self) -> None:
+        self.tag(name="docs-checkpoint")
+        output, _ = self.run_gate()
+        self.assertEqual(output, "should_release=true\n")
+
+    def test_new_product_commit_after_failure_builds_and_moves_marker(self) -> None:
+        self.run_gate()
+        sha = self.commit(path="client/module_core/lib/core.dart")
+        output, _ = self.run_gate()
+        self.assertEqual(output, "should_release=true\n")
+        self.assertEqual(self.attempt_sha(), sha)
+
+    def test_product_change_before_a_docs_only_tip_is_not_lost(self) -> None:
+        self.run_gate()
+        self.commit(path="shared/sesori_shared/lib/model.dart")
+        sha = self.commit(path="docs/notes.md")
+        output, _ = self.run_gate()
+        self.assertEqual(output, "should_release=true\n")
+        self.assertEqual(self.attempt_sha(), sha)
+
+    def test_irrelevant_changes_after_failure_do_not_retry_or_move_marker(self) -> None:
+        self.run_gate()
+        attempted = self.attempt_sha()
+        for path in [
+            "docs/notes.md",
+            "client/desktop/lib/app.dart",
+            "client/module_desktop_core/lib/core.dart",
+            ".github/workflows/desktop-ci.yml",
+        ]:
+            with self.subTest(path=path):
+                self.commit(path=path)
+                output, _ = self.run_gate()
+                self.assertEqual(output, "should_release=false\n")
+                self.assertEqual(self.attempt_sha(), attempted)
+
+    def test_bootstrap_from_release_skips_unrelated_changes(self) -> None:
+        self.tag(name="v1.2.3-internal.42", annotated=True)
+        self.commit(path="docs/notes.md")
+        output, _ = self.run_gate()
+        self.assertEqual(output, "should_release=false\n")
+        self.assertEqual(self.attempt_sha(), "")
+
+    def test_bootstrap_from_release_builds_product_changes(self) -> None:
+        self.tag(name="v1.2.3")
+        self.commit(path="bridge/app/lib/bridge.dart")
+        output, _ = self.run_gate()
+        self.assertEqual(output, "should_release=true\n")
+
+    def test_release_automation_fixes_allow_another_attempt(self) -> None:
+        self.run_gate()
+        for path in [
+            ".github/workflows/release-all-platforms.yml",
+            ".github/workflows/_reusable-ios-testflight.yml",
+            ".github/scripts/check_internal_release.sh",
+            ".tool-versions",
+            "tool/generate_release_notes.dart",
+        ]:
+            with self.subTest(path=path):
+                sha = self.commit(path=path)
+                output, _ = self.run_gate()
+                self.assertEqual(output, "should_release=true\n")
+                self.assertEqual(self.attempt_sha(), sha)
+
+    def test_manual_run_retries_an_attempted_commit(self) -> None:
+        self.run_gate()
+        output, _ = self.run_gate(event="workflow_dispatch")
+        self.assertEqual(output, "should_release=true\n")
+
+    def test_manual_run_can_rebuild_a_tagged_commit(self) -> None:
+        self.tag(name="v1.2.3-internal.42", annotated=True)
+        output, _ = self.run_gate(event="workflow_dispatch")
+        self.assertEqual(output, "should_release=true\n")
+
+    def test_manual_branch_run_does_not_change_main_checkpoint(self) -> None:
+        self.run_gate()
+        main_attempt = self.attempt_sha()
+        self.commit(path="client/app/lib/app.dart")
+        output, _ = self.run_gate(event="workflow_dispatch", ref="refs/heads/feature")
+        self.assertEqual(output, "should_release=true\n")
+        self.assertEqual(self.attempt_sha(), main_attempt)
+
+    def test_marker_push_failure_prevents_building(self) -> None:
+        self.git(args=["remote", "set-url", "--push", "origin", str(self.fixture / "missing.git")])
+        output, _ = self.run_gate(succeeds=False)
+        self.assertNotIn("should_release=true", output)
+        self.assertEqual(self.attempt_sha(), "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/_reusable-bridge-build.yml
+++ b/.github/workflows/_reusable-bridge-build.yml
@@ -2,7 +2,8 @@ name: Bridge Build (reusable)
 
 # Builds the 5-platform sesori-bridge archives and uploads them as workflow
 # artifacts (sesori-bridge-<os>-<arch>.<ext>). Used by:
-#   - release-all-platforms.yml — per main merge, baking an X.Y.Z-internal.<N>
+#   - release-all-platforms.yml — hourly when main has eligible changes (or on
+#     manual dispatch), baking an X.Y.Z-internal.<N>
 #     version so internal binaries self-report exactly their release tag.
 #   - submit-release.yml — at production submit, building from the resolved
 #     commit whose committed pubspec already holds the clean version.

--- a/.github/workflows/_reusable-bridge-build.yml
+++ b/.github/workflows/_reusable-bridge-build.yml
@@ -1,6 +1,6 @@
 name: Bridge Build (reusable)
 
-# Builds the 5-platform sesori-bridge archives and uploads them as workflow
+# Builds the 6-platform sesori-bridge archives and uploads them as workflow
 # artifacts (sesori-bridge-<os>-<arch>.<ext>). Used by:
 #   - release-all-platforms.yml — hourly when main has eligible changes (or on
 #     manual dispatch), baking an X.Y.Z-internal.<N>

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -2,7 +2,7 @@ name: Release All Platforms
 
 run-name: "release · build ${{ github.sha }}"
 
-# Per-merge internal release: uploads iOS to TestFlight and Android to the
+# Hourly internal release: uploads iOS to TestFlight and Android to the
 # Play internal track, builds the 5-platform bridge archives, and — only when
 # EVERYTHING succeeded (all-or-nothing) — pushes a `v<X>-internal.<N>` tag and
 # rolls the single internal GitHub pre-release onto it (previous pre-release
@@ -15,22 +15,10 @@ run-name: "release · build ${{ github.sha }}"
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    # Mobile-PRODUCT paths only (not blanket client/**) so future client/desktop
-    # PRs never trigger a mobile or bridge release — release-safety invariant #3.
-    paths:
-      - 'client/app/**'
-      - 'client/module_core/**'
-      - 'client/module_auth/**'
-      - 'client/module_prego/**'
-      - 'client/module_app_ui/**'
-      - 'client/pubspec.yaml'
-      - 'client/pubspec.lock'
-      - 'client/analysis_options.yaml'
-      - 'client/Makefile'
-      - 'shared/**'
-      - 'bridge/**'
+  schedule:
+    # GitHub schedules use UTC and may start late. Each run builds its immutable
+    # main SHA; later merges wait for the next run.
+    - cron: '45 * * * *'
 
 concurrency:
   group: release-all-${{ github.ref }}
@@ -38,13 +26,24 @@ concurrency:
 
 jobs:
   preflight:
-    name: Version guard
+    name: Release gate and version guard
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: write
     outputs:
+      should_release: ${{ steps.gate.outputs.should_release }}
       version: ${{ steps.check.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # Persist the attempt before version validation or store calls. Failed or
+      # cancelled builds are not retried hourly; workflow_dispatch can retry.
+      - name: Check and record release attempt
+        id: gate
+        run: bash .github/scripts/check_internal_release.sh
 
       # Fail the WHOLE run (mobile and bridge) when the committed version was
       # already released/submitted: a `v<version>` tag is pushed by every beta
@@ -52,6 +51,7 @@ jobs:
       # a `tool/sync_versions.dart` bump PR must land before main can produce
       # new internal builds. Never auto-increment.
       - name: Verify versions are in sync and unreleased
+        if: steps.gate.outputs.should_release == 'true'
         id: check
         run: |
           set -euo pipefail
@@ -81,6 +81,7 @@ jobs:
   next-build-number:
     name: Resolve aligned build number
     needs: preflight
+    if: needs.preflight.outputs.should_release == 'true'
     uses: ./.github/workflows/_reusable-next-build-number.yml
     secrets:
       APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -134,8 +135,8 @@ jobs:
 
   # All-or-nothing: runs only when iOS, Android AND all five bridge targets
   # succeeded, so every internal tag maps to a complete set (both store builds
-  # + all bridge binaries). On any failure nothing is tagged or published and
-  # the rolling pre-release keeps pointing at the previous good build.
+  # + all bridge binaries). On failure no release tag or release is published;
+  # the attempt marker remains and the pre-release stays on the previous build.
   finalize:
     name: Tag and roll internal pre-release
     runs-on: ubuntu-latest

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -3,7 +3,7 @@ name: Release All Platforms
 run-name: "release · build ${{ github.sha }}"
 
 # Hourly internal release: uploads iOS to TestFlight and Android to the
-# Play internal track, builds the 5-platform bridge archives, and — only when
+# Play internal track, builds the 6-platform bridge archives, and — only when
 # EVERYTHING succeeded (all-or-nothing) — pushes a `v<X>-internal.<N>` tag and
 # rolls the single internal GitHub pre-release onto it (previous pre-release
 # objects are deleted; their tags are kept forever as the build-number→commit
@@ -133,7 +133,7 @@ jobs:
       MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
       MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
 
-  # All-or-nothing: runs only when iOS, Android AND all five bridge targets
+  # All-or-nothing: runs only when iOS, Android AND all six bridge targets
   # succeeded, so every internal tag maps to a complete set (both store builds
   # + all bridge binaries). On failure no release tag or release is published;
   # the attempt marker remains and the pre-release stays on the previous build.
@@ -242,5 +242,5 @@ jobs:
             echo "- **Version**: \`${VERSION}-internal.${BUILD_NUMBER}\`"
             echo "- **Tag**: \`${TAG}\`"
             echo "- **iOS (TestFlight)** / **Android (internal track)**: build ${BUILD_NUMBER} (iOS next: ${{ needs.next-build-number.outputs.ios_next }}, Android next: ${{ needs.next-build-number.outputs.android_next }})"
-            echo "- **Bridge pre-release**: rolled to \`${TAG}\` (5 platform archives + checksums)"
+            echo "- **Bridge pre-release**: rolled to \`${TAG}\` (6 platform archives + checksums)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-workflow-ci.yml
+++ b/.github/workflows/release-workflow-ci.yml
@@ -4,12 +4,16 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/actions/**'
+      - '.github/workflows/_reusable-*.yml'
       - '.github/scripts/check_internal_release.sh'
       - '.github/scripts/test_check_internal_release.py'
       - '.github/workflows/release-all-platforms.yml'
       - '.github/workflows/release-workflow-ci.yml'
   pull_request:
     paths:
+      - '.github/actions/**'
+      - '.github/workflows/_reusable-*.yml'
       - '.github/scripts/check_internal_release.sh'
       - '.github/scripts/test_check_internal_release.py'
       - '.github/workflows/release-all-platforms.yml'

--- a/.github/workflows/release-workflow-ci.yml
+++ b/.github/workflows/release-workflow-ci.yml
@@ -1,0 +1,30 @@
+name: Release Workflow CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/check_internal_release.sh'
+      - '.github/scripts/test_check_internal_release.py'
+      - '.github/workflows/release-all-platforms.yml'
+      - '.github/workflows/release-workflow-ci.yml'
+  pull_request:
+    paths:
+      - '.github/scripts/check_internal_release.sh'
+      - '.github/scripts/test_check_internal_release.py'
+      - '.github/workflows/release-all-platforms.yml'
+      - '.github/workflows/release-workflow-ci.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  release-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Lint release gate
+        run: shellcheck .github/scripts/check_internal_release.sh
+      - name: Test scheduled release decisions and attempt recording
+        run: python3 .github/scripts/test_check_internal_release.py

--- a/bridge/RELEASING.md
+++ b/bridge/RELEASING.md
@@ -90,11 +90,21 @@ the workflows.
 make bump-version TYPE=patch
 ```
 
-That bump step is the source of truth for the release version. It must keep `bridge/app/pubspec.yaml`, `bridge/app/lib/src/version.dart`, all six npm package manifests in `bridge/app/npm/`, and `client/app/pubspec.yaml` aligned to the same `X.Y.Z` semantic release. For an explicit version, run `make bump-version VERSION=X.Y.Z`. The bump is REQUIRED after every production release: `release-all-platforms.yml` fails its preflight guard for any main push whose version already has a `v<version>` tag.
+That bump step is the source of truth for the release version. It must keep `bridge/app/pubspec.yaml`, `bridge/app/lib/src/version.dart`, all six npm package manifests in `bridge/app/npm/`, and `client/app/pubspec.yaml` aligned to the same `X.Y.Z` semantic release. For an explicit version, run `make bump-version VERSION=X.Y.Z`. The bump is REQUIRED after every production release: `release-all-platforms.yml` fails its preflight guard for a new build whose version already has a `v<version>` tag on another commit.
 
-### 2. Merge to main
+### 2. Merge to main and wait for the hourly release
 
-Every main merge runs `release-all-platforms.yml`: it uploads the mobile apps to TestFlight / Play internal, builds all five bridge platform archives with `X.Y.Z-internal.<N>` baked in, and — only when everything succeeded — pushes a `v<X.Y.Z>-internal.<N>` tag and rolls the single internal GitHub pre-release onto it (binaries + `checksums.txt` + regenerated notes). The auto-updater ignores pre-releases on the default `stable` track; bridges switched to the `internal` track (`sesori-bridge config track internal`) pick up these `-internal.<N>` pre-releases.
+`release-all-platforms.yml` checks main hourly at **45 minutes past the hour** (`45 * * * *`, UTC), not on each merge. GitHub may delay scheduled runs. Each run uses its triggering main SHA throughout; later merges wait for the next run. The existing concurrency group serializes main releases without cancelling an active build.
+
+Scheduled runs skip commits that already carry a release tag or match the rolling `internal-release-attempt` tag. Otherwise, they compare the whole batch against that attempt (or the nearest release tag before the first attempt). Only mobile-product, shared, bridge, or release-automation changes qualify; desktop-only and unrelated documentation changes do not consume store uploads. The exact paths live in `.github/scripts/check_internal_release.sh`.
+
+Before version validation, store queries, or builds, the workflow moves the lightweight `internal-release-attempt` tag to the chosen SHA. A failure or cancellation therefore cannot cause hourly retries of that commit. A later relevant change allows another attempt; the marker is not a release and creates no GitHub release object. If recording the marker fails, no build starts.
+
+An eligible run uploads the mobile apps to TestFlight / Play internal, builds all six bridge platform archives with `X.Y.Z-internal.<N>` baked in, and — only when everything succeeded — pushes a `v<X.Y.Z>-internal.<N>` tag and rolls the single internal GitHub pre-release onto it (binaries + `checksums.txt` + regenerated notes). Existing internal release tags remain immutable build-number-to-commit mappings. The auto-updater ignores pre-releases on the default `stable` track; bridges switched to the `internal` track (`sesori-bridge config track internal`) pick up these `-internal.<N>` pre-releases.
+
+For an immediate build or a retry after fixing credentials/store issues, open **Actions → Release All Platforms → Run workflow**, normally on `main`. Manual dispatch bypasses the scheduled tag/path checks but still validates versions and allocates a fresh aligned build number. Manual builds on another branch do not move main's attempt marker. The standalone iOS/Android manual workflows remain available.
+
+The cron provides 24 scheduled opportunities per day, not a strict store quota: delayed runs and manual uploads still count against each store's limits.
 
 ### 3. Submit to production
 
@@ -124,7 +134,7 @@ Use this sequence when you want to test the real packaged distribution flow end 
 ### A. Test a GitHub Release for the shell installers
 
 1. Bump the shared App + Bridge version with `make bump-version TYPE=<type>` or `make bump-version VERSION=X.Y.Z`.
-2. Merge to main and wait for `release-all-platforms.yml` to roll the internal pre-release.
+2. Merge to main and wait for the next hourly `release-all-platforms.yml` run to roll the internal pre-release, or use **Run workflow** for an immediate build.
 3. Run `Submit Release` for production (use `platforms: bridge-only` to skip the app stores).
 4. Wait for the `v<X.Y.Z>` GitHub Release to be published with its assets and `checksums.txt`.
 5. Verify the release contains all six platform archives plus `checksums.txt`.

--- a/bridge/RELEASING.md
+++ b/bridge/RELEASING.md
@@ -108,7 +108,7 @@ The cron provides 24 scheduled opportunities per day, not a strict store quota: 
 
 ### 3. Submit to production
 
-Run the `Submit Release` workflow (`submit-release.yml`) with the build number to promote. For production it rebuilds the bridge from the resolved commit with the clean version, tags `v<X.Y.Z>`, and creates the GitHub release with the five archives plus `checksums.txt`. Use `platforms: bridge-only` for a bridge hotfix that skips the app stores.
+Run the `Submit Release` workflow (`submit-release.yml`) with the build number to promote. For production it rebuilds the bridge from the resolved commit with the clean version, tags `v<X.Y.Z>`, and creates the GitHub release with the six archives plus `checksums.txt`. Use `platforms: bridge-only` for a bridge hotfix that skips the app stores.
 
 - `publish_bridge` ticked (default): the release is published immediately — bridge auto-update goes live for all users right away.
 - `publish_bridge` unticked: the release is created as a pre-release, invisible to the auto-updater until you promote it in the GitHub UI.

--- a/docs/regression/bridge-installation-and-updates.md
+++ b/docs/regression/bridge-installation-and-updates.md
@@ -8,6 +8,13 @@ reconciliation, periodic check, in-place apply, and explicit update command.
 
 ## Required Behavior
 
+- Internal releases check main hourly at `:45` UTC and build one immutable commit
+  across TestFlight, Play internal, and bridge archives. Released or already-attempted
+  commits skip before store queries; desktop-only and unrelated documentation batches
+  skip, but product changes before an unrelated tip commit still qualify.
+  A rolling `internal-release-attempt` tag is written before version validation or
+  builds, preventing hourly retries after failure or cancellation. Manual dispatch
+  can retry; release tags and the all-platform success requirement stay unchanged.
 - Installers and the npm bootstrap produce the same managed install, expose the
   `sesori-bridge` launcher, and report the version; installers take the newest
   non-prerelease release carrying the platform archive and its basename-keyed checksum
@@ -43,7 +50,7 @@ reconciliation, periodic check, in-place apply, and explicit update command.
 |---|---|
 | L1 Smoke | Not included. Distribution work is expensive and is not a per-run heartbeat. |
 | L2 Routine | Update-skip policy and startup reconciliation on a non-managed run: a build-tree or opted-out bridge neither rewrites itself nor fails startup, and reconciliation is silent with no pending attempt. Headless bridge; no plugin. |
-| L3 Release | The release artifact set and checksum manifest for the tag are complete and basename-keyed, and a managed install on the release-target bridge host reports the expected version and starts. Packaged or external. |
+| L3 Release | Scheduled-release gate tests cover batched changes, tagged/attempted skips, failure suppression, manual retries, and marker-write failure without store calls. The release artifact set and checksum manifest for the tag are complete and basename-keyed, and a managed install on the release-target bridge host reports the expected version and starts. Packaged or external. |
 | L4 Extended | Interrupted or failed apply reconciled at a later start, including lock-contended and deletion-failed residue retained observably for another retry; rollback; refused checksum mismatch; unavailable release service staying quiet; track switch; periodic cycle applying in place and reporting pending activation; and an alternate bridge host. Packaged or external for the install; headless bridge for policy. |
 | L5 Full | Both installers and the npm bootstrap on every supported platform and architecture, the npm fallback to the tagged release asset, an end-to-end upgrade from a prior release on both tracks, the update command including force, and the documented uninstall contract. Packaged or external. |
 
@@ -56,6 +63,11 @@ after apply. Use a throwaway machine when mutating an install root.
 
 ## Failure Signals
 
+- Store builds starting on every merge, repeated automatic uploads for the same
+  attempted commit, an unrelated batch consuming uploads, or a relevant change
+  hidden behind an unrelated tip commit being missed.
+- A build starting before its attempt marker is persisted, a manual branch run
+  moving main's marker, or an incomplete all-platform build being promoted as a release.
 - An installer selecting a pre-release, a release missing or mis-keying its manifest, or
   an artifact installed without verification.
 - Auto-update running for a supervised run, npm payload, CI, or opted-out process, or a
@@ -69,6 +81,8 @@ after apply. Use a throwaway machine when mutating an install root.
 
 ## Known Limitations
 
+- GitHub can delay cron starts. Hourly opportunities are not a strict daily upload
+  quota; manual runs and delayed uploads can still hit store limits.
 - Genuine distribution claims need real published artifacts; a local build proves policy
   and reconciliation only, and signing is verifiable only against CI-produced binaries.
 - The bootstrap and the updater share no lock; an apply-window collision is accepted.
@@ -77,6 +91,8 @@ after apply. Use a throwaway machine when mutating an install root.
 
 ## Sources
 
+- `.github/workflows/release-all-platforms.yml`, `.github/scripts/check_internal_release.sh`,
+  `.github/scripts/test_check_internal_release.py`
 - `bridge/RELEASING.md`, `bridge/INSTALL.md`, `install.sh`, `install.ps1`, `bridge/app/npm/`
 - `bridge/app/lib/src/foundation/bridge_startup_banner_formatter.dart`
 - `bridge/app/lib/src/updater/` policy, track, lock, repositories, services;


### PR DESCRIPTION
## Complexity
🌿 Straightforward: one release gate, workflow wiring, and local Git-fixture coverage. No application architecture changes.

## What
- Replace merge-triggered internal releases with `cron` `45 * * * *` (hourly at :45 UTC).
- Skip released/already-attempted commits and batches without release-relevant changes.
- Persist a rolling `internal-release-attempt` tag before validation/store calls, preventing hourly retries after failure or cancellation.
- Preserve manual dispatch retries, immutable success tags, aligned store build numbers, and all-platform finalization.
- Add lightweight gate CI and update release/regression guidance.

## Why
Frequent merges consume TestFlight upload capacity. Batch eligible changes while keeping broken commits from retrying automatically.

## Risk and test focus
Release orchestration only. The operational tag requires write permission; failure to persist it stops builds. Tests cover tag/bootstrap behavior, whole-batch path selection, failure suppression, manual retries, branch isolation, and rejected marker writes. GitHub cron can be delayed; manual uploads still count against store limits, so this is not a strict daily quota.

## Expected result
New eligible main changes produce at most one automatic attempt per scheduled opportunity. Unchanged or failed commits remain idle until a relevant change or manual dispatch. No runtime user-visible behavior or database impact; internal testers receive coalesced builds rather than one per merge.

## Verification
- 15 local Git-fixture tests passed (`python3 .github/scripts/test_check_internal_release.py`).
- Shell syntax, ShellCheck, Actionlint for touched workflows, and `git diff --check` passed.
- No signed builds, store queries/uploads, or live attempt-tag mutations were performed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches internal releases from per-merge to hourly, so eligible main commits are batched and testers get at most one build per scheduled opportunity. Failed or cancelled commits are marked as attempted and no longer retried automatically; manual dispatch still works.

**What changed**
- Replaces the merge-triggered `release-all-platforms.yml` trigger with a cron schedule at `:45` UTC.
- Adds a rolling `internal-release-attempt` tag written before any version check or store call, preventing hourly retries after a failed or cancelled build.
- Skips commits that already have a release tag, match the attempt tag, or contain no release-relevant changes; release-automation fixes, including shared actions, count as relevant and allow another attempt.
- Manual `workflow_dispatch` runs bypass the scheduled skip checks and can retry any commit.
- Adds a gate script with local Git-fixture tests and a release workflow CI job.
- Requires `contents: write` permission for the attempt tag; failure to persist it stops the build.
- Delayed runs and manual uploads still count against store limits, so this is not a strict daily quota.

<sup>Written for commit 8cc3efcb9dcebb50b15e1953b2b00e0307f01d96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

