### PR TITLE
🌿 Include batched commits in tester release notes

### DIFF
--- a/.github/workflows/_reusable-android-internal.yml
+++ b/.github/workflows/_reusable-android-internal.yml
@@ -40,6 +40,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Store notes need every commit since the previous successful release.
+          fetch-depth: 0
 
       - name: Setup Flutter
         uses: ./.github/actions/setup-flutter

--- a/.github/workflows/_reusable-ios-testflight.yml
+++ b/.github/workflows/_reusable-ios-testflight.yml
@@ -66,6 +66,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Store notes need every commit since the previous successful release.
+          fetch-depth: 0
 
       - name: Set up Xcode ${{ env.XCODE_VERSION }}
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/release-workflow-ci.yml
+++ b/.github/workflows/release-workflow-ci.yml
@@ -10,6 +10,9 @@ on:
       - '.github/scripts/test_check_internal_release.py'
       - '.github/workflows/release-all-platforms.yml'
       - '.github/workflows/release-workflow-ci.yml'
+      - 'client/app/fastlane/**'
+      - 'client/app/ios/fastlane/Fastfile'
+      - 'client/app/android/fastlane/Fastfile'
   pull_request:
     paths:
       - '.github/actions/**'
@@ -18,6 +21,9 @@ on:
       - '.github/scripts/test_check_internal_release.py'
       - '.github/workflows/release-all-platforms.yml'
       - '.github/workflows/release-workflow-ci.yml'
+      - 'client/app/fastlane/**'
+      - 'client/app/ios/fastlane/Fastfile'
+      - 'client/app/android/fastlane/Fastfile'
 
 permissions:
   contents: read
@@ -32,3 +38,12 @@ jobs:
         run: shellcheck .github/scripts/check_internal_release.sh
       - name: Test scheduled release decisions and attempt recording
         run: python3 .github/scripts/test_check_internal_release.py
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+      - name: Check store lane syntax
+        run: |
+          ruby -c client/app/ios/fastlane/Fastfile
+          ruby -c client/app/android/fastlane/Fastfile
+      - name: Test batched store release notes and length limits
+        run: ruby client/app/fastlane/test_build_changelog.rb

--- a/client/app/android/fastlane/Fastfile
+++ b/client/app/android/fastlane/Fastfile
@@ -5,6 +5,7 @@ require "fileutils"
 require "json"
 require "shellwords"
 require "tempfile"
+require_relative "../../fastlane/build_changelog"
 
 # Resolves an optional store-metadata directory passed via the named env var.
 # In CI this points at the private metadata repo that submit-release.yml clones
@@ -22,25 +23,6 @@ def metadata_dir_from_env(var)
   return nil if Dir.children(path).reject { |e| e.start_with?(".") }.empty?
 
   path
-end
-
-# Release notes for a TEST build (internal track): the message of the commit the
-# build was created for, so testers/operators see exactly what changed. A short
-# `commit: <sha>` trailer is appended so the originating commit is recoverable
-# even if the matching `build-<N>` git tag is ever lost. Falls back to the SHA
-# alone if git output is unavailable. `max_length` guards against store limits:
-# Google Play documents a 500-char cap but rejects internal-track changelogs
-# before that in practice, so we trim to a safe 400 chars. NOTE: production
-# "What's new" is NOT this — it's the fixed copy (default.txt) in the private
-# metadata repo.
-def build_commit_changelog(max_length: nil)
-  sha = ENV.fetch("GITHUB_SHA") { `git rev-parse HEAD`.strip }
-  message = `git log -1 --format=%B #{Shellwords.escape(sha)} 2>/dev/null`.strip
-  message = `git log -1 --format=%B 2>/dev/null`.strip if message.empty?
-  short_sha = sha[0, 7]
-  text = message.empty? ? "commit: #{short_sha}" : "#{message}\n\ncommit: #{short_sha}"
-  text = "#{text[0, max_length - 1].rstrip}…" if max_length && text.length > max_length
-  text
 end
 
 # Google Play finishes processing an uploaded App Bundle asynchronously: the
@@ -302,18 +284,19 @@ platform :android do
         UI.user_error!("AAB not found at #{aab_path} after build.")
       end
 
