### PR TITLE
⚙️ Trigger internal releases from Alex's Google Cloud Scheduler

### DIFF
--- a/.github/scripts/check_internal_release.sh
+++ b/.github/scripts/check_internal_release.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Run after a full checkout (including tags), inside release-all's concurrency
 # group. Only this workflow's main runs own the rolling attempt marker.
+# RELEASE_AUTOMATIC=true applies duplicate, released, and batch-path guards;
+# false preserves the explicit manual retry path.
 set -euo pipefail
 
 ATTEMPT_TAG="internal-release-attempt"
@@ -13,7 +15,16 @@ skip_release() {
   exit 0
 }
 
-if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+case "${RELEASE_AUTOMATIC:-}" in
+  true) AUTOMATIC=true ;;
+  false) AUTOMATIC=false ;;
+  *)
+    echo "::error::RELEASE_AUTOMATIC must be 'true' or 'false'." >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$AUTOMATIC" == true ]]; then
   RELEASE_TAGS=$(git tag --points-at "$GITHUB_SHA" --list 'v[0-9]*')
   if [[ -n "$RELEASE_TAGS" ]]; then
     skip_release "Commit ${GITHUB_SHA} already has a release tag: ${RELEASE_TAGS//$'\n'/, }."
@@ -64,5 +75,5 @@ fi
 echo "should_release=true" >> "$GITHUB_OUTPUT"
 {
   echo "## Internal release attempt"
-  echo "Building commit ${GITHUB_SHA}. Manual runs bypass the scheduled skip checks."
+  echo "Building commit ${GITHUB_SHA}. Manual runs bypass the automatic skip checks."
 } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/scripts/test_check_internal_release.py
+++ b/.github/scripts/test_check_internal_release.py
@@ -57,7 +57,7 @@ class InternalReleaseGateTest(unittest.TestCase):
         )
 
     def run_gate(
-        self, *, event: str = "schedule", ref: str = "refs/heads/main", succeeds: bool = True
+        self, *, automatic: str = "true", ref: str = "refs/heads/main", succeeds: bool = True
     ) -> tuple[str, str]:
         # Model checkout@v6 fetch-depth: 0, refreshing the moving remote tag.
         self.git(args=["fetch", "origin", "+refs/tags/*:refs/tags/*"])
@@ -68,7 +68,8 @@ class InternalReleaseGateTest(unittest.TestCase):
             cwd=self.repo,
             env={
                 **os.environ,
-                "GITHUB_EVENT_NAME": event,
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "RELEASE_AUTOMATIC": automatic,
                 "GITHUB_REF": ref,
                 "GITHUB_SHA": self.git(args=["rev-parse", "HEAD"]),
                 "GITHUB_OUTPUT": str(self.output),
@@ -175,21 +176,26 @@ class InternalReleaseGateTest(unittest.TestCase):
 
     def test_manual_run_retries_an_attempted_commit(self) -> None:
         self.run_gate()
-        output, _ = self.run_gate(event="workflow_dispatch")
+        output, _ = self.run_gate(automatic="false")
         self.assertEqual(output, "should_release=true\n")
 
     def test_manual_run_can_rebuild_a_tagged_commit(self) -> None:
         self.tag(name="v1.2.3-internal.42", annotated=True)
-        output, _ = self.run_gate(event="workflow_dispatch")
+        output, _ = self.run_gate(automatic="false")
         self.assertEqual(output, "should_release=true\n")
 
     def test_manual_branch_run_does_not_change_main_checkpoint(self) -> None:
         self.run_gate()
         main_attempt = self.attempt_sha()
         self.commit(path="client/app/lib/app.dart")
-        output, _ = self.run_gate(event="workflow_dispatch", ref="refs/heads/feature")
+        output, _ = self.run_gate(automatic="false", ref="refs/heads/feature")
         self.assertEqual(output, "should_release=true\n")
         self.assertEqual(self.attempt_sha(), main_attempt)
+
+    def test_invalid_automatic_value_fails_without_recording_attempt(self) -> None:
+        output, _ = self.run_gate(automatic="yes", succeeds=False)
+        self.assertNotIn("should_release=true", output)
+        self.assertEqual(self.attempt_sha(), "")
 
     def test_marker_push_failure_prevents_building(self) -> None:
         self.git(args=["remote", "set-url", "--push", "origin", str(self.fixture / "missing.git")])

--- a/.github/workflows/release-all-platforms.yml
+++ b/.github/workflows/release-all-platforms.yml
@@ -2,6 +2,10 @@ name: Release All Platforms
 
 run-name: "release · build ${{ github.sha }}"
 
+# Triggered by Alex's Google Cloud Scheduler at :45 UTC through the private
+# sesori-release-scheduler Cloud Run service in sesori-ai/europe-west1:
+# https://console.cloud.google.com/cloudscheduler?project=sesori-ai
+#
 # Hourly internal release: uploads iOS to TestFlight and Android to the
 # Play internal track, builds the 6-platform bridge archives, and — only when
 # EVERYTHING succeeded (all-or-nothing) — pushes a `v<X>-internal.<N>` tag and
@@ -15,10 +19,12 @@ run-name: "release · build ${{ github.sha }}"
 
 on:
   workflow_dispatch:
-  schedule:
-    # GitHub schedules use UTC and may start late. Each run builds its immutable
-    # main SHA; later merges wait for the next run.
-    - cron: '45 * * * *'
+    inputs:
+      automatic:
+        description: Apply automatic release skip guards
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: release-all-${{ github.ref }}
@@ -38,11 +44,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.sha }}
 
       # Persist the attempt before version validation or store calls. Failed or
-      # cancelled builds are not retried hourly; workflow_dispatch can retry.
+      # cancelled builds are not retried automatically; a manual dispatch can retry.
       - name: Check and record release attempt
         id: gate
+        env:
+          # workflow_dispatch inputs are booleans in the inputs context. GitHub
+          # renders this environment value as the explicit string true/false.
+          RELEASE_AUTOMATIC: ${{ inputs.automatic }}
         run: bash .github/scripts/check_internal_release.sh
 
       # Fail the WHOLE run (mobile and bridge) when the committed version was

--- a/.github/workflows/release-workflow-ci.yml
+++ b/.github/workflows/release-workflow-ci.yml
@@ -10,6 +10,8 @@ on:
       - '.github/scripts/test_check_internal_release.py'
       - '.github/workflows/release-all-platforms.yml'
       - '.github/workflows/release-workflow-ci.yml'
+      - 'tool/release_scheduler/**'
+      - 'docs/regression/bridge-installation-and-updates.md'
       - 'client/app/fastlane/**'
       - 'client/app/ios/fastlane/Fastfile'
       - 'client/app/android/fastlane/Fastfile'
@@ -21,6 +23,8 @@ on:
       - '.github/scripts/test_check_internal_release.py'
       - '.github/workflows/release-all-platforms.yml'
       - '.github/workflows/release-workflow-ci.yml'
+      - 'tool/release_scheduler/**'
+      - 'docs/regression/bridge-installation-and-updates.md'
       - 'client/app/fastlane/**'
       - 'client/app/ios/fastlane/Fastfile'
       - 'client/app/android/fastlane/Fastfile'
@@ -36,8 +40,19 @@ jobs:
       - uses: actions/checkout@v6
       - name: Lint release gate
         run: shellcheck .github/scripts/check_internal_release.sh
-      - name: Test scheduled release decisions and attempt recording
+      - name: Test automatic release decisions and attempt recording
         run: python3 .github/scripts/test_check_internal_release.py
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: tool/release_scheduler/package-lock.json
+      - name: Install release dispatcher tooling
+        run: npm ci --prefix tool/release_scheduler
+      - name: Typecheck release dispatcher
+        run: npm run typecheck --prefix tool/release_scheduler
+      - name: Test release dispatcher
+        run: npm test --prefix tool/release_scheduler
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'

