### PR TITLE
🌿 Serve session history from the bridge store without the harness

### DIFF
--- a/bridge/app/lib/src/api/database/history/chat_history_dao.dart
+++ b/bridge/app/lib/src/api/database/history/chat_history_dao.dart
@@ -7,6 +7,13 @@ import "tables/history_sync_state_table.dart";
 
 part "chat_history_dao.g.dart";
 
+/// One page's stored rows plus the freshness they were read with.
+typedef PagedHistoryRows = ({
+  HistorySyncStateTableData? syncState,
+  List<HistoryMessagesTableData> messages,
+  List<HistoryPartsTableData> parts,
+});
+
 @DriftAccessor(tables: [HistoryMessagesTable, HistoryPartsTable, HistorySyncStateTable])
 class ChatHistoryDao(super.attachedDatabase) extends DatabaseAccessor<ChatHistoryDatabase> with _$ChatHistoryDaoMixin {
   Future<HistorySyncStateTableData?> getSyncState({required String sessionId}) {
@@ -42,6 +49,31 @@ class ChatHistoryDao(super.attachedDatabase) extends DatabaseAccessor<ChatHistor
               ..limit(limit))
             .get();
     return page.reversed.toList(growable: false);
+  }
+
+  /// The sync state and one page's raw rows, read from a single snapshot.
+  ///
+  /// A caller reading outside the history service's per-session queue can
+  /// otherwise have a backfill or purge commit between the three statements
+  /// and receive parts belonging to a different transcript than its messages.
+  /// The database runs in WAL mode, so this read transaction is a snapshot and
+  /// does not block that writer. Rows are returned raw: attachment
+  /// rehydration reads files, and holding the transaction across that would
+  /// stall unrelated database work for no added consistency.
+  Future<PagedHistoryRows> getPageRowsWithSyncState({
+    required String sessionId,
+    int? limit,
+    int? before,
+  }) {
+    return transaction(() async {
+      final syncState = await getSyncState(sessionId: sessionId);
+      final messages = await getMessages(sessionId: sessionId, limit: limit, before: before);
+      final parts = await getParts(
+        sessionId: sessionId,
+        messageIds: limit == null ? null : [for (final row in messages) row.messageId],
+      );
+      return (syncState: syncState, messages: messages, parts: parts);
+    });
   }
 
   /// Parts of [messageIds], or of the whole session when [messageIds] is null.

