### PR TITLE
🌿 [deepseek-flash-update] Pin released Flash-capable runtime [step 2/2]

### DIFF
--- a/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_runtime_manifest.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_runtime_manifest.dart
@@ -7,65 +7,65 @@ import "../deepseek_identity.dart";
 
 /// Pinned Sesori DeepSeek ACP package archives used by managed installation.
 class const DeepSeekRuntimeManifest() extends RuntimeManifest {
-  static const String minimumVersion = "0.1.4";
+  static const String minimumVersion = "0.1.5";
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: minimumVersion);
 
   /// The latest stable adapter release targeted by this plugin.
-  static const String targetVersion = "0.1.4";
+  static const String targetVersion = "0.1.5";
 
   static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
 
   static const Map<PlatformOs, Map<PlatformArch, RuntimeAsset>> _assets = {
     PlatformOs.macos: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.4-darwin-arm64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.5-darwin-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "fe565d18efc228b5d5a93835f5f4d900c00ae113649a1480266c305fc5623082",
+        sha256: "4741d1e58b912a0d15018c956c4484b2b04be4dd5cd58710508d094ac604c254",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.4-darwin-x64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.5-darwin-x64.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "f3d5d4df05069daab221f5bdda8480bbb6448ea4d8139b3d75ccd0f2722fd151",
+        sha256: "c985bae87b7fc3f8b6ca01f27dd47e36725e9da496c08bf01e7a0a285458fb86",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
     PlatformOs.linux: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.4-linux-arm64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.5-linux-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "8fa13b6e5dea36eb33c38bc9e1b7960c690b5646d4010809f743e11555e0d979",
+        sha256: "5551a82f11838e4a3e73646283eed0c888547061428caab682c59a62fe72121b",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.4-linux-x64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.5-linux-x64.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "0f1b187e54acb008b56fa99fa1c1d0e2ad33913f7c986d801758adf3c642a74d",
+        sha256: "0675af1b24be0b8c35983b866a0624532767217db8a4254efb6e91e311a7d237",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
     PlatformOs.windows: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.4-windows-arm64.zip",
+        assetName: "sesori-deepseek-acp-v0.1.5-windows-arm64.zip",
         format: ArchiveFormat.zip,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "f32f26bb5540cb899b5704d67be8a1ff7521d567382fe2f1a4561026e32678d4",
+        sha256: "390e593ab24f37ca00f52543997c876d90a59affd080e01c3cb8979b744c92c7",
         archiveBinaryName: "sesori-deepseek-acp.cmd",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.4-windows-x64.zip",
+        assetName: "sesori-deepseek-acp-v0.1.5-windows-x64.zip",
         format: ArchiveFormat.zip,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "218cd61ad11c89a9f5d538e47ff0f27c4e23ce3748af235663917f58c3f8e252",
+        sha256: "013cd4a261bcf99fe3438645b19fa610cc565f94694d74c674df83f90cb4ea1e",
         archiveBinaryName: "sesori-deepseek-acp.cmd",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),

--- a/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/services/deepseek_session_service.dart
@@ -15,7 +15,7 @@ class const DeepSeekSessionService({
       throw const FormatException("DeepSeek adapter reported an invalid adapter version");
     }
     if (adapterVersion.compareTo(minimumAdapterVersion) < 0) {
-      throw const FormatException("DeepSeek adapter does not support atomic scoped stop");
+      throw FormatException("DeepSeek requires adapter ${minimumAdapterVersion.toString()} or newer");
     }
   }
 

