### PR TITLE
🌿 Stabilize harness focus during parallel catalog scans

### DIFF
--- a/client/app/test/features/project_list/project_list_catalog_scan_test.dart
+++ b/client/app/test/features/project_list/project_list_catalog_scan_test.dart
@@ -165,14 +165,19 @@ void main() {
 
   testWidgets("reports a running scan above the list without displacing it", (tester) async {
     final loc = await pumpLoadedList(tester);
-    expect(find.text(loc.catalogScanRunningTitle), findsNothing);
+    expect(find.text(loc.catalogScanRunningTitle(0, 1)), findsNothing);
 
     await emitScan(
       tester,
-      const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
+      const CatalogRescanState.reading(
+        activePluginName: "Codex",
+        sessionsSeen: 148,
+        finishedHarnessCount: 0,
+        pluginIds: {"codex"},
+      ),
     );
 
-    expect(find.text(loc.catalogScanRunningTitle), findsOneWidget);
+    expect(find.text(loc.catalogScanRunningTitle(0, 1)), findsOneWidget);
     expect(find.text("Codex — 148 sessions found"), findsOneWidget);
     expect(find.text("My Project"), findsOneWidget);
   });
@@ -183,12 +188,16 @@ void main() {
     final loc = await AppLocalizations.delegate.load(const Locale("en"));
     await emitScan(
       tester,
-      const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+      const CatalogRescanState.preparingOne(
+        pendingPluginName: "Codex",
+        finishedHarnessCount: 0,
+        pluginIds: {"codex"},
+      ),
     );
-    expect(find.text(loc.catalogScanRunningTitle), findsOneWidget);
+    expect(find.text(loc.catalogScanRunningTitle(0, 1)), findsOneWidget);
 
     await emitScan(tester, const CatalogRescanState.idle());
-    expect(find.text(loc.catalogScanRunningTitle), findsNothing);
+    expect(find.text(loc.catalogScanRunningTitle(0, 1)), findsNothing);
     expect(find.text("My Project"), findsOneWidget);
   });
 