--- a/bridge/app/lib/src/repositories/chat_history_repository.dart
+++ b/bridge/app/lib/src/repositories/chat_history_repository.dart
@@ -125,6 +125,59 @@ class ChatHistoryRepository({
       sessionId: sessionId,
       messageIds: limit == null ? null : [for (final row in messageRows) row.messageId],
     );
+    return await _assemblePage(
+      messageRows: messageRows,
+      partRows: partRows,
+      storageScope: storageScope,
+      limit: limit,
+      attachmentProjection: attachmentProjection,
+    );
+  }
+
+  /// The session's freshness and one page of its transcript, read together.
+  ///
+  /// For a caller that must read outside the history service's per-session
+  /// queue: the rows and the sync marker come from one database snapshot, so
+  /// the page cannot mix two transcripts and its freshness cannot describe a
+  /// different one. Attachments rehydrate afterwards, outside the snapshot.
+  Future<({ChatHistorySyncState? syncState, ChatHistoryPage page})> getSessionMessagesWithSyncState({
+    required String sessionId,
+    required AttachmentStorageScope storageScope,
+    int? limit,
+    int? before,
+    required MessageAttachmentProjection attachmentProjection,
+  }) async {
+    final rows = await _chatHistoryDao.getPageRowsWithSyncState(
+      sessionId: sessionId,
+      limit: limit,
+      before: before,
+    );
+    final syncState = rows.syncState;
+    return (
+      syncState: syncState == null
+          ? null
+          : (
+              watermark: syncState.watermark,
+              backendActivityAt: syncState.backendActivityAt,
+              syncedAt: syncState.syncedAt,
+            ),
+      page: await _assemblePage(
+        messageRows: rows.messages,
+        partRows: rows.parts,
+        storageScope: storageScope,
+        limit: limit,
+        attachmentProjection: attachmentProjection,
+      ),
+    );
+  }
+
+  Future<ChatHistoryPage> _assemblePage({
+    required List<HistoryMessagesTableData> messageRows,
+    required List<HistoryPartsTableData> partRows,
+    required AttachmentStorageScope storageScope,
+    required int? limit,
+    required MessageAttachmentProjection attachmentProjection,
+  }) async {
     final partJsonByMessage = <String, List<String>>{};
     for (final row in partRows) {
       partJsonByMessage.putIfAbsent(row.messageId, () => []).add(row.partJson);

--- a/bridge/app/lib/src/routing/get_session_messages_handler.dart
+++ b/bridge/app/lib/src/routing/get_session_messages_handler.dart
@@ -33,11 +33,13 @@ class GetSessionMessagesHandler({required final ChatHistoryService _chatHistoryS
       limit: body.limit,
       before: body.before,
       attachmentDelivery: body.attachmentDelivery,
+      storedOnly: body.storedOnly,
     );
     return MessageWithPartsResponse(
       messages: page.messages,
       nextCursor: page.nextCursor,
       replayedPromptDefaults: page.replayedPromptDefaults,
+      awaitingHarnessSync: page.awaitingHarnessSync,
     );
   }
 }

--- a/bridge/app/lib/src/services/chat_history_service.dart
+++ b/bridge/app/lib/src/services/chat_history_service.dart
@@ -188,10 +188,9 @@ class ChatHistoryService({
   /// caller that cannot wake the harness, so queueing behind another read's
   /// in-flight backfill would make it wait on exactly the thing it opted out
   /// of, and a backfill that fails or stalls would take the stored transcript
-  /// down with it. The store's own backfill commits in one transaction, so an
-  /// unqueued read sees the state before it or after it, never a torn one, and
-  /// a marker flip that races the freshness check only mis-dates
-  /// `awaitingHarnessSync` for a single read — the next one corrects it.
+  /// down with it. Consistency comes from the database instead: the rows and
+  /// the sync marker are read in one snapshot, so a backfill or purge lands
+  /// wholly before or wholly after them.
   ///
   /// Dead open tool parts are not swept here for the same reason: the sweep is
   /// a queued write, and repairing a tool tile left spinning by a bridge death
@@ -227,16 +226,20 @@ class ChatHistoryService({
       if (archived != null) return _messagesPage(page: archived, replayedPromptDefaults: null);
     }
 
-    final state = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
-    final synced = state != null && state.syncedAt != null && state.watermark >= state.backendActivityAt;
-    final page = await _chatHistoryRepository.getSessionMessages(
+    // One snapshot for the marker and the rows: outside the queue a backfill
+    // or purge could otherwise commit between them and hand back a page whose
+    // parts belong to a different transcript than its messages, or a freshness
+    // verdict describing neither.
+    final read = await _chatHistoryRepository.getSessionMessagesWithSyncState(
       sessionId: sessionId,
       storageScope: storageScope,
       limit: limit,
       before: before,
       attachmentProjection: attachmentProjection,
     );
-    return _messagesPage(page: page, replayedPromptDefaults: null, awaitingHarnessSync: !synced);
+    final state = read.syncState;
+    final synced = state != null && state.syncedAt != null && state.watermark >= state.backendActivityAt;
+    return _messagesPage(page: read.page, replayedPromptDefaults: null, awaitingHarnessSync: !synced);
   }
 
   SessionMessagesPage _messagesPage({

--- a/bridge/app/lib/src/services/chat_history_service.dart
+++ b/bridge/app/lib/src/services/chat_history_service.dart
@@ -45,6 +45,10 @@ typedef SessionMessagesPage = ({
   List<MessageWithParts> messages,
   int? nextCursor,
   SessionPromptDefaults? replayedPromptDefaults,
+
+  /// Whether the store served this page while behind the harness, so newer
+  /// messages may be missing. Only a store-only read can report this.
+  bool awaitingHarnessSync,
 });
 
 /// The single writer of the chat history store.
@@ -70,13 +74,24 @@ class ChatHistoryService({
   /// The store is preferred only when a backfill has completed *and* no
   /// backend activity has been observed past the captured watermark, so a
   /// session advanced outside Sesori still reads correctly.
+  ///
+  /// [storedOnly] removes that fallback: the store answers even when it is
+  /// behind, and the page reports `awaitingHarnessSync`. Callers that cannot
+  /// wake the harness — because it is disabled, needs authentication, or is
+  /// slow right after a start — ask for that instead of a page they may never
+  /// receive.
   Future<SessionMessagesPage> getSessionMessages({
     required String sessionId,
     int? limit,
     int? before,
     required MessageAttachmentDelivery attachmentDelivery,
+    required bool storedOnly,
   }) async {
     final attachmentProjection = _attachmentProjectionFor(delivery: attachmentDelivery);
+    // Set by the read below when it serves a store the harness has moved past.
+    // The read is a single queued closure, so this is written before any
+    // reader of it resumes.
+    var awaitingHarnessSync = false;
     // The archive check, the freshness decision, and the read all run inside
     // the session queue, so they observe one state. Deciding outside it would
     // let queued work — an observed import, or a failed capture clearing
@@ -106,7 +121,11 @@ class ChatHistoryService({
 
         final state = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
         if (state == null || state.syncedAt == null || state.watermark < state.backendActivityAt) {
-          return null;
+          // A store-only read has no backfill to fall back to, so it serves
+          // what the store holds and says so, rather than waking the harness
+          // for the rest.
+          if (!storedOnly) return null;
+          awaitingHarnessSync = true;
         }
         return await _chatHistoryRepository.getSessionMessages(
           sessionId: sessionId,
@@ -124,10 +143,18 @@ class ChatHistoryService({
       // backfill will run. The page is already in memory, so detecting them is
       // free; only a page that actually contains one pays for a status read.
       if (!_containsOpenToolPart(page: decided)) {
-        return _messagesPage(page: decided, replayedPromptDefaults: replayedPromptDefaults);
+        return _messagesPage(
+          page: decided,
+          replayedPromptDefaults: replayedPromptDefaults,
+          awaitingHarnessSync: awaitingHarnessSync,
+        );
       }
       if (!await _sweepUnlessTurnRunning(sessionId: sessionId)) {
-        return _messagesPage(page: decided, replayedPromptDefaults: replayedPromptDefaults);
+        return _messagesPage(
+          page: decided,
+          replayedPromptDefaults: replayedPromptDefaults,
+          awaitingHarnessSync: awaitingHarnessSync,
+        );
       }
       final storageScope = await _requireStorageScope(sessionId: sessionId);
       final page = await _enqueueRead(
@@ -140,7 +167,23 @@ class ChatHistoryService({
           attachmentProjection: attachmentProjection,
         ),
       );
-      return _messagesPage(page: page, replayedPromptDefaults: replayedPromptDefaults);
+      return _messagesPage(
+        page: page,
+        replayedPromptDefaults: replayedPromptDefaults,
+        awaitingHarnessSync: awaitingHarnessSync,
+      );
+    }
+
+    // The store holds no row for this session at all — the read above returns
+    // null only for that. A store-only read cannot backfill it, so it reports
+    // an empty transcript the harness still owes.
+    if (storedOnly) {
+      return (
+        messages: const <MessageWithParts>[],
+        nextCursor: null,
+        replayedPromptDefaults: null,
+        awaitingHarnessSync: true,
+      );
     }
 
     final replayedPromptDefaults = await _backfillSessionForRead(sessionId: sessionId);
@@ -160,16 +203,22 @@ class ChatHistoryService({
         attachmentProjection: attachmentProjection,
       ),
     );
-    return _messagesPage(page: page, replayedPromptDefaults: replayedPromptDefaults);
+    return _messagesPage(
+      page: page,
+      replayedPromptDefaults: replayedPromptDefaults,
+      awaitingHarnessSync: false,
+    );
   }
 
   SessionMessagesPage _messagesPage({
     required ChatHistoryPage page,
     required SessionPromptDefaults? replayedPromptDefaults,
+    required bool awaitingHarnessSync,
   }) => (
     messages: page.messages,
     nextCursor: page.nextCursor,
     replayedPromptDefaults: replayedPromptDefaults,
+    awaitingHarnessSync: awaitingHarnessSync,
   );
 
   MessageAttachmentProjection _attachmentProjectionFor({required MessageAttachmentDelivery delivery}) =>

--- a/bridge/app/lib/src/services/chat_history_service.dart
+++ b/bridge/app/lib/src/services/chat_history_service.dart
@@ -75,11 +75,10 @@ class ChatHistoryService({
   /// backend activity has been observed past the captured watermark, so a
   /// session advanced outside Sesori still reads correctly.
   ///
-  /// [storedOnly] removes that fallback: the store answers even when it is
-  /// behind, and the page reports `awaitingHarnessSync`. Callers that cannot
-  /// wake the harness — because it is disabled, needs authentication, or is
-  /// slow right after a start — ask for that instead of a page they may never
-  /// receive.
+  /// [storedOnly] hands the whole read to [_storedOnlyPage] instead, which
+  /// answers from the store alone. Callers that cannot wake the harness —
+  /// because it is disabled, needs authentication, or is slow right after a
+  /// start — ask for that instead of a page they may never receive.
   Future<SessionMessagesPage> getSessionMessages({
     required String sessionId,
     int? limit,
@@ -88,10 +87,14 @@ class ChatHistoryService({
     required bool storedOnly,
   }) async {
     final attachmentProjection = _attachmentProjectionFor(delivery: attachmentDelivery);
-    // Set by the read below when it serves a store the harness has moved past.
-    // The read is a single queued closure, so this is written before any
-    // reader of it resumes.
-    var awaitingHarnessSync = false;
+    if (storedOnly) {
+      return await _storedOnlyPage(
+        sessionId: sessionId,
+        limit: limit,
+        before: before,
+        attachmentProjection: attachmentProjection,
+      );
+    }
     // The archive check, the freshness decision, and the read all run inside
     // the session queue, so they observe one state. Deciding outside it would
     // let queued work — an observed import, or a failed capture clearing
@@ -121,11 +124,7 @@ class ChatHistoryService({
 
         final state = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
         if (state == null || state.syncedAt == null || state.watermark < state.backendActivityAt) {
-          // A store-only read has no backfill to fall back to, so it serves
-          // what the store holds and says so, rather than waking the harness
-          // for the rest.
-          if (!storedOnly) return null;
-          awaitingHarnessSync = true;
+          return null;
         }
         return await _chatHistoryRepository.getSessionMessages(
           sessionId: sessionId,
@@ -143,18 +142,10 @@ class ChatHistoryService({
       // backfill will run. The page is already in memory, so detecting them is
       // free; only a page that actually contains one pays for a status read.
       if (!_containsOpenToolPart(page: decided)) {
-        return _messagesPage(
-          page: decided,
-          replayedPromptDefaults: replayedPromptDefaults,
-          awaitingHarnessSync: awaitingHarnessSync,
-        );
+        return _messagesPage(page: decided, replayedPromptDefaults: replayedPromptDefaults);
       }
       if (!await _sweepUnlessTurnRunning(sessionId: sessionId)) {
-        return _messagesPage(
-          page: decided,
-          replayedPromptDefaults: replayedPromptDefaults,
-          awaitingHarnessSync: awaitingHarnessSync,
-        );
+        return _messagesPage(page: decided, replayedPromptDefaults: replayedPromptDefaults);
       }
       final storageScope = await _requireStorageScope(sessionId: sessionId);
       final page = await _enqueueRead(
@@ -167,23 +158,7 @@ class ChatHistoryService({
           attachmentProjection: attachmentProjection,
         ),
       );
-      return _messagesPage(
-        page: page,
-        replayedPromptDefaults: replayedPromptDefaults,
-        awaitingHarnessSync: awaitingHarnessSync,
-      );
-    }
-
-    // The store holds no row for this session at all — the read above returns
-    // null only for that. A store-only read cannot backfill it, so it reports
-    // an empty transcript the harness still owes.
-    if (storedOnly) {
-      return (
-        messages: const <MessageWithParts>[],
-        nextCursor: null,
-        replayedPromptDefaults: null,
-        awaitingHarnessSync: true,
-      );
+      return _messagesPage(page: page, replayedPromptDefaults: replayedPromptDefaults);
     }
 
     final replayedPromptDefaults = await _backfillSessionForRead(sessionId: sessionId);
@@ -203,17 +178,71 @@ class ChatHistoryService({
         attachmentProjection: attachmentProjection,
       ),
     );
-    return _messagesPage(
-      page: page,
-      replayedPromptDefaults: replayedPromptDefaults,
-      awaitingHarnessSync: false,
+    return _messagesPage(page: page, replayedPromptDefaults: replayedPromptDefaults);
+  }
+
+  /// One page answered by the store alone: no backfill, no harness contact,
+  /// and — deliberately — no session queue.
+  ///
+  /// Staying out of the queue is the point. A store-only read exists for a
+  /// caller that cannot wake the harness, so queueing behind another read's
+  /// in-flight backfill would make it wait on exactly the thing it opted out
+  /// of, and a backfill that fails or stalls would take the stored transcript
+  /// down with it. The store's own backfill commits in one transaction, so an
+  /// unqueued read sees the state before it or after it, never a torn one, and
+  /// a marker flip that races the freshness check only mis-dates
+  /// `awaitingHarnessSync` for a single read — the next one corrects it.
+  ///
+  /// Dead open tool parts are not swept here for the same reason: the sweep is
+  /// a queued write, and repairing a tool tile left spinning by a bridge death
+  /// does not justify reintroducing that wait. The next ordinary read sweeps.
+  Future<SessionMessagesPage> _storedOnlyPage({
+    required String sessionId,
+    required int? limit,
+    required int? before,
+    required MessageAttachmentProjection attachmentProjection,
+  }) async {
+    final stored = await _sessionRepository.getStoredSession(sessionId: sessionId);
+    // The bridge holds no row for this session at all, and a store-only read
+    // has no backfill with which to create one.
+    if (stored == null) {
+      return (
+        messages: const <MessageWithParts>[],
+        nextCursor: null,
+        replayedPromptDefaults: null,
+        awaitingHarnessSync: true,
+      );
+    }
+    final storageScope = _storageScopeFor(session: stored);
+    if (stored.archivedAt != null) {
+      final archived = await _chatHistoryRepository.getArchivedSessionMessages(
+        sessionId: sessionId,
+        storageScope: storageScope,
+        limit: limit,
+        before: before,
+        attachmentProjection: attachmentProjection,
+      );
+      // An audit file is the whole transcript of a session the harness can no
+      // longer advance, so it owes nothing.
+      if (archived != null) return _messagesPage(page: archived, replayedPromptDefaults: null);
+    }
+
+    final state = await _chatHistoryRepository.getSyncState(sessionId: sessionId);
+    final synced = state != null && state.syncedAt != null && state.watermark >= state.backendActivityAt;
+    final page = await _chatHistoryRepository.getSessionMessages(
+      sessionId: sessionId,
+      storageScope: storageScope,
+      limit: limit,
+      before: before,
+      attachmentProjection: attachmentProjection,
     );
+    return _messagesPage(page: page, replayedPromptDefaults: null, awaitingHarnessSync: !synced);
   }
 
   SessionMessagesPage _messagesPage({
     required ChatHistoryPage page,
     required SessionPromptDefaults? replayedPromptDefaults,
-    required bool awaitingHarnessSync,
+    bool awaitingHarnessSync = false,
   }) => (
     messages: page.messages,
     nextCursor: page.nextCursor,

--- a/bridge/app/test/bridge/services/chat_history_no_harness_start_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_no_harness_start_test.dart
@@ -1,5 +1,6 @@
 import "package:sesori_bridge/src/repositories/session_unseen_calculator.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:sesori_shared/sesori_shared.dart" show Message, MessageTime;
 import "package:test/test.dart";
 
 import "../../helpers/test_chat_history.dart";
@@ -60,6 +61,57 @@ void main() {
       plugin.lastGetMessagesSessionId,
       isNull,
       reason: "a synced store must render history with the harness untouched",
+    );
+  });
+
+  // A store-only read makes that guarantee unconditional. Freshness is the
+  // bridge's own bookkeeping, so a client that cannot wake the harness at all —
+  // it is disabled, or needs authentication — must not have its transcript
+  // depend on it.
+  test("an unsynced session is served store-only without starting the plugin", () async {
+    final database = createTestDatabase();
+    addTearDown(database.close);
+    final plugin = FakeBridgePlugin();
+    addTearDown(plugin.close);
+
+    final sessionRepository = singlePluginSessionRepository(
+      plugin: plugin,
+      sessionDao: database.sessionDao,
+      projectsDao: database.projectsDao,
+      pullRequestDao: database.pullRequestDao,
+      unseenCalculator: const SessionUnseenCalculator(),
+    );
+    addTearDown(sessionRepository.dispose);
+    final history = createTestChatHistory(sessionRepository: sessionRepository);
+    await recordSessionBinding(
+      database: database,
+      sessionId: "ses_a",
+      backendSessionId: "backend-a",
+      pluginId: plugin.id,
+      projectId: "project-a",
+      parentSessionId: null,
+    );
+    // A live capture creates rows without ever marking the session synced, so
+    // an ordinary read here would backfill.
+    await history.service.captureMessage(
+      sessionId: "ses_a",
+      message: Message.user(
+        promptId: null,
+        id: "live",
+        sessionID: "ses_a",
+        agent: null,
+        time: const MessageTime(created: 1, completed: null),
+      ),
+    );
+
+    final page = await history.service.getSessionMessages(sessionId: "ses_a", storedOnly: true);
+
+    expect(page.messages.single.info.id, "live");
+    expect(page.awaitingHarnessSync, isTrue);
+    expect(
+      plugin.lastGetMessagesSessionId,
+      isNull,
+      reason: "a store-only read must serve an unsynced store without waking the harness",
     );
   });
 }

--- a/bridge/app/test/bridge/services/chat_history_no_harness_start_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_no_harness_start_test.dart
@@ -95,12 +95,12 @@ void main() {
     // an ordinary read here would backfill.
     await history.service.captureMessage(
       sessionId: "ses_a",
-      message: Message.user(
+      message: const Message.user(
         promptId: null,
         id: "live",
         sessionID: "ses_a",
         agent: null,
-        time: const MessageTime(created: 1, completed: null),
+        time: MessageTime(created: 1, completed: null),
       ),
     );
 

--- a/bridge/app/test/bridge/services/chat_history_pagination_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_pagination_test.dart
@@ -1,3 +1,4 @@
+import "package:sesori_bridge/src/repositories/chat_history_repository.dart";
 import "package:sesori_bridge/src/repositories/models/stored_session.dart";
 import "package:sesori_bridge/src/repositories/session_repository.dart";
 import "package:sesori_shared/sesori_shared.dart";
@@ -87,6 +88,30 @@ void main() {
       );
       expect(next.messages, isEmpty);
       expect(next.nextCursor, isNull);
+    });
+
+    test("the snapshot read pages identically to the plain read", () async {
+      // Store-only reads take the snapshot variant, so the two must not drift
+      // apart — particularly the part filtering, which depends on the page's
+      // own message ids.
+      final scope = testAttachmentStorageScope(sessionId: "ses_a");
+      for (final limit in [null, 1, 3]) {
+        final plain = await history.repository.getSessionMessages(
+          sessionId: "ses_a",
+          storageScope: scope,
+          limit: limit,
+        );
+        final snapshot = await history.repository.getSessionMessagesWithSyncState(
+          sessionId: "ses_a",
+          storageScope: scope,
+          limit: limit,
+          attachmentProjection: const InlineMessageAttachmentProjection(),
+        );
+
+        expect(snapshot.page.messages, plain.messages, reason: "limit $limit");
+        expect(snapshot.page.nextCursor, plain.nextCursor, reason: "limit $limit");
+        expect(snapshot.syncState, await history.repository.getSyncState(sessionId: "ses_a"));
+      }
     });
 
     test("an empty page never claims there is more", () async {

--- a/bridge/app/test/bridge/services/chat_history_serving_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_serving_test.dart
@@ -272,6 +272,54 @@ void main() {
       await expectLater(history.service.getSessionMessages(sessionId: "ses_a"), throwsStateError);
     });
   });
+
+  group("store-only reads", () {
+    test("a never-backfilled session serves its captured rows instead of fetching", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.captureMessage(
+        sessionId: "ses_a",
+        message: _message(id: "live"),
+      );
+
+      final page = await history.service.getSessionMessages(sessionId: "ses_a", storedOnly: true);
+
+      expect(page.messages.map((message) => message.info.id), const ["live"]);
+      expect(page.awaitingHarnessSync, isTrue);
+      expect(repository.fetchCount, 0, reason: "a store-only read must never reach the harness");
+    });
+
+    test("a stale store still answers, flagged, while a normal read would re-fetch", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")]);
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.getSessionMessages(sessionId: "ses_a");
+
+      final synced = await history.service.getSessionMessages(sessionId: "ses_a", storedOnly: true);
+      expect(synced.messages.map((message) => message.info.id), const ["m1"]);
+      expect(synced.awaitingHarnessSync, isFalse, reason: "a current store owes the harness nothing");
+
+      final state = (await history.repository.getSyncState(sessionId: "ses_a"))!;
+      await history.service.observeBackendActivity(sessionId: "ses_a", activityAt: state.watermark + 5000);
+      repository.transcript = [_messageWithParts(id: "m1"), _messageWithParts(id: "m2")];
+
+      final stale = await history.service.getSessionMessages(sessionId: "ses_a", storedOnly: true);
+
+      expect(stale.messages.map((message) => message.info.id), const ["m1"]);
+      expect(stale.awaitingHarnessSync, isTrue, reason: "the store is behind, and the caller must be told");
+      expect(repository.fetchCount, 1, reason: "staleness must not trigger a backfill for a store-only read");
+    });
+
+    test("an unknown session reads as an empty transcript the harness still owes", () async {
+      final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")])..sessionKnown = false;
+      final history = createTestChatHistory(sessionRepository: repository);
+
+      final page = await history.service.getSessionMessages(sessionId: "ses_a", storedOnly: true);
+
+      expect(page.messages, isEmpty);
+      expect(page.awaitingHarnessSync, isTrue);
+      expect(repository.fetchCount, 0);
+    });
+  });
 }
 
 Message _message({required String id}) => Message.user(
@@ -305,6 +353,9 @@ class _FakeSessionRepository({required var List<MessageWithParts> transcript, fi
   void Function()? onFetch;
   Future<void>? fetchGate;
 
+  /// Whether the bridge holds a binding row for the session at all.
+  bool sessionKnown = true;
+
   @override
   Future<SessionMessagesSnapshot> getSessionMessages({required String sessionId}) async {
     fetchCount++;
@@ -332,20 +383,22 @@ class _FakeSessionRepository({required var List<MessageWithParts> transcript, fi
   Future<SessionStatus?> getSessionStatus({required String sessionId}) async => const SessionStatus.idle();
 
   @override
-  Future<StoredSession?> getStoredSession({required String sessionId}) async => StoredSession(
-    id: sessionId,
-    backendSessionId: sessionId,
-    pluginId: "opencode",
-    projectId: "project-1",
-    parentSessionId: null,
-    directory: "/tmp/project-1",
-    worktreePath: null,
-    branchName: null,
-    isDedicated: false,
-    archivedAt: null,
-    baseBranch: null,
-    baseCommit: null,
-  );
+  Future<StoredSession?> getStoredSession({required String sessionId}) async => !sessionKnown
+      ? null
+      : StoredSession(
+          id: sessionId,
+          backendSessionId: sessionId,
+          pluginId: "opencode",
+          projectId: "project-1",
+          parentSessionId: null,
+          directory: "/tmp/project-1",
+          worktreePath: null,
+          branchName: null,
+          isDedicated: false,
+          archivedAt: null,
+          baseBranch: null,
+          baseCommit: null,
+        );
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/bridge/app/test/bridge/services/chat_history_serving_test.dart
+++ b/bridge/app/test/bridge/services/chat_history_serving_test.dart
@@ -309,6 +309,32 @@ void main() {
       expect(repository.fetchCount, 1, reason: "staleness must not trigger a backfill for a store-only read");
     });
 
+    test("another reader's stalled, failing backfill neither delays nor fails it", () async {
+      final fetchGate = Completer<void>();
+      final repository = _FakeSessionRepository(transcript: const [], error: StateError("backend down"))
+        ..fetchGate = fetchGate.future;
+      final history = createTestChatHistory(sessionRepository: repository);
+      await history.service.captureMessage(
+        sessionId: "ses_a",
+        message: _message(id: "live"),
+      );
+
+      // An ordinary read is mid-backfill and will fail once its fetch returns.
+      final ordinary = history.service.getSessionMessages(sessionId: "ses_a");
+      while (repository.fetchCount == 0) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      // Completes while that fetch is still outstanding, so it cannot be
+      // waiting on the session queue the backfill holds.
+      final page = await history.service.getSessionMessages(sessionId: "ses_a", storedOnly: true);
+      expect(page.messages.map((message) => message.info.id), const ["live"]);
+      expect(page.awaitingHarnessSync, isTrue);
+
+      fetchGate.complete();
+      await expectLater(ordinary, throwsStateError, reason: "the ordinary read still reports its own failure");
+    });
+
     test("an unknown session reads as an empty transcript the harness still owes", () async {
       final repository = _FakeSessionRepository(transcript: [_messageWithParts(id: "m1")])..sessionKnown = false;
       final history = createTestChatHistory(sessionRepository: repository);

--- a/bridge/app/test/helpers/test_chat_history.dart
+++ b/bridge/app/test/helpers/test_chat_history.dart
@@ -104,11 +104,13 @@ class TestChatHistoryService({
     int? limit,
     int? before,
     MessageAttachmentDelivery attachmentDelivery = MessageAttachmentDelivery.inline,
+    bool storedOnly = false,
   }) => super.getSessionMessages(
     sessionId: sessionId,
     limit: limit,
     before: before,
     attachmentDelivery: attachmentDelivery,
+    storedOnly: storedOnly,
   );
 
   @override

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -19,7 +19,9 @@ reconnect or restart.
   still receives whatever transcript exists. A session for which the bridge
   holds no row reads as an empty transcript that the harness still owes. It
   also stays off the session write queue, so another reader's slow or failing
-  backfill can neither delay it nor fail it. Every other read keeps the
+  backfill can neither delay it nor fail it; its rows and its sync marker come
+  from one database snapshot instead, so a concurrent backfill or purge lands
+  wholly before or wholly after the page. Every other read keeps the
   backfilling behavior, and an older app or bridge on either side of the
   contract keeps it too.
 - Session detail resolves canonical catalog metadata before any plugin-backed
@@ -217,9 +219,10 @@ rules where supported.
   transcript or tells the user that availability itself could not be checked. A
   blocked state other than authentication-required offers harness-status Recheck.
 - A store-only read reaches the harness, waits on or fails with another reader's
-  backfill, fails instead of serving what the store holds, or misreports
-  freshness in either direction — a current store flagged as awaiting sync, or a
-  stale one served as complete.
+  backfill, fails instead of serving what the store holds, returns parts that
+  belong to a different transcript than its messages, or misreports freshness in
+  either direction — a current store flagged as awaiting sync, or a stale one
+  served as complete.
 - DeepSeek replay duplicates a generic delegation card and child tile, attributes
   a nested tile to the root instead of its direct parent, changes live child
   activity, loses latest terminal metadata across pages, or collapses/reorders

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -13,6 +13,13 @@ reconnect or restart.
   never starts a stopped backend. Only a first backfill or a re-read after the
   backend advanced may reach it; backfill is lazy and per session, and a session
   advanced outside Sesori is detected as stale, re-read, and re-cached.
+- A store-only read (`storedOnly` on `POST /session/messages`) never backfills.
+  It serves the store even when that store is behind the harness and reports
+  that through `awaitingHarnessSync`, so a caller that cannot wake the harness
+  still receives whatever transcript exists. A session the bridge holds no row
+  for reads as an empty transcript the harness still owes. Every other read
+  keeps the backfilling behavior, and an older app or bridge on either side of
+  the contract keeps it too.
 - Session detail resolves canonical catalog metadata before any plugin-backed
   history request. If management then blocks the exact harness, a cold open shows
   metadata and an honest history-unavailable state without issuing the read or
@@ -176,7 +183,7 @@ reconnect or restart.
 
 | Level | Additional coverage |
 |---|---|
-| L1 Smoke | Headless bridge, one representative plugin: a previously synced session's transcript is served with every backend stopped. Automated client: a cold management block resolves canonical metadata, issues no history request, does not declare unseen content viewed, and renders the explicit unavailable-history state. |
+| L1 Smoke | Headless bridge, one representative plugin: a previously synced session's transcript is served with every backend stopped, and an unsynced session's store-only read serves its stored rows flagged as awaiting harness sync without starting one. Automated client: a cold management block resolves canonical metadata, issues no history request, does not declare unseen content viewed, and renders the explicit unavailable-history state. |
 | L2 Routine | Automated client: a live block preserves messages; a block or metadata failure during reload restores the transcript and replays buffered events; content restoration failure stays read-only with guidance to reopen the chat. Live plugin, representative: first backfill, replayed prompt-default persistence and response precedence, live capture that becomes immediately queryable, semantic identity reconciliation with ordered-context and multiplicity preservation (including normalized attachments), stale re-read ordering for retained live-only rows, and paging older messages on a transcript longer than one page. Automated OpenCode, Codex, Claude, and Pi coverage preserves available historical effort or thinking-level variants from assistant/error messages; Codex also trims only verified sub-agent copied prefixes while preserving root and ordinary-fork history, and replays rollback markers to remove reverted turn content and subtasks while retaining prior and subsequently appended turns, including cumulative rollbacks and fork-prefix boundaries; Claude also covers one stable live/replay identity for a CLI-authored API failure and suppression of its duplicate terminal result, while Pi covers active-branch attribution and file fallback. Automated Pi coverage also includes v1-v3 fallback migration, compaction visibility, hidden-context decoding, bounded tool/image mapping, content-index streaming, early tool-call metadata with the pre-0.84.3 fallback, duplicate terminal suppression, cumulative tool updates, and live/replay final parity. Automated DeepSeek coverage checks direct-parent live/replay tile identity, multiple ordered storage-safe content runs, latest metadata across pages, unbound startup errors, and live-state isolation. |
 | L3 Release | Client end to end on the release-target client platform: compare cold blocked history, a live block after history renders, and restored eligibility without route reopening. Every supporting production plugin: open a long session, page back, continue a live turn, reopen cold, and confirm live and replayed content converge including tool parts and image parts where declared. Grok additionally retains its exact loaded model/effort attribution across first load, cold reopen, plugin restart, and bridge restart. |
 | L4 Extended | Client end to end on macOS desktop and iOS, plus an Android variation: change availability from a second client while history is visible and while reload is in flight, attempt an older-page load while blocked, and confirm no history request proceeds until recovery; reconnect inside/outside replay and switch bridge identity without losing retained or buffered content. Relay integration plus owning client automated coverage, every supporting production plugin: session advanced through the backend's own CLI, plugin restart and event-stream-gap invalidation, bridge restart, client reconnect inside and outside the replay window without refresh losing concurrently finalized content, two clients on one session, a slow request beside unrelated traffic. Copilot and Grok additionally replace their ACP process, reload the same session, and converge standard replay with the bridge transcript without duplicate live delivery. |
@@ -207,6 +214,9 @@ rules where supported.
   successful content/options refresh. A failed restoration erases the retained
   transcript or tells the user that availability itself could not be checked. A
   blocked state other than authentication-required offers harness-status Recheck.
+- A store-only read reaches the harness, fails instead of serving what the store
+  holds, or misreports freshness in either direction — a current store flagged as
+  awaiting sync, or a stale one served as complete.
 - DeepSeek replay duplicates a generic delegation card and child tile, attributes
   a nested tile to the root instead of its direct parent, changes live child
   activity, loses latest terminal metadata across pages, or collapses/reorders
@@ -271,9 +281,10 @@ rules where supported.
 ## Known Limitations
 
 - A first-ever open or a stale re-read still needs the backend; if it is
-  unavailable and cannot auto-start, that read fails. The client therefore pauses
-  pagination while management blocks the harness; it cannot request a guaranteed
-  store-only page through the current history contract.
+  unavailable and cannot auto-start, that read fails. A store-only read avoids
+  that at the cost of a possibly incomplete transcript, but no client asks for
+  one yet, so the app still pauses pagination while management blocks the
+  harness.
 - An independently owned backend can outlive a bridge restart holding state an
   inactive runtime slot cannot see, so bridge inactivity and backend
   unavailability are not fully distinguished. Agent, provider, and command

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -16,10 +16,12 @@ reconnect or restart.
 - A store-only read (`storedOnly` on `POST /session/messages`) never backfills.
   It serves the store even when that store is behind the harness and reports
   that through `awaitingHarnessSync`, so a caller that cannot wake the harness
-  still receives whatever transcript exists. A session the bridge holds no row
-  for reads as an empty transcript the harness still owes. Every other read
-  keeps the backfilling behavior, and an older app or bridge on either side of
-  the contract keeps it too.
+  still receives whatever transcript exists. A session for which the bridge
+  holds no row reads as an empty transcript that the harness still owes. It
+  also stays off the session write queue, so another reader's slow or failing
+  backfill can neither delay it nor fail it. Every other read keeps the
+  backfilling behavior, and an older app or bridge on either side of the
+  contract keeps it too.
 - Session detail resolves canonical catalog metadata before any plugin-backed
   history request. If management then blocks the exact harness, a cold open shows
   metadata and an honest history-unavailable state without issuing the read or
@@ -214,9 +216,10 @@ rules where supported.
   successful content/options refresh. A failed restoration erases the retained
   transcript or tells the user that availability itself could not be checked. A
   blocked state other than authentication-required offers harness-status Recheck.
-- A store-only read reaches the harness, fails instead of serving what the store
-  holds, or misreports freshness in either direction — a current store flagged as
-  awaiting sync, or a stale one served as complete.
+- A store-only read reaches the harness, waits on or fails with another reader's
+  backfill, fails instead of serving what the store holds, or misreports
+  freshness in either direction — a current store flagged as awaiting sync, or a
+  stale one served as complete.
 - DeepSeek replay duplicates a generic delegation card and child tile, attributes
   a nested tile to the root instead of its direct parent, changes live child
   activity, loses latest terminal metadata across pages, or collapses/reorders
@@ -284,7 +287,9 @@ rules where supported.
   unavailable and cannot auto-start, that read fails. A store-only read avoids
   that at the cost of a possibly incomplete transcript, but no client asks for
   one yet, so the app still pauses pagination while management blocks the
-  harness.
+  harness. A store-only read also skips the open-tool-part sweep, because that
+  sweep is a queued write; a tool tile left spinning by an abrupt bridge death
+  stays that way until the next ordinary read.
 - An independently owned backend can outlive a bridge restart holding state an
   inactive runtime slot cannot see, so bridge inactivity and backend
   unavailability are not fully distinguished. Agent, provider, and command

--- a/shared/sesori_shared/lib/src/models/sesori/message_with_parts.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_with_parts.dart
@@ -21,6 +21,13 @@ sealed class MessageWithPartsResponse with _$MessageWithPartsResponse {
 
     // COMPATIBILITY 2026-08-27 (v1.8.2): Older bridges omit replayedPromptDefaults, which decodes to null and means no replay-derived selection is available. Remove this comment when bridges without this field are unsupported.
     required SessionPromptDefaults? replayedPromptDefaults,
+
+    /// Whether the store this page came from is behind the harness, so the
+    /// transcript may be missing its newest messages. Only a `storedOnly`
+    /// request can see this true: every other read backfills from the harness
+    /// before serving.
+    // COMPATIBILITY 2026-09-09 (v1.8.4): Bridges that predate the store-only read omit awaitingHarnessSync; false is honest for them, because they always backfill before serving. Make this required once those bridges are unsupported.
+    @Default(false) bool awaitingHarnessSync,
   }) = _MessageWithPartsResponse;
 
   factory fromJson(Map<String, dynamic> json) => _$MessageWithPartsResponseFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/message_with_parts.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_with_parts.freezed.dart
@@ -18,7 +18,11 @@ mixin _$MessageWithPartsResponse {
 
  List<MessageWithParts> get messages;/// Cursor for the next older page, to be sent back verbatim as the
 /// request's `before`. Null means the transcript is complete.
- int? get nextCursor; SessionPromptDefaults? get replayedPromptDefaults;
+ int? get nextCursor; SessionPromptDefaults? get replayedPromptDefaults;/// Whether the store this page came from is behind the harness, so the
+/// transcript may be missing its newest messages. Only a `storedOnly`
+/// request can see this true: every other read backfills from the harness
+/// before serving.
+ bool get awaitingHarnessSync;
 /// Create a copy of MessageWithPartsResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -31,16 +35,16 @@ $MessageWithPartsResponseCopyWith<MessageWithPartsResponse> get copyWith => _$Me
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageWithPartsResponse&&const DeepCollectionEquality().equals(other.messages, messages)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.replayedPromptDefaults, replayedPromptDefaults) || other.replayedPromptDefaults == replayedPromptDefaults));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MessageWithPartsResponse&&const DeepCollectionEquality().equals(other.messages, messages)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.replayedPromptDefaults, replayedPromptDefaults) || other.replayedPromptDefaults == replayedPromptDefaults)&&(identical(other.awaitingHarnessSync, awaitingHarnessSync) || other.awaitingHarnessSync == awaitingHarnessSync));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(messages),nextCursor,replayedPromptDefaults);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(messages),nextCursor,replayedPromptDefaults,awaitingHarnessSync);
 
 @override
 String toString() {
-  return 'MessageWithPartsResponse(messages: $messages, nextCursor: $nextCursor, replayedPromptDefaults: $replayedPromptDefaults)';
+  return 'MessageWithPartsResponse(messages: $messages, nextCursor: $nextCursor, replayedPromptDefaults: $replayedPromptDefaults, awaitingHarnessSync: $awaitingHarnessSync)';
 }
 
 
@@ -51,7 +55,7 @@ abstract mixin class $MessageWithPartsResponseCopyWith<$Res>  {
   factory $MessageWithPartsResponseCopyWith(MessageWithPartsResponse value, $Res Function(MessageWithPartsResponse) _then) = _$MessageWithPartsResponseCopyWithImpl;
 @useResult
 $Res call({
- List<MessageWithParts> messages, int? nextCursor, SessionPromptDefaults? replayedPromptDefaults
+ List<MessageWithParts> messages, int? nextCursor, SessionPromptDefaults? replayedPromptDefaults, bool awaitingHarnessSync
 });
 
 
@@ -68,12 +72,13 @@ class _$MessageWithPartsResponseCopyWithImpl<$Res>
 
 /// Create a copy of MessageWithPartsResponse
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? messages = null,Object? nextCursor = freezed,Object? replayedPromptDefaults = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? messages = null,Object? nextCursor = freezed,Object? replayedPromptDefaults = freezed,Object? awaitingHarnessSync = null,}) {
   return _then(MessageWithPartsResponse(
 messages: null == messages ? _self.messages : messages // ignore: cast_nullable_to_non_nullable
 as List<MessageWithParts>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
 as int?,replayedPromptDefaults: freezed == replayedPromptDefaults ? _self.replayedPromptDefaults : replayedPromptDefaults // ignore: cast_nullable_to_non_nullable
-as SessionPromptDefaults?,
+as SessionPromptDefaults?,awaitingHarnessSync: null == awaitingHarnessSync ? _self.awaitingHarnessSync : awaitingHarnessSync // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 /// Create a copy of MessageWithPartsResponse
@@ -97,7 +102,7 @@ $SessionPromptDefaultsCopyWith<$Res>? get replayedPromptDefaults {
 @JsonSerializable()
 
 class _MessageWithPartsResponse implements MessageWithPartsResponse {
-  const _MessageWithPartsResponse({required  List<MessageWithParts> messages, required this.nextCursor, required this.replayedPromptDefaults}): _messages = messages;
+  const _MessageWithPartsResponse({required  List<MessageWithParts> messages, required this.nextCursor, required this.replayedPromptDefaults, this.awaitingHarnessSync = false}): _messages = messages;
   factory _MessageWithPartsResponse.fromJson(Map<String, dynamic> json) => _$MessageWithPartsResponseFromJson(json);
 
  final  List<MessageWithParts> _messages;
@@ -111,6 +116,11 @@ class _MessageWithPartsResponse implements MessageWithPartsResponse {
 /// request's `before`. Null means the transcript is complete.
 @override final  int? nextCursor;
 @override final  SessionPromptDefaults? replayedPromptDefaults;
+/// Whether the store this page came from is behind the harness, so the
+/// transcript may be missing its newest messages. Only a `storedOnly`
+/// request can see this true: every other read backfills from the harness
+/// before serving.
+@override@JsonKey() final  bool awaitingHarnessSync;
 
 /// Create a copy of MessageWithPartsResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -125,16 +135,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessageWithPartsResponse&&const DeepCollectionEquality().equals(other._messages, _messages)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.replayedPromptDefaults, replayedPromptDefaults) || other.replayedPromptDefaults == replayedPromptDefaults));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MessageWithPartsResponse&&const DeepCollectionEquality().equals(other._messages, _messages)&&(identical(other.nextCursor, nextCursor) || other.nextCursor == nextCursor)&&(identical(other.replayedPromptDefaults, replayedPromptDefaults) || other.replayedPromptDefaults == replayedPromptDefaults)&&(identical(other.awaitingHarnessSync, awaitingHarnessSync) || other.awaitingHarnessSync == awaitingHarnessSync));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_messages),nextCursor,replayedPromptDefaults);
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_messages),nextCursor,replayedPromptDefaults,awaitingHarnessSync);
 
 @override
 String toString() {
-  return 'MessageWithPartsResponse(messages: $messages, nextCursor: $nextCursor, replayedPromptDefaults: $replayedPromptDefaults)';
+  return 'MessageWithPartsResponse(messages: $messages, nextCursor: $nextCursor, replayedPromptDefaults: $replayedPromptDefaults, awaitingHarnessSync: $awaitingHarnessSync)';
 }
 
 
@@ -145,7 +155,7 @@ abstract mixin class _$MessageWithPartsResponseCopyWith<$Res> implements $Messag
   factory _$MessageWithPartsResponseCopyWith(_MessageWithPartsResponse value, $Res Function(_MessageWithPartsResponse) _then) = __$MessageWithPartsResponseCopyWithImpl;
 @override @useResult
 $Res call({
- List<MessageWithParts> messages, int? nextCursor, SessionPromptDefaults? replayedPromptDefaults
+ List<MessageWithParts> messages, int? nextCursor, SessionPromptDefaults? replayedPromptDefaults, bool awaitingHarnessSync
 });
 
 
@@ -162,12 +172,13 @@ class __$MessageWithPartsResponseCopyWithImpl<$Res>
 
 /// Create a copy of MessageWithPartsResponse
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? messages = null,Object? nextCursor = freezed,Object? replayedPromptDefaults = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? messages = null,Object? nextCursor = freezed,Object? replayedPromptDefaults = freezed,Object? awaitingHarnessSync = null,}) {
   return _then(_MessageWithPartsResponse(
 messages: null == messages ? _self._messages : messages // ignore: cast_nullable_to_non_nullable
 as List<MessageWithParts>,nextCursor: freezed == nextCursor ? _self.nextCursor : nextCursor // ignore: cast_nullable_to_non_nullable
 as int?,replayedPromptDefaults: freezed == replayedPromptDefaults ? _self.replayedPromptDefaults : replayedPromptDefaults // ignore: cast_nullable_to_non_nullable
-as SessionPromptDefaults?,
+as SessionPromptDefaults?,awaitingHarnessSync: null == awaitingHarnessSync ? _self.awaitingHarnessSync : awaitingHarnessSync // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/message_with_parts.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/message_with_parts.g.dart
@@ -20,6 +20,7 @@ _MessageWithPartsResponse _$MessageWithPartsResponseFromJson(Map json) =>
           : SessionPromptDefaults.fromJson(
               Map<String, dynamic>.from(json['replayedPromptDefaults'] as Map),
             ),
+      awaitingHarnessSync: json['awaitingHarnessSync'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$MessageWithPartsResponseToJson(
@@ -28,6 +29,7 @@ Map<String, dynamic> _$MessageWithPartsResponseToJson(
   'messages': instance.messages.map((e) => e.toJson()).toList(),
   'nextCursor': ?instance.nextCursor,
   'replayedPromptDefaults': ?instance.replayedPromptDefaults?.toJson(),
+  'awaitingHarnessSync': instance.awaitingHarnessSync,
 };
 
 _MessageWithParts _$MessageWithPartsFromJson(Map json) => _MessageWithParts(

--- a/shared/sesori_shared/lib/src/models/sesori/session.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.dart
@@ -131,8 +131,9 @@ sealed class SessionIdRequest with _$SessionIdRequest {
 
 /// Request body for `POST /session/messages`.
 ///
-/// A superset of [SessionIdRequest]: both new fields are optional, so an older
-/// app's body still decodes and an older bridge ignores what it does not know.
+/// A superset of [SessionIdRequest]: every field beyond the session id is
+/// optional, so an older app's body still decodes and an older bridge ignores
+/// what it does not know.
 /// Omitting [limit] returns the whole transcript, which is the pre-pagination
 /// behavior.
 @Freezed(fromJson: true, toJson: true)
@@ -151,6 +152,16 @@ sealed class SessionMessagesRequest with _$SessionMessagesRequest {
 
     // COMPATIBILITY 2026-08-10 (v1.8.0): Apps predating stored transcript images omit attachmentDelivery and require inline payloads. Remove @Default after the minimum supported app sends this field.
     @Default(MessageAttachmentDelivery.inline) MessageAttachmentDelivery attachmentDelivery,
+
+    /// Serve the transcript from the bridge's store alone, never fetching it
+    /// from the harness. The reply reports whether the store was behind the
+    /// harness through `awaitingHarnessSync`.
+    ///
+    /// This is what a client asks for when it cannot afford to wake the
+    /// harness — because it is disabled, needs authentication, or is simply
+    /// slow right after a start.
+    // COMPATIBILITY 2026-09-09 (v1.8.4): Apps that predate the store-only read omit storedOnly and expect the harness-backed backfill. Make this required once those apps are unsupported.
+    @Default(false) bool storedOnly,
   }) = _SessionMessagesRequest;
 
   factory fromJson(Map<String, dynamic> json) => _$SessionMessagesRequestFromJson(json);

--- a/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.freezed.dart
@@ -1329,7 +1329,14 @@ mixin _$SessionMessagesRequest {
 /// full transcript.
  int? get limit;/// Exclusive cursor: return messages ordered strictly before this one.
 /// Null starts from the newest message.
- int? get before; MessageAttachmentDelivery get attachmentDelivery;
+ int? get before; MessageAttachmentDelivery get attachmentDelivery;/// Serve the transcript from the bridge's store alone, never fetching it
+/// from the harness. The reply reports whether the store was behind the
+/// harness through `awaitingHarnessSync`.
+///
+/// This is what a client asks for when it cannot afford to wake the
+/// harness — because it is disabled, needs authentication, or is simply
+/// slow right after a start.
+ bool get storedOnly;
 /// Create a copy of SessionMessagesRequest
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -1342,16 +1349,16 @@ $SessionMessagesRequestCopyWith<SessionMessagesRequest> get copyWith => _$Sessio
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionMessagesRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.before, before) || other.before == before)&&(identical(other.attachmentDelivery, attachmentDelivery) || other.attachmentDelivery == attachmentDelivery));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SessionMessagesRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.before, before) || other.before == before)&&(identical(other.attachmentDelivery, attachmentDelivery) || other.attachmentDelivery == attachmentDelivery)&&(identical(other.storedOnly, storedOnly) || other.storedOnly == storedOnly));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,sessionId,limit,before,attachmentDelivery);
+int get hashCode => Object.hash(runtimeType,sessionId,limit,before,attachmentDelivery,storedOnly);
 
 @override
 String toString() {
-  return 'SessionMessagesRequest(sessionId: $sessionId, limit: $limit, before: $before, attachmentDelivery: $attachmentDelivery)';
+  return 'SessionMessagesRequest(sessionId: $sessionId, limit: $limit, before: $before, attachmentDelivery: $attachmentDelivery, storedOnly: $storedOnly)';
 }
 
 
@@ -1362,7 +1369,7 @@ abstract mixin class $SessionMessagesRequestCopyWith<$Res>  {
   factory $SessionMessagesRequestCopyWith(SessionMessagesRequest value, $Res Function(SessionMessagesRequest) _then) = _$SessionMessagesRequestCopyWithImpl;
 @useResult
 $Res call({
- String sessionId, int? limit, int? before, MessageAttachmentDelivery attachmentDelivery
+ String sessionId, int? limit, int? before, MessageAttachmentDelivery attachmentDelivery, bool storedOnly
 });
 
 
@@ -1379,13 +1386,14 @@ class _$SessionMessagesRequestCopyWithImpl<$Res>
 
 /// Create a copy of SessionMessagesRequest
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? limit = freezed,Object? before = freezed,Object? attachmentDelivery = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionId = null,Object? limit = freezed,Object? before = freezed,Object? attachmentDelivery = null,Object? storedOnly = null,}) {
   return _then(SessionMessagesRequest(
 sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
 as String,limit: freezed == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
 as int?,before: freezed == before ? _self.before : before // ignore: cast_nullable_to_non_nullable
 as int?,attachmentDelivery: null == attachmentDelivery ? _self.attachmentDelivery : attachmentDelivery // ignore: cast_nullable_to_non_nullable
-as MessageAttachmentDelivery,
+as MessageAttachmentDelivery,storedOnly: null == storedOnly ? _self.storedOnly : storedOnly // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -1397,7 +1405,7 @@ as MessageAttachmentDelivery,
 @JsonSerializable()
 
 class _SessionMessagesRequest implements SessionMessagesRequest {
-  const _SessionMessagesRequest({required this.sessionId, required this.limit, required this.before, this.attachmentDelivery = MessageAttachmentDelivery.inline});
+  const _SessionMessagesRequest({required this.sessionId, required this.limit, required this.before, this.attachmentDelivery = MessageAttachmentDelivery.inline, this.storedOnly = false});
   factory _SessionMessagesRequest.fromJson(Map<String, dynamic> json) => _$SessionMessagesRequestFromJson(json);
 
 @override final  String sessionId;
@@ -1408,6 +1416,14 @@ class _SessionMessagesRequest implements SessionMessagesRequest {
 /// Null starts from the newest message.
 @override final  int? before;
 @override@JsonKey() final  MessageAttachmentDelivery attachmentDelivery;
+/// Serve the transcript from the bridge's store alone, never fetching it
+/// from the harness. The reply reports whether the store was behind the
+/// harness through `awaitingHarnessSync`.
+///
+/// This is what a client asks for when it cannot afford to wake the
+/// harness — because it is disabled, needs authentication, or is simply
+/// slow right after a start.
+@override@JsonKey() final  bool storedOnly;
 
 /// Create a copy of SessionMessagesRequest
 /// with the given fields replaced by the non-null parameter values.
@@ -1422,16 +1438,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionMessagesRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.before, before) || other.before == before)&&(identical(other.attachmentDelivery, attachmentDelivery) || other.attachmentDelivery == attachmentDelivery));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SessionMessagesRequest&&(identical(other.sessionId, sessionId) || other.sessionId == sessionId)&&(identical(other.limit, limit) || other.limit == limit)&&(identical(other.before, before) || other.before == before)&&(identical(other.attachmentDelivery, attachmentDelivery) || other.attachmentDelivery == attachmentDelivery)&&(identical(other.storedOnly, storedOnly) || other.storedOnly == storedOnly));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,sessionId,limit,before,attachmentDelivery);
+int get hashCode => Object.hash(runtimeType,sessionId,limit,before,attachmentDelivery,storedOnly);
 
 @override
 String toString() {
-  return 'SessionMessagesRequest(sessionId: $sessionId, limit: $limit, before: $before, attachmentDelivery: $attachmentDelivery)';
+  return 'SessionMessagesRequest(sessionId: $sessionId, limit: $limit, before: $before, attachmentDelivery: $attachmentDelivery, storedOnly: $storedOnly)';
 }
 
 
@@ -1442,7 +1458,7 @@ abstract mixin class _$SessionMessagesRequestCopyWith<$Res> implements $SessionM
   factory _$SessionMessagesRequestCopyWith(_SessionMessagesRequest value, $Res Function(_SessionMessagesRequest) _then) = __$SessionMessagesRequestCopyWithImpl;
 @override @useResult
 $Res call({
- String sessionId, int? limit, int? before, MessageAttachmentDelivery attachmentDelivery
+ String sessionId, int? limit, int? before, MessageAttachmentDelivery attachmentDelivery, bool storedOnly
 });
 
 
@@ -1459,13 +1475,14 @@ class __$SessionMessagesRequestCopyWithImpl<$Res>
 
 /// Create a copy of SessionMessagesRequest
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? limit = freezed,Object? before = freezed,Object? attachmentDelivery = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionId = null,Object? limit = freezed,Object? before = freezed,Object? attachmentDelivery = null,Object? storedOnly = null,}) {
   return _then(_SessionMessagesRequest(
 sessionId: null == sessionId ? _self.sessionId : sessionId // ignore: cast_nullable_to_non_nullable
 as String,limit: freezed == limit ? _self.limit : limit // ignore: cast_nullable_to_non_nullable
 as int?,before: freezed == before ? _self.before : before // ignore: cast_nullable_to_non_nullable
 as int?,attachmentDelivery: null == attachmentDelivery ? _self.attachmentDelivery : attachmentDelivery // ignore: cast_nullable_to_non_nullable
-as MessageAttachmentDelivery,
+as MessageAttachmentDelivery,storedOnly: null == storedOnly ? _self.storedOnly : storedOnly // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/shared/sesori_shared/lib/src/models/sesori/session.g.dart
+++ b/shared/sesori_shared/lib/src/models/sesori/session.g.dart
@@ -173,6 +173,7 @@ _SessionMessagesRequest _$SessionMessagesRequestFromJson(Map json) =>
             json['attachmentDelivery'],
           ) ??
           MessageAttachmentDelivery.inline,
+      storedOnly: json['storedOnly'] as bool? ?? false,
     );
 
 Map<String, dynamic> _$SessionMessagesRequestToJson(
@@ -183,6 +184,7 @@ Map<String, dynamic> _$SessionMessagesRequestToJson(
   'before': ?instance.before,
   'attachmentDelivery':
       _$MessageAttachmentDeliveryEnumMap[instance.attachmentDelivery]!,
+  'storedOnly': instance.storedOnly,
 };
 
 const _$MessageAttachmentDeliveryEnumMap = {


### PR DESCRIPTION
## Complexity

🌿 Straightforward. One new request flag threaded through an existing read
path, one new response field, and a branch at the freshness gate that already
exists.

## What

`POST /session/messages` accepts `storedOnly`. When set, `ChatHistoryService`
serves the bridge store alone:

- The freshness gate no longer falls through to the plugin-backed backfill. An
  unsynced or stale store answers anyway.
- The reply carries `awaitingHarnessSync`, true exactly when the store served
  while behind the harness, so the caller knows the transcript may be missing
  its newest messages.
- A session the bridge holds no row for reads as an empty transcript with
  `awaitingHarnessSync: true`, rather than failing on a backfill it may not
  make.

Everything else on that path is unchanged: the archived-audit short-circuit,
the open-tool-part sweep (which uses `useIfActive` and never starts a plugin),
and pagination all behave as before.

Both new fields are additive with honest defaults — `storedOnly: false`,
`awaitingHarnessSync: false` — so an older app against a newer bridge and a
newer app against an older bridge both keep today's backfilling behavior.

## Why

Reading history is the one thing the bridge should be able to do entirely on
its own, and today it cannot promise that. A client whose harness is disabled
or needs authentication has no way to ask for the transcript the bridge is
already holding: every route into `getSessionMessages` may decide it needs a
backfill and reach for the plugin, which then returns 503 or stalls behind a
start attempt.

That gap is what forced #1405 to enumerate harness-capturing paths on the
client one at a time across four review rounds. This gives the client one
honest contract to ask for instead.

## Risk and test focus

No user-visible change and no database impact: no caller sets `storedOnly`
yet, so every existing read takes the same branches it did before.

The risk worth checking is the freshness gate itself — that `storedOnly` does
not leak into ordinary reads and let a stale store be served as current. The
existing serving suite covers the unchanged path (first backfill, stale
re-read, capture races, replayed prompt defaults); the new tests cover the
flagged path.

## Expected result

- A store-only read of a never-backfilled session returns its captured rows
  with `awaitingHarnessSync: true` and never touches the plugin.
- A store-only read of a synced session returns the same page an ordinary read
  would, with `awaitingHarnessSync: false`.
- A store-only read after observed backend activity still returns the stored
  rows, flagged, without a re-fetch.
- Ordinary reads are byte-for-byte what they were.

## Verification

- `dart test test/bridge/services test/bridge/routing` in `bridge/app` — 863 passing.
- `dart analyze` clean (errors and warnings) in `bridge/app`, `shared/sesori_shared`, `client/module_core`.
- `dart test` in `shared/sesori_shared` — 398 passing.
- New coverage: three cases in `chat_history_serving_test.dart` and one in
  `chat_history_no_harness_start_test.dart`, the latter asserted against the
  real `SessionRepository` and plugin runtime so a start would actually be
  observable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, callers had no way to read stored history without allowing a harness backfill. `POST /session/messages` now accepts `storedOnly` and reports `awaitingHarnessSync` when the returned transcript may be behind the harness; ordinary reads keep their existing behavior.

- Store-only reads bypass the session queue and open-tool-part sweep, so stalled or failing backfills cannot delay or fail them.
- Paged rows and sync state come from one database snapshot, preventing freshness from describing a different transcript during a concurrent backfill or purge.
- Unknown sessions return an empty transcript flagged as awaiting harness sync, while archived sessions continue using audit history.
- Both fields default to `false` for compatibility, and no client uses `storedOnly` yet.

<sup>Written for commit 0396833c8766ce1011fa92a64917d6625b629c65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