--- a/bridge/RELEASING.md
+++ b/bridge/RELEASING.md
@@ -94,17 +94,29 @@ That bump step is the source of truth for the release version. It must keep `bri
 
 ### 2. Merge to main and wait for the hourly release
 
-`release-all-platforms.yml` checks main hourly at **45 minutes past the hour** (`45 * * * *`, UTC), not on each merge. GitHub may delay scheduled runs. Each run uses its triggering main SHA throughout; later merges wait for the next run. The existing concurrency group serializes main releases without cancelling an active build.
+Internal releases are triggered by **Alex's Google Cloud Scheduler** job `sesori-internal-release` in
+`sesori-ai/europe-west1` at **45 minutes past the hour** (`45 * * * *`, UTC), not on each merge.
+The job calls the private Cloud Run service `sesori-release-scheduler`, which uses the repository-limited GitHub App to
+invoke `release-all-platforms.yml` on `main` with `automatic=true`. The workflow has no GitHub cron.
+Each run uses its triggering main SHA throughout; later merges wait for the next run. The existing concurrency group
+serializes main releases without cancelling an active build.
 
-Scheduled runs skip commits that already carry a release tag or match the rolling `internal-release-attempt` tag. Otherwise, they compare the whole batch against that attempt (or the nearest release tag before the first attempt). Only mobile-product, shared, bridge, or release-automation changes qualify; desktop-only and unrelated documentation changes do not consume store uploads. The exact paths live in `.github/scripts/check_internal_release.sh`.
+For missing hourly releases, inspect [Alex's scheduler job](https://console.cloud.google.com/cloudscheduler/jobs/edit/europe-west1/sesori-internal-release?project=sesori-ai)
+and the Cloud Run delivery/dispatch logs before checking the GitHub workflow run. Dispatch-failure alerts route to
+`alex@vespr.xyz`; GitHub owns build status and failed-action notifications. See the
+[dispatcher runbook](../tool/release_scheduler/README.md) for pause/resume, IAM, retry, and key-rotation instructions.
+
+Automatic runs skip commits that already carry a release tag or match the rolling `internal-release-attempt` tag. Otherwise, they compare the whole batch against that attempt (or the nearest release tag before the first attempt). Only mobile-product, shared, bridge, or release-automation changes qualify; desktop-only and unrelated documentation changes do not consume store uploads. The exact paths live in `.github/scripts/check_internal_release.sh`.
 
 Before version validation, store queries, or builds, the workflow moves the lightweight `internal-release-attempt` tag to the chosen SHA. A failure or cancellation therefore cannot cause hourly retries of that commit. A later relevant change allows another attempt; the marker is not a release and creates no GitHub release object. If recording the marker fails, no build starts.
 
 An eligible run uploads the mobile apps to TestFlight / Play internal, builds all six bridge platform archives with `X.Y.Z-internal.<N>` baked in, and — only when everything succeeded — pushes a `v<X.Y.Z>-internal.<N>` tag and rolls the single internal GitHub pre-release onto it (binaries + `checksums.txt` + regenerated notes). Existing internal release tags remain immutable build-number-to-commit mappings. The auto-updater ignores pre-releases on the default `stable` track; bridges switched to the `internal` track (`sesori-bridge config track internal`) pick up these `-internal.<N>` pre-releases.
 
-For an immediate build or a retry after fixing credentials/store issues, open **Actions → Release All Platforms → Run workflow**, normally on `main`. Manual dispatch bypasses the scheduled tag/path checks but still validates versions and allocates a fresh aligned build number. Manual builds on another branch do not move main's attempt marker. The standalone iOS/Android manual workflows remain available.
+For an immediate build or a retry after fixing credentials/store issues, open **Actions → Release All Platforms → Run workflow**, normally on `main`, leaving **automatic** unchecked (`false`). This explicit manual retry bypasses the automatic tag/path checks but still validates versions and allocates a fresh aligned build number. Manual builds on another branch do not move main's attempt marker. The standalone iOS/Android manual workflows remain available.
 
-The cron provides 24 scheduled opportunities per day, not a strict store quota: delayed runs and manual uploads still count against each store's limits.
+Cloud Scheduler provides hourly release opportunities with bounded delivery retries, not a strict store quota:
+delayed runs and manual uploads still count against each store's limits. Re-running the Scheduler job is an automatic
+dispatch, so it does not retry an already-attempted build; use GitHub's manual path above for that.
 
 ### 3. Submit to production
 

--- a/docs/regression/bridge-installation-and-updates.md
+++ b/docs/regression/bridge-installation-and-updates.md
@@ -9,12 +9,16 @@ reconciliation, periodic check, in-place apply, and explicit update command.
 ## Required Behavior
 
 - Internal releases check main hourly at `:45` UTC and build one immutable commit
-  across TestFlight, Play internal, and bridge archives. Released or already-attempted
-  commits skip before store queries; desktop-only and unrelated documentation batches
-  skip, but product changes before an unrelated tip commit still qualify.
-  A rolling `internal-release-attempt` tag is written before version validation or
-  builds, preventing hourly retries after failure or cancellation. Manual dispatch
-  can retry; release tags and the all-platform success requirement stay unchanged.
+  across TestFlight, Play internal, and bridge archives. They are triggered by Alex's
+  Google Cloud Scheduler job `sesori-internal-release` in project `sesori-ai`, location
+  `europe-west1` ([Scheduler console](https://console.cloud.google.com/cloudscheduler?project=sesori-ai)),
+  through a private Cloud Run dispatcher and repository-limited GitHub App. Released or
+  already-attempted commits skip before store queries; desktop-only and unrelated
+  documentation batches skip, but product changes before an unrelated tip commit still
+  qualify. A rolling `internal-release-attempt` tag is written before version validation
+  or builds, preventing automatic retries after failure or cancellation. Manual GitHub
+  dispatch with `automatic=false` can retry; release tags, branch checkpoint behavior,
+  serialized release concurrency, and all-platform success requirement stay unchanged.
 - TestFlight and Play internal notes list commit subjects since the nearest
   `v*` release tag on the build's first-parent history, newest first, and retain
   the build SHA. Failed attempts do not reset this range. With no release tag,
@@ -93,8 +97,11 @@ after apply. Use a throwaway machine when mutating an install root.
 
 ## Known Limitations
 
-- GitHub can delay cron starts. Hourly opportunities are not a strict daily upload
-  quota; manual runs and delayed uploads can still hit store limits.
+- Cloud Scheduler delivery and GitHub dispatch acceptance do not report build
+  completion. Google Cloud alert policy `2058247532448449377` covers Scheduler and
+  dispatcher error logs, not GitHub build failures; GitHub Actions owns build status and
+  failed-action notifications. Hourly opportunities are not a strict daily upload quota;
+  manual runs and delayed uploads can still hit store limits.
 - Genuine distribution claims need real published artifacts; a local build proves policy
   and reconciliation only, and signing is verifiable only against CI-produced binaries.
 - The bootstrap and the updater share no lock; an apply-window collision is accepted.
@@ -104,7 +111,7 @@ after apply. Use a throwaway machine when mutating an install root.
 ## Sources
 
 - `.github/workflows/release-all-platforms.yml`, `.github/scripts/check_internal_release.sh`,
-  `.github/scripts/test_check_internal_release.py`
+  `.github/scripts/test_check_internal_release.py`, `tool/release_scheduler/README.md`
 - `client/app/fastlane/build_changelog.rb`, `client/app/fastlane/test_build_changelog.rb`,
   `client/app/{ios,android}/fastlane/Fastfile`
 - `bridge/RELEASING.md`, `bridge/INSTALL.md`, `install.sh`, `install.ps1`, `bridge/app/npm/`

--- a/tool/release_scheduler/.dockerignore
+++ b/tool/release_scheduler/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+*.pem
+**/*.pem
+README.md
+test
+tsconfig.json

--- a/tool/release_scheduler/.gcloudignore
+++ b/tool/release_scheduler/.gcloudignore
@@ -1,0 +1,8 @@
+.git
+node_modules
+npm-debug.log
+*.pem
+**/*.pem
+README.md
+test
+tsconfig.json

--- a/tool/release_scheduler/.gitignore
+++ b/tool/release_scheduler/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+npm-debug.log
+*.pem

--- a/tool/release_scheduler/Dockerfile
+++ b/tool/release_scheduler/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:24-bookworm-slim
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY --chown=node:node src ./src
+
+USER node
+EXPOSE 8080
+CMD ["node", "src/server.ts"]

--- a/tool/release_scheduler/README.md
+++ b/tool/release_scheduler/README.md
@@ -171,9 +171,12 @@ Cloud Run console:
 <https://console.cloud.google.com/run/detail/europe-west1/sesori-release-scheduler/metrics?project=sesori-ai>.
 Logs:
 <https://console.cloud.google.com/logs/query?project=sesori-ai>.
-Logs contain successful workflow run ID/API URL/web URL, or bounded failure
-operation/status/GitHub request ID. They omit JWTs, installation tokens, PEMs,
-exception text, and upstream response bodies.
+Logs contain successful workflow run ID/API URL/web URL, or failure
+operation/status/GitHub request ID plus diagnostic error/cause names, codes,
+messages, and stack traces. The key-signing and HTTP boundaries redact their
+actual credentials. JSON parser diagnostics omit message/stack text because it
+may quote upstream response bodies. JWTs, installation tokens, PEMs, and upstream
+response bodies remain excluded.
 
 ```bash
 # Pause or resume hourly automatic opportunities.