-      # Internal-track release notes = the build commit's message (with a
-      # `commit: <sha>` trailer for recoverability if the matching `build-<N>`
-      # git tag is ever lost). This is the TEST changelog only — production
-      # "What's new" is the fixed copy (default.txt) in the private metadata
-      # repo. Supply expects metadata_path to point directly at the directory
-      # containing locale folders, i.e. `<metadata_path>/<lang>/changelogs/<versionCode>.txt`.
+      # Internal-track notes cover the whole batch since the previous release.
+      # Production "What's new" stays in the private metadata repo. Supply expects
+      # `<metadata_path>/<lang>/changelogs/<versionCode>.txt`.
       metadata_path = File.expand_path("metadata/android", __dir__)
       changelog_dir = File.join(metadata_path, "en-US", "changelogs")
       FileUtils.mkdir_p(changelog_dir)
       File.write(
         File.join(changelog_dir, "#{new_build_number}.txt"),
-        "#{build_commit_changelog(max_length: 400)}\n"
+        SesoriBuildChangelog.generate(
+          repo_path: File.expand_path("../../../..", __dir__),
+          target: ENV.fetch("GITHUB_SHA", "HEAD"),
+          max_length: SesoriBuildChangelog::PLAY_MAX_LENGTH
+        )
       )
 
       with_play_upload_retry do

--- a/client/app/fastlane/build_changelog.rb
+++ b/client/app/fastlane/build_changelog.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "open3"
+
+# Shared TEST release notes. Production store copy still comes from private metadata.
+module SesoriBuildChangelog
+  TESTFLIGHT_MAX_LENGTH = 4000
+  # Play documents 500 Unicode characters, but this pipeline has seen rejections
+  # below that cap. Preserve its existing conservative 400-character budget.
+  PLAY_MAX_LENGTH = 400
+
+  def self.generate(repo_path:, target:, max_length:)
+    if git(repo_path: repo_path, args: ["rev-parse", "--is-shallow-repository"]).strip == "true"
+      raise "Release notes require full Git history. Fetch with --unshallow and --tags."
+    end
+
+    sha = git(repo_path: repo_path, args: ["rev-parse", "--verify", "#{target}^{commit}"]).strip
+    # v* tags mark completed releases; internal-release-attempt must never reset
+    # this range after a failed build. Follow the target's own release history,
+    # not a newer tag elsewhere or a release on a merged side branch.
+    baseline = git(
+      repo_path: repo_path,
+      args: ["describe", "--tags", "--first-parent", "--match", "v[0-9]*", "--abbrev=0", "--always", sha]
+    ).strip
+    # --always returns a SHA when no release exists: include all history then.
+    range = baseline.start_with?("v") ? "#{baseline}..#{sha}" : sha
+    subjects = git(
+      repo_path: repo_path,
+      args: ["log", "--topo-order", "--format=%s", range, "--"]
+    ).lines(chomp: true)
+    render(subjects: subjects, sha: sha, max_length: max_length)
+  end
+
+  def self.render(subjects:, sha:, max_length:)
+    header = "commit: #{sha[0, 7]}"
+    entries = subjects.map { |subject| "- #{subject}" }
+    full_text = ([header] + entries).join("\n")
+    return full_text if full_text.length <= max_length
+
+    # Keep complete newest entries only. Reserve the exact footer (including
+    # its newline and count digits) before accepting each entry. Even one huge
+    # subject is omitted and counted rather than being silently cut mid-message.
+    lines = [header]
+    length = header.length
+    entries.each_with_index do |entry, index|
+      remaining = entries.length - index - 1
+      footer_length = remaining.positive? ? "\n+ #{remaining} others".length : 0
+      break if length + 1 + entry.length + footer_length > max_length
+
+      lines << entry
+      length += 1 + entry.length
+    end
+    omitted = entries.length - (lines.length - 1)
+    lines << "+ #{omitted} others" if omitted.positive?
+    lines.join("\n")
+  end
+
+  def self.git(repo_path:, args:)
+    output, error, status = Open3.capture3("git", "-C", repo_path, *args)
+    raise "git #{args.join(' ')} failed: #{error.strip}" unless status.success?
+
+    output
+  end
+  private_class_method :git
+end

