### PR TITLE
🌿 [opencode-scan-reliability] Preserve sessions from unregistered OpenCode worktrees [step 1/2]

### DIFF
--- a/bridge/sesori_plugin_opencode/lib/src/repositories/open_code_catalog_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/repositories/open_code_catalog_repository.dart
@@ -169,14 +169,16 @@ class OpenCodeCatalogRepository({
     }
 
     for (final root in sessionsById.values.where((session) => session.parentId == null)) {
-      final familyId = _bestFamilyFor(directory: root.directory, aliasesByProjectId: aliasesByProjectId);
-      if (familyId == null && root.projectId != _globalProjectId) {
-        // The project id was validated above, so retain roots whose directory
-        // no longer appears in OpenCode's recorded project aliases.
-        families[root.projectId]!.roots.add(root);
-      } else if (familyId == null) {
+      // A validated project id retains roots whose directory is no longer
+      // recorded. Only the global project has no real family and falls through.
+      final familyId =
+          _bestFamilyFor(directory: root.directory, aliasesByProjectId: aliasesByProjectId) ?? root.projectId;
+      final family = families[familyId];
+      if (family != null) {
+        family.roots.add(root);
+      } else {
         final virtualId = "virtual:${_normalizedPath(root.directory)}";
-        families.putIfAbsent(
+        final virtualFamily = families.putIfAbsent(
           virtualId,
           () => _CatalogFamily(
             project: OpenCodeCatalogProjectRow(
@@ -191,9 +193,7 @@ class OpenCodeCatalogRepository({
             sessions: [],
           ),
         );
-        families[virtualId]!.roots.add(root);
-      } else {
-        families[familyId]!.roots.add(root);
+        virtualFamily.roots.add(root);
       }
     }
 

--- a/bridge/sesori_plugin_opencode/lib/src/repositories/open_code_catalog_repository.dart
+++ b/bridge/sesori_plugin_opencode/lib/src/repositories/open_code_catalog_repository.dart
@@ -170,13 +170,11 @@ class OpenCodeCatalogRepository({
 
     for (final root in sessionsById.values.where((session) => session.parentId == null)) {
       final familyId = _bestFamilyFor(directory: root.directory, aliasesByProjectId: aliasesByProjectId);
-      if (familyId == null) {
-        if (root.projectId != _globalProjectId) {
-          throw const OpenCodeCatalogDatabaseException(
-            message: "OpenCode root session is outside its project directories",
-            cause: null,
-          );
-        }
+      if (familyId == null && root.projectId != _globalProjectId) {
+        // The project id was validated above, so retain roots whose directory
+        // no longer appears in OpenCode's recorded project aliases.
+        families[root.projectId]!.roots.add(root);
+      } else if (familyId == null) {
         final virtualId = "virtual:${_normalizedPath(root.directory)}";
         families.putIfAbsent(
           virtualId,

--- a/bridge/sesori_plugin_opencode/test/open_code_catalog_repository_test.dart
+++ b/bridge/sesori_plugin_opencode/test/open_code_catalog_repository_test.dart
@@ -133,6 +133,58 @@ void main() {
       );
     });
 
+    test("retains non-global roots outside aliases with descendants and timestamps", () async {
+      final database = sqlite3.open(databasePath);
+      _createSchema(database: database);
+      _insertProject(database: database, id: "real", worktree: "${temporaryDirectory.path}/repo");
+      database.execute(
+        "INSERT INTO session(id,project_id,parent_id,directory,title,time_created,time_updated,time_archived) "
+        "VALUES(?,?,?,?,?,?,?,?)",
+        [
+          "external-root",
+          "real",
+          null,
+          "${temporaryDirectory.path}/external-root",
+          "External root",
+          100,
+          110,
+          120,
+        ],
+      );
+      database.execute(
+        "INSERT INTO session(id,project_id,parent_id,directory,title,time_created,time_updated,time_archived) "
+        "VALUES(?,?,?,?,?,?,?,?)",
+        [
+          "external-child",
+          "real",
+          "external-root",
+          "${temporaryDirectory.path}/external-root",
+          "External child",
+          101,
+          111,
+          121,
+        ],
+      );
+      database.close();
+
+      final result = await _repository().read(
+        environment: {"OPENCODE_DB": databasePath, "HOME": temporaryDirectory.path},
+        cancellation: const _NeverCancelled(),
+      );
+
+      final family = (result as PluginCatalogSnapshotAvailable).snapshot.projects.single;
+      expect(family.project.directory, "${temporaryDirectory.path}/repo");
+      expect(family.sessions.map((session) => session.id), unorderedEquals(["external-root", "external-child"]));
+      final root = family.sessions.singleWhere((session) => session.id == "external-root");
+      expect(root.directory, "${temporaryDirectory.path}/external-root");
+      expect(root.parentID, isNull);
+      expect(root.time?.archived, 120);
+      final child = family.sessions.singleWhere((session) => session.id == "external-child");
+      expect(child.directory, "${temporaryDirectory.path}/external-root");
+      expect(child.parentID, "external-root");
+      expect(child.time?.archived, 121);
+    });
+
     test("retains archived-only global families with descendants and timestamps", () async {
       final database = sqlite3.open(databasePath);
       _createSchema(database: database);

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -60,9 +60,10 @@ state.
   The consumed schema is OpenCode v1.18.19's `project`, `project_directory`, and
   `session` table shapes: additive columns are allowed, while incompatible required
   columns, types, or values trigger the live-import fallback.
-  Complete discovery includes real global roots stored in ancestor directories;
-  unlike the old project-list API, it does not exclude them from their best matching
-  project family.
+  Complete discovery includes real global roots stored in ancestor directories and
+  retains non-global roots under their validated `project_id` when no recorded
+  directory alias matches; unlike the old project-list API, it does not exclude
+  global roots from their best matching project family.
   The complete read-only transaction runs in a short-lived worker isolate so the
   bridge isolate remains responsive to cancellation and bounded force-stop while
   native SQLite finishes. The connection uses the live database and WAL normally


### PR DESCRIPTION
## Complexity
🌿 Straightforward: one localized catalog-family fallback with a synthetic regression fixture.

## What
- Retain non-global OpenCode session families under their validated project ID when recorded directory aliases no longer cover the session directory.
- Preserve the original directories, parent links, and archive timestamps.
- Document the DB-first discovery behavior.

## Why
OpenCode can retain archived sessions after an external worktree is removed from its directory metadata. One such root previously rejected the complete SQL snapshot and unnecessarily started OpenCode for live import.

## Risk and test focus
Low, localized mapping risk. Existing directory matches and global virtual-project handling are unchanged. Verify missing-worktree roots and descendants remain attached to the existing project with their historical paths and archive state.
No database schema migration or rewrite of existing rows; OpenCode's database remains read-only. Normal subsequent imports can recover previously omitted sessions.

## Expected result
The SQL scan completes without booting OpenCode merely because a retained session references an unregistered worktree. Archived history remains discoverable without inventing a replacement working directory.

## Verification
- OpenCode catalog repository tests: 11 passed.
- Full OpenCode plugin test suite passed.
- Owning package `dart analyze --fatal-infos` passed.
- Existing attach/no-auto-start test passed; no live backend started.
- Formatting and `git diff --check` passed.

## Series
Independent PR 1/2 in `opencode-scan-reliability`. The scan-status UX PR will use a separate branch from main; neither depends on the other.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves OpenCode session families from unregistered worktrees so archived history stays discoverable instead of rejecting the SQL snapshot and launching OpenCode for live import.

**Bug Fixes**
- Roots whose directory no longer matches a recorded project alias now attach to their validated project ID.
- Original session directories, parent links, and archive timestamps are retained.
- Existing directory matches and global virtual-project handling are unchanged; no schema changes or row rewrites.
- Docs now describe the DB-first discovery behavior.

<sup>Written for commit b92792a9437af702651abc9ac2515b8733956aa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