--- a/tool/release_scheduler/README.md
+++ b/tool/release_scheduler/README.md
@@ -175,8 +175,9 @@ Logs contain successful workflow run ID/API URL/web URL, or failure
 operation/status/GitHub request ID plus diagnostic error/cause names, codes,
 messages, and stack traces. The key-signing and HTTP boundaries redact their
 actual credentials. JSON parser diagnostics omit message/stack text because it
-may quote upstream response bodies. JWTs, installation tokens, PEMs, and upstream
-response bodies remain excluded.
+may quote upstream response bodies. Unexpected exceptions outside those I/O
+boundaries log only operation, code, and error type. JWTs, installation tokens,
+PEMs, and upstream response bodies remain excluded.
 
 ```bash
 # Pause or resume hourly automatic opportunities.

--- a/tool/release_scheduler/README.md
+++ b/tool/release_scheduler/README.md
@@ -1,0 +1,207 @@
+# Internal release scheduler dispatcher
+
+Triggered by Alex's Google Cloud Scheduler. Job `sesori-internal-release` lives in
+Google Cloud project `sesori-ai`, location `europe-west1`, and runs at `45 * * * *`
+UTC. Scheduler console:
+<https://console.cloud.google.com/cloudscheduler/jobs/edit/europe-west1/sesori-internal-release?project=sesori-ai>.
+
+Private Cloud Run service `sesori-release-scheduler` accepts authenticated
+`POST /dispatch`, authenticates to GitHub as App `4897384` installation
+`160598508`, and dispatches `release-all-platforms.yml` on `main` with
+`automatic=true`. GitHub's `2026-03-10` REST response identifies the created run.
+`GET /health` performs no GitHub call.
+
+Dispatch acceptance means GitHub created a workflow run. It does **not** mean
+mobile uploads or bridge builds completed. Alert policy
+`projects/sesori-ai/alertPolicies/2058247532448449377` sends severity `ERROR`
+or higher logs for this Scheduler job and Cloud Run service in `europe-west1` to
+`alex@vespr.xyz` through notification channel
+`projects/sesori-ai/notificationChannels/13175960969888864777`. It does not
+monitor GitHub Actions; GitHub owns build status and failed-action notifications.
+
+## Security and ownership
+
+- Scheduler calls private Cloud Run with an OIDC token whose audience is the
+  service base URL. IAM performs request authentication; application code does
+  not implement another caller credential.
+- `sesori-release-scheduler@sesori-ai.iam.gserviceaccount.com` is caller identity.
+  It has `roles/run.invoker` only on this Cloud Run service.
+- `sesori-release-dispatcher@sesori-ai.iam.gserviceaccount.com` is runtime identity.
+  It has `roles/secretmanager.secretAccessor` only on secret
+  `sesori-release-scheduler-app-key`.
+- `sesori-release-builder@sesori-ai.iam.gserviceaccount.com` is the separate
+  build identity with project-level `roles/run.builder`. It has no access to the
+  GitHub App secret. Cloud Build requires a user-managed identity when one is
+  explicitly selected; do not select its legacy service account.
+- GitHub App installation is limited to `sesori-ai/sesori_apps_monorepo` with
+  Actions write and Metadata read. Installation tokens request this repository
+  and Actions write again.
+- App PEM is mounted at `/secrets/github-app-key.pem`. It never belongs in source,
+  an image, command arguments, environment variables, or logs.
+- Repository, workflow, ref, installation, and automatic input are fixed in code.
+  Caller body and query parameters cannot select another target.
+- Dispatcher has 10-second upstream timeouts and no retry loop. Cloud Scheduler
+  owns bounded delivery retries. Workflow concurrency plus release gate prevents
+  a retried automatic dispatch from uploading an attempted commit again.
+
+## One-time bootstrap
+
+The identities and alert resources above are provisioned in `sesori-ai`. Secret
+`sesori-release-scheduler-app-key` version 1 uses user-managed `europe-west1`
+replication and grants its secret-only accessor binding to the runtime identity.
+The dispatcher mounts an explicit secret version; adding a version does not
+silently change the running service's key.
+
+Run from repository root. Commands mutate Google Cloud and belong to the resource
+owner, not CI. Source must remain the dispatcher directory. Job creation is a
+one-time operation; for existing resources use the update and operations sections.
+
+```bash
+PROJECT=sesori-ai
+REGION=europe-west1
+SERVICE=sesori-release-scheduler
+JOB=sesori-internal-release
+RUNTIME_SA=sesori-release-dispatcher
+CALLER_SA=sesori-release-scheduler
+SECRET=sesori-release-scheduler-app-key
+BUILD_SA="projects/${PROJECT}/serviceAccounts/sesori-release-builder@${PROJECT}.iam.gserviceaccount.com"
+SECRET_VERSION=1 # Current deployed version; update when rotating the key.
+
+gcloud run deploy "$SERVICE" --project="$PROJECT" --region="$REGION" \
+  --source=tool/release_scheduler --build-service-account="$BUILD_SA" \
+  --service-account="${RUNTIME_SA}@${PROJECT}.iam.gserviceaccount.com" \
+  --no-allow-unauthenticated --min=0 --max=1 --cpu=1 --memory=256Mi \
+  --concurrency=10 --timeout=30s \
+  --set-secrets="/secrets/github-app-key.pem=${SECRET}:${SECRET_VERSION}"
+
+gcloud run services add-iam-policy-binding "$SERVICE" \
+  --project="$PROJECT" --region="$REGION" \
+  --member="serviceAccount:${CALLER_SA}@${PROJECT}.iam.gserviceaccount.com" \
+  --role=roles/run.invoker
+
+SERVICE_URL="$(gcloud run services describe "$SERVICE" \
+  --project="$PROJECT" --region="$REGION" --format='value(status.url)')"
+
+# Creation cannot be paused atomically. Start on side-effect-free health route.
+gcloud scheduler jobs create http "$JOB" \
+  --project="$PROJECT" --location="$REGION" --schedule='45 * * * *' \
+  --time-zone=Etc/UTC --uri="${SERVICE_URL}/health" --http-method=GET \
+  --oidc-service-account-email="${CALLER_SA}@${PROJECT}.iam.gserviceaccount.com" \
+  --oidc-token-audience="$SERVICE_URL" --attempt-deadline=30s \
+  --max-retry-attempts=5 --max-retry-duration=2700s \
+  --min-backoff=30s --max-backoff=600s --max-doublings=5
+
+gcloud scheduler jobs pause "$JOB" --project="$PROJECT" --location="$REGION"
+gcloud scheduler jobs describe "$JOB" --project="$PROJECT" --location="$REGION" \
+  --format='value(state,httpTarget.uri,httpTarget.httpMethod)'
+
+# Only after PAUSED is confirmed, arm dispatch target without resuming job.
+gcloud scheduler jobs update http "$JOB" \
+  --project="$PROJECT" --location="$REGION" \
+  --uri="${SERVICE_URL}/dispatch" --http-method=POST \
+  --oidc-service-account-email="${CALLER_SA}@${PROJECT}.iam.gserviceaccount.com" \
+  --oidc-token-audience="$SERVICE_URL"
+gcloud scheduler jobs describe "$JOB" --project="$PROJECT" --location="$REGION" \
+  --format='value(state,httpTarget.uri,httpTarget.httpMethod)'
+```
+
+Both descriptions must show `PAUSED`; final target must be `/dispatch` with
+`POST`. Keep job paused until release PR merges and owner validates live auth and
+resource IAM. Operator needs `iam.serviceAccounts.actAs` on caller identity.
+Cloud Scheduler service agent retains standard `roles/cloudscheduler.serviceAgent`;
+neither application identity needs a project-wide role.
+
+## Verify and update
+
+Offline verification:
+
+```bash
+npm ci --prefix tool/release_scheduler
+npm run typecheck --prefix tool/release_scheduler
+npm test --prefix tool/release_scheduler
+```
+
+Deploy updates from repository root. Source argument must stay exactly
+`tool/release_scheduler`; never deploy `.` or a PEM-containing folder.
+
+```bash
+SECRET_VERSION=1 # Current deployed version; update when rotating the key.
+gcloud run deploy sesori-release-scheduler \
+  --project=sesori-ai --region=europe-west1 --source=tool/release_scheduler \
+  --build-service-account=projects/sesori-ai/serviceAccounts/sesori-release-builder@sesori-ai.iam.gserviceaccount.com \
+  --service-account=sesori-release-dispatcher@sesori-ai.iam.gserviceaccount.com \
+  --no-allow-unauthenticated --min=0 --max=1 --cpu=1 --memory=256Mi \
+  --concurrency=10 --timeout=30s \
+  --set-secrets="/secrets/github-app-key.pem=sesori-release-scheduler-app-key:${SECRET_VERSION}"
+```
+
+Check health without dispatching a release:
+
+```bash
+SERVICE_URL="$(gcloud run services describe sesori-release-scheduler \
+  --project=sesori-ai --region=europe-west1 --format='value(status.url)')"
+curl --fail --show-error \
+  -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
+  "$SERVICE_URL/health"
+```
+
+This command uses an authenticated operator account with Cloud Run invocation
+permission. Scheduler instead uses its service account's OIDC token with the
+service URL as audience. Validate GitHub auth and the created-run response before
+enabling scheduled traffic; `POST /dispatch` is a real automatic release
+opportunity, not a harmless probe.
+
+IAM review:
+
+```bash
+RUNTIME_EMAIL=sesori-release-dispatcher@sesori-ai.iam.gserviceaccount.com
+CALLER_EMAIL=sesori-release-scheduler@sesori-ai.iam.gserviceaccount.com
+gcloud run services get-iam-policy sesori-release-scheduler \
+  --project=sesori-ai --region=europe-west1
+gcloud secrets get-iam-policy sesori-release-scheduler-app-key --project=sesori-ai
+gcloud projects get-iam-policy sesori-ai \
+  --flatten='bindings[].members' \
+  --filter="bindings.members:(${RUNTIME_EMAIL} OR ${CALLER_EMAIL})" \
+  --format='table(bindings.role,bindings.members)'
+```
+
+## Operations
+
+Cloud Run console:
+<https://console.cloud.google.com/run/detail/europe-west1/sesori-release-scheduler/metrics?project=sesori-ai>.
+Logs:
+<https://console.cloud.google.com/logs/query?project=sesori-ai>.
+Logs contain successful workflow run ID/API URL/web URL, or bounded failure
+operation/status/GitHub request ID. They omit JWTs, installation tokens, PEMs,
+exception text, and upstream response bodies.
+
+```bash
+# Pause or resume hourly automatic opportunities.
+gcloud scheduler jobs pause sesori-internal-release --project=sesori-ai --location=europe-west1
+gcloud scheduler jobs resume sesori-internal-release --project=sesori-ai --location=europe-west1
+
+# Inspect recent dispatcher logs.
+gcloud run services logs read sesori-release-scheduler \
+  --project=sesori-ai --region=europe-west1 --limit=50
+```
+
+Do not use `gcloud scheduler jobs run` to retry a failed/cancelled build: it is an
+automatic dispatch and gate will skip the attempted SHA. Retry build failures
+from GitHub Actions **Run workflow**, leaving `automatic` false. This preserves
+manual retry and branch checkpoint behavior. A Scheduler delivery failure may be
+retried by Scheduler within its 45-minute window; operators can inspect logs and
+run job only when no GitHub run was created.
+
+## GitHub App key rotation
+
+1. Create second private key in GitHub App settings; keep old key active.
+2. Add PEM as new secret version with `gcloud secrets versions add ... --data-file=...`.
+3. Set `SECRET_VERSION` to the new numeric version and redeploy Cloud Run; verify
+   `/health`, IAM, and the next intended dispatch's created run. Record the deployed
+   version in this runbook.
+4. Delete old GitHub App key only after new-key dispatch acceptance is confirmed.
+5. Destroy local PEM copies according to operator key-handling policy.
+
+Rotation validation through `/dispatch` creates a real workflow run. Use next
+intended automatic opportunity or coordinate a controlled run; never treat it as
+an authentication-only test.

--- a/tool/release_scheduler/package-lock.json
+++ b/tool/release_scheduler/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "sesori-release-scheduler",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sesori-release-scheduler",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^24.10.0",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/tool/release_scheduler/package.json
+++ b/tool/release_scheduler/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "sesori-release-scheduler",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/tool/release_scheduler/src/github_dispatcher.ts
+++ b/tool/release_scheduler/src/github_dispatcher.ts
@@ -8,6 +8,7 @@ export const GITHUB_REF = "main";
 
 const GITHUB_APP_ID = "4897384";
 const GITHUB_INSTALLATION_ID = "160598508";
+// This version removes return_run_details and always returns 200 with run IDs.
 const GITHUB_API_VERSION = "2026-03-10";
 const GITHUB_API_ROOT = "https://api.github.com";
 const PRIVATE_KEY_PATH = "/secrets/github-app-key.pem";
@@ -34,6 +35,7 @@ type DispatchFailureOptions = {
   status?: number | undefined;
   requestId?: string | undefined;
   cause?: unknown;
+  diagnostics: Record<string, string>;
 };
 
 export class DispatchFailure extends Error {
@@ -41,6 +43,7 @@ export class DispatchFailure extends Error {
   readonly code: string;
   readonly status: number | undefined;
   readonly requestId: string | undefined;
+  readonly diagnostics: Record<string, string>;
 
   constructor(options: DispatchFailureOptions) {
     super(`GitHub operation failed: ${options.operation}`, { cause: options.cause });
@@ -49,6 +52,7 @@ export class DispatchFailure extends Error {
     this.code = options.code;
     this.status = options.status;
     this.requestId = options.requestId;
+    this.diagnostics = options.diagnostics;
   }
 }
 
@@ -82,6 +86,7 @@ export class GitHubDispatcher {
         operation: "read_private_key",
         code: "private_key_unavailable",
         cause: error,
+        diagnostics: describeError({ error, redactions: [] }),
       });
     }
   }
@@ -154,6 +159,10 @@ export class GitHubDispatcher {
         operation: options.operation,
         code: "request_failed",
         cause: error,
+        diagnostics: describeError({
+          error,
+          redactions: [new Headers(options.init.headers).get("Authorization")!.replace(/^Bearer /, "")],
+        }),
       });
     }
     if (!response.ok) {
@@ -172,11 +181,20 @@ export function createAppJwt(options: { appId: string; nowSeconds: number; priva
     iss: options.appId,
   });
   const unsignedToken = `${header}.${payload}`;
-  const signer = createSign("RSA-SHA256");
-  signer.update(unsignedToken);
-  signer.end();
-  const signature = signer.sign(options.privateKey, "base64url");
-  return `${unsignedToken}.${signature}`;
+  try {
+    const signer = createSign("RSA-SHA256");
+    signer.update(unsignedToken);
+    signer.end();
+    const signature = signer.sign(options.privateKey, "base64url");
+    return `${unsignedToken}.${signature}`;
+  } catch (error: unknown) {
+    throw new DispatchFailure({
+      operation: "sign_app_jwt",
+      code: "private_key_invalid",
+      cause: error,
+      diagnostics: describeError({ error, redactions: [options.privateKey] }),
+    });
+  }
 }
 
 function githubHeaders(options: { authorization: string }): Record<string, string> {
@@ -203,6 +221,8 @@ async function parseJson(options: { operation: string; response: Response }): Pr
       status: options.response.status,
       requestId: readRequestId(options.response),
       cause: error,
+      // JSON parser messages may quote the response body, including a token.
+      diagnostics: { error_name: error instanceof Error ? error.name : typeof error },
     });
   }
 }
@@ -217,7 +237,32 @@ function responseFailure(options: {
     code: options.code,
     status: options.response.status,
     requestId: readRequestId(options.response),
+    diagnostics: {},
   });
+}
+
+// Native fetch errors retain DNS/TLS details in cause. Redact credentials at
+// the boundary that owns them, without discarding useful messages or frames.
+export function describeError(options: { error: unknown; redactions: readonly string[] }): Record<string, string> {
+  const diagnostics: Record<string, string> = {};
+  const errors = [options.error, options.error instanceof Error ? options.error.cause : undefined];
+  for (const [index, error] of errors.entries()) {
+    if (!(error instanceof Error)) continue;
+    const prefix = index === 0 ? "error" : "cause";
+    const fields: Record<string, string> = { name: error.name, message: error.message };
+    if (error.stack !== undefined) fields.stack = error.stack;
+    if ("code" in error && (typeof error.code === "string" || typeof error.code === "number")) {
+      fields.code = String(error.code);
+    }
+    for (const [field, value] of Object.entries(fields)) {
+      let redacted = value;
+      for (const secret of options.redactions) {
+        if (secret.length > 0) redacted = redacted.replaceAll(secret, "[REDACTED]");
+      }
+      diagnostics[`${prefix}_${field}`] = redacted;
+    }
+  }
+  return diagnostics;
 }
 
 function readRequestId(response: Response): string | undefined {

--- a/tool/release_scheduler/src/github_dispatcher.ts
+++ b/tool/release_scheduler/src/github_dispatcher.ts
@@ -243,7 +243,7 @@ function responseFailure(options: {
 
 // Native fetch errors retain DNS/TLS details in cause. Redact credentials at
 // the boundary that owns them, without discarding useful messages or frames.
-export function describeError(options: { error: unknown; redactions: readonly string[] }): Record<string, string> {
+function describeError(options: { error: unknown; redactions: readonly string[] }): Record<string, string> {
   const diagnostics: Record<string, string> = {};
   const errors = [options.error, options.error instanceof Error ? options.error.cause : undefined];
   for (const [index, error] of errors.entries()) {

--- a/tool/release_scheduler/src/github_dispatcher.ts
+++ b/tool/release_scheduler/src/github_dispatcher.ts
@@ -1,0 +1,233 @@
+import { createSign } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+export const GITHUB_OWNER = "sesori-ai";
+export const GITHUB_REPOSITORY = "sesori_apps_monorepo";
+export const GITHUB_WORKFLOW = "release-all-platforms.yml";
+export const GITHUB_REF = "main";
+
+const GITHUB_APP_ID = "4897384";
+const GITHUB_INSTALLATION_ID = "160598508";
+const GITHUB_API_VERSION = "2026-03-10";
+const GITHUB_API_ROOT = "https://api.github.com";
+const PRIVATE_KEY_PATH = "/secrets/github-app-key.pem";
+const REQUEST_TIMEOUT_MS = 10_000;
+
+type FetchRequest = (input: string | URL, init?: RequestInit) => Promise<Response>;
+type ReadPrivateKey = () => Promise<string>;
+
+type DispatcherOptions = {
+  fetchRequest?: FetchRequest;
+  nowSeconds?: () => number;
+  readPrivateKey?: ReadPrivateKey;
+};
+
+export type DispatchResult = {
+  workflowRunId: number;
+  runUrl: string;
+  htmlUrl: string;
+};
+
+type DispatchFailureOptions = {
+  operation: string;
+  code: string;
+  status?: number | undefined;
+  requestId?: string | undefined;
+  cause?: unknown;
+};
+
+export class DispatchFailure extends Error {
+  readonly operation: string;
+  readonly code: string;
+  readonly status: number | undefined;
+  readonly requestId: string | undefined;
+
+  constructor(options: DispatchFailureOptions) {
+    super(`GitHub operation failed: ${options.operation}`, { cause: options.cause });
+    this.name = "DispatchFailure";
+    this.operation = options.operation;
+    this.code = options.code;
+    this.status = options.status;
+    this.requestId = options.requestId;
+  }
+}
+
+export class GitHubDispatcher {
+  readonly #fetchRequest: FetchRequest;
+  readonly #nowSeconds: () => number;
+  readonly #readPrivateKey: ReadPrivateKey;
+
+  constructor(options: DispatcherOptions = {}) {
+    this.#fetchRequest = options.fetchRequest ?? fetch;
+    this.#nowSeconds = options.nowSeconds ?? (() => Math.floor(Date.now() / 1000));
+    this.#readPrivateKey = options.readPrivateKey ?? (() => readFile(PRIVATE_KEY_PATH, "utf8"));
+  }
+
+  async dispatch(): Promise<DispatchResult> {
+    const privateKey = await this.#loadPrivateKey();
+    const appJwt = createAppJwt({
+      appId: GITHUB_APP_ID,
+      nowSeconds: this.#nowSeconds(),
+      privateKey,
+    });
+    const installationToken = await this.#mintInstallationToken({ appJwt });
+    return this.#dispatchWorkflow({ installationToken });
+  }
+
+  async #loadPrivateKey(): Promise<string> {
+    try {
+      return await this.#readPrivateKey();
+    } catch (error: unknown) {
+      throw new DispatchFailure({
+        operation: "read_private_key",
+        code: "private_key_unavailable",
+        cause: error,
+      });
+    }
+  }
+
+  async #mintInstallationToken(options: { appJwt: string }): Promise<string> {
+    const operation = "mint_installation_token";
+    const response = await this.#request({
+      operation,
+      url: `${GITHUB_API_ROOT}/app/installations/${GITHUB_INSTALLATION_ID}/access_tokens`,
+      init: {
+        method: "POST",
+        headers: githubHeaders({ authorization: `Bearer ${options.appJwt}` }),
+        body: JSON.stringify({
+          repositories: [GITHUB_REPOSITORY],
+          permissions: { actions: "write" },
+        }),
+      },
+    });
+    const json = await parseJson({ operation, response });
+    if (!isRecord(json) || typeof json.token !== "string" || json.token.length === 0) {
+      throw responseFailure({ operation, response, code: "invalid_response" });
+    }
+    return json.token;
+  }
+
+  async #dispatchWorkflow(options: { installationToken: string }): Promise<DispatchResult> {
+    const operation = "dispatch_workflow";
+    const response = await this.#request({
+      operation,
+      url:
+        `${GITHUB_API_ROOT}/repos/${GITHUB_OWNER}/${GITHUB_REPOSITORY}` +
+        `/actions/workflows/${GITHUB_WORKFLOW}/dispatches`,
+      init: {
+        method: "POST",
+        headers: githubHeaders({ authorization: `Bearer ${options.installationToken}` }),
+        body: JSON.stringify({
+          ref: GITHUB_REF,
+          inputs: { automatic: "true" },
+        }),
+      },
+    });
+    const json = await parseJson({ operation, response });
+    if (
+      !isRecord(json) ||
+      typeof json.workflow_run_id !== "number" ||
+      !Number.isSafeInteger(json.workflow_run_id) ||
+      typeof json.run_url !== "string" ||
+      json.run_url.length === 0 ||
+      typeof json.html_url !== "string" ||
+      json.html_url.length === 0
+    ) {
+      throw responseFailure({ operation, response, code: "invalid_response" });
+    }
+    return {
+      workflowRunId: json.workflow_run_id,
+      runUrl: json.run_url,
+      htmlUrl: json.html_url,
+    };
+  }
+
+  async #request(options: { operation: string; url: string; init: RequestInit }): Promise<Response> {
+    let response: Response;
+    try {
+      response = await this.#fetchRequest(options.url, {
+        ...options.init,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (error: unknown) {
+      throw new DispatchFailure({
+        operation: options.operation,
+        code: "request_failed",
+        cause: error,
+      });
+    }
+    if (!response.ok) {
+      void response.body?.cancel();
+      throw responseFailure({ operation: options.operation, response, code: "http_error" });
+    }
+    return response;
+  }
+}
+
+export function createAppJwt(options: { appId: string; nowSeconds: number; privateKey: string }): string {
+  const header = encodeJwtPart({ alg: "RS256", typ: "JWT" });
+  const payload = encodeJwtPart({
+    iat: options.nowSeconds - 60,
+    exp: options.nowSeconds + 9 * 60,
+    iss: options.appId,
+  });
+  const unsignedToken = `${header}.${payload}`;
+  const signer = createSign("RSA-SHA256");
+  signer.update(unsignedToken);
+  signer.end();
+  const signature = signer.sign(options.privateKey, "base64url");
+  return `${unsignedToken}.${signature}`;
+}
+
+function githubHeaders(options: { authorization: string }): Record<string, string> {
+  return {
+    Accept: "application/vnd.github+json",
+    Authorization: options.authorization,
+    "Content-Type": "application/json",
+    "User-Agent": "sesori-release-scheduler",
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+  };
+}
+
+function encodeJwtPart(value: object): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+async function parseJson(options: { operation: string; response: Response }): Promise<unknown> {
+  try {
+    return (await options.response.json()) as unknown;
+  } catch (error: unknown) {
+    throw new DispatchFailure({
+      operation: options.operation,
+      code: "invalid_json",
+      status: options.response.status,
+      requestId: readRequestId(options.response),
+      cause: error,
+    });
+  }
+}
+
+function responseFailure(options: {
+  operation: string;
+  response: Response;
+  code: string;
+}): DispatchFailure {
+  return new DispatchFailure({
+    operation: options.operation,
+    code: options.code,
+    status: options.response.status,
+    requestId: readRequestId(options.response),
+  });
+}
+
+function readRequestId(response: Response): string | undefined {
+  const requestId = response.headers.get("x-github-request-id");
+  if (requestId === null || requestId.length > 128 || !/^[A-Za-z0-9:._-]+$/.test(requestId)) {
+    return undefined;
+  }
+  return requestId;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/tool/release_scheduler/src/server.ts
+++ b/tool/release_scheduler/src/server.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { pathToFileURL } from "node:url";
 
-import { DispatchFailure, GitHubDispatcher, type DispatchResult } from "./github_dispatcher.ts";
+import { describeError, DispatchFailure, GitHubDispatcher, type DispatchResult } from "./github_dispatcher.ts";
 
 type LogEntry = Record<string, string | number>;
 type LogWriter = (entry: LogEntry) => void;
@@ -14,8 +14,8 @@ type HandlerOptions = {
 
 export function createRequestHandler(options: HandlerOptions) {
   return async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
-    const url = new URL(request.url ?? "/", "http://localhost");
-    if (url.pathname === "/health") {
+    const path = request.url?.split("?", 1)[0];
+    if (path === "/health") {
       if (request.method !== "GET") {
         writeJson({ response, status: 405, body: { status: "method_not_allowed" }, allow: "GET" });
         return;
@@ -24,7 +24,7 @@ export function createRequestHandler(options: HandlerOptions) {
       return;
     }
 
-    if (url.pathname !== "/dispatch") {
+    if (path !== "/dispatch") {
       writeJson({ response, status: 404, body: { status: "not_found" } });
       return;
     }
@@ -87,11 +87,12 @@ export function startServer(): void {
 
 function safeFailureLog(error: unknown): LogEntry {
   if (!(error instanceof DispatchFailure)) {
-    return { operation: "dispatch", code: "unexpected_error" };
+    return { operation: "dispatch", code: "unexpected_error", ...describeError({ error, redactions: [] }) };
   }
   const entry: LogEntry = {
     operation: error.operation,
     code: error.code,
+    ...error.diagnostics,
   };
   if (error.status !== undefined) {
     entry.status = error.status;

--- a/tool/release_scheduler/src/server.ts
+++ b/tool/release_scheduler/src/server.ts
@@ -1,0 +1,133 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { pathToFileURL } from "node:url";
+
+import { DispatchFailure, GitHubDispatcher, type DispatchResult } from "./github_dispatcher.ts";
+
+type LogEntry = Record<string, string | number>;
+type LogWriter = (entry: LogEntry) => void;
+type Dispatch = () => Promise<DispatchResult>;
+
+type HandlerOptions = {
+  dispatch: Dispatch;
+  writeLog: LogWriter;
+};
+
+export function createRequestHandler(options: HandlerOptions) {
+  return async (request: IncomingMessage, response: ServerResponse): Promise<void> => {
+    const url = new URL(request.url ?? "/", "http://localhost");
+    if (url.pathname === "/health") {
+      if (request.method !== "GET") {
+        writeJson({ response, status: 405, body: { status: "method_not_allowed" }, allow: "GET" });
+        return;
+      }
+      writeJson({ response, status: 200, body: { status: "ok" } });
+      return;
+    }
+
+    if (url.pathname !== "/dispatch") {
+      writeJson({ response, status: 404, body: { status: "not_found" } });
+      return;
+    }
+    if (request.method !== "POST") {
+      writeJson({ response, status: 405, body: { status: "method_not_allowed" }, allow: "POST" });
+      return;
+    }
+
+    try {
+      const result = await options.dispatch();
+      options.writeLog({
+        severity: "INFO",
+        message: "GitHub workflow dispatch accepted and run created",
+        workflow_run_id: result.workflowRunId,
+        run_url: result.runUrl,
+        html_url: result.htmlUrl,
+      });
+      writeJson({
+        response,
+        status: 200,
+        body: {
+          status: "accepted",
+          workflow_run_id: result.workflowRunId,
+          run_url: result.runUrl,
+          html_url: result.htmlUrl,
+        },
+      });
+    } catch (error: unknown) {
+      const failure = safeFailureLog(error);
+      options.writeLog({
+        severity: "ERROR",
+        message: "GitHub workflow dispatch failed",
+        ...failure,
+      });
+      writeJson({ response, status: 502, body: { status: "dispatch_failed" } });
+    }
+  };
+}
+
+export function startServer(): void {
+  const dispatcher = new GitHubDispatcher();
+  const handler = createRequestHandler({
+    dispatch: () => dispatcher.dispatch(),
+    writeLog: (entry) => console.log(JSON.stringify(entry)),
+  });
+  const port = readPort();
+  const server = createServer((request, response) => {
+    void handler(request, response);
+  });
+  server.listen(port, "0.0.0.0", () => {
+    console.log(
+      JSON.stringify({
+        severity: "INFO",
+        message: "Release scheduler dispatcher listening",
+        port,
+      }),
+    );
+  });
+}
+
+function safeFailureLog(error: unknown): LogEntry {
+  if (!(error instanceof DispatchFailure)) {
+    return { operation: "dispatch", code: "unexpected_error" };
+  }
+  const entry: LogEntry = {
+    operation: error.operation,
+    code: error.code,
+  };
+  if (error.status !== undefined) {
+    entry.status = error.status;
+  }
+  if (error.requestId !== undefined) {
+    entry.request_id = error.requestId;
+  }
+  return entry;
+}
+
+function writeJson(options: {
+  response: ServerResponse;
+  status: number;
+  body: object;
+  allow?: string;
+}): void {
+  const body = JSON.stringify(options.body);
+  options.response.statusCode = options.status;
+  options.response.setHeader("Content-Type", "application/json; charset=utf-8");
+  options.response.setHeader("Content-Length", Buffer.byteLength(body));
+  if (options.allow !== undefined) {
+    options.response.setHeader("Allow", options.allow);
+  }
+  options.response.end(body);
+}
+
+function readPort(): number {
+  const rawPort = process.env.PORT ?? "8080";
+  const port = Number(rawPort);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("PORT must be an integer between 1 and 65535");
+  }
+  return port;
+}
+
+const entrypoint = process.argv[1];
+if (entrypoint !== undefined && import.meta.url === pathToFileURL(entrypoint).href) {
+  startServer();
+}

--- a/tool/release_scheduler/src/server.ts
+++ b/tool/release_scheduler/src/server.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { pathToFileURL } from "node:url";
 
-import { describeError, DispatchFailure, GitHubDispatcher, type DispatchResult } from "./github_dispatcher.ts";
+import { DispatchFailure, GitHubDispatcher, type DispatchResult } from "./github_dispatcher.ts";
 
 type LogEntry = Record<string, string | number>;
 type LogWriter = (entry: LogEntry) => void;
@@ -87,7 +87,12 @@ export function startServer(): void {
 
 function safeFailureLog(error: unknown): LogEntry {
   if (!(error instanceof DispatchFailure)) {
-    return { operation: "dispatch", code: "unexpected_error", ...describeError({ error, redactions: [] }) };
+    // Only the owning I/O boundary knows which credentials to redact.
+    return {
+      operation: "dispatch",
+      code: "unexpected_error",
+      error_name: error instanceof Error ? error.name : typeof error,
+    };
   }
   const entry: LogEntry = {
     operation: error.operation,

--- a/tool/release_scheduler/test/github_dispatcher.test.ts
+++ b/tool/release_scheduler/test/github_dispatcher.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { generateKeyPairSync, verify } from "node:crypto";
+import test from "node:test";
+
+import {
+  DispatchFailure,
+  GITHUB_REF,
+  GITHUB_REPOSITORY,
+  GITHUB_WORKFLOW,
+  GitHubDispatcher,
+} from "../src/github_dispatcher.ts";
+
+const { privateKey, publicKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs8" }).toString();
+
+test("mints a repository-scoped token and dispatches fixed automatic workflow", async () => {
+  const calls: Array<{ url: string; init: RequestInit }> = [];
+  const fetchRequest = async (input: string | URL, init: RequestInit = {}): Promise<Response> => {
+    calls.push({ url: input.toString(), init });
+    if (calls.length === 1) {
+      return Response.json({ token: "installation-token" }, { status: 201 });
+    }
+    return Response.json(
+      {
+        workflow_run_id: 123456789,
+        run_url: "https://api.github.com/repos/sesori-ai/sesori_apps_monorepo/actions/runs/123456789",
+        html_url: "https://github.com/sesori-ai/sesori_apps_monorepo/actions/runs/123456789",
+      },
+      { status: 200 },
+    );
+  };
+  const dispatcher = new GitHubDispatcher({
+    fetchRequest,
+    nowSeconds: () => 2_000_000_000,
+    readPrivateKey: async () => privateKeyPem,
+  });
+
+  const result = await dispatcher.dispatch();
+
+  assert.equal(result.workflowRunId, 123456789);
+  assert.equal(calls.length, 2);
+  const tokenCall = requiredCall(calls, 0);
+  assert.equal(tokenCall.url, "https://api.github.com/app/installations/160598508/access_tokens");
+  assert.equal(tokenCall.init.method, "POST");
+  assert.deepEqual(JSON.parse(requiredBody(tokenCall.init)), {
+    repositories: [GITHUB_REPOSITORY],
+    permissions: { actions: "write" },
+  });
+  const tokenHeaders = new Headers(tokenCall.init.headers);
+  assert.equal(tokenHeaders.get("x-github-api-version"), "2026-03-10");
+  const authorization = tokenHeaders.get("authorization");
+  if (authorization === null || !authorization.startsWith("Bearer ")) {
+    assert.fail("Expected Bearer App JWT");
+  }
+  const jwt = authorization.slice("Bearer ".length);
+  const jwtParts = jwt.split(".");
+  assert.equal(jwtParts.length, 3);
+  const payload = JSON.parse(Buffer.from(requiredString(jwtParts, 1), "base64url").toString()) as unknown;
+  assert.deepEqual(payload, { iat: 1_999_999_940, exp: 2_000_000_540, iss: "4897384" });
+  assert.equal(
+    verify(
+      "RSA-SHA256",
+      Buffer.from(`${requiredString(jwtParts, 0)}.${requiredString(jwtParts, 1)}`),
+      publicKey,
+      Buffer.from(requiredString(jwtParts, 2), "base64url"),
+    ),
+    true,
+  );
+
+  const dispatchCall = requiredCall(calls, 1);
+  assert.equal(
+    dispatchCall.url,
+    `https://api.github.com/repos/sesori-ai/${GITHUB_REPOSITORY}/actions/workflows/${GITHUB_WORKFLOW}/dispatches`,
+  );
+  assert.equal(new Headers(dispatchCall.init.headers).get("authorization"), "Bearer installation-token");
+  assert.deepEqual(JSON.parse(requiredBody(dispatchCall.init)), {
+    ref: GITHUB_REF,
+    inputs: { automatic: "true" },
+  });
+  assert.ok(dispatchCall.init.signal instanceof AbortSignal);
+});
+
+test("reports bounded GitHub failure metadata without retrying or retaining response body", async () => {
+  let callCount = 0;
+  const dispatcher = new GitHubDispatcher({
+    fetchRequest: async () => {
+      callCount += 1;
+      return new Response("sensitive upstream response body", {
+        status: 401,
+        headers: { "x-github-request-id": "ABCD:5678" },
+      });
+    },
+    readPrivateKey: async () => privateKeyPem,
+  });
+
+  await assert.rejects(dispatcher.dispatch(), (error: unknown) => {
+    assert.ok(error instanceof DispatchFailure);
+    assert.equal(error.operation, "mint_installation_token");
+    assert.equal(error.code, "http_error");
+    assert.equal(error.status, 401);
+    assert.equal(error.requestId, "ABCD:5678");
+    assert.doesNotMatch(JSON.stringify(error), /sensitive upstream response body/);
+    return true;
+  });
+  assert.equal(callCount, 1);
+});
+
+function requiredCall(
+  calls: Array<{ url: string; init: RequestInit }>,
+  index: number,
+): { url: string; init: RequestInit } {
+  const call = calls[index];
+  assert.ok(call);
+  return call;
+}
+
+function requiredBody(init: RequestInit): string {
+  if (typeof init.body !== "string") {
+    assert.fail("Expected string request body");
+  }
+  return init.body;
+}
+
+function requiredString(values: string[], index: number): string {
+  const value = values[index];
+  assert.ok(value);
+  return value;
+}