@@ -197,7 +206,11 @@ void main() {
 
     await emitScan(
       tester,
-      const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+      const CatalogRescanState.preparingOne(
+        pendingPluginName: "Codex",
+        finishedHarnessCount: 0,
+        pluginIds: {"codex"},
+      ),
     );
     await tester.tap(find.bySemanticsLabel(loc.catalogScanCancel));
 

--- a/client/app/test/features/settings/harnesses_settings_screen_test.dart
+++ b/client/app/test/features/settings/harnesses_settings_screen_test.dart
@@ -2056,6 +2056,7 @@ void main() {
       rescan.emit(
         const CatalogRescanState.preparingOne(
           pendingPluginName: "Future Harness",
+          finishedHarnessCount: 0,
           pluginIds: {"future-harness"},
         ),
       );

--- a/client/app/test/playbook/catalog_scan_row_playbook.dart
+++ b/client/app/test/playbook/catalog_scan_row_playbook.dart
@@ -199,9 +199,10 @@ const catalogScanRowScenarios = <CatalogScanRowScenario>[
   CatalogScanRowScenario(
     id: "preparing",
     name: "Preparing / Awaiting progress",
-    description: "Requests were dispatched, but no harness has reported yet.",
-    scan: CatalogRescanState.preparingMany(
-      pendingPluginNames: ["Codex", "OpenCode"],
+    description: "Requests were dispatched; the first harness keeps focus until it reports.",
+    scan: CatalogRescanState.preparingOne(
+      pendingPluginName: "Codex",
+      finishedHarnessCount: 0,
       pluginIds: {"codex", "opencode"},
     ),
     action: CatalogScanRowAction.cancel,
@@ -213,6 +214,7 @@ const catalogScanRowScenarios = <CatalogScanRowScenario>[
     scan: CatalogRescanState.reading(
       activePluginName: "Codex",
       sessionsSeen: 0,
+      finishedHarnessCount: 0,
       pluginIds: {"codex", "opencode"},
     ),
     action: CatalogScanRowAction.cancel,
@@ -224,6 +226,7 @@ const catalogScanRowScenarios = <CatalogScanRowScenario>[
     scan: CatalogRescanState.reading(
       activePluginName: "Codex",
       sessionsSeen: 1,
+      finishedHarnessCount: 0,
       pluginIds: {"codex", "opencode"},
     ),
     action: CatalogScanRowAction.cancel,
@@ -235,6 +238,7 @@ const catalogScanRowScenarios = <CatalogScanRowScenario>[
     scan: CatalogRescanState.reading(
       activePluginName: "Claude Code",
       sessionsSeen: 148,
+      finishedHarnessCount: 0,
       pluginIds: {"claude-code", "codex", "opencode"},
     ),
     action: CatalogScanRowAction.cancel,
@@ -575,32 +579,36 @@ class _CatalogScanRowInActionExampleState() extends State<CatalogScanRowInAction
     if (widget.selection is! CatalogScanGestureDemo) return;
     _cancelTimers();
     setState(() {
-      _scan = const CatalogRescanState.preparingMany(
-        pendingPluginNames: ["Claude Code", "Codex", "OpenCode"],
+      _scan = const CatalogRescanState.preparingOne(
+        pendingPluginName: "Claude Code",
+        finishedHarnessCount: 0,
         pluginIds: {"claude-code", "codex", "opencode"},
       );
     });
     _schedule(
       const Duration(milliseconds: 650),
       const CatalogRescanState.reading(
-        activePluginName: "Codex",
+        activePluginName: "Claude Code",
         sessionsSeen: 0,
+        finishedHarnessCount: 0,
         pluginIds: {"claude-code", "codex", "opencode"},
       ),
     );
     _schedule(
       const Duration(milliseconds: 1400),
       const CatalogRescanState.reading(
-        activePluginName: "Codex",
+        activePluginName: "Claude Code",
         sessionsSeen: 3,
+        finishedHarnessCount: 0,
         pluginIds: {"claude-code", "codex", "opencode"},
       ),
     );
     _schedule(
       const Duration(milliseconds: 2200),
       const CatalogRescanState.reading(
-        activePluginName: "OpenCode",
+        activePluginName: "Codex",
         sessionsSeen: 8,
+        finishedHarnessCount: 1,
         pluginIds: {"claude-code", "codex", "opencode"},
       ),
     );

--- a/client/app/test/playbook/catalog_scan_row_playbook_test.dart
+++ b/client/app/test/playbook/catalog_scan_row_playbook_test.dart
@@ -42,7 +42,7 @@ void main() {
     expect(find.text("Projects"), findsOneWidget);
     expect(find.text("MacBook-Pro"), findsOneWidget);
     expect(find.text("Landing"), findsOneWidget);
-    expect(find.text("Scanning all harnesses"), findsNothing);
+    expect(find.text("Scanning · 0 of 3 finished"), findsNothing);
 
     final gesture = await tester.startGesture(const Offset(200, 320));
     var sawInvitation = false;
@@ -63,17 +63,18 @@ void main() {
 
     await gesture.up();
     await tester.pump();
-    expect(find.text("Preparing Claude Code, Codex, and 1 other scans…", skipOffstage: false), findsOneWidget);
-    expect(find.text("Scanning all harnesses", skipOffstage: false), findsOneWidget);
+    expect(find.text("Preparing Claude Code scan…", skipOffstage: false), findsOneWidget);
+    expect(find.text("Scanning · 0 of 3 finished", skipOffstage: false), findsOneWidget);
 
     await tester.pump(const Duration(milliseconds: 650));
-    expect(find.text("Reading Codex sessions…"), findsOneWidget);
+    expect(find.text("Reading Claude Code sessions…"), findsOneWidget);
 
     await tester.pump(const Duration(milliseconds: 750));
-    expect(find.text("Codex — 3 sessions found"), findsOneWidget);
+    expect(find.text("Claude Code — 3 sessions found"), findsOneWidget);
 
     await tester.pump(const Duration(milliseconds: 800));
-    expect(find.text("OpenCode — 8 sessions found"), findsOneWidget);
+    expect(find.text("Codex — 8 sessions found"), findsOneWidget);
+    expect(find.text("Scanning · 1 of 3 finished"), findsOneWidget);
 
     await tester.pump(const Duration(milliseconds: 900));
     expect(find.text("Scan complete"), findsOneWidget);

--- a/client/module_app_ui/lib/src/l10n/app_en.arb
+++ b/client/module_app_ui/lib/src/l10n/app_en.arb
@@ -1162,9 +1162,17 @@
   "@catalogScanPullCaption": {
     "description": "Caption under the pull-to-refresh spinner once the pull has passed the ordinary trigger, inviting the user to keep pulling to start a full catalog scan. Names what the user gets rather than the mechanism: scanning harnesses is how it works, not what it is for."
   },
-  "catalogScanRunningTitle": "Scanning all harnesses",
+  "catalogScanRunningTitle": "Scanning · {finished} of {total} finished",
   "@catalogScanRunningTitle": {
-    "description": "Title of the row above a list while a catalog scan is in flight across every enabled harness."
+    "description": "Ordinary title of the row above a list while a catalog scan is in flight, including the number of terminal harnesses.",
+    "placeholders": {
+      "finished": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
   },
   "catalogScanPreparingOneDetail": "Preparing {harness} scan…",
   "@catalogScanPreparingOneDetail": {
@@ -1173,43 +1181,6 @@
       "harness": {
         "type": "String",
         "example": "Codex"
-      }
-    }
-  },
-  "catalogScanPreparingManyDetail": "Preparing {harnesses} scans…",
-  "@catalogScanPreparingManyDetail": {
-    "description": "Supporting line before multiple pending harnesses report catalog progress. The harnesses placeholder is a bounded localized name summary.",
-    "placeholders": {
-      "harnesses": {
-        "type": "String",
-        "example": "Codex and Claude"
-      }
-    }
-  },
-  "catalogScanTwoHarnesses": "{first} and {second}",
-  "@catalogScanTwoHarnesses": {
-    "description": "Joins two pending harness display names in scan progress copy.",
-    "placeholders": {
-      "first": {
-        "type": "String"
-      },
-      "second": {
-        "type": "String"
-      }
-    }
-  },
-  "catalogScanHarnessesWithOthers": "{first}, {second}, and {others, plural, =1{1 other} other{{others} others}}",
-  "@catalogScanHarnessesWithOthers": {
-    "description": "Bounded summary for three or more pending harnesses in scan progress copy.",
-    "placeholders": {
-      "first": {
-        "type": "String"
-      },
-      "second": {
-        "type": "String"
-      },
-      "others": {
-        "type": "int"
       }
     }
   },
@@ -1256,13 +1227,19 @@
       }
     }
   },
-  "catalogScanWaitingTitle": "Waiting for {harness}",
+  "catalogScanWaitingTitle": "Waiting for {harness} · {finished} of {total} finished",
   "@catalogScanWaitingTitle": {
-    "description": "Title after one harness has remained authoritatively in startup for three seconds.",
+    "description": "Title after one harness has remained authoritatively in startup for three seconds, including the number of terminal harnesses.",
     "placeholders": {
       "harness": {
         "type": "String",
         "example": "Codex"
+      },
+      "finished": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
       }
     }
   },

--- a/client/module_app_ui/lib/src/l10n/app_localizations.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations.dart
@@ -3631,35 +3631,17 @@ abstract class AppLocalizations {
   /// **'Keep pulling to find new sessions'**
   String get catalogScanPullCaption;
 
-  /// Title of the row above a list while a catalog scan is in flight across every enabled harness.
+  /// Ordinary title of the row above a list while a catalog scan is in flight, including the number of terminal harnesses.
   ///
   /// In en, this message translates to:
-  /// **'Scanning all harnesses'**
-  String get catalogScanRunningTitle;
+  /// **'Scanning · {finished} of {total} finished'**
+  String catalogScanRunningTitle(int finished, int total);
 
   /// Supporting line before one pending harness reports catalog progress.
   ///
   /// In en, this message translates to:
   /// **'Preparing {harness} scan…'**
   String catalogScanPreparingOneDetail(String harness);
-
-  /// Supporting line before multiple pending harnesses report catalog progress. The harnesses placeholder is a bounded localized name summary.
-  ///
-  /// In en, this message translates to:
-  /// **'Preparing {harnesses} scans…'**
-  String catalogScanPreparingManyDetail(String harnesses);
-
-  /// Joins two pending harness display names in scan progress copy.
-  ///
-  /// In en, this message translates to:
-  /// **'{first} and {second}'**
-  String catalogScanTwoHarnesses(String first, String second);
-
-  /// Bounded summary for three or more pending harnesses in scan progress copy.
-  ///
-  /// In en, this message translates to:
-  /// **'{first}, {second}, and {others, plural, =1{1 other} other{{others} others}}'**
-  String catalogScanHarnessesWithOthers(String first, String second, int others);
 
   /// Supporting line while a fresh management snapshot authoritatively reports the named harness as starting.
   ///
@@ -3685,11 +3667,11 @@ abstract class AppLocalizations {
   /// **'Saving {harness} scan results…'**
   String catalogScanSavingDetail(String harness);
 
-  /// Title after one harness has remained authoritatively in startup for three seconds.
+  /// Title after one harness has remained authoritatively in startup for three seconds, including the number of terminal harnesses.
   ///
   /// In en, this message translates to:
-  /// **'Waiting for {harness}'**
-  String catalogScanWaitingTitle(String harness);
+  /// **'Waiting for {harness} · {finished} of {total} finished'**
+  String catalogScanWaitingTitle(String harness, int finished, int total);
 
   /// Wrapped explanation after one harness has remained authoritatively in startup for three seconds.
   ///

--- a/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
+++ b/client/module_app_ui/lib/src/l10n/app_localizations_en.dart
@@ -1982,32 +1982,13 @@ class AppLocalizationsEn extends AppLocalizations {
   String get catalogScanPullCaption => 'Keep pulling to find new sessions';
 
   @override
-  String get catalogScanRunningTitle => 'Scanning all harnesses';
+  String catalogScanRunningTitle(int finished, int total) {
+    return 'Scanning · $finished of $total finished';
+  }
 
   @override
   String catalogScanPreparingOneDetail(String harness) {
     return 'Preparing $harness scan…';
-  }
-
-  @override
-  String catalogScanPreparingManyDetail(String harnesses) {
-    return 'Preparing $harnesses scans…';
-  }
-
-  @override
-  String catalogScanTwoHarnesses(String first, String second) {
-    return '$first and $second';
-  }
-
-  @override
-  String catalogScanHarnessesWithOthers(String first, String second, int others) {
-    String _temp0 = intl.Intl.pluralLogic(
-      others,
-      locale: localeName,
-      other: '$others others',
-      one: '1 other',
-    );
-    return '$first, $second, and $_temp0';
   }
 
   @override
@@ -2037,8 +2018,8 @@ class AppLocalizationsEn extends AppLocalizations {
   }
 
   @override
-  String catalogScanWaitingTitle(String harness) {
-    return 'Waiting for $harness';
+  String catalogScanWaitingTitle(String harness, int finished, int total) {
+    return 'Waiting for $harness · $finished of $total finished';
   }
 
   @override

--- a/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
+++ b/client/module_app_ui/lib/src/widgets/catalog_scan_row.dart
@@ -27,8 +27,8 @@ const Duration _startupWaitThreshold = Duration(seconds: 3);
 /// terminal outcomes keep their severity-tinted report cards.
 ///
 /// Ordinary live phases keep one supporting row, so progress changes do not
-/// shove the list. Only the prolonged-startup explanation may wrap and grow;
-/// preserving its guidance is more important than the baseline card height.
+/// shove the list. The prolonged-startup heading and explanation may wrap and
+/// grow; preserving their guidance is more important than baseline card height.
 class const CatalogScanRow({
   super.key,
 
@@ -166,7 +166,6 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
       CatalogRescanStarting(:final activePluginName) => activePluginName,
       CatalogRescanIdle() ||
       CatalogRescanPreparingOne() ||
-      CatalogRescanPreparingMany() ||
       CatalogRescanReading() ||
       CatalogRescanSaving() ||
       CatalogRescanSucceeded() ||
@@ -188,7 +187,6 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
         CatalogRescanStarting(:final activePluginName) => activePluginName == pluginName,
         CatalogRescanIdle() ||
         CatalogRescanPreparingOne() ||
-        CatalogRescanPreparingMany() ||
         CatalogRescanReading() ||
         CatalogRescanSaving() ||
         CatalogRescanSucceeded() ||
@@ -286,23 +284,18 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
   /// `null` is the idle row, which folds away to nothing.
   _RowContent? _contentFor({required AppLocalizations loc, required CatalogRescanState scan}) => switch (scan) {
     CatalogRescanIdle() => null,
-    CatalogRescanPreparingOne(:final pendingPluginName) => _RowContent(
+    CatalogRescanPreparingOne(:final pendingPluginName, :final finishedHarnessCount, :final pluginIds) => _RowContent(
       tone: _ScanTone.working,
-      title: loc.catalogScanRunningTitle,
+      title: loc.catalogScanRunningTitle(finishedHarnessCount, pluginIds.length),
       detail: loc.catalogScanPreparingOneDetail(pendingPluginName),
       actionLabel: loc.catalogScanCancel,
       onAction: widget._onCancel,
     ),
-    CatalogRescanPreparingMany(:final pendingPluginNames) => _RowContent(
+    CatalogRescanStarting(:final activePluginName, :final finishedHarnessCount, :final pluginIds) => _RowContent(
       tone: _ScanTone.working,
-      title: loc.catalogScanRunningTitle,
-      detail: loc.catalogScanPreparingManyDetail(_pendingHarnessSummary(loc: loc, names: pendingPluginNames)),
-      actionLabel: loc.catalogScanCancel,
-      onAction: widget._onCancel,
-    ),
-    CatalogRescanStarting(:final activePluginName) => _RowContent(
-      tone: _ScanTone.working,
-      title: _startupWaitElapsed ? loc.catalogScanWaitingTitle(activePluginName) : loc.catalogScanRunningTitle,
+      title: _startupWaitElapsed
+          ? loc.catalogScanWaitingTitle(activePluginName, finishedHarnessCount, pluginIds.length)
+          : loc.catalogScanRunningTitle(finishedHarnessCount, pluginIds.length),
       detail: _startupWaitElapsed
           ? loc.catalogScanWaitingDetail(activePluginName)
           : loc.catalogScanStartingDetail(activePluginName),
@@ -310,18 +303,19 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
       actionLabel: loc.catalogScanCancel,
       onAction: widget._onCancel,
     ),
-    CatalogRescanReading(:final activePluginName, :final sessionsSeen) => _RowContent(
+    CatalogRescanReading(:final activePluginName, :final sessionsSeen, :final finishedHarnessCount, :final pluginIds) =>
+      _RowContent(
+        tone: _ScanTone.working,
+        title: loc.catalogScanRunningTitle(finishedHarnessCount, pluginIds.length),
+        detail: sessionsSeen == 0
+            ? loc.catalogScanReadingDetail(activePluginName)
+            : loc.catalogScanReadingCountDetail(activePluginName, sessionsSeen),
+        actionLabel: loc.catalogScanCancel,
+        onAction: widget._onCancel,
+      ),
+    CatalogRescanSaving(:final activePluginName, :final finishedHarnessCount, :final pluginIds) => _RowContent(
       tone: _ScanTone.working,
-      title: loc.catalogScanRunningTitle,
-      detail: sessionsSeen == 0
-          ? loc.catalogScanReadingDetail(activePluginName)
-          : loc.catalogScanReadingCountDetail(activePluginName, sessionsSeen),
-      actionLabel: loc.catalogScanCancel,
-      onAction: widget._onCancel,
-    ),
-    CatalogRescanSaving(:final activePluginName) => _RowContent(
-      tone: _ScanTone.working,
-      title: loc.catalogScanRunningTitle,
+      title: loc.catalogScanRunningTitle(finishedHarnessCount, pluginIds.length),
       detail: loc.catalogScanSavingDetail(activePluginName),
       actionLabel: loc.catalogScanCancel,
       onAction: widget._onCancel,
@@ -373,11 +367,6 @@ class _CatalogScanRowState() extends State<CatalogScanRow> with TickerProviderSt
       onAction: widget._onDismiss,
     ),
   };
-}
-
-String _pendingHarnessSummary({required AppLocalizations loc, required List<String> names}) {
-  if (names.length == 2) return loc.catalogScanTwoHarnesses(names[0], names[1]);
-  return loc.catalogScanHarnessesWithOthers(names[0], names[1], names.length - 2);
 }
 
 /// What a finished scan found, sessions first.
@@ -693,8 +682,8 @@ class _ScanLoadingCardState()
                           children: [
                             Text(
                               widget.title,
-                              maxLines: wrapsText ? null : 1,
-                              overflow: wrapsText ? null : TextOverflow.ellipsis,
+                              maxLines: wrapsText || widget.wrapSupportingText ? null : 1,
+                              overflow: wrapsText || widget.wrapSupportingText ? null : TextOverflow.ellipsis,
                               style: prego.textTheme.textSm.medium.copyWith(color: colors.textPrimary),
                             ),
                             const SizedBox(height: PregoSpacing.xxs),

--- a/client/module_app_ui/test/widgets/catalog_scan_row_test.dart
+++ b/client/module_app_ui/test/widgets/catalog_scan_row_test.dart
@@ -126,7 +126,7 @@ void main() {
       await pumpRow(tester, const CatalogRescanState.idle());
 
       final loc = await AppLocalizations.delegate.load(const Locale("en"));
-      expect(find.text(loc.catalogScanRunningTitle), findsNothing);
+      expect(find.text(loc.catalogScanRunningTitle(0, 1)), findsNothing);
       expect(tester.getSize(find.byType(CatalogScanRow, skipOffstage: false)).height, 0);
     });
 
@@ -139,10 +139,19 @@ void main() {
       }
 
       final preparing = await heightFor(
-        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
       final reading = await heightFor(
-        const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
+        const CatalogRescanState.reading(
+          activePluginName: "Codex",
+          sessionsSeen: 148,
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
 
       expect(preparing, greaterThan(0));
@@ -154,12 +163,21 @@ void main() {
         final loc = await AppLocalizations.delegate.load(const Locale("en"));
         final states = [
           (
-            const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
-            loc.catalogScanRunningTitle,
+            const CatalogRescanState.preparingOne(
+              pendingPluginName: "Codex",
+              finishedHarnessCount: 0,
+              pluginIds: {"codex"},
+            ),
+            loc.catalogScanRunningTitle(0, 1),
           ),
           (
-            const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 148, pluginIds: {"codex"}),
-            loc.catalogScanRunningTitle,
+            const CatalogRescanState.reading(
+              activePluginName: "Codex",
+              sessionsSeen: 148,
+              finishedHarnessCount: 0,
+              pluginIds: {"codex"},
+            ),
+            loc.catalogScanRunningTitle(0, 1),
           ),
           (
             const CatalogRescanState.succeeded(
@@ -203,11 +221,15 @@ void main() {
     testWidgets("reports the scan before any harness has reported progress", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
 
       final loc = await AppLocalizations.delegate.load(const Locale("en"));
-      expect(find.text(loc.catalogScanRunningTitle), findsOneWidget);
+      expect(find.text(loc.catalogScanRunningTitle(0, 1)), findsOneWidget);
       expect(find.byKey(const ValueKey("prego-deep-scan-card")), findsOneWidget);
       expect(find.bySemanticsLabel(loc.catalogScanCancel), findsOneWidget);
     });
@@ -215,7 +237,11 @@ void main() {
     testWidgets("matches the 402 by 101 Figma loading geometry", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
         designSystem: PregoDesignSystem.dark,
         width: 402,
       );
@@ -241,7 +267,11 @@ void main() {
     testWidgets("keeps the scan graphic visible in the light theme", (tester) async {
       await tester.pumpWidget(
         harness(
-          const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex"}),
+          const CatalogRescanState.starting(
+            activePluginName: "Codex",
+            finishedHarnessCount: 0,
+            pluginIds: {"codex"},
+          ),
           designSystem: PregoDesignSystem.light,
           width: 402,
         ),
@@ -250,7 +280,7 @@ void main() {
 
       // This point crosses the second skeleton row's inset border. The white
       // surface still needs enough tokenized edge contrast to remain visible.
-      final skeleton = await renderedPixel(tester, const Offset(270, 35));
+      final skeleton = await renderedPixel(tester, const Offset(290, 35));
       expect(skeleton.r, lessThan(250 / 255));
       expect(skeleton.g, lessThan(250 / 255));
       expect(skeleton.b, lessThan(250 / 255));
@@ -265,7 +295,11 @@ void main() {
     testWidgets("repeats both loading motions on one ten-second timeline", (tester) async {
       await tester.pumpWidget(
         harness(
-          const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+          const CatalogRescanState.preparingOne(
+            pendingPluginName: "Codex",
+            finishedHarnessCount: 0,
+            pluginIds: {"codex"},
+          ),
           width: 402,
         ),
       );
@@ -296,7 +330,13 @@ void main() {
       await tester.pump();
 
       await tester.pumpWidget(
-        harness(const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"})),
+        harness(
+          const CatalogRescanState.preparingOne(
+            pendingPluginName: "Codex",
+            finishedHarnessCount: 0,
+            pluginIds: {"codex"},
+          ),
+        ),
       );
 
       expect(entranceScale(tester), closeTo(0.97, 0.0001));
@@ -322,7 +362,11 @@ void main() {
     testWidgets("does not replay the entrance for progress updates or exit", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
       expect(entranceScale(tester), 1);
 
@@ -331,6 +375,7 @@ void main() {
           const CatalogRescanState.reading(
             activePluginName: "Codex",
             sessionsSeen: 4,
+            finishedHarnessCount: 0,
             pluginIds: {"codex"},
           ),
         ),
@@ -346,7 +391,11 @@ void main() {
     testWidgets("stops the looping scan graphic when a terminal outcome replaces it", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
 
       expect(find.byKey(const ValueKey("prego-deep-scan-loader")), findsOneWidget);
@@ -374,6 +423,7 @@ void main() {
         const CatalogRescanState.reading(
           activePluginName: "Codex",
           sessionsSeen: 148,
+          finishedHarnessCount: 0,
           pluginIds: {"codex"},
         ),
       );
@@ -387,6 +437,7 @@ void main() {
         const CatalogRescanState.reading(
           activePluginName: "Codex",
           sessionsSeen: 1,
+          finishedHarnessCount: 0,
           pluginIds: {"codex"},
         ),
       );
@@ -405,42 +456,59 @@ void main() {
     testWidgets("renders preparing, reading, and saving phase copy", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.preparingMany(
-          pendingPluginNames: ["Codex", "Claude", "Cursor"],
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
           pluginIds: {"codex", "claude", "cursor"},
         ),
       );
-      expect(find.text("Preparing Codex, Claude, and 1 other scans…"), findsOneWidget);
+      expect(find.text("Preparing Codex scan…"), findsOneWidget);
+      expect(find.text("Scanning · 0 of 3 finished"), findsOneWidget);
 
       await pumpRow(
         tester,
-        const CatalogRescanState.reading(activePluginName: "Claude", sessionsSeen: 0, pluginIds: {"claude"}),
+        const CatalogRescanState.reading(
+          activePluginName: "Claude",
+          sessionsSeen: 0,
+          finishedHarnessCount: 1,
+          pluginIds: {"codex", "claude"},
+        ),
       );
       expect(find.text("Reading Claude sessions…"), findsOneWidget);
+      expect(find.text("Scanning · 1 of 2 finished"), findsOneWidget);
 
       await pumpRow(
         tester,
-        const CatalogRescanState.saving(activePluginName: "Claude", pluginIds: {"claude"}),
+        const CatalogRescanState.saving(
+          activePluginName: "Claude",
+          finishedHarnessCount: 1,
+          pluginIds: {"codex", "claude"},
+        ),
       );
       expect(find.text("Saving Claude scan results…"), findsOneWidget);
+      expect(find.text("Scanning · 1 of 2 finished"), findsOneWidget);
     });
 
     testWidgets("explains a prolonged confirmed harness startup after three seconds", (tester) async {
       await tester.pumpWidget(
         harness(
-          const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex"}),
+          const CatalogRescanState.starting(
+            activePluginName: "Codex",
+            finishedHarnessCount: 0,
+            pluginIds: {"codex"},
+          ),
           width: 402,
         ),
       );
       await tester.pump();
 
-      expect(find.text("Scanning all harnesses"), findsOneWidget);
+      expect(find.text("Scanning · 0 of 1 finished"), findsOneWidget);
       expect(find.text("Starting Codex…"), findsOneWidget);
       await tester.pump(const Duration(seconds: 2));
-      expect(find.text("Waiting for Codex"), findsNothing);
+      expect(find.text("Waiting for Codex · 0 of 1 finished"), findsNothing);
 
       await tester.pump(const Duration(seconds: 1));
-      expect(find.text("Waiting for Codex"), findsOneWidget);
+      expect(find.text("Waiting for Codex · 0 of 1 finished"), findsOneWidget);
       expect(
         find.text("Codex must finish starting before scanning can continue. You can keep browsing."),
         findsOneWidget,
@@ -457,26 +525,92 @@ void main() {
 
     testWidgets("restarts the prolonged startup threshold when the harness changes", (tester) async {
       await tester.pumpWidget(
-        harness(const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex", "claude"})),
+        harness(
+          const CatalogRescanState.starting(
+            activePluginName: "Codex",
+            finishedHarnessCount: 0,
+            pluginIds: {"codex", "claude"},
+          ),
+        ),
       );
       await tester.pump();
       await tester.pump(const Duration(seconds: 2));
 
       await tester.pumpWidget(
-        harness(const CatalogRescanState.starting(activePluginName: "Claude", pluginIds: {"codex", "claude"})),
+        harness(
+          const CatalogRescanState.starting(
+            activePluginName: "Claude",
+            finishedHarnessCount: 0,
+            pluginIds: {"codex", "claude"},
+          ),
+        ),
       );
       await tester.pump(const Duration(seconds: 2));
-      expect(find.text("Waiting for Claude"), findsNothing);
+      expect(find.text("Waiting for Claude · 0 of 2 finished"), findsNothing);
       expect(find.text("Starting Claude…"), findsOneWidget);
 
       await tester.pump(const Duration(seconds: 1));
-      expect(find.text("Waiting for Claude"), findsOneWidget);
+      expect(find.text("Waiting for Claude · 0 of 2 finished"), findsOneWidget);
+    });
+
+    testWidgets("wraps the localized waiting heading at narrow mobile width", (tester) async {
+      const waitingTitle = "Waiting for Codex · 0 of 2 finished";
+      await pumpRow(
+        tester,
+        const CatalogRescanState.starting(
+          activePluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex", "claude"},
+        ),
+        width: 320,
+      );
+      await tester.pump(const Duration(seconds: 3));
+
+      expect(find.text(waitingTitle), findsOneWidget);
+      final title = tester.renderObject<RenderParagraph>(find.text(waitingTitle));
+      expect(title.didExceedMaxLines, isFalse);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets("keeps the startup threshold when a background completion changes the count", (tester) async {
+      const pluginIds = {"codex", "claude"};
+      await tester.pumpWidget(
+        harness(
+          const CatalogRescanState.starting(
+            activePluginName: "Codex",
+            finishedHarnessCount: 0,
+            pluginIds: pluginIds,
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 2));
+
+      await tester.pumpWidget(
+        harness(
+          const CatalogRescanState.starting(
+            activePluginName: "Codex",
+            finishedHarnessCount: 1,
+            pluginIds: pluginIds,
+          ),
+        ),
+      );
+      await tester.pump(const Duration(milliseconds: 900));
+      expect(find.text("Waiting for Codex · 1 of 2 finished"), findsNothing);
+
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(find.text("Waiting for Codex · 1 of 2 finished"), findsOneWidget);
     });
 
     testWidgets("cancels the scan in flight from the running row", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 1, pluginIds: {"codex"}),
+        const CatalogRescanState.reading(
+          activePluginName: "Codex",
+          sessionsSeen: 1,
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
 
       final loc = await AppLocalizations.delegate.load(const Locale("en"));
@@ -496,7 +630,12 @@ void main() {
     testWidgets("focuses and activates Cancel from the keyboard", (tester) async {
       await pumpRow(
         tester,
-        const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 1, pluginIds: {"codex"}),
+        const CatalogRescanState.reading(
+          activePluginName: "Codex",
+          sessionsSeen: 1,
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
 
       await tester.sendKeyEvent(LogicalKeyboardKey.tab);
@@ -802,14 +941,23 @@ void main() {
 
       expect(
         await announcesFor(
-          const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex"}),
+          const CatalogRescanState.starting(
+            activePluginName: "Codex",
+            finishedHarnessCount: 0,
+            pluginIds: {"codex"},
+          ),
         ),
         isTrue,
       );
       expect(await announcesFor(const CatalogRescanState.failed(harnessCount: 1)), isTrue);
       expect(
         await announcesFor(
-          const CatalogRescanState.reading(activePluginName: "Codex", sessionsSeen: 9, pluginIds: {"codex"}),
+          const CatalogRescanState.reading(
+            activePluginName: "Codex",
+            sessionsSeen: 9,
+            finishedHarnessCount: 0,
+            pluginIds: {"codex"},
+          ),
         ),
         isFalse,
       );
@@ -869,6 +1017,7 @@ void main() {
                 child: CatalogScanRow(
                   scan: const CatalogRescanState.preparingOne(
                     pendingPluginName: "Codex",
+                    finishedHarnessCount: 0,
                     pluginIds: {"codex"},
                   ),
                   onCancel: () => cancelCount++,
@@ -905,7 +1054,13 @@ void main() {
       await tester.pumpWidget(harness(const CatalogRescanState.idle()));
       await tester.pump();
       await tester.pumpWidget(
-        harness(const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"})),
+        harness(
+          const CatalogRescanState.preparingOne(
+            pendingPluginName: "Codex",
+            finishedHarnessCount: 0,
+            pluginIds: {"codex"},
+          ),
+        ),
       );
       await tester.pump(const Duration(milliseconds: 16));
 
@@ -925,7 +1080,13 @@ void main() {
       await tester.pumpWidget(harness(const CatalogRescanState.idle()));
       await tester.pump();
       await tester.pumpWidget(
-        harness(const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"})),
+        harness(
+          const CatalogRescanState.preparingOne(
+            pendingPluginName: "Codex",
+            finishedHarnessCount: 0,
+            pluginIds: {"codex"},
+          ),
+        ),
       );
       await tester.pump(const Duration(milliseconds: 80));
       expect(entranceScale(tester), isNot(1));
@@ -977,12 +1138,16 @@ void main() {
 
       await pumpRow(
         tester,
-        const CatalogRescanState.starting(activePluginName: "Codex", pluginIds: {"codex"}),
+        const CatalogRescanState.starting(
+          activePluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
         textScaler: textScaler,
         width: 402,
       );
       expect(tester.getSize(find.byType(CatalogScanRow)).height, greaterThan(101));
-      for (final label in [loc.catalogScanRunningTitle, loc.catalogScanStartingDetail("Codex")]) {
+      for (final label in [loc.catalogScanRunningTitle(0, 1), loc.catalogScanStartingDetail("Codex")]) {
         final text = tester.widget<Text>(find.text(label));
         expect(text.maxLines, isNull);
         expect(text.overflow, isNull);

--- a/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
+++ b/client/module_core/lib/src/cubits/plugin_management/plugin_management_cubit.dart
@@ -670,7 +670,6 @@ class PluginManagementCubit({
   /// terminal state still carries no ids, and an idle one covers nothing.
   Set<String> get _scanningPluginIds => switch (_catalogRescanService.state.value) {
     CatalogRescanPreparingOne(:final pluginIds) ||
-    CatalogRescanPreparingMany(:final pluginIds) ||
     CatalogRescanStarting(:final pluginIds) ||
     CatalogRescanReading(:final pluginIds) ||
     CatalogRescanSaving(:final pluginIds) => pluginIds,
@@ -731,7 +730,6 @@ class PluginManagementCubit({
     CatalogRescanFailed() => const CatalogRescanOutcome.failed(),
     CatalogRescanIdle() ||
     CatalogRescanPreparingOne() ||
-    CatalogRescanPreparingMany() ||
     CatalogRescanStarting() ||
     CatalogRescanReading() ||
     CatalogRescanSaving() ||

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -258,6 +258,9 @@ class CatalogRescanService({
       for (final pluginId in pluginIds)
         _pluginRepository.startCatalogImport(pluginId: pluginId).then((outcome) {
           results[pluginId] = _applyStartOutcome(pluginId: pluginId, outcome: outcome);
+          // A rejected start can change focus/counts while another response
+          // is still pending. Do not hold that update behind the batch wait.
+          _publishLive();
         }),
     ];
     _pendingStarts.addAll(dispatched);

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -395,8 +395,8 @@ class CatalogRescanService({
     _progressByPluginId[pluginId] = progress;
     if (_isTerminal(progress)) {
       _settleIfComplete();
-      // Still running: re-point the row at a harness that is actually working,
-      // rather than leaving it naming the one that just finished.
+      // Still running: advance to the next unfinished member in operation
+      // order, rather than leaving the row naming the one that just finished.
       if (_members.isNotEmpty) _publishLive();
       return;
     }
@@ -406,24 +406,34 @@ class CatalogRescanService({
   void _publishLive() {
     if (_members.isEmpty) return;
     final pluginIds = Set<String>.unmodifiable(_members);
-    final active = _activeProgress();
+    final focusedPluginId = _focusedPluginId();
+    if (focusedPluginId == null) return;
+    final finishedHarnessCount = _finishedHarnessCount();
+    final active = _progressByPluginId[focusedPluginId];
     if (active != null) {
-      final pluginName = _displayName(pluginId: active.pluginId);
+      final pluginName = _displayName(pluginId: focusedPluginId);
       final next = switch (active) {
         CatalogImportEnumerating(:final sessionsSeen)
-            when sessionsSeen == 0 && _isConfirmedStarting(pluginId: active.pluginId) =>
-          CatalogRescanState.starting(activePluginName: pluginName, pluginIds: pluginIds),
+            when sessionsSeen == 0 && _isConfirmedStarting(pluginId: focusedPluginId) =>
+          CatalogRescanState.starting(
+            activePluginName: pluginName,
+            finishedHarnessCount: finishedHarnessCount,
+            pluginIds: pluginIds,
+          ),
         CatalogImportEnumerating(:final sessionsSeen) => CatalogRescanState.reading(
           activePluginName: pluginName,
           sessionsSeen: sessionsSeen,
+          finishedHarnessCount: finishedHarnessCount,
           pluginIds: pluginIds,
         ),
         CatalogImportCommitting() => CatalogRescanState.saving(
           activePluginName: pluginName,
+          finishedHarnessCount: finishedHarnessCount,
           pluginIds: pluginIds,
         ),
-        // Unreachable: _activeProgress returns only non-terminal statuses. The
-        // exhaustive switch keeps any new transport phase visible here.
+        // Unreachable: _focusedPluginId returns only missing or non-terminal
+        // statuses. The exhaustive switch keeps any new transport phase
+        // visible here.
         CatalogImportCompleted() ||
         CatalogImportCancelled() ||
         CatalogImportFailed() => throw StateError("Terminal catalog progress cannot be active"),
@@ -432,33 +442,17 @@ class CatalogRescanService({
       return;
     }
 
-    final pendingPluginIds = [
-      for (final pluginId in _members)
-        if (_progressByPluginId[pluginId] == null) pluginId,
-    ];
-    for (final pluginId in pendingPluginIds) {
-      if (_isConfirmedStarting(pluginId: pluginId)) {
-        _publish(
-          CatalogRescanState.starting(
-            activePluginName: _displayName(pluginId: pluginId),
-            pluginIds: pluginIds,
-          ),
-        );
-        return;
-      }
-    }
-    if (pendingPluginIds.isEmpty) return;
-    final pendingPluginNames = List<String>.unmodifiable(
-      pendingPluginIds.map((pluginId) => _displayName(pluginId: pluginId)),
-    );
+    final pluginName = _displayName(pluginId: focusedPluginId);
     _publish(
-      pendingPluginNames.length == 1
-          ? CatalogRescanState.preparingOne(
-              pendingPluginName: pendingPluginNames.first,
+      _isConfirmedStarting(pluginId: focusedPluginId)
+          ? CatalogRescanState.starting(
+              activePluginName: pluginName,
+              finishedHarnessCount: finishedHarnessCount,
               pluginIds: pluginIds,
             )
-          : CatalogRescanState.preparingMany(
-              pendingPluginNames: pendingPluginNames,
+          : CatalogRescanState.preparingOne(
+              pendingPluginName: pluginName,
+              finishedHarnessCount: finishedHarnessCount,
               pluginIds: pluginIds,
             ),
     );
@@ -471,14 +465,24 @@ class CatalogRescanService({
       _operationBridgeId == _activeBridgeId &&
       _runtimeStates[pluginId] == PluginRuntimeState.starting;
 
-  /// The harness whose progress the row names, preferring whichever is still
-  /// working over one that already settled.
-  CatalogImportProgress? _activeProgress() {
+  /// The first member without terminal progress, preserving operation order.
+  /// A missing progress event is unfinished and therefore keeps foreground
+  /// focus ahead of later harnesses that have already started.
+  String? _focusedPluginId() {
     for (final pluginId in _members) {
       final progress = _progressByPluginId[pluginId];
-      if (progress != null && !_isTerminal(progress)) return progress;
+      if (progress == null || !_isTerminal(progress)) return pluginId;
     }
     return null;
+  }
+
+  int _finishedHarnessCount() {
+    var finished = 0;
+    for (final pluginId in _members) {
+      final progress = _progressByPluginId[pluginId];
+      if (progress != null && _isTerminal(progress)) finished++;
+    }
+    return finished;
   }
 
   void _settleIfComplete() {

--- a/client/module_core/lib/src/services/catalog_rescan_service.dart
+++ b/client/module_core/lib/src/services/catalog_rescan_service.dart
@@ -403,7 +403,9 @@ class CatalogRescanService({
       if (_members.isNotEmpty) _publishLive();
       return;
     }
-    _publishLive();
+    // Keep background progress for handoff without rebuilding the lists for
+    // each hidden enumeration or phase change.
+    if (pluginId == _focusedPluginId()) _publishLive();
   }
 
   void _publishLive() {

--- a/client/module_core/lib/src/services/models/catalog_rescan_state.dart
+++ b/client/module_core/lib/src/services/models/catalog_rescan_state.dart
@@ -36,27 +36,26 @@ sealed class const CatalogRescanState() {
 
   const factory preparingOne({
     required String pendingPluginName,
+    required int finishedHarnessCount,
     required Set<String> pluginIds,
   }) = CatalogRescanPreparingOne;
 
-  const factory preparingMany({
-    required List<String> pendingPluginNames,
-    required Set<String> pluginIds,
-  }) = CatalogRescanPreparingMany;
-
   const factory starting({
     required String activePluginName,
+    required int finishedHarnessCount,
     required Set<String> pluginIds,
   }) = CatalogRescanStarting;
 
   const factory reading({
     required String activePluginName,
     required int sessionsSeen,
+    required int finishedHarnessCount,
     required Set<String> pluginIds,
   }) = CatalogRescanReading;
 
   const factory saving({
     required String activePluginName,
+    required int finishedHarnessCount,
     required Set<String> pluginIds,
   }) = CatalogRescanSaving;
 
@@ -80,7 +79,6 @@ sealed class const CatalogRescanState() {
   /// refresh, since a committed import raises no invalidation of its own.
   bool get isLive =>
       this is CatalogRescanPreparingOne ||
-      this is CatalogRescanPreparingMany ||
       this is CatalogRescanStarting ||
       this is CatalogRescanReading ||
       this is CatalogRescanSaving;
@@ -88,18 +86,10 @@ sealed class const CatalogRescanState() {
 
 final class const CatalogRescanIdle() extends CatalogRescanState;
 
-/// Scan members that have not reported catalog progress yet.
-///
-/// Names include only unfinished members, so a harness that already completed
-/// cannot remain visible while another waits to begin.
+/// The first scan member that has not reported a terminal progress state yet.
 final class const CatalogRescanPreparingOne({
   required final String pendingPluginName,
-  required final Set<String> pluginIds,
-}) extends CatalogRescanState;
-
-/// Multiple scan members have not reported catalog progress yet.
-final class const CatalogRescanPreparingMany({
-  required final List<String> pendingPluginNames,
+  required final int finishedHarnessCount,
   required final Set<String> pluginIds,
 }) extends CatalogRescanState;
 
@@ -107,6 +97,7 @@ final class const CatalogRescanPreparingMany({
 /// fresh management snapshot.
 final class const CatalogRescanStarting({
   required final String activePluginName,
+  required final int finishedHarnessCount,
   required final Set<String> pluginIds,
 }) extends CatalogRescanState;
 
@@ -114,12 +105,14 @@ final class const CatalogRescanStarting({
 final class const CatalogRescanReading({
   required final String activePluginName,
   required final int sessionsSeen,
+  required final int finishedHarnessCount,
   required final Set<String> pluginIds,
 }) extends CatalogRescanState;
 
 /// One scan member is committing its catalog snapshot.
 final class const CatalogRescanSaving({
   required final String activePluginName,
+  required final int finishedHarnessCount,
   required final Set<String> pluginIds,
 }) extends CatalogRescanState;
 

--- a/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
+++ b/client/module_core/test/cubits/plugin_management/plugin_management_cubit_test.dart
@@ -1425,8 +1425,9 @@ void main() {
       await ready();
 
       rescan.emit(
-        const CatalogRescanState.preparingMany(
-          pendingPluginNames: ["Codex", "Claude"],
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
           pluginIds: {"codex", "claude"},
         ),
       );
@@ -1456,7 +1457,11 @@ void main() {
       expect((cubit.state as PluginManagementReady).scanRejections, isNotEmpty);
 
       rescan.emit(
-        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
       await _settle();
 
@@ -1469,7 +1474,11 @@ void main() {
       await cubit.startCatalogScanFor(pluginId: "codex");
 
       rescan.emit(
-        const CatalogRescanState.preparingOne(pendingPluginName: "Claude", pluginIds: {"claude"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Claude",
+          finishedHarnessCount: 0,
+          pluginIds: {"claude"},
+        ),
       );
       await _settle();
 
@@ -1487,7 +1496,11 @@ void main() {
         CatalogRescanStartResult.failed(cause: ApiError.nonSuccessCode(errorCode: 500, rawErrorString: null)),
       );
       rescan.emit(
-        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
       await _settle();
 
@@ -1639,7 +1652,11 @@ void main() {
       await ready();
       await cubit.startCatalogScanFor(pluginId: "codex");
       rescan.emit(
-        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
       await _settle();
 
@@ -1682,7 +1699,11 @@ void main() {
       rescan.stubStartResult(const CatalogRescanStartResult.unsupported());
       await cubit.startCatalogScanFor(pluginId: "codex");
       rescan.emit(
-        const CatalogRescanState.preparingOne(pendingPluginName: "Claude", pluginIds: {"claude"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Claude",
+          finishedHarnessCount: 0,
+          pluginIds: {"claude"},
+        ),
       );
       await _settle();
 
@@ -1696,7 +1717,11 @@ void main() {
 
     test("a cubit created mid-scan seeds its members from the service", () async {
       rescan.emit(
-        const CatalogRescanState.preparingOne(pendingPluginName: "Codex", pluginIds: {"codex"}),
+        const CatalogRescanState.preparingOne(
+          pendingPluginName: "Codex",
+          finishedHarnessCount: 0,
+          pluginIds: {"codex"},
+        ),
       );
       await _settle();
 

--- a/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
+++ b/client/module_core/test/cubits/project_list/project_list_cubit_test.dart
@@ -2548,6 +2548,7 @@ void main() {
           const CatalogRescanState.reading(
             activePluginName: "Codex",
             sessionsSeen: 148,
+            finishedHarnessCount: 0,
             pluginIds: {"codex"},
           ),
         );

--- a/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
+++ b/client/module_core/test/cubits/session_list/session_list_cubit_test.dart
@@ -2456,6 +2456,7 @@ void main() {
           const CatalogRescanState.reading(
             activePluginName: "Codex",
             sessionsSeen: 148,
+            finishedHarnessCount: 0,
             pluginIds: {"codex"},
           ),
         );

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -55,9 +55,129 @@ void main() {
       expect(repository.startedPluginIds, unorderedEquals(["codex", "claude"]));
       expect(
         service.state.value,
-        isA<CatalogRescanPreparingMany>()
-            .having((s) => s.pendingPluginNames, "pendingPluginNames", ["Codex", "Claude"])
+        isA<CatalogRescanPreparingOne>()
+            .having((s) => s.pendingPluginName, "pendingPluginName", "Codex")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 0)
             .having((s) => s.pluginIds, "pluginIds", {"codex", "claude"}),
+      );
+    });
+
+    test("keeps first unfinished harness focused while later harness reports progress", () async {
+      await service.startAll();
+
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "claude",
+          projectsSeen: 2,
+          sessionsSeen: 9,
+        ),
+      );
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>()
+            .having((s) => s.pendingPluginName, "pendingPluginName", "Codex")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 0),
+        reason: "a later harness must not steal focus before Codex reports",
+      );
+
+      connection.emitProgress(
+        const CatalogImportProgress.committing(
+          pluginId: "claude",
+          projectsSeen: 2,
+          sessionsSeen: 9,
+        ),
+      );
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>().having((s) => s.pendingPluginName, "pendingPluginName", "Codex"),
+        reason: "background phase changes must not change the selected harness",
+      );
+    });
+
+    test("shows background completion in count while focus remains stable", () async {
+      await service.startAll();
+
+      connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 2));
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>()
+            .having((s) => s.pendingPluginName, "pendingPluginName", "Codex")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 1)
+            .having((s) => s.pluginIds.length, "total harness count", 2),
+        reason: "background completion is visible without moving focus",
+      );
+
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "codex",
+          projectsSeen: 1,
+          sessionsSeen: 3,
+        ),
+      );
+      expect(
+        service.state.value,
+        isA<CatalogRescanReading>()
+            .having((s) => s.activePluginName, "activePluginName", "Codex")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 1),
+      );
+    });
+
+    test("hands focus off after terminal progress and skips finished members", () async {
+      build(snapshot: _snapshot(routable: const {"codex": "Codex", "claude": "Claude", "cursor": "Cursor"}));
+      await service.startAll();
+
+      // Claude finishes out of order while Codex is still the first member.
+      connection.emitProgress(_completed("claude", newProjects: 0, newSessions: 0));
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>()
+            .having((s) => s.pendingPluginName, "pendingPluginName", "Codex")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 1),
+      );
+
+      connection.emitProgress(_completed("codex", newProjects: 0, newSessions: 0));
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>()
+            .having((s) => s.pendingPluginName, "pendingPluginName", "Cursor")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 2),
+        reason: "handoff skips Claude, which already finished",
+      );
+    });
+
+    test("hands focus off when the first harness is rejected", () async {
+      repository.resultFor["codex"] = const CatalogImportMutationResult.unavailable();
+
+      await service.startAll();
+
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>()
+            .having((s) => s.pendingPluginName, "pendingPluginName", "Claude")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 0)
+            .having((s) => s.pluginIds, "pluginIds", {"claude"}),
+      );
+    });
+
+    test("counts failed and cancelled members as finished", () async {
+      build(snapshot: _snapshot(routable: const {"codex": "Codex", "claude": "Claude", "cursor": "Cursor"}));
+      await service.startAll();
+
+      connection.emitProgress(const CatalogImportProgress.cancelled(pluginId: "claude"));
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>()
+            .having((s) => s.pendingPluginName, "pendingPluginName", "Codex")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 1),
+      );
+
+      connection.emitProgress(const CatalogImportProgress.failed(pluginId: "codex", message: "failed"));
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>()
+            .having((s) => s.pendingPluginName, "pendingPluginName", "Cursor")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 2),
       );
     });
 
@@ -293,7 +413,9 @@ void main() {
 
         expect(
           service.state.value,
-          isA<CatalogRescanPreparingMany>(),
+          isA<CatalogRescanPreparingOne>()
+              .having((s) => s.pendingPluginName, "pendingPluginName", "Codex")
+              .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 0),
           reason: "the previous success timer must not reset the new run",
         );
       });
@@ -310,7 +432,9 @@ void main() {
 
       expect(
         service.state.value,
-        isA<CatalogRescanPreparingMany>(),
+        isA<CatalogRescanPreparingOne>()
+            .having((s) => s.pendingPluginName, "pendingPluginName", "Codex")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 0),
         reason: "retained progress from the previous run must be cleared",
       );
       connection.emitProgress(_completed("codex", newProjects: 0, newSessions: 0));
@@ -330,7 +454,7 @@ void main() {
 
       expect(result, isA<CatalogRescanStartAccepted>());
       expect(
-        (service.state.value as CatalogRescanPreparingMany).pluginIds,
+        (service.state.value as CatalogRescanPreparingOne).pluginIds,
         {"codex", "claude"},
         reason: "codex must stay in aggregation and cancellation",
       );
@@ -444,7 +568,7 @@ void main() {
       expect(catalogChanges, hasLength(1), reason: "its committed import must refresh the lists");
     });
 
-    test("re-points the row at a harness still working when another settles", () async {
+    test("keeps the first harness focused until it settles", () async {
       await service.startAll();
       connection.emitProgress(
         const CatalogImportProgress.enumerating(
@@ -453,18 +577,32 @@ void main() {
           sessionsSeen: 9,
         ),
       );
-      expect((service.state.value as CatalogRescanReading).activePluginName, "Claude");
+      expect(
+        service.state.value,
+        isA<CatalogRescanPreparingOne>().having((s) => s.pendingPluginName, "pendingPluginName", "Codex"),
+      );
 
       connection.emitProgress(_completed("claude", newProjects: 1, newSessions: 1));
 
       expect(
         service.state.value,
-        isA<CatalogRescanPreparingOne>().having(
-          (s) => s.pendingPluginName,
-          "pendingPluginName",
-          "Codex",
+        isA<CatalogRescanPreparingOne>()
+            .having((s) => s.pendingPluginName, "pendingPluginName", "Codex")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 1),
+        reason: "background completion must not steal focus",
+      );
+
+      connection.emitProgress(
+        const CatalogImportProgress.enumerating(
+          pluginId: "codex",
+          projectsSeen: 1,
+          sessionsSeen: 2,
         ),
-        reason: "only the unfinished harness remains in preparing copy",
+      );
+      expect(
+        service.state.value,
+        isA<CatalogRescanReading>().having((s) => s.activePluginName, "activePluginName", "Codex"),
+        reason: "focus advances after the first harness settles",
       );
     });
 
@@ -572,7 +710,7 @@ void main() {
 
     test("cancel fans out one request per member, including while starting", () async {
       await service.startAll();
-      expect(service.state.value, isA<CatalogRescanPreparingMany>());
+      expect(service.state.value, isA<CatalogRescanPreparingOne>());
 
       await service.cancel();
 
@@ -879,7 +1017,7 @@ void main() {
       final catalogChanges = <void>[];
       service.catalogChanged.listen(catalogChanges.add);
       await service.startAll();
-      expect(service.state.value, isA<CatalogRescanPreparingMany>());
+      expect(service.state.value, isA<CatalogRescanPreparingOne>());
 
       connection.emitStatus(const ConnectionStatus.disconnected());
       await pumpEventQueue();

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -64,6 +64,7 @@ void main() {
 
     test("keeps first unfinished harness focused while later harness reports progress", () async {
       await service.startAll();
+      final focusedState = service.state.value;
 
       connection.emitProgress(
         const CatalogImportProgress.enumerating(
@@ -79,6 +80,7 @@ void main() {
             .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 0),
         reason: "a later harness must not steal focus before Codex reports",
       );
+      expect(service.state.value, same(focusedState), reason: "hidden enumeration must not republish the row");
 
       connection.emitProgress(
         const CatalogImportProgress.committing(
@@ -91,6 +93,16 @@ void main() {
         service.state.value,
         isA<CatalogRescanPreparingOne>().having((s) => s.pendingPluginName, "pendingPluginName", "Codex"),
         reason: "background phase changes must not change the selected harness",
+      );
+      expect(service.state.value, same(focusedState), reason: "hidden committing must not republish the row");
+
+      connection.emitProgress(_completed("codex", newProjects: 0, newSessions: 0));
+      expect(
+        service.state.value,
+        isA<CatalogRescanSaving>()
+            .having((s) => s.activePluginName, "activePluginName", "Claude")
+            .having((s) => s.finishedHarnessCount, "finishedHarnessCount", 1),
+        reason: "handoff must use the latest stored background progress",
       );
     });
 

--- a/client/module_core/test/services/catalog_rescan_service_test.dart
+++ b/client/module_core/test/services/catalog_rescan_service_test.dart
@@ -160,6 +160,39 @@ void main() {
       );
     });
 
+    for (final (label, outcome, finishedHarnessCount, pluginIds) in [
+      ("unavailable", const CatalogImportMutationResult.unavailable(), 0, const {"claude"}),
+      ("not found", const CatalogImportMutationResult.notFound(), 0, const {"claude"}),
+      (
+        "failure",
+        CatalogImportMutationResult.failure(error: ApiError.nonSuccessCode(errorCode: 500, rawErrorString: null)),
+        1,
+        const {"codex", "claude"},
+      ),
+    ]) {
+      test("hands focus off after $label while another start is pending", () async {
+        final pendingStart = Completer<CatalogImportMutationResult>();
+        repository.resultFor["codex"] = outcome;
+        repository.pendingFor["claude"] = pendingStart.future;
+
+        final starting = service.startAll();
+        await pumpEventQueue();
+
+        expect(repository.startedPluginIds, ["codex", "claude"]);
+        expect(
+          service.state.value,
+          isA<CatalogRescanPreparingOne>()
+              .having((s) => s.pendingPluginName, "pendingPluginName", "Claude")
+              .having((s) => s.finishedHarnessCount, "finishedHarnessCount", finishedHarnessCount)
+              .having((s) => s.pluginIds, "pluginIds", pluginIds),
+          reason: "the first definitive response must update focus/counts without waiting for the batch",
+        );
+
+        pendingStart.complete(const CatalogImportMutationResult.accepted());
+        await starting;
+      });
+    }
+
     test("counts failed and cancelled members as finished", () async {
       build(snapshot: _snapshot(routable: const {"codex": "Codex", "claude": "Claude", "cursor": "Cursor"}));
       await service.startAll();

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -74,28 +74,37 @@ state.
   non-overridden OpenCode installs use the public-channel `opencode.db`; an explicit
   custom binary does not guess that default or a channel-specific filename. OpenCode
   attach/no-auto-start mode always retains its existing server path.
-- One scan is one row above the list, however many harnesses take part. It names
-  only unfinished harnesses while preparing, distinguishes confirmed harness
-  startup from catalog reading, reports found-session counts during enumeration,
-  and says when results are being saved. Startup wording is driven only by a
-  fresh management snapshot for the same bridge; unknown or older metadata does
-  not infer it. After the same harness remains confirmed as starting for three
-  seconds, the row explains that scanning is waiting for startup and that the
-  user can keep browsing. This one-shot presentation timer resets on any phase
-  or harness change and never polls or changes bridge work. It offers to cancel
-  throughout live work. Every live phase shares the same Deep Scan loading-card
-  treatment, and the row scrolls with the list rather than pinning. The entrance
-  animation plays once when a pull first reveals the row; later updates do not
-  replay it, and the scan indicator keeps animating until a terminal outcome
-  replaces it. Android Remove Animations and iOS Reduce Motion both hold the
-  intentional first frame without the entrance bounce, and the pull-caption
-  invitation keeps only its gentle opacity transition. Finished outcomes use the
-  shared PREGO result-card geometry, expanding rather than clipping at
-  accessibility text sizes: a success, warning, or error glow rises from the
-  lower edge and the matching tinted Dismiss action remains available until the
-  result clears. Loading and every result state use a vertically centered 20px
-  leading mark with identical edge inset and icon-to-text gap. Titles do not
-  shift horizontally between states; at standard text size, icon and title
+- One scan is one row above the list, however many harnesses take part. The
+  service chooses the first unfinished harness in the operation's fixed
+  membership order, including members with no progress event yet, and keeps
+  later harness progress in stored state without letting it steal focus. Focus
+  advances only when the selected harness completes, fails, is cancelled, or
+  is removed by an unavailable/not-found start outcome. The row names that
+  harness while preparing, distinguishes confirmed harness startup from
+  catalog reading, reports found-session counts during enumeration, and says
+  when results are being saved. Every live phase also reports finished
+  harnesses out of the current membership; completed, failed, and cancelled
+  members count as finished, while unavailable/not-found members removed from
+  membership do not. Startup
+  wording is driven only by a fresh management snapshot for the same bridge;
+  unknown or older metadata does not infer it. After the same harness remains
+  confirmed as starting for three seconds, the row explains that scanning is
+  waiting for startup and that the user can keep browsing. This one-shot
+  presentation timer resets on any phase or harness change and never polls or
+  changes bridge work. It offers to cancel throughout live work. Every live
+  phase shares the same Deep Scan loading-card treatment, and the row scrolls
+  with the list rather than pinning. The entrance animation plays once when a
+  pull first reveals the row; later updates do not replay it, and the scan
+  indicator keeps animating until a terminal outcome replaces it. Android
+  Remove Animations and iOS Reduce Motion both hold the intentional first
+  frame without the entrance bounce, and the pull-caption invitation keeps
+  only its gentle opacity transition. Finished outcomes use the shared PREGO
+  result-card geometry, expanding rather than clipping at accessibility text
+  sizes: a success, warning, or error glow rises from the lower edge and the
+  matching tinted Dismiss action remains available until the result clears.
+  Loading and every result state use a vertically centered 20px leading mark
+  with identical edge inset and icon-to-text gap. Titles do not shift
+  horizontally between states; at standard text size, icon and title
   positions stay fixed vertically too. Enlarged text may grow the card without
   changing those horizontal insets.
 - A scan the pull started is reported by that row alone: the pull raises no


### PR DESCRIPTION
## Complexity
🌿 Straightforward: localized scan selection and client-only progress-state changes, with shared UI and fixture updates.

## What
- Keep the first unfinished harness focused in operation order, even before its first progress event arrives.
- Continue processing other harnesses in parallel without allowing their updates to take over the row.
- Show finished/total harness counts during preparing, starting, reading, saving, and prolonged startup waits.
- Advance focus after terminal outcomes or existing unavailable/not-found removal, skipping harnesses that already finished.
- Remove the now-unused multi-harness preparing state and update shared widgets, mobile playbooks, and regression documentation.

## Why
A later harness could report progress first and temporarily take over the row, only to lose focus when an earlier harness finally reported. Stable selection removes that jumping without slowing down parallel imports. Overall counts make background completions visible.

## Risk and test focus
Low risk, confined to client presentation and the existing rescan service. User-visible impact: stable named scan status and overall completion counts on mobile and desktop. No database, bridge, relay, public wire-contract, or analytics impact; older bridges remain supported.

Focus on interleaved events, delayed first progress, background completion, failed/cancelled counts, rejected starts, and handoff past already-finished harnesses. Preserve the authoritative three-second startup explanation, its timer across background updates, and cancellation/reset behavior. Waiting headings wrap at narrow mobile widths. No real-device visual QA was performed.

## Expected result
The scan row stays on one unfinished harness until it settles while the overall finished count continues advancing. Parallel import performance is unchanged, and no bridge update is required for this client-side correction.

## Verification
Using pinned Flutter 3.47.2-stable:
- Core rescan-service tests passed.
- Plugin-management, project-list, and session-list cubit tests passed.
- Shared scan-row widget tests passed.
- Mobile scan-row playbook and project-list scan tests passed.
- Targeted settings test preventing duplicate live scans passed.
- Owning analyzers passed for `client/module_core`, `client/module_app_ui`, and `client/app`.
- Architecture implementation review approved; `git diff --check` passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the catalog scan row so it stays focused on the first unfinished harness instead of letting a later harness's progress jump in and take over the row.

- Focus advances only when the focused harness completes, fails, cancels, or is removed; finished harnesses are skipped during handoff.
- Rejected starts update focus and counts immediately without waiting for other pending start responses.
- Live phases show a `finished/total` harness count so background completions stay visible.
- Hidden background progress no longer republishes the row; only the focused harness's progress and terminal outcomes do.
- Removes the multi-harness preparing state and its specialized copy in favor of a single always-focused harness presentation.

<sup>Written for commit db912ec5fdb7d77a8573019229765679f3de4fb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