--- a/client/app/fastlane/test_build_changelog.rb
+++ b/client/app/fastlane/test_build_changelog.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require "tmpdir"
+require "fileutils"
+require_relative "build_changelog"
+
+class BuildChangelogHistoryTest < Minitest::Test
+  ROOT = File.expand_path("../../..", __dir__)
+
+  def setup
+    # Keep disposable Git fixtures inside the caller's checkout, not a worktree.
+    @repo = Dir.mktmpdir(".release-notes-test-", ROOT)
+    git(args: ["init", "--initial-branch=main"])
+    git(args: ["config", "user.name", "Release Notes Test"])
+    git(args: ["config", "user.email", "release-notes@example.invalid"])
+    git(args: ["config", "commit.gpgsign", "false"])
+    git(args: ["config", "tag.gpgsign", "false"])
+    commit(message: "Initial commit")
+  end
+
+  def teardown
+    FileUtils.remove_entry(@repo)
+  end
+
+  def test_all_commits_since_annotated_internal_release_not_attempt_marker
+    git(args: ["tag", "-a", "v1.2.3-internal.42", "-m", "Successful release"])
+    commit(message: "First fix\n\nLong commit body is not a separate entry.")
+    git(args: ["tag", "internal-release-attempt"])
+    commit(message: "Second fix")
+    git(args: ["tag", "unrelated-checkpoint"])
+    sha = commit(message: "Docs after product changes")
+
+    assert_equal "commit: #{sha[0, 7]}\n- Docs after product changes\n- Second fix\n- First fix", notes(target: sha)
+  end
+
+  def test_stable_tag_is_a_release_baseline
+    git(args: ["tag", "v1.2.3"])
+    sha = commit(message: "New feature")
+
+    assert_equal "commit: #{sha[0, 7]}\n- New feature", notes(target: "HEAD")
+  end
+
+  def test_nearest_internal_release_replaces_older_stable_baseline
+    git(args: ["tag", "v1.2.3"])
+    commit(message: "Already released internally")
+    git(args: ["tag", "-a", "v1.2.4-internal.43", "-m", "Next release"])
+    sha = commit(message: "Only new change")
+
+    assert_equal "commit: #{sha[0, 7]}\n- Only new change", notes(target: sha)
+  end
+
+  def test_first_release_includes_all_history
+    commit(message: "Second commit")
+    git(args: ["tag", "internal-release-attempt"])
+    sha = commit(message: "Third commit")
+
+    assert_equal "commit: #{sha[0, 7]}\n- Third commit\n- Second commit\n- Initial commit", notes(target: sha)
+  end
+
+  def test_target_is_immutable_even_with_newer_head_and_release_tag
+    git(args: ["tag", "v1.2.3"])
+    sha = commit(message: "Build this commit")
+    commit(message: "Later commit")
+    git(args: ["tag", "v1.2.4-internal.44"])
+
+    assert_equal "commit: #{sha[0, 7]}\n- Build this commit", notes(target: sha)
+  end
+
+  def test_release_on_merged_side_branch_does_not_hide_newly_merged_commits
+    git(args: ["tag", "v1.2.3"])
+    git(args: ["checkout", "-b", "feature"])
+    commit(message: "Feature from branch")
+    git(args: ["tag", "v1.2.4-internal.44"])
+    git(args: ["checkout", "main"])
+    commit(message: "Main change")
+    git(args: ["merge", "--no-ff", "feature", "-m", "Merge feature"])
+
+    text = notes(target: "HEAD")
+    assert_includes text, "- Feature from branch"
+    assert_includes text, "- Main change"
+    assert_includes text, "- Merge feature"
+    refute_includes text, "- Initial commit"
+  end
+
+  def test_rebuilding_tagged_commit_shows_only_build_sha
+    git(args: ["tag", "v1.2.3-internal.42"])
+    sha = git(args: ["rev-parse", "HEAD"])
+
+    assert_equal "commit: #{sha[0, 7]}", notes(target: sha)
+  end
+
+  def test_git_errors_are_not_replaced_with_misleading_tip_notes
+    error = assert_raises(RuntimeError) { notes(target: "missing-ref") }
+    assert_includes error.message, "rev-parse --verify missing-ref^{commit} failed:"
+  end
+
+  def test_shallow_history_is_rejected
+    sha = git(args: ["rev-parse", "HEAD"])
+    File.write(File.join(@repo, ".git", "shallow"), "#{sha}\n")
+
+    error = assert_raises(RuntimeError) { notes(target: "HEAD") }
+    assert_includes error.message, "full Git history"
+  end
+
+  private
+
+  def git(args:)
+    output, error, status = Open3.capture3("git", "-C", @repo, *args)
+    raise "Git fixture failed: #{error}" unless status.success?
+
+    output.strip
+  end
+
+  def commit(message:)
+    git(args: ["commit", "--allow-empty", "-m", message])
+    git(args: ["rev-parse", "HEAD"])
+  end
+
+  def notes(target:)
+    SesoriBuildChangelog.generate(
+      repo_path: @repo, target: target, max_length: SesoriBuildChangelog::TESTFLIGHT_MAX_LENGTH
+    )
+  end
+end
+
+class BuildChangelogLengthTest < Minitest::Test
+  HEADER = "commit: 1234567"
+
+  def test_all_entries_fit_without_footer_including_exact_limit
+    text = render(subjects: ["Newest", "Older"], max_length: 100)
+
+    assert_equal "#{HEADER}\n- Newest\n- Older", text
+    assert_equal text, render(subjects: ["Newest", "Older"], max_length: text.length)
+  end
+
+  def test_do_not_reserve_footer_when_all_short_entries_fit
+    subjects = ["Newest", "x"]
+    expected = "#{HEADER}\n- Newest\n- x"
+
+    assert_equal expected, render(subjects: subjects, max_length: expected.length)
+  end
+
+  def test_footer_is_last_and_count_includes_entries_displaced_by_footer
+    expected = "#{HEADER}\n- Newest\n+ 2 others"
+    text = render(subjects: ["Newest", "Middle", "Oldest"], max_length: expected.length)
+
+    assert_equal expected, text
+  end
+
+  def test_single_oversized_entry_is_omitted_and_counted
+    assert_equal "#{HEADER}\n+ 1 others", render(subjects: ["x" * 5000], max_length: 4000)
+  end
+
+  def test_oversized_newest_entry_counts_every_omitted_commit
+    assert_equal "#{HEADER}\n+ 3 others", render(subjects: ["x" * 500, "Older", "Oldest"], max_length: 400)
+  end
+
+  def test_footer_accounts_for_count_digit_boundary
+    subjects = Array.new(11) { |index| "Change #{index}" }
+    expected = "#{HEADER}\n- Change 0\n+ 10 others"
+
+    assert_equal expected, render(subjects: subjects, max_length: expected.length)
+    assert_equal "#{HEADER}\n+ 11 others", render(subjects: subjects, max_length: expected.length - 1)
+  end
+
+  def test_unicode_is_counted_as_characters_not_bytes_and_never_split
+    subjects = ["🌿 Café 中文", "⚙️ Résumé", "Oldest change" * 10]
+    expected = "#{HEADER}\n- 🌿 Café 中文\n- ⚙️ Résumé\n+ 1 others"
+    text = render(subjects: subjects, max_length: expected.length)
+
+    assert_equal expected, text
+    assert text.valid_encoding?
+    assert_operator text.bytesize, :>, text.length
+  end
+
+  def test_both_store_limits_keep_maximal_complete_prefix_and_exact_count
+    subjects = Array.new(120) { |index| "🌿 Change #{index}: improve release batching" }
+    [SesoriBuildChangelog::PLAY_MAX_LENGTH, SesoriBuildChangelog::TESTFLIGHT_MAX_LENGTH].each do |limit|
+      text = render(subjects: subjects, max_length: limit)
+      shown = text.lines.count { |line| line.start_with?("- ") }
+      omitted = subjects.length - shown
+
+      assert_operator text.length, :<=, limit
+      assert_operator shown, :>, 0
+      assert_equal "+ #{omitted} others", text.lines.last
+      assert_equal subjects.first(shown).map { |subject| "- #{subject}" }, text.lines(chomp: true)[1, shown]
+      with_next = ([HEADER] + subjects.first(shown + 1).map { |subject| "- #{subject}" } +
+        ["+ #{omitted - 1} others"]).join("\n")
+      assert_operator with_next.length, :>, limit
+    end
+  end
+
+  private
+
+  def render(subjects:, max_length:)
+    SesoriBuildChangelog.render(subjects: subjects, sha: "1234567890abcdef", max_length: max_length)
+  end
+end

