### PR TITLE
🌿 Keep archived chats read-only during Stop confirmation

### DIFF
--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -1013,6 +1013,33 @@ void main() {
     );
   });
 
+  for (final (name, interaction) in [
+    ("legacy", const SessionInteractionState.legacyUnverified()),
+    ("refresh-error", SessionInteractionState.available(refreshError: ApiError.generic())),
+  ]) {
+    testWidgets("archiving hides the $name harness warning", (tester) async {
+      final loaded = _loadedState(pendingQuestions: const [], pendingPermissions: const []).copyWith(
+        interaction: interaction,
+      );
+      final states = StreamController<SessionDetailState>();
+      addTearDown(states.close);
+      whenListen(cubit, states.stream, initialState: loaded);
+
+      await tester.pumpWidget(_buildApp(cubit: cubit));
+      await tester.pumpAndSettle();
+      expect(find.byKey(const Key("session_harness_settings")), findsOneWidget);
+      expect(find.byType(PromptInput), findsOneWidget);
+
+      states.add(loaded.copyWith(isArchived: true));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const Key("session_harness_settings")), findsNothing);
+      expect(find.text("This session is archived and read-only."), findsOneWidget);
+      expect(find.byType(PromptInput), findsNothing);
+      expect(tester.takeException(), isNull);
+    });
+  }
+
   testWidgets("covered current routes suppress questions, permissions and notices", (tester) async {
     final questions = StreamController<SesoriQuestionAsked>.broadcast();
     final permissions = StreamController<SesoriPermissionAsked>.broadcast();

--- a/client/module_app_ui/lib/src/features/session_detail/widgets/session_detail_body.dart
+++ b/client/module_app_ui/lib/src/features/session_detail/widgets/session_detail_body.dart
@@ -158,6 +158,7 @@ class _SessionDetailBodyState() extends State<SessionDetailBody> {
     ];
 
     final statusWarning = switch (state) {
+      SessionDetailLoaded(isArchived: true) => null,
       SessionDetailLoaded(:final SessionInteractionLegacyUnverified interaction) => interaction,
       SessionDetailLoaded(:final SessionInteractionAvailable interaction) when interaction.refreshError != null =>
         interaction,

--- a/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
+++ b/client/module_core/lib/src/cubits/session_detail/session_detail_cubit.dart
@@ -2618,7 +2618,8 @@ class SessionDetailCubit(
   /// Under `stop` every busy child session is aborted too — plugins whose
   /// children are real sessions keep today's stop-everything behavior.
   Future<SessionAbortOutcome> abort({required SessionAbortSubAgentPolicy subAgents}) async {
-    if (_refuseWhenInteractionBlocked(action: "stop the session")) {
+    // A scope dialog can outlive an archive event from another surface.
+    if (_refuseWhenArchived(action: "stop the session") || _refuseWhenInteractionBlocked(action: "stop the session")) {
       return const SessionAbortOutcome.failed();
     }
     try {

--- a/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
+++ b/client/module_core/test/cubits/session_detail/session_detail_cubit_test.dart
@@ -19,6 +19,7 @@ import "package:sesori_dart_core/src/foundation/models/session_options/session_o
 import "package:sesori_dart_core/src/platform/lifecycle_source.dart";
 import "package:sesori_dart_core/src/repositories/models/plugin_discovery_snapshot.dart";
 import "package:sesori_dart_core/src/repositories/models/plugin_management_result.dart";
+import "package:sesori_dart_core/src/repositories/models/session_abort_rejected_exception.dart";
 import "package:sesori_dart_core/src/repositories/models/session_options_repository_result.dart";
 import "package:sesori_dart_core/src/repositories/permission_repository.dart";
 import "package:sesori_dart_core/src/repositories/plugin_repository.dart";
@@ -1208,6 +1209,52 @@ void main() {
         ).called(1);
       },
     );
+
+    test("abort refuses every scope after archiving while stop confirmation is pending", () async {
+      const rejection = SessionAbortRejection(runningSubAgentCount: 2, mainAgentRunning: true);
+      when(
+        () => mockSessionRepository.abortSession(sessionId: sessionId, subAgents: SessionAbortSubAgentPolicy.confirm),
+      ).thenThrow(SessionAbortRejectedException(rejection: rejection, innerError: StateError("409")));
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+      await _awaitLoaded(cubit);
+
+      expect(await cubit.abort(subAgents: SessionAbortSubAgentPolicy.confirm), isA<SessionAbortRejected>());
+      clearInteractions(mockSessionRepository);
+      clearInteractions(mockProductAnalyticsService);
+
+      // Another surface archives the session while the scope dialog is open.
+      sessionEvents.add(
+        SesoriSessionUpdated(
+          info: testSession(id: sessionId, archivedAt: DateTime.utc(2026)),
+        ),
+      );
+      await awaitState(
+        cubit: cubit,
+        predicate: (state) => state is SessionDetailLoaded && state.isArchived,
+        description: "session archived during stop confirmation",
+      );
+      final archivedState = cubit.state;
+      expect((archivedState as SessionDetailLoaded).interaction.canInteract, isTrue);
+
+      for (final policy in SessionAbortSubAgentPolicy.values) {
+        expect(await cubit.abort(subAgents: policy), isA<SessionAbortFailed>());
+      }
+
+      expect(cubit.state, same(archivedState));
+      verifyNever(
+        () => mockSessionRepository.abortSession(
+          sessionId: any(named: "sessionId"),
+          subAgents: any(named: "subAgents"),
+        ),
+      );
+      verifyNever(
+        () => mockProductAnalyticsService.logEvent(
+          event: const ProductAnalyticsEvent.sessionAbortSucceeded(),
+          occurredAtUtc: any(named: "occurredAtUtc"),
+        ),
+      );
+    });
 
     test("abort skips legacy descendant fanout after bridge acknowledgment", () async {
       const childId = "child-1";

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -35,7 +35,9 @@ defaults and queued client sends coherent.
   options and pending interactions before enabling input, without reopening the
   route. A failed content refresh remains read-only and directs the user to reopen
   the chat; it does not offer a harness-status recheck. Existing archive and route
-  read-only restrictions remain stronger.
+  read-only restrictions remain stronger. Archived chats omit harness warnings
+  and refuse Stop, including a scope confirmation left open while another surface
+  archives the session.
 - Pending local sends stop draining while blocked; users can still cancel those
   local-only entries, but cannot cancel a bridge-owned prompt until interaction is
   usable. Existing queue behavior otherwise stays unchanged. Availability gating


### PR DESCRIPTION
## Complexity
🌿 Straightforward: two localized client guards with focused regression coverage; no new architecture.

## What
- Refuse every Stop scope once the session-detail cubit knows the session is archived, before remote dispatch or local queue changes.
- Hide legacy and refresh-error harness banners on archived chats.
- Cover archive updates arriving while Stop confirmation is pending and while either warning is visible.
- Document the supported archive behavior in `docs/regression/session-turns.md`.

## Why
A Stop scope dialog can remain open while another surface archives the session. Confirming it previously dispatched an abort despite the archived state. Harness warnings also remained visible on audit-only chats where setup guidance was irrelevant.

## Risk and test focus
Low risk, shared mobile/desktop client behavior only. Tests cover all Stop policies, no abort dispatch or success analytics after archiving, unchanged cubit state, and warning removal without losing the archived notice. Existing non-archived Stop, queued-prompt, composer and session-body coverage passes.

No database, transport-contract, backend-plugin or bridge changes. Remote cancellation and unrelated guard ordering are intentionally unchanged.

## Expected result
Archived chats remain read-only even when an earlier Stop dialog is confirmed, and show the archive notice without irrelevant harness warnings. Non-archived chats retain existing controls and warnings.

## Verification
- New core regression failed before the fix because archived Stop still reached the repository.
- Both new widget regressions failed before the fix because harness warnings remained after archiving.
- `client/module_core`: `dart test test/cubits/session_detail/session_detail_cubit_test.dart test/cubits/session_detail/session_detail_bridge_queue_test.dart --reporter expanded` — passed.
- `client/app`: `flutter test --no-pub test/features/session_detail/widgets/session_detail_body_test.dart --reporter expanded` — passed.
- `dart analyze --fatal-infos` in `client/module_core` and `client/module_app_ui` — passed.
- Targeted analyzer for the changed app widget test — passed.
- `git diff --check` — passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where a Stop confirmation dialog could still abort an archived session, and hides harness warnings on archived chats. Archived sessions now refuse every Stop scope before any remote dispatch, and legacy/refresh-error warnings are suppressed once the session is archived. Non-archived chats retain existing controls and warnings.

<sup>Written for commit b8d6d38a95ae6d441c1994bc62433b89b1a2717b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