--- a/tool/release_scheduler/test/github_dispatcher.test.ts
+++ b/tool/release_scheduler/test/github_dispatcher.test.ts
@@ -105,6 +105,65 @@ test("reports bounded GitHub failure metadata without retrying or retaining resp
   assert.equal(callCount, 1);
 });
 
+test("network failures retain DNS diagnostics and redact the authorization credential", async () => {
+  let credential = "";
+  const dispatcher = new GitHubDispatcher({
+    readPrivateKey: async () => privateKeyPem,
+    fetchRequest: async (_input, init) => {
+      credential = new Headers(init?.headers).get("authorization")!.slice("Bearer ".length);
+      const cause = Object.assign(new Error(`getaddrinfo ENOTFOUND api.github.com; token=${credential}`), {
+        code: "ENOTFOUND",
+      });
+      throw new TypeError("fetch failed", { cause });
+    },
+  });
+
+  await assert.rejects(dispatcher.dispatch(), (error: unknown) => {
+    assert.ok(error instanceof DispatchFailure);
+    assert.equal(error.diagnostics.error_name, "TypeError");
+    assert.equal(error.diagnostics.cause_code, "ENOTFOUND");
+    assert.match(error.diagnostics.cause_message!, /api.github.com; token=\[REDACTED\]/);
+    assert.match(error.diagnostics.error_stack!, /fetch failed/);
+    assert.ok(!JSON.stringify(error.diagnostics).includes(credential));
+    assert.ok(error.cause instanceof TypeError);
+    return true;
+  });
+});
+
+test("malformed keys retain signing diagnostics without logging key material", async () => {
+  const malformedKey = "malformed-private-key-material";
+  const dispatcher = new GitHubDispatcher({
+    readPrivateKey: async () => malformedKey,
+    fetchRequest: async () => assert.fail("Invalid keys must not make HTTP requests"),
+  });
+
+  await assert.rejects(dispatcher.dispatch(), (error: unknown) => {
+    assert.ok(error instanceof DispatchFailure);
+    assert.equal(error.operation, "sign_app_jwt");
+    assert.equal(error.code, "private_key_invalid");
+    assert.ok(error.diagnostics.error_message);
+    assert.match(error.diagnostics.error_stack!, /createAppJwt/);
+    assert.ok(!JSON.stringify(error.diagnostics).includes(malformedKey));
+    assert.ok(error.cause instanceof Error);
+    return true;
+  });
+});
+
+test("invalid JSON diagnostics omit parser messages that quote response bodies", async () => {
+  const dispatcher = new GitHubDispatcher({
+    readPrivateKey: async () => privateKeyPem,
+    fetchRequest: async () => new Response('upstream-sensitive-token-not-json', { status: 201 }),
+  });
+
+  await assert.rejects(dispatcher.dispatch(), (error: unknown) => {
+    assert.ok(error instanceof DispatchFailure);
+    assert.equal(error.code, "invalid_json");
+    assert.deepEqual(error.diagnostics, { error_name: "SyntaxError" });
+    assert.ok(error.cause instanceof SyntaxError);
+    return true;
+  });
+});
+
 function requiredCall(
   calls: Array<{ url: string; init: RequestInit }>,
   index: number,

--- a/tool/release_scheduler/test/server.test.ts
+++ b/tool/release_scheduler/test/server.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { createServer, type Server } from "node:http";
+import { createServer, request as httpRequest, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import test, { type TestContext } from "node:test";
 
@@ -57,6 +57,7 @@ test("dispatch failure omits secret and upstream response body details", async (
         status: 401,
         requestId: "ABCD:1234",
         cause: new Error("private-key-and-upstream-body-must-not-appear"),
+        diagnostics: { error_name: "TypeError", cause_code: "ENOTFOUND", cause_message: "api.github.com [REDACTED]" },
       });
     },
     writeLog: (entry) => logs.push(entry),
@@ -75,9 +76,30 @@ test("dispatch failure omits secret and upstream response body details", async (
       code: "http_error",
       status: 401,
       request_id: "ABCD:1234",
+      error_name: "TypeError",
+      cause_code: "ENOTFOUND",
+      cause_message: "api.github.com [REDACTED]",
     },
   ]);
   assert.doesNotMatch(JSON.stringify(logs) + responseBody, /private-key|upstream-body/);