--- a/client/app/ios/fastlane/Fastfile
+++ b/client/app/ios/fastlane/Fastfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "shellwords"
+require_relative "../../fastlane/build_changelog"
 
 default_platform(:ios)
 
@@ -58,23 +59,6 @@ def metadata_dir_from_env(var)
   return nil if Dir.children(path).reject { |e| e.start_with?(".") }.empty?
 
   path
-end
-
-# Release notes for a TEST build (TestFlight): the message of the commit the
-# build was created for, so testers/operators see exactly what changed. A short
-# `commit: <sha>` trailer is appended so the originating commit is recoverable
-# even if the matching `build-<N>` git tag is ever lost. Falls back to the SHA
-# alone if git output is unavailable. `max_length` guards against store limits
-# (App Store "What to Test" caps at 4000 chars). NOTE: production "What's new"
-# is NOT this — it's the fixed copy in the private metadata repo.
-def build_commit_changelog(max_length: nil)
-  sha = ENV.fetch("GITHUB_SHA") { `git rev-parse HEAD`.strip }
-  message = `git log -1 --format=%B #{Shellwords.escape(sha)} 2>/dev/null`.strip
-  message = `git log -1 --format=%B 2>/dev/null`.strip if message.empty?
-  short_sha = sha[0, 7]
-  text = message.empty? ? "commit: #{short_sha}" : "#{message}\n\ncommit: #{short_sha}"
-  text = "#{text[0, max_length - 1].rstrip}…" if max_length && text.length > max_length
-  text
 end
 
 # App Store "What's New" (the `whatsNew` attribute) is VERSION-scoped: every new
