### PR TITLE
⚙️ [opencode-scan-reliability] Explain harness startup during session scans [step 2/2]

### DIFF
--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -75,6 +75,15 @@ class CatalogImportRepository({
     final publicationFinished = Completer<void>();
     ({int projectsImported, int sessionsImported, CatalogImportNewItems newItems, int completedAt})? result;
     var cancelledEmitted = false;
+    yield CatalogImportProgress.enumerating(
+      pluginId: pluginId,
+      projectsSeen: 0,
+      sessionsSeen: 0,
+    );
+    if (control.isCancelled) {
+      yield CatalogImportProgress.cancelled(pluginId: pluginId);
+      return;
+    }
     try {
       await for (final event in _runtime.useCatalogImportStream<Object>(
         pluginId: pluginId,
@@ -137,11 +146,6 @@ class CatalogImportRepository({
     var derivedProjectPathsByBackendId = const <String, String>{};
     String? derivedLaunchDirectory;
 
-    yield CatalogImportProgress.enumerating(
-      pluginId: pluginId,
-      projectsSeen: 0,
-      sessionsSeen: 0,
-    );
     if (cancellation.isCancelled) {
       yield CatalogImportProgress.cancelled(pluginId: pluginId);
       return;

--- a/bridge/app/test/repositories/catalog_import_repository_test.dart
+++ b/bridge/app/test/repositories/catalog_import_repository_test.dart
@@ -860,13 +860,26 @@ void main() {
         explicitImportRequested: true,
         hydrationMarkerRequested: true,
       );
-      final result = repository.importCatalog(pluginId: "snapshot", control: control).toList();
+      final statuses = <CatalogImportProgress>[];
+      final completed = Completer<void>();
+      final subscription = repository
+          .importCatalog(pluginId: "snapshot", control: control)
+          .listen(
+            statuses.add,
+            onDone: completed.complete,
+          );
+      addTearDown(subscription.cancel);
       await runtime.descriptorReadStarted.future;
 
+      expect(
+        statuses,
+        [isA<CatalogImportEnumerating>()],
+        reason: "progress must be visible before runtime acquisition finishes",
+      );
       control.cancellationRequested = true;
-      final statuses = await result;
+      await completed.future;
 
-      expect(statuses, [isA<CatalogImportCancelled>()]);
+      expect(statuses, [isA<CatalogImportEnumerating>(), isA<CatalogImportCancelled>()]);
       expect(await database.projectsDao.getAllProjects(), isEmpty);
       expect(await repository.getHydrationCompletion(pluginId: "snapshot"), isNull);
     });
@@ -891,7 +904,7 @@ void main() {
           )
           .toList();
 
-      expect(statuses, [isA<CatalogImportCancelled>()]);
+      expect(statuses, [isA<CatalogImportEnumerating>(), isA<CatalogImportCancelled>()]);
       expect(await database.projectsDao.getAllProjects(), isEmpty);
       expect(await repository.getHydrationCompletion(pluginId: "snapshot"), isNull);
     });

--- a/client/app/test/features/project_list/project_list_catalog_scan_test.dart
+++ b/client/app/test/features/project_list/project_list_catalog_scan_test.dart
@@ -169,11 +169,11 @@ void main() {
 
     await emitScan(
       tester,
-      const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
+      const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
     );
 
     expect(find.text(loc.catalogScanRunningTitle), findsOneWidget);
-    expect(find.text("Codex — 148 sessions"), findsOneWidget);
+    expect(find.text("Codex — 148 sessions found"), findsOneWidget);
     expect(find.text("My Project"), findsOneWidget);
   });
 
@@ -181,7 +181,10 @@ void main() {
     await pumpLoadedList(tester);
 
     final loc = await AppLocalizations.delegate.load(const Locale("en"));
-    await emitScan(tester, const CatalogRescanState.starting(pluginIds: {"codex"}));
+    await emitScan(
+      tester,
+      const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+    );
     expect(find.text(loc.catalogScanRunningTitle), findsOneWidget);
 
     await emitScan(tester, const CatalogRescanState.idle());
@@ -192,7 +195,10 @@ void main() {
   testWidgets("cancels the scan from the row it is reported in", (tester) async {
     final loc = await pumpLoadedList(tester);
 
-    await emitScan(tester, const CatalogRescanState.starting(pluginIds: {"codex"}));
+    await emitScan(
+      tester,
+      const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+    );
     await tester.tap(find.bySemanticsLabel(loc.catalogScanCancel));
 
     expect(rescanService.cancelCalls, 1);

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -1827,7 +1827,12 @@ void main() {
       await openHarnesses(tester);
       final row = find.byKey(const Key("harness_management_scan_future-harness"));
       await tester.ensureVisible(row);
-      rescan.emit(const CatalogRescanState.starting(pluginIds: {"future-harness"}));
+      rescan.emit(
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Future Harness",
+          pluginIds: {"future-harness"},
+        ),
+      );
       // Fixed pumps rather than settling: the row's spinner never stops.
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));

--- a/client/app/test/playbook/catalog_scan_row_playbook.dart
+++ b/client/app/test/playbook/catalog_scan_row_playbook.dart
@@ -197,17 +197,20 @@ const catalogScanRowScenarios = <CatalogScanRowScenario>[
     action: CatalogScanRowAction.none,
   ),
   CatalogScanRowScenario(
-    id: "starting",
-    name: "Starting / Awaiting progress",
-    description: "The request was dispatched, but no harness has reported yet.",
-    scan: CatalogRescanState.starting(pluginIds: {"codex", "opencode"}),
+    id: "preparing",
+    name: "Preparing / Awaiting progress",
+    description: "Requests were dispatched, but no harness has reported yet.",
+    scan: CatalogRescanState.preparingMany(
+      pendingPluginNames: ["Codex", "OpenCode"],
+      pluginIds: {"codex", "opencode"},
+    ),
     action: CatalogScanRowAction.cancel,
   ),
   CatalogScanRowScenario(
     id: "running-zero",
     name: "Running / Zero sessions",
     description: "Codex is active but has not reported a session yet.",
-    scan: CatalogRescanState.running(
+    scan: CatalogRescanState.reading(
       activePluginName: "Codex",
       sessionsSeen: 0,
       pluginIds: {"codex", "opencode"},
@@ -218,7 +221,7 @@ const catalogScanRowScenarios = <CatalogScanRowScenario>[
     id: "running-singular",
     name: "Running / One session",
     description: "The singular live-count branch is visible while Codex scans.",
-    scan: CatalogRescanState.running(
+    scan: CatalogRescanState.reading(
       activePluginName: "Codex",
       sessionsSeen: 1,
       pluginIds: {"codex", "opencode"},
@@ -229,7 +232,7 @@ const catalogScanRowScenarios = <CatalogScanRowScenario>[
     id: "running-large-count",
     name: "Running / Large count",
     description: "A long-running scan with a representative three-digit count.",
-    scan: CatalogRescanState.running(
+    scan: CatalogRescanState.reading(
       activePluginName: "Claude Code",
       sessionsSeen: 148,
       pluginIds: {"claude-code", "codex", "opencode"},
@@ -572,11 +575,14 @@ class _CatalogScanRowInActionExampleState() extends State<CatalogScanRowInAction
     if (widget.selection is! CatalogScanGestureDemo) return;
     _cancelTimers();
     setState(() {
-      _scan = const CatalogRescanState.starting(pluginIds: {"claude-code", "codex", "opencode"});
+      _scan = const CatalogRescanState.preparingMany(
+        pendingPluginNames: ["Claude Code", "Codex", "OpenCode"],
+        pluginIds: {"claude-code", "codex", "opencode"},
+      );
     });
     _schedule(
       const Duration(milliseconds: 650),
-      const CatalogRescanState.running(
+      const CatalogRescanState.reading(
         activePluginName: "Codex",
         sessionsSeen: 0,
         pluginIds: {"claude-code", "codex", "opencode"},
@@ -584,7 +590,7 @@ class _CatalogScanRowInActionExampleState() extends State<CatalogScanRowInAction
     );
     _schedule(
       const Duration(milliseconds: 1400),
-      const CatalogRescanState.running(
+      const CatalogRescanState.reading(
         activePluginName: "Codex",
         sessionsSeen: 3,
         pluginIds: {"claude-code", "codex", "opencode"},
@@ -592,7 +598,7 @@ class _CatalogScanRowInActionExampleState() extends State<CatalogScanRowInAction
     );
     _schedule(
       const Duration(milliseconds: 2200),
-      const CatalogRescanState.running(
+      const CatalogRescanState.reading(
         activePluginName: "OpenCode",
         sessionsSeen: 8,
         pluginIds: {"claude-code", "codex", "opencode"},

--- a/client/app/test/playbook/catalog_scan_row_playbook_test.dart
+++ b/client/app/test/playbook/catalog_scan_row_playbook_test.dart
@@ -63,17 +63,17 @@ void main() {
 
     await gesture.up();
     await tester.pump();
-    expect(find.text("Starting…", skipOffstage: false), findsOneWidget);
+    expect(find.text("Preparing Claude Code, Codex, and 1 other scans…", skipOffstage: false), findsOneWidget);
     expect(find.text("Scanning all harnesses", skipOffstage: false), findsOneWidget);
 
     await tester.pump(const Duration(milliseconds: 650));
-    expect(find.text("Codex — 0 sessions"), findsOneWidget);
+    expect(find.text("Reading Codex sessions…"), findsOneWidget);
 
     await tester.pump(const Duration(milliseconds: 750));
-    expect(find.text("Codex — 3 sessions"), findsOneWidget);
+    expect(find.text("Codex — 3 sessions found"), findsOneWidget);
 
     await tester.pump(const Duration(milliseconds: 800));
-    expect(find.text("OpenCode — 8 sessions"), findsOneWidget);
+    expect(find.text("OpenCode — 8 sessions found"), findsOneWidget);
 
     await tester.pump(const Duration(milliseconds: 900));
     expect(find.text("Scan complete"), findsOneWidget);

--- a/client/module_app_ui/lib/src/l10n/app_en.arb
+++ b/client/module_app_ui/lib/src/l10n/app_en.arb
@@ -1250,7 +1250,7 @@
   },
   "catalogScanWaitingTitle": "Waiting for {harness}",
   "@catalogScanWaitingTitle": {
-    "description": "Title after one harness has remained authoritatively in startup for ten seconds.",
+    "description": "Title after one harness has remained authoritatively in startup for three seconds.",
     "placeholders": {
       "harness": {
         "type": "String",
@@ -1260,7 +1260,7 @@
   },
   "catalogScanWaitingDetail": "{harness} must finish starting before scanning can continue. You can keep browsing.",
   "@catalogScanWaitingDetail": {
-    "description": "Wrapped explanation after one harness has remained authoritatively in startup for ten seconds.",
+    "description": "Wrapped explanation after one harness has remained authoritatively in startup for three seconds.",
     "placeholders": {
       "harness": {
         "type": "String",

--- a/client/module_app_ui/lib/src/l10n/app_en.arb
+++ b/client/module_app_ui/lib/src/l10n/app_en.arb
@@ -1158,13 +1158,76 @@
   "@catalogScanRunningTitle": {
     "description": "Title of the row above a list while a catalog scan is in flight across every enabled harness."
   },
-  "catalogScanStartingDetail": "Starting…",
-  "@catalogScanStartingDetail": {
-    "description": "Supporting line on the scan row between dispatch and the first progress event, when no harness has reported yet. Holds the line's place so the row does not change height when the real detail arrives."
+  "catalogScanPreparingOneDetail": "Preparing {harness} scan…",
+  "@catalogScanPreparingOneDetail": {
+    "description": "Supporting line before one pending harness reports catalog progress.",
+    "placeholders": {
+      "harness": {
+        "type": "String",
+        "example": "Codex"
+      }
+    }
   },
-  "catalogScanRunningDetail": "{harness} — {sessions, plural, =1{1 session} other{{sessions} sessions}}",
-  "@catalogScanRunningDetail": {
-    "description": "Supporting line on the running scan row: the harness currently being scanned and how many sessions it has reported so far.",
+  "catalogScanPreparingManyDetail": "Preparing {harnesses} scans…",
+  "@catalogScanPreparingManyDetail": {
+    "description": "Supporting line before multiple pending harnesses report catalog progress. The harnesses placeholder is a bounded localized name summary.",
+    "placeholders": {
+      "harnesses": {
+        "type": "String",
+        "example": "Codex and Claude"
+      }
+    }
+  },
+  "catalogScanTwoHarnesses": "{first} and {second}",
+  "@catalogScanTwoHarnesses": {
+    "description": "Joins two pending harness display names in scan progress copy.",
+    "placeholders": {
+      "first": {
+        "type": "String"
+      },
+      "second": {
+        "type": "String"
+      }
+    }
+  },
+  "catalogScanHarnessesWithOthers": "{first}, {second}, and {others, plural, =1{1 other} other{{others} others}}",
+  "@catalogScanHarnessesWithOthers": {
+    "description": "Bounded summary for three or more pending harnesses in scan progress copy.",
+    "placeholders": {
+      "first": {
+        "type": "String"
+      },
+      "second": {
+        "type": "String"
+      },
+      "others": {
+        "type": "int"
+      }
+    }
+  },
+  "catalogScanStartingDetail": "Starting {harness}…",
+  "@catalogScanStartingDetail": {
+    "description": "Supporting line while a fresh management snapshot authoritatively reports the named harness as starting.",
+    "placeholders": {
+      "harness": {
+        "type": "String",
+        "example": "Codex"
+      }
+    }
+  },
+  "catalogScanReadingDetail": "Reading {harness} sessions…",
+  "@catalogScanReadingDetail": {
+    "description": "Supporting line while the named harness is enumerating but has not found a session yet.",
+    "placeholders": {
+      "harness": {
+        "type": "String",
+        "example": "Codex"
+      }
+    }
+  },
+  "catalogScanReadingCountDetail": "{harness} — {sessions, plural, =1{1 session found} other{{sessions} sessions found}}",
+  "@catalogScanReadingCountDetail": {
+    "description": "Supporting line while the named harness enumerates sessions.",
     "placeholders": {
       "harness": {
         "type": "String",
@@ -1172,6 +1235,36 @@
       },
       "sessions": {
         "type": "int"
+      }
+    }
+  },
+  "catalogScanSavingDetail": "Saving {harness} scan results…",
+  "@catalogScanSavingDetail": {
+    "description": "Supporting line while the named harness commits its catalog snapshot.",
+    "placeholders": {
+      "harness": {
+        "type": "String",
+        "example": "Codex"
+      }
+    }
+  },
+  "catalogScanWaitingTitle": "Waiting for {harness}",
+  "@catalogScanWaitingTitle": {
+    "description": "Title after one harness has remained authoritatively in startup for ten seconds.",
+    "placeholders": {
+      "harness": {
+        "type": "String",
+        "example": "Codex"
+      }
+    }
+  },
+  "catalogScanWaitingDetail": "{harness} must finish starting before scanning can continue. You can keep browsing.",
+  "@catalogScanWaitingDetail": {
+    "description": "Wrapped explanation after one harness has remained authoritatively in startup for ten seconds.",
+    "placeholders": {
+      "harness": {
+        "type": "String",
+        "example": "Codex"
       }
     }
   },

--- a/client/module_app_ui/lib/src/l10n/app_localizations.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations.dart
@@ -3637,13 +3637,13 @@ abstract class AppLocalizations {
   /// **'Saving {harness} scan results…'**
   String catalogScanSavingDetail(String harness);
 
-  /// Title after one harness has remained authoritatively in startup for ten seconds.
+  /// Title after one harness has remained authoritatively in startup for three seconds.
   ///
   /// In en, this message translates to:
   /// **'Waiting for {harness}'**
   String catalogScanWaitingTitle(String harness);
 
-  /// Wrapped explanation after one harness has remained authoritatively in startup for ten seconds.
+  /// Wrapped explanation after one harness has remained authoritatively in startup for three seconds.
   ///
   /// In en, this message translates to:
   /// **'{harness} must finish starting before scanning can continue. You can keep browsing.'**

--- a/client/module_app_ui/lib/src/l10n/app_localizations.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations.dart
@@ -3589,17 +3589,65 @@ abstract class AppLocalizations {
   /// **'Scanning all harnesses'**
   String get catalogScanRunningTitle;
 
-  /// Supporting line on the scan row between dispatch and the first progress event, when no harness has reported yet. Holds the line's place so the row does not change height when the real detail arrives.
+  /// Supporting line before one pending harness reports catalog progress.
   ///
   /// In en, this message translates to:
-  /// **'Starting…'**
-  String get catalogScanStartingDetail;
+  /// **'Preparing {harness} scan…'**
+  String catalogScanPreparingOneDetail(String harness);
 
-  /// Supporting line on the running scan row: the harness currently being scanned and how many sessions it has reported so far.
+  /// Supporting line before multiple pending harnesses report catalog progress. The harnesses placeholder is a bounded localized name summary.
   ///
   /// In en, this message translates to:
-  /// **'{harness} — {sessions, plural, =1{1 session} other{{sessions} sessions}}'**
-  String catalogScanRunningDetail(String harness, int sessions);
+  /// **'Preparing {harnesses} scans…'**
+  String catalogScanPreparingManyDetail(String harnesses);
+
+  /// Joins two pending harness display names in scan progress copy.
+  ///
+  /// In en, this message translates to:
+  /// **'{first} and {second}'**
+  String catalogScanTwoHarnesses(String first, String second);
+
+  /// Bounded summary for three or more pending harnesses in scan progress copy.
+  ///
+  /// In en, this message translates to:
+  /// **'{first}, {second}, and {others, plural, =1{1 other} other{{others} others}}'**
+  String catalogScanHarnessesWithOthers(String first, String second, int others);
+
+  /// Supporting line while a fresh management snapshot authoritatively reports the named harness as starting.
+  ///
+  /// In en, this message translates to:
+  /// **'Starting {harness}…'**
+  String catalogScanStartingDetail(String harness);
+
+  /// Supporting line while the named harness is enumerating but has not found a session yet.
+  ///
+  /// In en, this message translates to:
+  /// **'Reading {harness} sessions…'**
+  String catalogScanReadingDetail(String harness);
+
+  /// Supporting line while the named harness enumerates sessions.
+  ///
+  /// In en, this message translates to:
+  /// **'{harness} — {sessions, plural, =1{1 session found} other{{sessions} sessions found}}'**
+  String catalogScanReadingCountDetail(String harness, int sessions);
+
+  /// Supporting line while the named harness commits its catalog snapshot.
+  ///
+  /// In en, this message translates to:
+  /// **'Saving {harness} scan results…'**
+  String catalogScanSavingDetail(String harness);
+
+  /// Title after one harness has remained authoritatively in startup for ten seconds.
+  ///
+  /// In en, this message translates to:
+  /// **'Waiting for {harness}'**
+  String catalogScanWaitingTitle(String harness);
+
+  /// Wrapped explanation after one harness has remained authoritatively in startup for ten seconds.
+  ///
+  /// In en, this message translates to:
+  /// **'{harness} must finish starting before scanning can continue. You can keep browsing.'**
+  String catalogScanWaitingDetail(String harness);
 
   /// Action on the running scan row that stops the catalog scan in flight.
   ///

--- a/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
@@ -1959,17 +1959,65 @@ class AppLocalizationsEn extends AppLocalizations {
   String get catalogScanRunningTitle => 'Scanning all harnesses';
 
   @override
-  String get catalogScanStartingDetail => 'Starting…';
+  String catalogScanPreparingOneDetail(String harness) {
+    return 'Preparing $harness scan…';
+  }
 
   @override
-  String catalogScanRunningDetail(String harness, int sessions) {
+  String catalogScanPreparingManyDetail(String harnesses) {
+    return 'Preparing $harnesses scans…';
+  }
+
+  @override
+  String catalogScanTwoHarnesses(String first, String second) {
+    return '$first and $second';
+  }
+
+  @override
+  String catalogScanHarnessesWithOthers(String first, String second, int others) {
+    String _temp0 = intl.Intl.pluralLogic(
+      others,
+      locale: localeName,
+      other: '$others others',
+      one: '1 other',
+    );
+    return '$first, $second, and $_temp0';
+  }
+
+  @override
+  String catalogScanStartingDetail(String harness) {
+    return 'Starting $harness…';
+  }
+
+  @override
+  String catalogScanReadingDetail(String harness) {
+    return 'Reading $harness sessions…';
+  }
+
+  @override
+  String catalogScanReadingCountDetail(String harness, int sessions) {
     String _temp0 = intl.Intl.pluralLogic(
       sessions,
       locale: localeName,
-      other: '$sessions sessions',
-      one: '1 session',
+      other: '$sessions sessions found',
+      one: '1 session found',
     );
     return '$harness — $_temp0';
+  }
+
+  @override
+  String catalogScanSavingDetail(String harness) {
+    return 'Saving $harness scan results…';
+  }
+
+  @override
+  String catalogScanWaitingTitle(String harness) {
+    return 'Waiting for $harness';
+  }
+
+  @override
+  String catalogScanWaitingDetail(String harness) {
+    return '$harness must finish starting before scanning can continue. You can keep browsing.';
   }
 
   @override

--- a/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
+++ b/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:ui" as ui;
 
 import "package:material_ui/material_ui.dart";
@@ -18,15 +19,16 @@ const double _entranceScaleFrom = 0.97;
 const double _entranceBlurSigma = 2;
 // Keep the leading footprint identical when loading becomes a result.
 const double _scanMarkSize = 20;
+const Duration _startupWaitThreshold = Duration(seconds: 10);
 
 /// The catalog scan reported as one quiet row above a list.
 ///
 /// Live scans use the coordinated loading card designed for this flow;
 /// terminal outcomes keep their severity-tinted report cards.
 ///
-/// Its height never changes while the scan is live. The supporting line always
-/// occupies a row, so a scan that starts before it can name a harness does not
-/// shove the list down again when the first progress event lands.
+/// Ordinary live phases keep one supporting row, so progress changes do not
+/// shove the list. Only the prolonged-startup explanation may wrap and grow;
+/// preserving its guidance is more important than the baseline card height.
 class const CatalogScanRow({
   super.key,
 
@@ -85,6 +87,10 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
   /// an empty box collapsing behind it.
   _RowContent? _shown;
 
+  Timer? _startupWaitTimer;
+  String? _startupWaitPluginName;
+  bool _startupWaitElapsed = false;
+
   /// Whether the current scan has anything to report. Decided from the scan
   /// alone, so the animation can be driven from lifecycle callbacks rather than
   /// from [build], where starting a controller races its own frame.
@@ -98,6 +104,7 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
     // its labels and its live action button stay mounted at zero height, where
     // a keyboard or screen reader can still reach an invisible control.
     _reveal.addStatusListener(_onRevealStatus);
+    _syncStartupWait();
   }
 
   @override
@@ -109,6 +116,7 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
   @override
   void didUpdateWidget(CatalogScanRow oldWidget) {
     super.didUpdateWidget(oldWidget);
+    _syncStartupWait();
     final reducedMotion = _syncReducedMotionPreference();
     final hadContent = oldWidget._scan is! CatalogRescanIdle;
     if (_hasContent) {
@@ -153,8 +161,50 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
     setState(() => _shown = null);
   }
 
+  void _syncStartupWait() {
+    final pluginName = switch (widget._scan) {
+      CatalogRescanStarting(:final activePluginName) => activePluginName,
+      CatalogRescanIdle() ||
+      CatalogRescanPreparingOne() ||
+      CatalogRescanPreparingMany() ||
+      CatalogRescanReading() ||
+      CatalogRescanSaving() ||
+      CatalogRescanSucceeded() ||
+      CatalogRescanPartlyFailed() ||
+      CatalogRescanFailed() ||
+      CatalogRescanUnsupported() ||
+      CatalogRescanNoHarness() => null,
+    };
+    if (pluginName == _startupWaitPluginName && (_startupWaitTimer != null || _startupWaitElapsed)) return;
+    _startupWaitTimer?.cancel();
+    _startupWaitTimer = null;
+    _startupWaitPluginName = pluginName;
+    _startupWaitElapsed = false;
+    if (pluginName == null) return;
+    _startupWaitTimer = Timer(_startupWaitThreshold, () {
+      _startupWaitTimer = null;
+      if (!mounted) return;
+      final stillWaitingForSameHarness = switch (widget._scan) {
+        CatalogRescanStarting(:final activePluginName) => activePluginName == pluginName,
+        CatalogRescanIdle() ||
+        CatalogRescanPreparingOne() ||
+        CatalogRescanPreparingMany() ||
+        CatalogRescanReading() ||
+        CatalogRescanSaving() ||
+        CatalogRescanSucceeded() ||
+        CatalogRescanPartlyFailed() ||
+        CatalogRescanFailed() ||
+        CatalogRescanUnsupported() ||
+        CatalogRescanNoHarness() => false,
+      };
+      if (!stillWaitingForSameHarness) return;
+      setState(() => _startupWaitElapsed = true);
+    });
+  }
+
   @override
   void dispose() {
+    _startupWaitTimer?.cancel();
     WidgetsBinding.instance.removeObserver(this);
     _reveal.removeStatusListener(_onRevealStatus);
     _entranceCurve.dispose();
@@ -181,7 +231,7 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
         // Announced when it appears without moving focus, the same treatment
         // the connection banner uses: a scan started by a pull finishes with
         // no other signal that it is done. Every state announces except the
-        // running one, whose session count changes with each enumerated
+        // reading one, whose session count changes with each enumerated
         // session and would otherwise interrupt a screen reader hundreds of
         // times during one scan.
         child: AnimatedBuilder(
@@ -212,11 +262,12 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
             // otherwise this live-region container merges its localized label
             // into the changing status announcement.
             explicitChildNodes: true,
-            liveRegion: widget._scan is! CatalogRescanRunning,
+            liveRegion: widget._scan is! CatalogRescanReading,
             child: shown.tone == _ScanTone.working
                 ? _ScanLoadingCard(
                     title: shown.title,
                     supportingText: shown.detail,
+                    wrapSupportingText: shown.wrapDetail,
                     cancelLabel: shown.actionLabel,
                     onCancel: shown.onAction,
                   )
@@ -235,20 +286,43 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
   /// `null` is the idle row, which folds away to nothing.
   _RowContent? _contentFor({required AppLocalizations loc, required CatalogRescanState scan}) => switch (scan) {
     CatalogRescanIdle() => null,
-    // The spinner is the progress report: a scan has no total to count towards,
-    // so there is nothing to fill a bar with. The detail line holds its place
-    // until the first harness reports.
-    CatalogRescanStarting() => _RowContent(
+    CatalogRescanPreparingOne(:final pendingPluginName) => _RowContent(
       tone: _ScanTone.working,
       title: loc.catalogScanRunningTitle,
-      detail: loc.catalogScanStartingDetail,
+      detail: loc.catalogScanPreparingOneDetail(pendingPluginName),
       actionLabel: loc.catalogScanCancel,
       onAction: widget._onCancel,
     ),
-    CatalogRescanRunning(:final activePluginName, :final sessionsSeen) => _RowContent(
+    CatalogRescanPreparingMany(:final pendingPluginNames) => _RowContent(
       tone: _ScanTone.working,
       title: loc.catalogScanRunningTitle,
-      detail: loc.catalogScanRunningDetail(activePluginName, sessionsSeen),
+      detail: loc.catalogScanPreparingManyDetail(_pendingHarnessSummary(loc: loc, names: pendingPluginNames)),
+      actionLabel: loc.catalogScanCancel,
+      onAction: widget._onCancel,
+    ),
+    CatalogRescanStarting(:final activePluginName) => _RowContent(
+      tone: _ScanTone.working,
+      title: _startupWaitElapsed ? loc.catalogScanWaitingTitle(activePluginName) : loc.catalogScanRunningTitle,
+      detail: _startupWaitElapsed
+          ? loc.catalogScanWaitingDetail(activePluginName)
+          : loc.catalogScanStartingDetail(activePluginName),
+      wrapDetail: _startupWaitElapsed,
+      actionLabel: loc.catalogScanCancel,
+      onAction: widget._onCancel,
+    ),
+    CatalogRescanReading(:final activePluginName, :final sessionsSeen) => _RowContent(
+      tone: _ScanTone.working,
+      title: loc.catalogScanRunningTitle,
+      detail: sessionsSeen == 0
+          ? loc.catalogScanReadingDetail(activePluginName)
+          : loc.catalogScanReadingCountDetail(activePluginName, sessionsSeen),
+      actionLabel: loc.catalogScanCancel,
+      onAction: widget._onCancel,
+    ),
+    CatalogRescanSaving(:final activePluginName) => _RowContent(
+      tone: _ScanTone.working,
+      title: loc.catalogScanRunningTitle,
+      detail: loc.catalogScanSavingDetail(activePluginName),
       actionLabel: loc.catalogScanCancel,
       onAction: widget._onCancel,
     ),
@@ -309,6 +383,11 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
 ///
 /// Shared by the row and by the Settings toast, so one scan never reads two
 /// different ways depending on where it is reported.
+String _pendingHarnessSummary({required AppLocalizations loc, required List<String> names}) {
+  if (names.length == 2) return loc.catalogScanTwoHarnesses(names[0], names[1]);
+  return loc.catalogScanHarnessesWithOthers(names[0], names[1], names.length - 2);
+}
+
 String catalogScanCountsLine({required AppLocalizations loc, required CatalogRescanCounts counts}) {
   final (sessions, projects) = switch (counts) {
     CatalogRescanDelta(:final newSessions, :final newProjects) => (
@@ -350,6 +429,7 @@ class const _RowContent({
   final IconData? icon,
   required final String title,
   required final String detail,
+  final bool wrapDetail = false,
   required final String actionLabel,
   required final VoidCallback onAction,
 });
@@ -492,6 +572,7 @@ class const _ScanCard({required final _RowContent content}) extends StatelessWid
 class const _ScanLoadingCard({
   required final String title,
   required final String supportingText,
+  required final bool wrapSupportingText,
   required final String cancelLabel,
   required final VoidCallback onCancel,
 }) extends StatefulWidget {
@@ -619,8 +700,8 @@ class _ScanLoadingCardState()
                             const SizedBox(height: PregoSpacing.xxs),
                             Text(
                               widget.supportingText,
-                              maxLines: wrapsText ? null : 1,
-                              overflow: wrapsText ? null : TextOverflow.ellipsis,
+                              maxLines: wrapsText || widget.wrapSupportingText ? null : 1,
+                              overflow: wrapsText || widget.wrapSupportingText ? null : TextOverflow.ellipsis,
                               style: prego.textTheme.textSm.regular.copyWith(color: colors.textSecondary),
                             ),
                           ],

--- a/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
+++ b/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
@@ -19,7 +19,7 @@ const double _entranceScaleFrom = 0.97;
 const double _entranceBlurSigma = 2;
 // Keep the leading footprint identical when loading becomes a result.
 const double _scanMarkSize = 20;
-const Duration _startupWaitThreshold = Duration(seconds: 10);
+const Duration _startupWaitThreshold = Duration(seconds: 3);
 
 /// The catalog scan reported as one quiet row above a list.
 ///

--- a/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
+++ b/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
@@ -375,6 +375,11 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
   };
 }
 
+String _pendingHarnessSummary({required AppLocalizations loc, required List<String> names}) {
+  if (names.length == 2) return loc.catalogScanTwoHarnesses(names[0], names[1]);
+  return loc.catalogScanHarnessesWithOthers(names[0], names[1], names.length - 2);
+}
+
 /// What a finished scan found, sessions first.
 ///
 /// A clause counting nothing is dropped rather than joined, so an ordinary
@@ -383,11 +388,6 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
 ///
 /// Shared by the row and by the Settings toast, so one scan never reads two
 /// different ways depending on where it is reported.
-String _pendingHarnessSummary({required AppLocalizations loc, required List<String> names}) {
-  if (names.length == 2) return loc.catalogScanTwoHarnesses(names[0], names[1]);
-  return loc.catalogScanHarnessesWithOthers(names[0], names[1], names.length - 2);
-}
-
 String catalogScanCountsLine({required AppLocalizations loc, required CatalogRescanCounts counts}) {
   final (sessions, projects) = switch (counts) {
     CatalogRescanDelta(:final newSessions, :final newProjects) => (

--- a/client/module_app_ui/test/widgets/catalog_scan_row_test.dart
+++ b/client/module_app_ui/test/widgets/catalog_scan_row_test.dart
@@ -132,28 +132,33 @@ void main() {
 
     // The Figma loading component reserves both text lines before a harness
     // reports, so the row does not shove the list down on the first event.
-    testWidgets("keeps the same height from starting through running", (tester) async {
+    testWidgets("keeps the same height from preparing through reading", (tester) async {
       Future<double> heightFor(CatalogRescanState scan) async {
         await pumpRow(tester, scan);
         return tester.getSize(find.byType(CatalogScanRow)).height;
       }
 
-      final starting = await heightFor(const CatalogRescanState.starting(pluginIds: {"codex"}));
-      final running = await heightFor(
-        const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
+      final preparing = await heightFor(
+        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+      );
+      final reading = await heightFor(
+        const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
       );
 
-      expect(starting, greaterThan(0));
-      expect(running, starting);
+      expect(preparing, greaterThan(0));
+      expect(reading, preparing);
     });
 
     for (final textScale in [1.0, 2.0]) {
       testWidgets("keeps scan marks and text in place across states at ${textScale}x text", (tester) async {
         final loc = await AppLocalizations.delegate.load(const Locale("en"));
         final states = [
-          (const CatalogRescanState.starting(pluginIds: {"codex"}), loc.catalogScanRunningTitle),
           (
-            const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
+            const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+            loc.catalogScanRunningTitle,
+          ),
+          (
+            const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
             loc.catalogScanRunningTitle,
           ),
           (
@@ -196,7 +201,10 @@ void main() {
     }
 
     testWidgets("reports the scan before any harness has reported progress", (tester) async {
-      await pumpRow(tester, const CatalogRescanState.starting(pluginIds: {"codex"}));
+      await pumpRow(
+        tester,
+        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+      );
 
       final loc = await AppLocalizations.delegate.load(const Locale("en"));
       expect(find.text(loc.catalogScanRunningTitle), findsOneWidget);
@@ -207,7 +215,7 @@ void main() {
     testWidgets("matches the 402 by 101 Figma loading geometry", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.starting(pluginIds: {"codex"}),
+        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
         designSystem: PregoDesignSystem.dark,
         width: 402,
       );
@@ -233,7 +241,7 @@ void main() {
     testWidgets("keeps the scan graphic visible in the light theme", (tester) async {
       await tester.pumpWidget(
         harness(
-          const CatalogRescanState.starting(pluginIds: {"codex"}),
+          const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex"}),
           designSystem: PregoDesignSystem.light,
           width: 402,
         ),
@@ -257,7 +265,7 @@ void main() {
     testWidgets("repeats both loading motions on one ten-second timeline", (tester) async {
       await tester.pumpWidget(
         harness(
-          const CatalogRescanState.starting(pluginIds: {"codex"}),
+          const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
           width: 402,
         ),
       );
@@ -288,7 +296,7 @@ void main() {
       await tester.pump();
 
       await tester.pumpWidget(
-        harness(const CatalogRescanState.starting(pluginIds: {"codex"})),
+        harness(const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"})),
       );
 
       expect(entranceScale(tester), closeTo(0.97, 0.0001));
@@ -312,12 +320,15 @@ void main() {
     });
 
     testWidgets("does not replay the entrance for progress updates or exit", (tester) async {
-      await pumpRow(tester, const CatalogRescanState.starting(pluginIds: {"codex"}));
+      await pumpRow(
+        tester,
+        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+      );
       expect(entranceScale(tester), 1);
 
       await tester.pumpWidget(
         harness(
-          const CatalogRescanState.running(
+          const CatalogRescanState.reading(
             activePluginName: "Codex",
             sessionsSeen: 4,
             pluginIds: {"codex"},
@@ -333,7 +344,10 @@ void main() {
     });
 
     testWidgets("stops the looping scan graphic when a terminal outcome replaces it", (tester) async {
-      await pumpRow(tester, const CatalogRescanState.starting(pluginIds: {"codex"}));
+      await pumpRow(
+        tester,
+        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+      );
 
       expect(find.byKey(const ValueKey("prego-deep-scan-loader")), findsOneWidget);
       expect(find.byKey(const ValueKey("prego-deep-scan-beam")), findsOneWidget);
@@ -357,26 +371,26 @@ void main() {
     testWidgets("names the harness being scanned and what it has seen", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.running(
+        const CatalogRescanState.reading(
           activePluginName: "Codex",
           sessionsSeen: 148,
           pluginIds: {"codex"},
         ),
       );
 
-      expect(find.text("Codex — 148 sessions"), findsOneWidget);
+      expect(find.text("Codex — 148 sessions found"), findsOneWidget);
     });
 
     testWidgets("uses localized singular copy for live and completed counts", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.running(
+        const CatalogRescanState.reading(
           activePluginName: "Codex",
           sessionsSeen: 1,
           pluginIds: {"codex"},
         ),
       );
-      expect(find.text("Codex — 1 session"), findsOneWidget);
+      expect(find.text("Codex — 1 session found"), findsOneWidget);
 
       await pumpRow(
         tester,
@@ -388,10 +402,81 @@ void main() {
       expect(find.text("1 new session in 1 new project"), findsOneWidget);
     });
 
+    testWidgets("renders preparing, reading, and saving phase copy", (tester) async {
+      await pumpRow(
+        tester,
+        const CatalogRescanState.preparingMany(
+          pendingPluginNames: ["Codex", "Claude", "Cursor"],
+          pluginIds: {"codex", "claude", "cursor"},
+        ),
+      );
+      expect(find.text("Preparing Codex, Claude, and 1 other scans…"), findsOneWidget);
+
+      await pumpRow(
+        tester,
+        const CatalogRescanState.reading(activePluginName: "Claude", sessionsSeen: 0, pluginIds: {"claude"}),
+      );
+      expect(find.text("Reading Claude sessions…"), findsOneWidget);
+
+      await pumpRow(
+        tester,
+        const CatalogRescanState.saving(activePluginName: "Claude", pluginIds: {"claude"}),
+      );
+      expect(find.text("Saving Claude scan results…"), findsOneWidget);
+    });
+
+    testWidgets("explains a prolonged confirmed harness startup after ten seconds", (tester) async {
+      await tester.pumpWidget(
+        harness(
+          const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex"}),
+          width: 402,
+        ),
+      );
+      await tester.pump();
+
+      expect(find.text("Scanning all harnesses"), findsOneWidget);
+      expect(find.text("Starting Codex…"), findsOneWidget);
+      await tester.pump(const Duration(seconds: 9));
+      expect(find.text("Waiting for Codex"), findsNothing);
+
+      await tester.pump(const Duration(seconds: 1));
+      expect(find.text("Waiting for Codex"), findsOneWidget);
+      expect(
+        find.text("Codex must finish starting before scanning can continue. You can keep browsing."),
+        findsOneWidget,
+      );
+      final explanation = tester.widget<Text>(
+        find.text("Codex must finish starting before scanning can continue. You can keep browsing."),
+      );
+      expect(explanation.maxLines, isNull);
+      expect(explanation.overflow, isNull);
+      final loc = await AppLocalizations.delegate.load(const Locale("en"));
+      await tester.tap(find.bySemanticsLabel(loc.catalogScanCancel));
+      expect(cancelCount, 1);
+    });
+
+    testWidgets("restarts the prolonged startup threshold when the harness changes", (tester) async {
+      await tester.pumpWidget(
+        harness(const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex", "claude"})),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 9));
+
+      await tester.pumpWidget(
+        harness(const CatalogRescanState.starting(activePluginName: "Claude", pluginIds: {"codex", "claude"})),
+      );
+      await tester.pump(const Duration(seconds: 2));
+      expect(find.text("Waiting for Claude"), findsNothing);
+      expect(find.text("Starting Claude…"), findsOneWidget);
+
+      await tester.pump(const Duration(seconds: 8));
+      expect(find.text("Waiting for Claude"), findsOneWidget);
+    });
+
     testWidgets("cancels the scan in flight from the running row", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 1, pluginIds: {"codex"}),
+        const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 1, pluginIds: {"codex"}),
       );
 
       final loc = await AppLocalizations.delegate.load(const Locale("en"));
@@ -411,7 +496,7 @@ void main() {
     testWidgets("focuses and activates Cancel from the keyboard", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 1, pluginIds: {"codex"}),
+        const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 1, pluginIds: {"codex"}),
       );
 
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
@@ -702,7 +787,7 @@ void main() {
       expect(find.text(loc.catalogScanNoHarnessDetail), findsOneWidget);
     });
 
-    // The running row's session count changes with every enumerated session, so
+    // The reading row's session count changes with every enumerated session, so
     // announcing it would interrupt a screen reader throughout a long scan.
     testWidgets("announces every state except the one whose count keeps moving", (tester) async {
       Future<bool?> announcesFor(CatalogRescanState scan) async {
@@ -715,11 +800,16 @@ void main() {
             .liveRegion;
       }
 
-      expect(await announcesFor(const CatalogRescanState.starting(pluginIds: {"codex"})), isTrue);
+      expect(
+        await announcesFor(
+          const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex"}),
+        ),
+        isTrue,
+      );
       expect(await announcesFor(const CatalogRescanState.failed(harnessCount: 1)), isTrue);
       expect(
         await announcesFor(
-          const CatalogRescanState.running(activePluginName: "Codex", sessionsSeen: 9, pluginIds: {"codex"}),
+          const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 9, pluginIds: {"codex"}),
         ),
         isFalse,
       );
@@ -777,7 +867,10 @@ void main() {
               builder: (context) => MediaQuery(
                 data: MediaQuery.of(context).copyWith(disableAnimations: true),
                 child: CatalogScanRow(
-                  scan: const CatalogRescanState.starting(pluginIds: {"codex"}),
+                  scan: const CatalogRescanState.preparingOne(
+                    pendingPluginName: "Codex",
+                    pluginIds: {"codex"},
+                  ),
                   onCancel: () => cancelCount++,
                   onDismiss: () => dismissCount++,
                 ),
@@ -812,7 +905,7 @@ void main() {
       await tester.pumpWidget(harness(const CatalogRescanState.idle()));
       await tester.pump();
       await tester.pumpWidget(
-        harness(const CatalogRescanState.starting(pluginIds: {"codex"})),
+        harness(const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"})),
       );
       await tester.pump(const Duration(milliseconds: 16));
 
@@ -832,7 +925,7 @@ void main() {
       await tester.pumpWidget(harness(const CatalogRescanState.idle()));
       await tester.pump();
       await tester.pumpWidget(
-        harness(const CatalogRescanState.starting(pluginIds: {"codex"})),
+        harness(const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"})),
       );
       await tester.pump(const Duration(milliseconds: 80));
       expect(entranceScale(tester), isNot(1));
@@ -884,12 +977,12 @@ void main() {
 
       await pumpRow(
         tester,
-        const CatalogRescanState.starting(pluginIds: {"codex"}),
+        const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex"}),
         textScaler: textScaler,
         width: 402,
       );
       expect(tester.getSize(find.byType(CatalogScanRow)).height, greaterThan(101));
-      for (final label in [loc.catalogScanRunningTitle, loc.catalogScanStartingDetail]) {
+      for (final label in [loc.catalogScanRunningTitle, loc.catalogScanStartingDetail("Codex")]) {
         final text = tester.widget<Text>(find.text(label));
         expect(text.maxLines, isNull);
         expect(text.overflow, isNull);

--- a/client/module_app_ui/test/widgets/catalog_scan_row_test.dart
+++ b/client/module_app_ui/test/widgets/catalog_scan_row_test.dart
@@ -425,7 +425,7 @@ void main() {
       expect(find.text("Saving Claude scan results…"), findsOneWidget);
     });
 
-    testWidgets("explains a prolonged confirmed harness startup after ten seconds", (tester) async {
+    testWidgets("explains a prolonged confirmed harness startup after three seconds", (tester) async {
       await tester.pumpWidget(
         harness(
           const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex"}),
@@ -436,7 +436,7 @@ void main() {
 
       expect(find.text("Scanning all harnesses"), findsOneWidget);
       expect(find.text("Starting Codex…"), findsOneWidget);
-      await tester.pump(const Duration(seconds: 9));
+      await tester.pump(const Duration(seconds: 2));
       expect(find.text("Waiting for Codex"), findsNothing);
 
       await tester.pump(const Duration(seconds: 1));
@@ -460,7 +460,7 @@ void main() {
         harness(const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex", "claude"})),
       );
       await tester.pump();
-      await tester.pump(const Duration(seconds: 9));
+      await tester.pump(const Duration(seconds: 2));
 
       await tester.pumpWidget(
         harness(const CatalogRescanState.starting(activePluginName: "Claude", pluginIds: {"codex", "claude"})),
@@ -469,7 +469,7 @@ void main() {
       expect(find.text("Waiting for Claude"), findsNothing);
       expect(find.text("Starting Claude…"), findsOneWidget);
 
-      await tester.pump(const Duration(seconds: 8));
+      await tester.pump(const Duration(seconds: 1));
       expect(find.text("Waiting for Claude"), findsOneWidget);
     });
 

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -684,7 +684,11 @@ class PluginManagementCubit({
   /// Only a live operation names members worth disabling an action for: a
   /// terminal state still carries no ids, and an idle one covers nothing.
   Set<String> get _scanningPluginIds => switch (_catalogRescanService.state.value) {
-    CatalogRescanStarting(:final pluginIds) || CatalogRescanRunning(:final pluginIds) => pluginIds,
+    CatalogRescanPreparingOne(:final pluginIds) ||
+    CatalogRescanPreparingMany(:final pluginIds) ||
+    CatalogRescanStarting(:final pluginIds) ||
+    CatalogRescanReading(:final pluginIds) ||
+    CatalogRescanSaving(:final pluginIds) => pluginIds,
     CatalogRescanIdle() ||
     CatalogRescanSucceeded() ||
     CatalogRescanPartlyFailed() ||
@@ -741,8 +745,11 @@ class PluginManagementCubit({
     ),
     CatalogRescanFailed() => const CatalogRescanOutcome.failed(),
     CatalogRescanIdle() ||
+    CatalogRescanPreparingOne() ||
+    CatalogRescanPreparingMany() ||
     CatalogRescanStarting() ||
-    CatalogRescanRunning() ||
+    CatalogRescanReading() ||
+    CatalogRescanSaving() ||
     CatalogRescanUnsupported() ||
     CatalogRescanNoHarness() => null,
   };

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -408,9 +408,10 @@ class CatalogRescanService({
     final pluginIds = Set<String>.unmodifiable(_members);
     final active = _activeProgress();
     if (active != null) {
-      final pluginName = _displayName(active.pluginId);
+      final pluginName = _displayName(pluginId: active.pluginId);
       final next = switch (active) {
-        CatalogImportEnumerating(:final sessionsSeen) when sessionsSeen == 0 && _isConfirmedStarting(active.pluginId) =>
+        CatalogImportEnumerating(:final sessionsSeen)
+            when sessionsSeen == 0 && _isConfirmedStarting(pluginId: active.pluginId) =>
           CatalogRescanState.starting(activePluginName: pluginName, pluginIds: pluginIds),
         CatalogImportEnumerating(:final sessionsSeen) => CatalogRescanState.reading(
           activePluginName: pluginName,
@@ -436,10 +437,10 @@ class CatalogRescanService({
         if (_progressByPluginId[pluginId] == null) pluginId,
     ];
     for (final pluginId in pendingPluginIds) {
-      if (_isConfirmedStarting(pluginId)) {
+      if (_isConfirmedStarting(pluginId: pluginId)) {
         _publish(
           CatalogRescanState.starting(
-            activePluginName: _displayName(pluginId),
+            activePluginName: _displayName(pluginId: pluginId),
             pluginIds: pluginIds,
           ),
         );
@@ -447,7 +448,9 @@ class CatalogRescanService({
       }
     }
     if (pendingPluginIds.isEmpty) return;
-    final pendingPluginNames = List<String>.unmodifiable(pendingPluginIds.map(_displayName));
+    final pendingPluginNames = List<String>.unmodifiable(
+      pendingPluginIds.map((pluginId) => _displayName(pluginId: pluginId)),
+    );
     _publish(
       pendingPluginNames.length == 1
           ? CatalogRescanState.preparingOne(
@@ -461,9 +464,9 @@ class CatalogRescanService({
     );
   }
 
-  String _displayName(String pluginId) => _displayNames[pluginId] ?? pluginId;
+  String _displayName({required String pluginId}) => _displayNames[pluginId] ?? pluginId;
 
-  bool _isConfirmedStarting(String pluginId) =>
+  bool _isConfirmedStarting({required String pluginId}) =>
       _operationBridgeId != null &&
       _operationBridgeId == _activeBridgeId &&
       _runtimeStates[pluginId] == PluginRuntimeState.starting;

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -61,9 +61,14 @@ class CatalogRescanService({
   /// The live operation's members, or empty when none is live.
   final Set<String> _members = {};
 
-  /// Display names for the current bridge's harnesses, so a running row can
-  /// name the harness rather than echo its id.
+  /// Display names and runtime states from the current bridge's latest
+  /// management snapshot.
   Map<String, String> _displayNames = const {};
+  Map<String, PluginRuntimeState> _runtimeStates = const {};
+
+  /// Bridge identity whose management snapshot opened the live operation.
+  /// Runtime state can describe its phases only while this still matches.
+  String? _operationBridgeId;
 
   /// True when the live operation was discovered rather than started here.
   bool _observed = false;
@@ -104,6 +109,16 @@ class CatalogRescanService({
   /// Rescans every harness this bridge can import from.
   Future<void> startAll() async {
     if (_disposed) return;
+    // CatalogRescanService is lazy and can first exist at the pull gesture.
+    // Bootstrap one authoritative management read before deciding there is no
+    // harness; PluginManagementService fences this refresh to its connection
+    // and bridge identity. A current terminal snapshot needs no async gap, so
+    // an immediate cancel can still see the operation before this call returns.
+    if (_managementService.snapshots.valueOrNull
+        case PluginManagementLoadResultLoading() || PluginManagementLoadResultFailure() || null) {
+      await _managementService.refresh();
+      if (_disposed) return;
+    }
     switch (_managementService.snapshots.valueOrNull) {
       // Without a management snapshot there are no harness ids to fan out to,
       // so no request is made and no `404` would ever come back to reveal the
@@ -121,7 +136,11 @@ class CatalogRescanService({
           if (_members.isEmpty) _publish(const CatalogRescanState.noHarness());
           return;
         }
-        await _start(pluginIds: pluginIds, coversEveryHarness: true);
+        await _start(
+          pluginIds: pluginIds,
+          coversEveryHarness: true,
+          operationBridgeId: response.bridgeId,
+        );
       // No snapshot to fan out over. Reported rather than returned silently,
       // because the caller is a gesture that has already told the user a scan
       // started, and a failed snapshot keeps answering this way until it is
@@ -137,13 +156,29 @@ class CatalogRescanService({
   /// harness can report a rejection instead of silently skipping it.
   Future<CatalogRescanStartResult> start({required String pluginId}) async {
     if (_disposed) return const CatalogRescanStartResult.notImportable();
+    if (_managementService.snapshots.valueOrNull
+        case PluginManagementLoadResultLoading() || PluginManagementLoadResultFailure() || null) {
+      await _managementService.refresh();
+      if (_disposed) return const CatalogRescanStartResult.notImportable();
+    }
     if (_managementService.snapshots.valueOrNull is PluginManagementLoadResultUnsupported) {
       // Tell the caller either way, but never overwrite a run in flight with a
       // state that reads as terminal.
       if (_members.isEmpty) _publish(const CatalogRescanState.unsupported());
       return const CatalogRescanStartResult.unsupported();
     }
-    final results = await _start(pluginIds: [pluginId], coversEveryHarness: false);
+    final operationBridgeId = switch (_managementService.snapshots.valueOrNull) {
+      PluginManagementLoadResultSupported(:final response) => response.bridgeId,
+      PluginManagementLoadResultLoading() ||
+      PluginManagementLoadResultUnsupported() ||
+      PluginManagementLoadResultFailure() ||
+      null => null,
+    };
+    final results = await _start(
+      pluginIds: [pluginId],
+      coversEveryHarness: false,
+      operationBridgeId: operationBridgeId,
+    );
     return results[pluginId] ?? const CatalogRescanStartResult.notImportable();
   }
 
@@ -202,6 +237,7 @@ class CatalogRescanService({
   Future<Map<String, CatalogRescanStartResult>> _start({
     required List<String> pluginIds,
     required bool coversEveryHarness,
+    required String? operationBridgeId,
   }) async {
     // Never begin inside a cancellation's window: its DELETEs are already
     // aimed at these plugin ids and would cancel this run instead. Guarded
@@ -212,7 +248,11 @@ class CatalogRescanService({
       await cancelling;
       if (_disposed) return {};
     }
-    _openOrJoin(pluginIds: pluginIds, observed: false);
+    _openOrJoin(
+      pluginIds: pluginIds,
+      observed: false,
+      operationBridgeId: operationBridgeId,
+    );
     final results = <String, CatalogRescanStartResult>{};
     final dispatched = [
       for (final pluginId in pluginIds)
@@ -288,11 +328,16 @@ class CatalogRescanService({
     }
   }
 
-  void _openOrJoin({required List<String> pluginIds, required bool observed}) {
+  void _openOrJoin({
+    required List<String> pluginIds,
+    required bool observed,
+    required String? operationBridgeId,
+  }) {
     if (_members.isEmpty) {
       _clearTimer?.cancel();
       _clearTimer = null;
       _progressByPluginId.clear();
+      _operationBridgeId = operationBridgeId;
       _observed = observed;
     } else if (observed) {
       // A harness someone else started joined a run this client owned. The
@@ -329,7 +374,11 @@ class CatalogRescanService({
       // sessions still reach the lists, but as an observed operation, which
       // claims no summary.
       if (_isTerminal(progress) || _cancellingPluginIds.contains(pluginId)) return;
-      _openOrJoin(pluginIds: [pluginId], observed: true);
+      _openOrJoin(
+        pluginIds: [pluginId],
+        observed: true,
+        operationBridgeId: _activeBridgeId,
+      );
     }
     // Someone else cancelled a member of this run. That is intervention, not
     // failure, and it means this client no longer saw the whole operation, so
@@ -356,24 +405,68 @@ class CatalogRescanService({
 
   void _publishLive() {
     if (_members.isEmpty) return;
+    final pluginIds = Set<String>.unmodifiable(_members);
     final active = _activeProgress();
+    if (active != null) {
+      final pluginName = _displayName(active.pluginId);
+      final next = switch (active) {
+        CatalogImportEnumerating(:final sessionsSeen) when sessionsSeen == 0 && _isConfirmedStarting(active.pluginId) =>
+          CatalogRescanState.starting(activePluginName: pluginName, pluginIds: pluginIds),
+        CatalogImportEnumerating(:final sessionsSeen) => CatalogRescanState.reading(
+          activePluginName: pluginName,
+          sessionsSeen: sessionsSeen,
+          pluginIds: pluginIds,
+        ),
+        CatalogImportCommitting() => CatalogRescanState.saving(
+          activePluginName: pluginName,
+          pluginIds: pluginIds,
+        ),
+        // Unreachable: _activeProgress returns only non-terminal statuses. The
+        // exhaustive switch keeps any new transport phase visible here.
+        CatalogImportCompleted() ||
+        CatalogImportCancelled() ||
+        CatalogImportFailed() => throw StateError("Terminal catalog progress cannot be active"),
+      };
+      _publish(next);
+      return;
+    }
+
+    final pendingPluginIds = [
+      for (final pluginId in _members)
+        if (_progressByPluginId[pluginId] == null) pluginId,
+    ];
+    for (final pluginId in pendingPluginIds) {
+      if (_isConfirmedStarting(pluginId)) {
+        _publish(
+          CatalogRescanState.starting(
+            activePluginName: _displayName(pluginId),
+            pluginIds: pluginIds,
+          ),
+        );
+        return;
+      }
+    }
+    if (pendingPluginIds.isEmpty) return;
+    final pendingPluginNames = List<String>.unmodifiable(pendingPluginIds.map(_displayName));
     _publish(
-      active == null
-          ? CatalogRescanState.starting(pluginIds: Set<String>.unmodifiable(_members))
-          : CatalogRescanState.running(
-              activePluginName: _displayNames[active.pluginId] ?? active.pluginId,
-              sessionsSeen: switch (active) {
-                CatalogImportEnumerating(:final sessionsSeen) => sessionsSeen,
-                CatalogImportCommitting(:final sessionsSeen) => sessionsSeen,
-                // Unreachable: _activeProgress only returns a non-terminal
-                // status, and the switch stays exhaustive so a new phase is a
-                // compile error rather than a silent zero.
-                CatalogImportCompleted() || CatalogImportCancelled() || CatalogImportFailed() => 0,
-              },
-              pluginIds: Set<String>.unmodifiable(_members),
+      pendingPluginNames.length == 1
+          ? CatalogRescanState.preparingOne(
+              pendingPluginName: pendingPluginNames.first,
+              pluginIds: pluginIds,
+            )
+          : CatalogRescanState.preparingMany(
+              pendingPluginNames: pendingPluginNames,
+              pluginIds: pluginIds,
             ),
     );
   }
+
+  String _displayName(String pluginId) => _displayNames[pluginId] ?? pluginId;
+
+  bool _isConfirmedStarting(String pluginId) =>
+      _operationBridgeId != null &&
+      _operationBridgeId == _activeBridgeId &&
+      _runtimeStates[pluginId] == PluginRuntimeState.starting;
 
   /// The harness whose progress the row names, preferring whichever is still
   /// working over one that already settled.
@@ -448,6 +541,7 @@ class CatalogRescanService({
   void _closeOperation(CatalogRescanState next) {
     _members.clear();
     _progressByPluginId.clear();
+    _operationBridgeId = null;
     _observed = false;
     _publish(next);
     if (next is CatalogRescanSucceeded) {
@@ -462,6 +556,7 @@ class CatalogRescanService({
     _clearTimer = null;
     _members.clear();
     _progressByPluginId.clear();
+    _operationBridgeId = null;
     _observed = false;
     _publish(const CatalogRescanState.idle());
   }
@@ -472,15 +567,29 @@ class CatalogRescanService({
     if (nextConnected == _connected) return;
     _connected = nextConnected;
     _reset();
+    _activeBridgeId = null;
+    _runtimeStates = const {};
     if (nextConnected) unawaited(_recoverInFlight());
   }
 
   void _onManagementSnapshot(PluginManagementLoadResult snapshot) {
     if (_disposed) return;
-    if (snapshot is! PluginManagementLoadResultSupported) return;
+    if (snapshot is! PluginManagementLoadResultSupported) {
+      // Loading, failed, and legacy snapshots cannot authoritatively describe
+      // a runtime phase. Keep known names for stable fallback copy, but never
+      // carry a prior bridge's `starting` attribution across them.
+      _runtimeStates = const {};
+      if (_members.isNotEmpty) _publishLive();
+      return;
+    }
     _displayNames = {
       for (final plugin in snapshot.response.plugins) plugin.setup.id: plugin.setup.displayName,
     };
+    _runtimeStates = snapshot.refreshError == null
+        ? {
+            for (final plugin in snapshot.response.plugins) plugin.setup.id: plugin.runtimeState,
+          }
+        : const {};
     final bridgeId = snapshot.response.bridgeId;
     if (_activeBridgeId != null && _activeBridgeId != bridgeId) {
       _reset();
@@ -493,6 +602,7 @@ class CatalogRescanService({
       return;
     }
     _activeBridgeId = bridgeId;
+    if (_members.isNotEmpty) _publishLive();
   }
 
   /// Adopts a rescan that was already running when this client connected.
@@ -511,6 +621,7 @@ class CatalogRescanService({
         _openOrJoin(
           pluginIds: [for (final status in inFlight) status.pluginId],
           observed: true,
+          operationBridgeId: _activeBridgeId,
         );
         for (final status in inFlight) {
           _progressByPluginId[status.pluginId] = status;

--- a/client/module_core/lib/src/services/models/catalog_rescan_state.dart
+++ b/client/module_core/lib/src/services/models/catalog_rescan_state.dart
@@ -34,13 +34,31 @@ final class const CatalogRescanTotals({
 sealed class const CatalogRescanState() {
   const factory idle() = CatalogRescanIdle;
 
-  const factory starting({required Set<String> pluginIds}) = CatalogRescanStarting;
+  const factory preparingOne({
+    required String pendingPluginName,
+    required Set<String> pluginIds,
+  }) = CatalogRescanPreparingOne;
 
-  const factory running({
+  const factory preparingMany({
+    required List<String> pendingPluginNames,
+    required Set<String> pluginIds,
+  }) = CatalogRescanPreparingMany;
+
+  const factory starting({
+    required String activePluginName,
+    required Set<String> pluginIds,
+  }) = CatalogRescanStarting;
+
+  const factory reading({
     required String activePluginName,
     required int sessionsSeen,
     required Set<String> pluginIds,
-  }) = CatalogRescanRunning;
+  }) = CatalogRescanReading;
+
+  const factory saving({
+    required String activePluginName,
+    required Set<String> pluginIds,
+  }) = CatalogRescanSaving;
 
   const factory succeeded({
     required int harnessCount,
@@ -60,22 +78,48 @@ sealed class const CatalogRescanState() {
 
   /// Whether a rescan is in flight. Leaving this is what tells a list to
   /// refresh, since a committed import raises no invalidation of its own.
-  bool get isLive => this is CatalogRescanStarting || this is CatalogRescanRunning;
+  bool get isLive =>
+      this is CatalogRescanPreparingOne ||
+      this is CatalogRescanPreparingMany ||
+      this is CatalogRescanStarting ||
+      this is CatalogRescanReading ||
+      this is CatalogRescanSaving;
 }
 
 final class const CatalogRescanIdle() extends CatalogRescanState;
 
-/// Requests are dispatched but no progress has arrived yet.
+/// Scan members that have not reported catalog progress yet.
 ///
-/// Separate from [CatalogRescanRunning] because between dispatch and the first
-/// progress event there is no active harness and no session count, and a single
-/// running state carrying both would have to invent them.
-final class const CatalogRescanStarting({required final Set<String> pluginIds})
-    extends CatalogRescanState;
+/// Names include only unfinished members, so a harness that already completed
+/// cannot remain visible while another waits to begin.
+final class const CatalogRescanPreparingOne({
+  required final String pendingPluginName,
+  required final Set<String> pluginIds,
+}) extends CatalogRescanState;
 
-final class const CatalogRescanRunning({
+/// Multiple scan members have not reported catalog progress yet.
+final class const CatalogRescanPreparingMany({
+  required final List<String> pendingPluginNames,
+  required final Set<String> pluginIds,
+}) extends CatalogRescanState;
+
+/// One scan member is authoritatively reported as starting by this bridge's
+/// fresh management snapshot.
+final class const CatalogRescanStarting({
+  required final String activePluginName,
+  required final Set<String> pluginIds,
+}) extends CatalogRescanState;
+
+/// One scan member is enumerating its catalog.
+final class const CatalogRescanReading({
   required final String activePluginName,
   required final int sessionsSeen,
+  required final Set<String> pluginIds,
+}) extends CatalogRescanState;
+
+/// One scan member is committing its catalog snapshot.
+final class const CatalogRescanSaving({
+  required final String activePluginName,
   required final Set<String> pluginIds,
 }) extends CatalogRescanState;
 
@@ -95,8 +139,7 @@ final class const CatalogRescanPartlyFailed({
 
 /// Every harness failed. Carries no message: `CatalogImportFailed.message` is
 /// the bridge's raw `error.toString()` and is never lifted into client state.
-final class const CatalogRescanFailed({required final int harnessCount})
-    extends CatalogRescanState;
+final class const CatalogRescanFailed({required final int harnessCount}) extends CatalogRescanState;
 
 /// This bridge cannot rescan at all, because it predates the import route.
 final class const CatalogRescanUnsupported() extends CatalogRescanState;
@@ -136,5 +179,4 @@ final class const CatalogRescanStartUnsupported() extends CatalogRescanStartResu
 /// transport or decoding failure may never have reached the bridge and so
 /// cannot be explained by the bridge's own log. It is not for display: the card
 /// renders bounded text only.
-final class const CatalogRescanStartFailed({required final ApiError cause})
-    extends CatalogRescanStartResult;
+final class const CatalogRescanStartFailed({required final ApiError cause}) extends CatalogRescanStartResult;

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -1287,7 +1287,12 @@ void main() {
     test("names the harnesses a live scan covers, whoever started it", () async {
       await ready();
 
-      rescan.emit(const CatalogRescanState.starting(pluginIds: {"codex", "claude"}));
+      rescan.emit(
+        const CatalogRescanState.preparingMany(
+          pendingPluginNames: ["Codex", "Claude"],
+          pluginIds: {"codex", "claude"},
+        ),
+      );
       await _settle();
       expect((cubit.state as PluginManagementReady).scanningPluginIds, {"codex", "claude"});
 
@@ -1313,7 +1318,9 @@ void main() {
       await cubit.startCatalogScanFor(pluginId: "codex");
       expect((cubit.state as PluginManagementReady).scanRejections, isNotEmpty);
 
-      rescan.emit(const CatalogRescanState.starting(pluginIds: {"codex"}));
+      rescan.emit(
+        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+      );
       await _settle();
 
       expect((cubit.state as PluginManagementReady).scanRejections, isEmpty);
@@ -1324,7 +1331,9 @@ void main() {
       rescan.stubStartResult(const CatalogRescanStartResult.notImportable());
       await cubit.startCatalogScanFor(pluginId: "codex");
 
-      rescan.emit(const CatalogRescanState.starting(pluginIds: {"claude"}));
+      rescan.emit(
+        const CatalogRescanState.preparingOne(pendingPluginName: "Claude", pluginIds: {"claude"}),
+      );
       await _settle();
 
       expect(
@@ -1340,7 +1349,9 @@ void main() {
       rescan.stubStartResult(
         CatalogRescanStartResult.failed(cause: ApiError.nonSuccessCode(errorCode: 500, rawErrorString: null)),
       );
-      rescan.emit(const CatalogRescanState.starting(pluginIds: {"codex"}));
+      rescan.emit(
+        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+      );
       await _settle();
 
       await cubit.startCatalogScanFor(pluginId: "codex");
@@ -1490,7 +1501,9 @@ void main() {
     test("a second harness being refused leaves the first one's claim alone", () async {
       await ready();
       await cubit.startCatalogScanFor(pluginId: "codex");
-      rescan.emit(const CatalogRescanState.starting(pluginIds: {"codex"}));
+      rescan.emit(
+        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+      );
       await _settle();
 
       rescan.stubStartResult(const CatalogRescanStartResult.notImportable());
@@ -1531,7 +1544,9 @@ void main() {
       await ready();
       rescan.stubStartResult(const CatalogRescanStartResult.unsupported());
       await cubit.startCatalogScanFor(pluginId: "codex");
-      rescan.emit(const CatalogRescanState.starting(pluginIds: {"claude"}));
+      rescan.emit(
+        const CatalogRescanState.preparingOne(pendingPluginName: "Claude", pluginIds: {"claude"}),
+      );
       await _settle();
 
       snapshots.add(const PluginManagementLoadResult.supported(response: _response, refreshError: null));
@@ -1543,7 +1558,9 @@ void main() {
     });
 
     test("a cubit created mid-scan seeds its members from the service", () async {
-      rescan.emit(const CatalogRescanState.starting(pluginIds: {"codex"}));
+      rescan.emit(
+        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+      );
       await _settle();
 
       final reopened = PluginManagementCubit(

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -2545,7 +2545,7 @@ void main() {
         await Future<void>.delayed(Duration.zero);
 
         fakeCatalogRescanService.emit(
-          const CatalogRescanState.running(
+          const CatalogRescanState.reading(
             activePluginName: "Codex",
             sessionsSeen: 148,
             pluginIds: {"codex"},
@@ -2555,7 +2555,7 @@ void main() {
 
         expect(
           (cubit.state as ProjectListLoaded).catalogScan,
-          isA<CatalogRescanRunning>().having((s) => s.sessionsSeen, "sessionsSeen", 148),
+          isA<CatalogRescanReading>().having((s) => s.sessionsSeen, "sessionsSeen", 148),
         );
       });
 

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -2453,7 +2453,7 @@ void main() {
         await cubit.stream.firstWhere((state) => state is SessionListLoaded);
 
         fakeCatalogRescanService.emit(
-          const CatalogRescanState.running(
+          const CatalogRescanState.reading(
             activePluginName: "Codex",
             sessionsSeen: 148,
             pluginIds: {"codex"},
@@ -2463,7 +2463,7 @@ void main() {
 
         expect(
           (cubit.state as SessionListLoaded).catalogScan,
-          isA<CatalogRescanRunning>().having((s) => s.activePluginName, "activePluginName", "Codex"),
+          isA<CatalogRescanReading>().having((s) => s.activePluginName, "activePluginName", "Codex"),
         );
       });
 

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -55,7 +55,23 @@ void main() {
       expect(repository.startedPluginIds, unorderedEquals(["codex", "claude"]));
       expect(
         service.state.value,
-        isA<CatalogRescanStarting>().having((s) => s.pluginIds, "pluginIds", {"codex", "claude"}),
+        isA<CatalogRescanPreparingMany>()
+            .having((s) => s.pendingPluginNames, "pendingPluginNames", ["Codex", "Claude"])
+            .having((s) => s.pluginIds, "pluginIds", {"codex", "claude"}),
+      );
+    });
+
+    test("bootstraps management before deciding which harnesses to scan", () async {
+      build(snapshot: const PluginManagementLoadResult.loading());
+      management.nextRefreshSnapshot = _snapshot(routable: const {"codex": "Codex"});
+
+      await service.startAll();
+
+      expect(management.refreshCalls, 1);
+      expect(repository.startedPluginIds, ["codex"]);
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>().having((s) => s.pendingPluginName, "pendingPluginName", "Codex"),
       );
     });
 
@@ -72,9 +88,94 @@ void main() {
 
       expect(
         service.state.value,
-        isA<CatalogRescanRunning>()
+        isA<CatalogRescanReading>()
             .having((s) => s.activePluginName, "activePluginName", "Codex")
             .having((s) => s.sessionsSeen, "sessionsSeen", 42),
+      );
+    });
+
+    test("uses fresh management state only to confirm harness startup", () async {
+      build(
+        snapshot: _runtimeSnapshot(
+          pluginId: "codex",
+          name: "Codex",
+          state: PluginRuntimeState.dormant,
+          refreshError: null,
+        ),
+      );
+      await service.startAll();
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "codex",
+          projectsSeen: 0,
+          sessionsSeen: 0,
+        ),
+      );
+      expect(service.state.value, isA<CatalogRescanReading>());
+
+      management.emit(
+        _runtimeSnapshot(
+          pluginId: "codex",
+          name: "Codex",
+          state: PluginRuntimeState.starting,
+          refreshError: null,
+        ),
+      );
+      await pumpEventQueue();
+      expect(
+        service.state.value,
+        isA<CatalogRescanStarting>().having((s) => s.activePluginName, "activePluginName", "Codex"),
+      );
+
+      management.emit(
+        _runtimeSnapshot(
+          pluginId: "codex",
+          name: "Codex",
+          state: PluginRuntimeState.active,
+          refreshError: null,
+        ),
+      );
+      await pumpEventQueue();
+      expect(service.state.value, isA<CatalogRescanReading>());
+    });
+
+    test("does not infer startup from a retained snapshot after refresh failure", () async {
+      build(
+        snapshot: _runtimeSnapshot(
+          pluginId: "codex",
+          name: "Codex",
+          state: PluginRuntimeState.starting,
+          refreshError: ApiError.generic(),
+        ),
+      );
+      await service.startAll();
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "codex",
+          projectsSeen: 0,
+          sessionsSeen: 0,
+        ),
+      );
+      await pumpEventQueue();
+
+      expect(service.state.value, isA<CatalogRescanReading>());
+    });
+
+    test("reports the committing harness as saving", () async {
+      build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
+      await service.startAll();
+
+      connection.emitProgress(
+        const CatalogImportProgress.committing(
+          pluginId: "codex",
+          projectsSeen: 2,
+          sessionsSeen: 8,
+        ),
+      );
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanSaving>().having((s) => s.activePluginName, "activePluginName", "Codex"),
       );
     });
 
@@ -192,7 +293,7 @@ void main() {
 
         expect(
           service.state.value,
-          isA<CatalogRescanStarting>(),
+          isA<CatalogRescanPreparingMany>(),
           reason: "the previous success timer must not reset the new run",
         );
       });
@@ -209,23 +310,27 @@ void main() {
 
       expect(
         service.state.value,
-        isA<CatalogRescanStarting>(),
+        isA<CatalogRescanPreparingMany>(),
         reason: "retained progress from the previous run must be cleared",
       );
       connection.emitProgress(_completed("codex", newProjects: 0, newSessions: 0));
-      expect(service.state.value, isA<CatalogRescanStarting>(), reason: "claude has not settled");
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>().having((s) => s.pendingPluginName, "pendingPluginName", "Claude"),
+        reason: "claude has not settled",
+      );
     });
 
     test("a targeted start joins the live operation instead of replacing it", () async {
       build(snapshot: _snapshot(routable: const {"codex": "Codex"}));
       await service.startAll();
-      expect((service.state.value as CatalogRescanStarting).pluginIds, {"codex"});
+      expect((service.state.value as CatalogRescanPreparingOne).pluginIds, {"codex"});
 
       final result = await service.start(pluginId: "claude");
 
       expect(result, isA<CatalogRescanStartAccepted>());
       expect(
-        (service.state.value as CatalogRescanStarting).pluginIds,
+        (service.state.value as CatalogRescanPreparingMany).pluginIds,
         {"codex", "claude"},
         reason: "codex must stay in aggregation and cancellation",
       );
@@ -236,7 +341,7 @@ void main() {
 
       await service.startAll();
 
-      expect((service.state.value as CatalogRescanStarting).pluginIds, {"codex"});
+      expect((service.state.value as CatalogRescanPreparingOne).pluginIds, {"codex"});
       connection.emitProgress(_completed("codex", newProjects: 1, newSessions: 0));
       expect(
         service.state.value,
@@ -300,7 +405,7 @@ void main() {
 
       expect(result, isA<CatalogRescanStartUnsupported>());
       expect(
-        (service.state.value as CatalogRescanStarting).pluginIds,
+        (service.state.value as CatalogRescanPreparingOne).pluginIds,
         {"codex"},
         reason: "one unknown harness must not be read as a bridge without the route",
       );
@@ -348,14 +453,18 @@ void main() {
           sessionsSeen: 9,
         ),
       );
-      expect((service.state.value as CatalogRescanRunning).activePluginName, "Claude");
+      expect((service.state.value as CatalogRescanReading).activePluginName, "Claude");
 
       connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
 
       expect(
         service.state.value,
-        isA<CatalogRescanStarting>(),
-        reason: "codex has reported nothing yet, so no harness can be named",
+        isA<CatalogRescanPreparingOne>().having(
+          (s) => s.pendingPluginName,
+          "pendingPluginName",
+          "Codex",
+        ),
+        reason: "only the unfinished harness remains in preparing copy",
       );
     });
 
@@ -435,7 +544,7 @@ void main() {
 
       expect(
         service.state.value,
-        isA<CatalogRescanStarting>(),
+        isA<CatalogRescanPreparingOne>(),
         reason: "the run in flight is still the truth about what is happening",
       );
     });
@@ -463,7 +572,7 @@ void main() {
 
     test("cancel fans out one request per member, including while starting", () async {
       await service.startAll();
-      expect(service.state.value, isA<CatalogRescanStarting>());
+      expect(service.state.value, isA<CatalogRescanPreparingMany>());
 
       await service.cancel();
 
@@ -482,7 +591,7 @@ void main() {
           sessionsSeen: 4,
         ),
       );
-      expect(service.state.value, isA<CatalogRescanRunning>());
+      expect(service.state.value, isA<CatalogRescanReading>());
 
       connection.emitProgress(_completed("codex", newProjects: 5, newSessions: 5));
 
@@ -644,7 +753,7 @@ void main() {
       );
       connection.emitStatus(_connected);
       await pumpEventQueue();
-      expect(service.state.value, isA<CatalogRescanRunning>());
+      expect(service.state.value, isA<CatalogRescanReading>());
 
       // The management snapshot for the newly connected bridge arrives after
       // the recovery read and reports a different identity.
@@ -653,7 +762,7 @@ void main() {
 
       expect(
         service.state.value,
-        isA<CatalogRescanRunning>().having((s) => s.sessionsSeen, "sessionsSeen", 6),
+        isA<CatalogRescanReading>().having((s) => s.sessionsSeen, "sessionsSeen", 6),
         reason: "the reset for the new identity must be followed by another read",
       );
     });
@@ -730,7 +839,7 @@ void main() {
 
       expect(
         service.state.value,
-        isA<CatalogRescanRunning>().having((s) => s.sessionsSeen, "sessionsSeen", 5),
+        isA<CatalogRescanReading>().having((s) => s.sessionsSeen, "sessionsSeen", 5),
       );
     });
 
@@ -747,7 +856,7 @@ void main() {
 
       expect(
         service.state.value,
-        isA<CatalogRescanRunning>().having((s) => s.sessionsSeen, "sessionsSeen", 7),
+        isA<CatalogRescanReading>().having((s) => s.sessionsSeen, "sessionsSeen", 7),
       );
     });
 
@@ -770,7 +879,7 @@ void main() {
       final catalogChanges = <void>[];
       service.catalogChanged.listen(catalogChanges.add);
       await service.startAll();
-      expect(service.state.value, isA<CatalogRescanStarting>());
+      expect(service.state.value, isA<CatalogRescanPreparingMany>());
 
       connection.emitStatus(const ConnectionStatus.disconnected());
       await pumpEventQueue();
@@ -835,6 +944,40 @@ PluginManagementLoadResult _snapshot({
   );
 }
 
+PluginManagementLoadResult _runtimeSnapshot({
+  required String pluginId,
+  required String name,
+  required PluginRuntimeState state,
+  required ApiError? refreshError,
+}) {
+  return PluginManagementLoadResult.supported(
+    response: PluginManagementResponse(
+      snapshotToken: "runtime-$state",
+      bridgeId: "bridge-1",
+      defaultPluginId: null,
+      defaultIdleTimeoutMins: 10,
+      plugins: [
+        PluginManagementMetadata(
+          setup: PluginSetupMetadata(
+            id: pluginId,
+            displayName: name,
+            state: PluginSetupState.ready,
+            runtimeVersion: null,
+            actionHint: null,
+          ),
+          runtimeState: state,
+          workState: PluginManagementWorkState.idle,
+          idleTimeoutMins: 10,
+          hasIdleTimeoutOverride: false,
+          managementCapabilities: const {PluginManagementCapability.lifecycle},
+          actionHint: null,
+        ),
+      ],
+    ),
+    refreshError: refreshError,
+  );
+}
+
 class _FakePluginRepository() implements PluginRepository {
   final Map<String, CatalogImportMutationResult> resultFor = {};
   final Map<String, Future<CatalogImportMutationResult>> pendingFor = {};
@@ -865,8 +1008,17 @@ class _FakePluginRepository() implements PluginRepository {
 class _FakeManagementService(PluginManagementLoadResult initial) implements PluginManagementService {
   final BehaviorSubject<PluginManagementLoadResult> _snapshots = BehaviorSubject.seeded(initial);
 
+  PluginManagementLoadResult? nextRefreshSnapshot;
+  int refreshCalls = 0;
+
   @override
   ValueStream<PluginManagementLoadResult> get snapshots => _snapshots.stream;
+
+  @override
+  Future<void> refresh() async {
+    refreshCalls++;
+    if (nextRefreshSnapshot case final snapshot?) emit(snapshot);
+  }
 
   void emit(PluginManagementLoadResult snapshot) => _snapshots.add(snapshot);
 

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -78,7 +78,7 @@ state.
   startup from catalog reading, reports found-session counts during enumeration,
   and says when results are being saved. Startup wording is driven only by a
   fresh management snapshot for the same bridge; unknown or older metadata does
-  not infer it. After the same harness remains confirmed as starting for ten
+  not infer it. After the same harness remains confirmed as starting for three
   seconds, the row explains that scanning is waiting for startup and that the
   user can keep browsing. This one-shot presentation timer resets on any phase
   or harness change and never polls or changes bridge work. It offers to cancel

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -73,25 +73,30 @@ state.
   non-overridden OpenCode installs use the public-channel `opencode.db`; an explicit
   custom binary does not guess that default or a channel-specific filename. OpenCode
   attach/no-auto-start mode always retains its existing server path.
-- One scan is one row above the list, however many harnesses take part. Between
-  dispatch and the first progress event it can name neither a harness nor a
-  count and says only that it is starting; from that event on it names the
-  harness being read and how many sessions it has seen so far. It offers to
-  cancel while it runs. Starting and running share the same Deep Scan
-  loading-card geometry, so the first progress event does not move the list, and
-  the row scrolls with the list rather than pinning. The entrance animation plays
-  once when a pull first reveals the row; later updates do not replay it, and the
-  scan indicator keeps animating until a terminal outcome replaces it. Android
-  Remove Animations and iOS Reduce Motion both hold the intentional first frame
-  without the entrance bounce, and the pull-caption invitation keeps only its
-  gentle opacity transition. Finished outcomes use the shared PREGO result-card
-  geometry, expanding rather than clipping at accessibility text sizes: a
-  success, warning, or error glow rises from the lower edge and the matching
-  tinted Dismiss action remains available until the result clears. Loading and
-  every result state use a vertically centered 20px leading mark with identical
-  edge inset and icon-to-text gap. Titles do not shift horizontally between
-  states; at standard text size, icon and title positions stay fixed vertically
-  too. Enlarged text may grow the card without changing those horizontal insets.
+- One scan is one row above the list, however many harnesses take part. It names
+  only unfinished harnesses while preparing, distinguishes confirmed harness
+  startup from catalog reading, reports found-session counts during enumeration,
+  and says when results are being saved. Startup wording is driven only by a
+  fresh management snapshot for the same bridge; unknown or older metadata does
+  not infer it. After the same harness remains confirmed as starting for ten
+  seconds, the row explains that scanning is waiting for startup and that the
+  user can keep browsing. This one-shot presentation timer resets on any phase
+  or harness change and never polls or changes bridge work. It offers to cancel
+  throughout live work. Every live phase shares the same Deep Scan loading-card
+  treatment, and the row scrolls with the list rather than pinning. The entrance
+  animation plays once when a pull first reveals the row; later updates do not
+  replay it, and the scan indicator keeps animating until a terminal outcome
+  replaces it. Android Remove Animations and iOS Reduce Motion both hold the
+  intentional first frame without the entrance bounce, and the pull-caption
+  invitation keeps only its gentle opacity transition. Finished outcomes use the
+  shared PREGO result-card geometry, expanding rather than clipping at
+  accessibility text sizes: a success, warning, or error glow rises from the
+  lower edge and the matching tinted Dismiss action remains available until the
+  result clears. Loading and every result state use a vertically centered 20px
+  leading mark with identical edge inset and icon-to-text gap. Titles do not
+  shift horizontally between states; at standard text size, icon and title
+  positions stay fixed vertically too. Enlarged text may grow the card without
+  changing those horizontal insets.
 - A scan the pull started is reported by that row alone: the pull raises no
   confirmation of its own, having run no ordinary refresh. A scan started from
   harness settings is the exception, because that surface has no row — it


### PR DESCRIPTION
## Complexity
⚙️ Moderate: coordinate existing bridge import progress and plugin-management state in the shared client scan service and widget. No new wire fields or endpoints.

## What
- Emit plugin-attributed catalog progress before snapshot reading or live runtime acquisition.
- Name unfinished harnesses immediately and distinguish preparing, confirmed startup, reading, and saving.
- After 3 seconds of confirmed startup for the same harness, show “Waiting for <harness>” and explain that the harness must finish starting before scanning can continue; existing sessions remain browsable and Cancel stays available.
- Bootstrap missing management metadata, scope startup attribution to fresh same-bridge state, and update shared mobile/desktop consumers and localized copy.

## Why
A slow harness startup previously left deep-pull refresh showing a nameless “Starting…” state. Faster harnesses finishing could also leave the remaining wait unattributed. Users should know which harness is blocking the scan without attributing unconfirmed delays to it.

## Risk and test focus
Focus on immediate attribution, actual runtime startup versus ordinary reads, completed-fast/pending-slow combinations, reconnect metadata, cancellation, committing, and the row-local timer resetting on phase/harness changes.
The timer changes presentation only; no polling or new backend-specific client logic. The prolonged explanation may wrap instead of clipping.
No database schema or persisted-data changes. Existing public transport shapes remain unchanged and older metadata gets honest non-startup copy. No new analytics events.

## Expected result
A scan shows “Preparing OpenCode scan…”, “Starting OpenCode…”, “Reading OpenCode sessions…”, or “Saving OpenCode scan results…” as appropriate. A sustained confirmed startup explains “OpenCode must finish starting before scanning can continue. You can keep browsing.” The same behavior applies to every harness on shared mobile and desktop surfaces.

## Verification
- Architecture implementation review approved.
- Bridge catalog repository: 24 tests passed; owning analyzer passed.
- Catalog rescan service: 47 tests passed, including after the named-parameter follow-up; focused dependent cubit tests passed.
- Shared scan widget: 39 tests passed after the 3-second threshold change; owning analyzer passed.
- Scan playbook: 24 tests passed after updating obsolete pre-change copy expectations reported by CI.
- Mobile project-scan integration: 8 tests passed; targeted harness-settings test passed.
- Focused desktop settings/project shell tests passed.
- Core, shared UI, mobile, and desktop analyzers passed.
- Localization regenerated; `git diff --check` passed.
- Real-device visual QA was not run; service/widget/shell tests cover this change.

## Series
Independent PR 2/2 in `opencode-scan-reliability`. SQL mapping fix #1413 has already merged; this branch was developed independently from the same base and contains no SQL-mapping changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the scan row so a slow harness startup no longer leaves users with a nameless "Starting…" state. The row now names the harness immediately, distinguishes preparing, confirmed startup, reading, and saving phases, and after 3 seconds of confirmed startup explains that the harness must finish starting before scanning can continue.

**Behavior details**
- Startup wording is used only when a fresh management snapshot for the same bridge confirms it; older or unknown metadata falls back to reading copy.
- The 3-second explanation is presentation-only: it never polls or changes bridge work, and the timer resets on phase or harness changes.
- The explanation may wrap to a second line instead of clipping; Cancel stays available and existing sessions remain browsable.
- Missing management metadata is bootstrapped before deciding which harnesses to scan.
- No schema, wire, or analytics changes; existing public transport shapes are unchanged.

<sup>Written for commit d4e38f4bb143da3187149dabb0de89529da8f4ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