+});
+
+test("malformed absolute-form targets return 404 without rejecting the handler", async (context) => {
+  const server = await serve(context, {
+    dispatch: async () => assert.fail("Unknown routes must not dispatch"),
+    writeLog: () => undefined,
+  });
+
+  const status = await new Promise<number | undefined>((resolve, reject) => {
+    const request = httpRequest(server, { path: "http://[", method: "GET" }, (response) => {
+      response.resume();
+      resolve(response.statusCode);
+    });
+    request.on("error", reject);
+    request.end();
+  });
+  assert.equal(status, 404);
+  assert.equal((await fetch(`${server}/health?probe=1`)).status, 200);
 });
 
 type HandlerOptions = Parameters<typeof createRequestHandler>[0];

--- a/tool/release_scheduler/test/server.test.ts
+++ b/tool/release_scheduler/test/server.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import test, { type TestContext } from "node:test";
+
+import { DispatchFailure } from "../src/github_dispatcher.ts";
+import { createRequestHandler } from "../src/server.ts";
+
+test("GET /health reports readiness without dispatching", async (context) => {
+  let dispatchCount = 0;
+  const server = await serve(context, {
+    dispatch: async () => {
+      dispatchCount += 1;
+      throw new Error("unexpected dispatch");
+    },
+    writeLog: () => undefined,
+  });
+
+  const response = await fetch(`${server}/health`);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { status: "ok" });
+  assert.equal(dispatchCount, 0);
+});
+
+test("POST /dispatch reports created workflow run and logs bounded identifiers", async (context) => {
+  const logs: Array<Record<string, string | number>> = [];
+  const server = await serve(context, {
+    dispatch: async () => ({
+      workflowRunId: 42,
+      runUrl: "https://api.github.com/repos/sesori-ai/sesori_apps_monorepo/actions/runs/42",
+      htmlUrl: "https://github.com/sesori-ai/sesori_apps_monorepo/actions/runs/42",
+    }),
+    writeLog: (entry) => logs.push(entry),
+  });
+
+  const response = await fetch(`${server}/dispatch`, { method: "POST" });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    status: "accepted",
+    workflow_run_id: 42,
+    run_url: "https://api.github.com/repos/sesori-ai/sesori_apps_monorepo/actions/runs/42",
+    html_url: "https://github.com/sesori-ai/sesori_apps_monorepo/actions/runs/42",
+  });
+  assert.equal(logs.length, 1);
+  assert.equal(logs[0]?.workflow_run_id, 42);
+});
+
+test("dispatch failure omits secret and upstream response body details", async (context) => {
+  const logs: Array<Record<string, string | number>> = [];
+  const server = await serve(context, {
+    dispatch: async () => {
+      throw new DispatchFailure({
+        operation: "mint_installation_token",
+        code: "http_error",
+        status: 401,
+        requestId: "ABCD:1234",
+        cause: new Error("private-key-and-upstream-body-must-not-appear"),
+      });
+    },
+    writeLog: (entry) => logs.push(entry),
+  });
+
+  const response = await fetch(`${server}/dispatch`, { method: "POST" });
+  const responseBody = await response.text();
+
+  assert.equal(response.status, 502);
+  assert.equal(responseBody, '{"status":"dispatch_failed"}');
+  assert.deepEqual(logs, [
+    {
+      severity: "ERROR",
+      message: "GitHub workflow dispatch failed",
+      operation: "mint_installation_token",
+      code: "http_error",
+      status: 401,
+      request_id: "ABCD:1234",
+    },
+  ]);
+  assert.doesNotMatch(JSON.stringify(logs) + responseBody, /private-key|upstream-body/);
+});
+
+type HandlerOptions = Parameters<typeof createRequestHandler>[0];
+
+async function serve(context: TestContext, options: HandlerOptions): Promise<string> {
+  const handler = createRequestHandler(options);
+  const server = createServer((request, response) => {
+    void handler(request, response);
+  });
+  await listen(server);
+  context.after(() => close(server));
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function listen(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+}
+
+async function close(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error === undefined ? resolve() : reject(error)));
+  });
+}