@@ -384,14 +368,16 @@ platform :ios do
       dsym_path
     )
 
-    # Upload to TestFlight. The "What to Test" notes are the build commit's
-    # message (with a `commit: <sha>` trailer for recoverability if the matching
-    # `build-<N>` git tag is ever lost). This is the TEST changelog only —
-    # production "What's new" is the fixed copy in the private metadata repo.
+    # Test notes cover the whole batch since the previous release. Production
+    # "What's new" remains the fixed copy in the private metadata repo.
     upload_to_testflight(
       api_key: api_key,
       skip_waiting_for_build_processing: true,
-      changelog: build_commit_changelog(max_length: 4000)
+      changelog: SesoriBuildChangelog.generate(
+        repo_path: File.expand_path("../../../..", __dir__),
+        target: ENV.fetch("GITHUB_SHA", "HEAD"),
+        max_length: SesoriBuildChangelog::TESTFLIGHT_MAX_LENGTH
+      )
     )
 
     # Write build info for CI summary

--- a/docs/regression/bridge-installation-and-updates.md
+++ b/docs/regression/bridge-installation-and-updates.md
@@ -15,6 +15,15 @@ reconciliation, periodic check, in-place apply, and explicit update command.
   A rolling `internal-release-attempt` tag is written before version validation or
   builds, preventing hourly retries after failure or cancellation. Manual dispatch
   can retry; release tags and the all-platform success requirement stay unchanged.
+- TestFlight and Play internal notes list commit subjects since the nearest
+  `v*` release tag on the build's first-parent history, newest first, and retain
+  the build SHA. Failed attempts do not reset this range. With no release tag,
+  notes cover all history; rebuilding an already-tagged commit shows its SHA only.
+  Store checkouts include full history and tags. Notes keep complete entries
+  within 4,000 characters for TestFlight and the existing conservative 400 for
+  Play, ending with `+ X others` when entries are omitted (including an oversized
+  first entry). Production store copy and GitHub's stable-release-based notes
+  remain unchanged.
 - Installers and the npm bootstrap produce the same managed install, expose the
   `sesori-bridge` launcher, and report the version; installers take the newest
   non-prerelease release carrying the platform archive and its basename-keyed checksum
@@ -50,7 +59,7 @@ reconciliation, periodic check, in-place apply, and explicit update command.
 |---|---|
 | L1 Smoke | Not included. Distribution work is expensive and is not a per-run heartbeat. |
 | L2 Routine | Update-skip policy and startup reconciliation on a non-managed run: a build-tree or opted-out bridge neither rewrites itself nor fails startup, and reconciliation is silent with no pending attempt. Headless bridge; no plugin. |
-| L3 Release | Scheduled-release gate tests cover batched changes, tagged/attempted skips, failure suppression, manual retries, and marker-write failure without store calls. The release artifact set and checksum manifest for the tag are complete and basename-keyed, and a managed install on the release-target bridge host reports the expected version and starts. Packaged or external. |
+| L3 Release | Scheduled-release gate tests cover batched changes, tagged/attempted skips, failure suppression, manual retries, and marker-write failure without store calls. Store-note tests cover release ranges, failed attempts, immutable targets, Unicode, and exact omission counts at both length limits. The release artifact set and checksum manifest for the tag are complete and basename-keyed, and a managed install on the release-target bridge host reports the expected version and starts. Packaged or external. |
 | L4 Extended | Interrupted or failed apply reconciled at a later start, including lock-contended and deletion-failed residue retained observably for another retry; rollback; refused checksum mismatch; unavailable release service staying quiet; track switch; periodic cycle applying in place and reporting pending activation; and an alternate bridge host. Packaged or external for the install; headless bridge for policy. |
 | L5 Full | Both installers and the npm bootstrap on every supported platform and architecture, the npm fallback to the tagged release asset, an end-to-end upgrade from a prior release on both tracks, the update command including force, and the documented uninstall contract. Packaged or external. |
 