--- a/bridge/sesori_plugin_deepseek/test/deepseek_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_plugin_descriptor_test.dart
@@ -36,7 +36,7 @@ void main() {
     });
 
     test("asks for an upgrade when a superseded version is installed", () {
-      installedVersion("0.1.3");
+      installedVersion("0.1.4");
 
       expect(
         const DeepSeekPluginDescriptor().needsManagedRuntimeUpgrade(
@@ -48,7 +48,7 @@ void main() {
     });
 
     test("declines with an explicit binary override", () {
-      installedVersion("0.1.3");
+      installedVersion("0.1.4");
 
       expect(
         const DeepSeekPluginDescriptor().needsManagedRuntimeUpgrade(
@@ -156,7 +156,7 @@ void main() {
       probes: [
         _ProbeProcess(
           pid: 1,
-          stdoutBytes: utf8.encode("sesori-deepseek-acp/0.1.3 deepseek-harness/0.1.1-rc.2 acp/1\n"),
+          stdoutBytes: utf8.encode("sesori-deepseek-acp/0.1.4 deepseek-harness/0.1.1-rc.2 acp/1\n"),
           stderrBytes: const [],
           exitCodeValue: 0,
         ),
@@ -198,7 +198,7 @@ void main() {
       probes: [
         _ProbeProcess(
           pid: 1,
-          stdoutBytes: utf8.encode("sesori-deepseek-acp/0.1.3 deepseek-harness/0.1.1-rc.2 acp/1\n"),
+          stdoutBytes: utf8.encode("sesori-deepseek-acp/0.1.4 deepseek-harness/0.1.1-rc.2 acp/1\n"),
           stderrBytes: const [],
           exitCodeValue: 0,
         ),
@@ -422,7 +422,7 @@ class _AcpProcess({@override required final int pid, required final bool omitIni
             "sesori.ai/deepseek": {
               "extensionProtocolVersion": 2,
               "adapterVersion": DeepSeekPluginDescriptor.targetVersion,
-              "harnessVersion": "0.1.1-rc.2",
+              "harnessVersion": "0.1.5-rc.2",
               "persistenceOwner": "sesori",
             },
           },

--- a/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_plugin_test.dart
@@ -7,7 +7,7 @@ import "package:test/test.dart";
 import "support/deepseek_test_plugin.dart";
 
 void main() {
-  test("live initialization requires adapter 0.1.4 or newer", () async {
+  test("live initialization requires adapter 0.1.5 or newer", () async {
     final fake = FakeAcpProcess();
     final plugin = buildDeepSeekTestPlugin(fake: fake);
     AcpInitializeResult result(String version) => AcpInitializeResult.fromJson({
@@ -35,8 +35,18 @@ void main() {
       ),
     );
     expect(() => plugin.validateInitializeResult(result("0.1.3")), throwsFormatException);
-    expect(() => plugin.validateInitializeResult(result("0.1.4")), returnsNormally);
+    expect(
+      () => plugin.validateInitializeResult(result("0.1.4")),
+      throwsA(
+        isA<FormatException>().having(
+          (error) => error.message,
+          "message",
+          "DeepSeek requires adapter 0.1.5 or newer",
+        ),
+      ),
+    );
     expect(() => plugin.validateInitializeResult(result("0.1.5")), returnsNormally);
+    expect(() => plugin.validateInitializeResult(result("0.1.6")), returnsNormally);
     await plugin.dispose();
     await fake.close();
   });

--- a/bridge/sesori_plugin_deepseek/test/deepseek_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_runtime_manifest_test.dart
@@ -15,9 +15,9 @@ void main() {
       manifest.binaryFileName,
       Platform.isWindows ? "sesori-deepseek-acp.cmd" : "sesori-deepseek-acp",
     );
-    expect(manifest.minPathVersion.raw, "0.1.4");
+    expect(manifest.minPathVersion.raw, "0.1.5");
     expect(manifest.minPathVersion.raw, DeepSeekPluginDescriptor.minVersion);
-    expect(manifest.bundledVersion.raw, "0.1.4");
+    expect(manifest.bundledVersion.raw, "0.1.5");
     expect(manifest.parseVersion(value: "sesori-deepseek-acp/0.1.0")?.raw, "0.1.0");
   });
 
@@ -37,18 +37,18 @@ void main() {
     expect(
       {for (final asset in assets) asset.assetName: asset.sha256},
       {
-        "sesori-deepseek-acp-v0.1.4-darwin-arm64.tar.gz":
-            "fe565d18efc228b5d5a93835f5f4d900c00ae113649a1480266c305fc5623082",
-        "sesori-deepseek-acp-v0.1.4-darwin-x64.tar.gz":
-            "f3d5d4df05069daab221f5bdda8480bbb6448ea4d8139b3d75ccd0f2722fd151",
-        "sesori-deepseek-acp-v0.1.4-linux-arm64.tar.gz":
-            "8fa13b6e5dea36eb33c38bc9e1b7960c690b5646d4010809f743e11555e0d979",
-        "sesori-deepseek-acp-v0.1.4-linux-x64.tar.gz":
-            "0f1b187e54acb008b56fa99fa1c1d0e2ad33913f7c986d801758adf3c642a74d",
-        "sesori-deepseek-acp-v0.1.4-windows-arm64.zip":
-            "f32f26bb5540cb899b5704d67be8a1ff7521d567382fe2f1a4561026e32678d4",
-        "sesori-deepseek-acp-v0.1.4-windows-x64.zip":
-            "218cd61ad11c89a9f5d538e47ff0f27c4e23ce3748af235663917f58c3f8e252",
+        "sesori-deepseek-acp-v0.1.5-darwin-arm64.tar.gz":
+            "4741d1e58b912a0d15018c956c4484b2b04be4dd5cd58710508d094ac604c254",
+        "sesori-deepseek-acp-v0.1.5-darwin-x64.tar.gz":
+            "c985bae87b7fc3f8b6ca01f27dd47e36725e9da496c08bf01e7a0a285458fb86",
+        "sesori-deepseek-acp-v0.1.5-linux-arm64.tar.gz":
+            "5551a82f11838e4a3e73646283eed0c888547061428caab682c59a62fe72121b",
+        "sesori-deepseek-acp-v0.1.5-linux-x64.tar.gz":
+            "0675af1b24be0b8c35983b866a0624532767217db8a4254efb6e91e311a7d237",
+        "sesori-deepseek-acp-v0.1.5-windows-arm64.zip":
+            "390e593ab24f37ca00f52543997c876d90a59affd080e01c3cb8979b744c92c7",
+        "sesori-deepseek-acp-v0.1.5-windows-x64.zip":
+            "013cd4a261bcf99fe3438645b19fa610cc565f94694d74c674df83f90cb4ea1e",
       },
     );
     expect(
@@ -68,7 +68,7 @@ void main() {
     )!;
     expect(
       manifest.downloadUrlFor(asset: asset),
-      "https://github.com/sesori-ai/sesori-deepseek-acp/releases/download/v0.1.4/sesori-deepseek-acp-v0.1.4-darwin-arm64.tar.gz",
+      "https://github.com/sesori-ai/sesori-deepseek-acp/releases/download/v0.1.5/sesori-deepseek-acp-v0.1.5-darwin-arm64.tar.gz",
     );
   });
 }

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -262,11 +262,16 @@ generic `tool_call` with no ids or lifecycle notifications; those exist only in
 `--mode rpc`, which Sesori does not drive. `session/cancel` aborts the whole
 turn.
 
-⁹ DeepSeek's published adapter 0.1.4 over dsh 0.1.1-rc.2 is the managed target
+⁹ DeepSeek's published adapter 0.1.5 over dsh 0.1.5-rc.2 is the managed target
 and minimum accepted runtime. ACP uses native subtree stop for the named scope
 and every independently resident descendant root, while ordered input cancel,
 exact-child authority, lifecycle, tiles, and child catalogs remain native-backed.
 Released clients retain their own child fanout; final phone/desktop E2E remains outstanding.
+The native model catalog includes `deepseek-flash` (DeepSeek V4.1 Flash) with
+image input and reasoning controls. Refresh rereads the installed harness's
+configured catalog; it does not upgrade that harness or fetch a live provider catalog.
+Native `web_search` and `web_fetch` tools are enabled: outbound requests occur
+when invoked, without a Web BFF, HTTP listener, extra process, or telemetry exporter.
 
 ¹⁰ Grok Build (1.0.5, probed 2026-09-03) sends `subagent_spawned`/`subagent_progress`/
 `subagent_finished` with parent and child session ids as

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -63,8 +63,8 @@ idle suspension, the management snapshot, and lifecycle commands.
   Hermes entries give local setup guidance rather than offering bridge-managed login.
 - DeepSeek is an ACP harness with six-platform managed package archives. Its
   descriptor honors an explicit `--deepseek-bin` path before a compatible PATH
-  release (`>=0.1.3`) and then a managed release at or above that minimum,
-  preferring the pinned `0.1.3` target. An outdated explicit
+  release (`>=0.1.5`) and then a managed release at or above that minimum,
+  preferring the pinned `0.1.5` target. An outdated explicit
   binary is rejected; an old or malformed PATH candidate falls through to managed
   selection. It performs bounded parseable-version and
   side-effect-free `check --state-dir` probes, advertises install only on a

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -90,7 +90,11 @@ variant, and worktree mode, and creating the session with its first input.
   header resolves that opaque identity through the loaded provider catalog and
   shows the model name when available. Catalog reads use the connected adapter
   without creating a session or model request; selection is session-local and
-  never writes normal `DSH_HOME` settings.
+  never writes normal `DSH_HOME` settings. The default native catalog includes
+  DeepSeek V4.1 Flash (`deepseek-flash`) with image input and reasoning controls.
+  Refresh rereads the installed harness's configured catalog, not a live provider
+  model endpoint; discovering models added by a newer harness requires updating
+  the runtime. Explicit user model configuration remains authoritative.
 - Grok exposes one primary agent and one provider group from initialize-owned
   model state. Model IDs and canonical reasoning-effort values remain exact and
   opaque; declared defaults stay distinct from the current selection. Explicit
@@ -313,6 +317,8 @@ refresh failure with a last-good catalog, and headless-auth discovery failure.
 - A dedicated workspace name comes from generated metadata, is not lowercase
   `color-animal` form, or collides with an existing branch or path.
 - Bridge-owned context renders as the user's own message or command arguments.
+- DeepSeek's default catalog omits V4.1 Flash after installing the target runtime,
+  or selecting it sends a different upstream model ID.
 - A DeepSeek catalog loses sound providers because one provider failed, parses
   an opaque model ID, exposes a catalog-resolvable opaque ID in the session
   header, dispatches before both requested config writes settle, or records a

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -64,8 +64,11 @@ reconnect or restart.
 - When DeepSeek needs a first or stale backfill, its plugin calls
   `deepseek/session/history` through the one long-lived adapter connection and
   reads isolated persistence without resuming an agent or starting a scratch
-  process. It pages at complete message boundaries, returns at most 100 messages
-  per page, rejects non-progressing or over-100-page traversal, and reuses the
+  process. Native session observations preserve seeded-child inherited boundaries
+  and parent lineage. Released JSONL sessions use the harness's native format
+  migration; history reads leave source bytes unchanged, and resuming may create
+  a new native generation. It pages at complete message boundaries, returns at
+  most 100 messages per page, rejects non-progressing or over-100-page traversal, and reuses the
   shared ACP replay collector. Direct user message IDs remain exact; assistant
   IDs use the deterministic ACP projection. Known DeepSeek history metadata is
   decoded once into typed fields and validated at the API boundary; malformed

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -60,8 +60,11 @@ signal that a tool changed files.
   rollout, never live tracker state.
 - DeepSeek projects tool calls and updates through standard ACP with exact call
   identity, bounded presenter output, terminal result/error state, and diff
-  content. Presenter failure degrades to a generic bounded tool card instead of
-  dropping the call or result. With adapter 0.1.3 and protocol v2, correlated
+  content. Its native `web_search` and `web_fetch` tools use the same tool lifecycle;
+  they make outbound requests when invoked, without starting a Web BFF, HTTP
+  listener, or another process. Telemetry remains disabled. Presenter failure
+  degrades to a generic bounded tool card instead of dropping the call or result.
+  With protocol v2, correlated
   sub-agent starts replace exact `subagent`/`subagent_fork` cards with one child-linked tile;
   identifiable updates arriving before their call are deferred too. Start/end
   events retain the direct parent's transcript and keep root activity busy.


### PR DESCRIPTION
## Complexity
🌿 Straightforward consumer pin, version-gate copy, tests, and documentation. The native harness migration shipped separately in [adapter PR #19](https://github.com/sesori-ai/sesori-deepseek-acp/pull/19).

## What
- Pin the published [adapter v0.1.5](https://github.com/sesori-ai/sesori-deepseek-acp/releases/tag/v0.1.5), embedding DeepSeek harness `0.1.5-rc.2`, across all six supported targets.
- Raise the minimum accepted adapter to `0.1.5`; cover replacing/rejecting the preceding `0.1.4` runtime and report the actual minimum version on live initialization failure.
- Document Flash discovery, native outbound web tools, and released-session history preservation.

## Why
Model refresh rereads the installed harness's configured catalog; it cannot discover Flash while the old harness remains installed. The new runtime advertises `deepseek-flash` with image input and reasoning controls and uses native model selection, session observations/migration, streaming, questions, and descendant lifecycle support.

## Risk and test focus
The consumer diff is small, but it selects a substantial harness upgrade. Focus on six-platform installation, configured model selection, session history/resume, and scoped stop. Native outbound `web_search`/`web_fetch` are intentionally enabled; telemetry, a private Web BFF/HTTP listener, and adapter-owned extra processes remain disabled/absent.

No client/bridge wire-contract or Sesori database schema changes. Native released JSONL sessions retain their source bytes; resume may create the harness's new session generation. No authenticated phone/desktop E2E was run.

## Expected result
After the managed runtime upgrade, DeepSeek V4.1 Flash appears in the default catalog and can be selected. Explicit model configuration stays authoritative. Existing ACP/scoped-stop behavior and released history remain supported.

## Verification
- Adapter [release workflow](https://github.com/sesori-ai/sesori-deepseek-acp/actions/runs/34517451486): cross-repository conformance, all six build/package/relocation smokes, release-set verification, and publication passed.
- Independently downloaded all six published archives and recomputed every SHA-256; verified safe paths/links, launcher/Node layout, package versions, all 130 embedded DeepSeek harness package pins, and exact `BUILD-METADATA.json` target/source/consumer/protocol provenance. No local smoke hashes were used.
- Release tag points to merge `306229fe2ca1fb2ae32b60c4fb4dbc84af102b43`, whose tree exactly matches the reviewed adapter head `043f7c4`.
- `dart analyze --fatal-infos` in `bridge/sesori_plugin_deepseek`: passed.
- DeepSeek plugin suite: **116 tests passed**, including the updated `0.1.4` rejection/replacement and live minimum-version assertions.
- Changed Dart formatting and Git whitespace checks passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the managed DeepSeek runtime to adapter v0.1.5 so the installed harness can discover `deepseek-flash` (DeepSeek V4.1 Flash) with image input and reasoning controls.

- Minimum accepted adapter is now 0.1.5; live initialization rejects older versions with the required version in the error.
- Existing 0.1.4 installations are replaced during managed upgrade.
- Native `web_search` and `web_fetch` tools are enabled, making outbound requests when invoked without extra processes or telemetry.
- Released JSONL sessions keep their source bytes; resuming may create a new native generation.
- No client/bridge wire-contract or Sesori database schema changes.

<sup>Written for commit d1fcd12e8ef4bbec8625c97e1155d6adc648ecba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