--- a/tool/release_scheduler/test/server.test.ts
+++ b/tool/release_scheduler/test/server.test.ts
@@ -84,6 +84,25 @@ test("dispatch failure omits secret and upstream response body details", async (
   assert.doesNotMatch(JSON.stringify(logs) + responseBody, /private-key|upstream-body/);
 });
 
+test("unexpected exceptions log only non-content metadata", async (context) => {
+  const logs: Array<Record<string, string | number>> = [];
+  const server = await serve(context, {
+    dispatch: async () => { throw new Error("unexpected-credential-or-upstream-body"); },
+    writeLog: (entry) => logs.push(entry),
+  });
+
+  const response = await fetch(`${server}/dispatch`, { method: "POST" });
+  assert.equal(response.status, 502);
+  assert.deepEqual(logs, [{
+    severity: "ERROR",
+    message: "GitHub workflow dispatch failed",
+    operation: "dispatch",
+    code: "unexpected_error",
+    error_name: "Error",
+  }]);
+  assert.doesNotMatch(await response.text(), /unexpected-credential-or-upstream-body/);
+});
+
 test("malformed absolute-form targets return 404 without rejecting the handler", async (context) => {
   const server = await serve(context, {
     dispatch: async () => assert.fail("Unknown routes must not dispatch"),

--- a/tool/release_scheduler/tsconfig.json
+++ b/tool/release_scheduler/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "exactOptionalPropertyTypes": true,
+    "lib": ["ES2024"],
+    "module": "NodeNext",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "target": "ES2024",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Complexity
⚙️ Moderate — a small authenticated cloud dispatcher plus release-trigger and operational setup changes.

## What
- Replace GitHub cron with automatic workflow dispatch from **Alex's Google Cloud Scheduler** in `sesori-ai/europe-west1`.
- Add a private Node 24/TypeScript Cloud Run dispatcher using a repository-only GitHub App and a mounted Secret Manager key. No runtime npm dependencies.
- Preserve automatic released/attempted-commit and relevant-change guards, serialized builds, and explicit manual retry behavior.
- Add dispatcher tests/typechecking to Release Workflow CI and document ownership, IAM, retries, key rotation, and operations.

## Why
The hourly GitHub cron produced gaps approaching five hours. Cloud Scheduler supplies acknowledged delivery with bounded retries; GitHub Actions keeps signing, builds, store uploads, and publishing.

## Risk and test focus
Main risks are duplicate uploads and credential exposure. Automatic dispatch uses the existing attempt marker before builds; manual dispatch defaults to the retry path. Runtime, scheduler caller, and build identities are separate. Only the runtime can access this one key secret; only the caller has service-level invocation access. Tokens and upstream response bodies are not logged.

No user-visible app behavior or database impact. Internal release timing changes. Dispatch success proves a run was created, not that the release completed; GitHub still owns build-failure notifications.

## Expected result
Every hour at `:45 UTC`, Alex's Google Cloud Scheduler offers current `main` to the release gate. Unchanged/released/attempted commits skip, while relevant new changes build across the existing platform lanes. Failed builds are not automatically retried.

## Verification
- 16 release-gate tests and 10 dispatcher tests passed.
- Strict TypeScript typecheck, shellcheck, bash syntax, actionlint, and diff checks passed.
- Architecture plan and implementation reviews approved.
- Deployed private Cloud Run revision `sesori-release-scheduler-00003-6bn`; authenticated `/health` returned 200 and unauthenticated access returned 403.
- Real Cloud Scheduler OIDC health invocation returned 200.
- GitHub App minted a token restricted to this repository and read the target workflow; the test token was revoked. Pre-merge authentication verification performed no workflow dispatch or store upload. Post-merge activation created the real automatic run linked below.
- IAM confirmed: caller has only service-level invoker; runtime has only secret-scoped accessor; dedicated builder has `roles/run.builder` without key access.

## Deployment and activation
Cloud resources are provisioned. **Activated after merge:** the job is ENABLED at `:45 UTC`, targeting authenticated `POST /dispatch`. The first real automatic dispatch returned HTTP 200 and created [run 34484062594](https://github.com/sesori-ai/sesori_apps_monorepo/actions/runs/34484062594). Dispatch acceptance does not mean the platform builds/uploads have completed.

- [Alex's scheduler job](https://console.cloud.google.com/cloudscheduler/jobs/edit/europe-west1/sesori-internal-release?project=sesori-ai)
- [Private Cloud Run service](https://console.cloud.google.com/run/detail/europe-west1/sesori-release-scheduler/metrics?project=sesori-ai)
- Dispatch failure alert policy `2058247532448449377` routes to `alex@vespr.xyz`; email delivery has not been exercised. This does not monitor subsequent GitHub build failures.
- Operational instructions: `tool/release_scheduler/README.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the hourly GitHub cron for internal releases with Alex's Google Cloud Scheduler, fixing delivery gaps that approached five hours. A private Cloud Run dispatcher authenticates as a repository-limited GitHub App and triggers the existing release workflow on `main` at `:45` UTC.

- The release gate now uses the `automatic` workflow input instead of the event name; manual dispatch defaults to `false` and preserves the retry path for failed builds.
- The scheduler job stays paused until this PR merges; after merging, validate one intended automatic dispatch and then resume the schedule.
- Dispatcher typechecking and tests run in Release Workflow CI; logs redact credentials and upstream response bodies and keep unexpected errors content-free.
- The alert policy covers Scheduler/dispatcher errors only, not GitHub build failures; operations live in `tool/release_scheduler/README.md`.

<sup>Written for commit bd54d07ea50ee1b111b1b0753d000d77e1692ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