@@ -68,6 +77,9 @@ after apply. Use a throwaway machine when mutating an install root.
   hidden behind an unrelated tip commit being missed.
 - A build starting before its attempt marker is persisted, a manual branch run
   moving main's marker, or an incomplete all-platform build being promoted as a release.
+- Store notes showing only the tip commit of a batch, losing commits after a failed
+  attempt, exceeding store limits, cutting entries mid-message, or reporting an
+  incorrect omitted-commit count.
 - An installer selecting a pre-release, a release missing or mis-keying its manifest, or
   an artifact installed without verification.
 - Auto-update running for a supervised run, npm payload, CI, or opted-out process, or a
@@ -93,6 +105,8 @@ after apply. Use a throwaway machine when mutating an install root.
 
 - `.github/workflows/release-all-platforms.yml`, `.github/scripts/check_internal_release.sh`,
   `.github/scripts/test_check_internal_release.py`
+- `client/app/fastlane/build_changelog.rb`, `client/app/fastlane/test_build_changelog.rb`,
+  `client/app/{ios,android}/fastlane/Fastfile`
 - `bridge/RELEASING.md`, `bridge/INSTALL.md`, `install.sh`, `install.ps1`, `bridge/app/npm/`
 - `bridge/app/lib/src/foundation/bridge_startup_banner_formatter.dart`
 - `bridge/app/lib/src/updater/` policy, track, lock, repositories, services;


### PR DESCRIPTION
## Complexity
🌿 Straightforward: one shared Ruby formatter and small store-lane/workflow changes.

## What
- TestFlight and Play internal notes list commit subjects since the nearest successful release tag on the build’s first-parent history, newest first.
- Keep the build SHA and complete entries; overflow ends with `+ X others`, including the exact omitted-commit count.
- Preserve limits: 4,000 characters for TestFlight and the existing conservative 400 for Play.
- Fetch full history/tags in both reusable deploy workflows; add release-note tests to Release Workflow CI.

## Why
Hourly releases batch multiple commits, but both store lanes still described only the tip commit. Failed release attempts must not hide changes from the next successful batch.

## Risk and test focus
Low risk, limited to tester release descriptions and checkout depth. Tests cover internal/stable release baselines, ignored attempt markers, immutable targets, first release, tagged rebuilds, oversized subjects, Unicode, and exact footer counts/budgets. Production store copy, GitHub release notes, release scheduling, and runtime behavior remain unchanged. No database impact.

## Expected result
Testers see all commits since the preceding release that fit the platform’s budget, with `+ X others` as the final line when commits are omitted. With no prior release, notes cover all history; rebuilding an already-tagged commit shows its SHA only.

## Verification
- `ruby client/app/fastlane/test_build_changelog.rb`: 17 tests, 48 assertions, all passing.
- Ruby syntax checks pass for both Fastfiles.
- `git diff --check`: passed.
- `actionlint`: release CI workflow is clean; deploy workflows retain the same 14 pre-existing setup-action/shellcheck findings as HEAD, with no new findings.
- No signed builds, store uploads, or production submissions triggered locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tester release notes now cover the whole commit batch since the previous release instead of only the tip commit, so changes from failed release attempts are no longer hidden from the next successful batch. TestFlight and Play internal notes list commit subjects from the nearest `v*` release tag on the build's first-parent history, newest first, keep the build SHA, and end with `+ X others` when the platform's character budget runs out (4,000 for TestFlight, 400 for Play).

**Migration**
- Both reusable deploy workflows now check out full history with tags; the store lanes fail on shallow clones instead of silently falling back to the tip commit.
- Release Workflow CI now runs the new formatter tests when fastlane files change.
- Production store copy and GitHub release notes are unchanged.

<sup>Written for commit 46d454ae209709fa6d10078eb364e3b264f12c03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

