### PR TITLE
🌿 [claude-inline-subtasks] grok: cover child session history [step 4/6]

### DIFF
--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -295,7 +295,7 @@ confirmation, no child session or partial stop) and gets that subset.
 | 6/9 | 🚧 | `codex: integrate live and replay tiles [step 6/9]` | PR #1399 merged at `db2b71134d`; full live/replay production integration, lifecycle, busy accounting, focused tests, and behavior docs |
 | 7/9 | 🌿 | `codex: cover live tile lifecycle [step 7/9]` | PR #1420 merged at `ae2a9297e3`; write-path/lifecycle regressions and documentation |
 | 8/9 | ⚙️ | `codex: scoped stop for sub-agent threads [step 8/9]` | PR #1421 merged at `77165f784f`; per-thread policy, pending-admission fencing, and automated isolation/failure coverage |
-| 9/9 | 🌱 | `docs: record Codex sub-agent coverage [step 9/9]` | current; managed-0.153.4 actual-plugin scoped-stop policy QA passed; pending-input live case unexecuted |
+| 9/9 | 🌱 | `docs: record Codex sub-agent coverage [step 9/9]` | PR #1424 merged at `b945755bfe`; managed-0.153.4 actual-plugin scoped-stop policy QA passed; pending-input live case unexecuted |
 
 ### Probe results (0.148.0 and 0.153.4; details in `followups/codex-probe.md`)
 
@@ -393,14 +393,14 @@ confirmation, no child session or partial stop) and gets that subset.
 - **Child history and streaming.** Child ids use inherited `session/load` and
   replay their own standard prompt/tool/text stream. For root replay,
   `GrokSessionStoreApi` preserves typed persisted records in file order;
-  `GrokSessionHistoryRepository` extracts only each exact spawned child's first
-  non-empty child-owned user-message run; `GrokSessionService` resolves the
-  canonical directory and returns immutable context; and pure
+  `GrokSessionHistoryRepository` uses each exact spawned child's first child-owned
+  user-message run only when that run is nonblank; `GrokSessionService` resolves
+  the canonical directory and returns immutable context; and pure
   `GrokSessionReplayCollector` inserts/settles deterministic tiles without reading
-  live state. Unknown non-user updates end the first run. Both Grok lifecycle
-  methods are consumed through the existing post-response quiet drain. Missing
-  prompts produce no tile. No permission outcome, persistence, or deferred
-  machinery is implemented.
+  live state. Unknown non-user updates end the first run. A blank or missing first
+  run produces no tile, and later runs never substitute. Both Grok lifecycle
+  methods are consumed through the existing post-response quiet drain. No
+  permission outcome, persistence, or deferred machinery is implemented.
 - **Busy accounting.** Through seam 1: root idle is deferred while
   `busyChildIds` is non-empty. `GrokEventMapper` alone parses
   `subagent_finished.will_wake` and recognizes the matching root

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -12,8 +12,8 @@
   preparation, and cleanup remain steps 1/9–4/9. Native rollout facts are
   step 5/9, live/replay tile integration 6/9, lifecycle coverage 7/9, scoped
   stop 8/9, and coverage 9/9. Step 8 merged as PR #1421 at `77165f784f`;
-  Step 9 actual-plugin policy QA passed against managed 0.153.4; its
-  documentation step is current and remains unchecked until merge. Historical
+  Step 9 merged as PR #1424 at `b945755bfe` after actual-plugin policy QA
+  passed against managed 0.153.4. Historical
   PR titles are unchanged. Progress is tracked in
   `TRACKER.md` "Harness Follow-Ups". The DeepSeek phone handoff is recorded in
   `followups/deepseek-phone-qa.md`; desktop remains deferred.
@@ -84,28 +84,15 @@ confirmation, no child session or partial stop) and gets that subset.
      deleted (siblings under other roots keep their busy state and cancel
      targets), and calls `clear()` only on process exit. The child directory
      is `directoryForSession(root)`, never the launch directory.
-  2. A protected tool-call classification method on `AcpEventMapper` returns a
-     sealed `AcpToolCallClassification`: render as a tool card, suppress because
-     a lifecycle-derived tile represents the same work, defer a permission-
-     gated decision, or track a tile-only task. A Layer-2
-     `AcpDeferredToolCallTracker`
-     (`bridge/sesori_plugin_acp/lib/src/repositories/trackers/acp_deferred_tool_call_tracker.dart`)
-     is constructed at the harness composition point and injected into
-     `AcpEventMapper`. For `defer`, that tracker—not the mapper—owns the typed
-     standard call by session and tool call id and resolves it from the later
-     permission/tool update; denial or cancellation can then emit and
-     terminally settle the generic card even when no child is spawned. The
-     mapper only classifies each update and delegates the state transition.
-     `AcpPlugin` forgets one session's deferred calls on deletion and clears the
-     tracker on disconnect and process exit. The tile-only outcome carries the
-     stable tool call id, prompt,
-     agent/description, and observed tool state; the generic standard-update
-     path feeds that typed fact into `AcpChildSessionTracker` instead of
-     rendering a card. A session-backed tile is still opened only from a
-     lifecycle event that carries the child id. Grok uses `defer` because its
-     tool call and child lifecycle share no id; Cursor uses the tile-only
-     outcome because its standard and extension frames do. Neither path matches
-     by description or arrival order, so concurrent spawns stay deterministic.
+  2. `AcpEventMapper.isSubagentSpawnToolCall` is the current narrow live
+     classifier: exact backend metadata may suppress a generic card when a
+     lifecycle-derived tile owns presentation. Grok uses this because its
+     standard call and child lifecycle share no id. No deferred permission
+     tracker or permission-outcome model exists; a denied Grok generic card may
+     be absent after replay. Replay has a separate typed suppression callback,
+     while DeepSeek's existing nullable replacement callback keeps null meaning
+     “retain generic.” Cursor's future tile-only mapping must land with its own
+     production need rather than prebuilding unused classification machinery.
   3. The scoped-stop policy, once, in `AcpPlugin.abortSession`: `confirm` with
      running children is side-effect free and rejects with their count,
      `mainAgentRunning` from pending prompts or an active named child, and `mainAgentOnlySupported` true only
@@ -353,14 +340,9 @@ confirmation, no child session or partial stop) and gets that subset.
 
 ## Grok Build (1.0.5, ACP stdio)
 
-Implementation status: PR #1426 delivers replay-local collectors and streamed
-child-owned prompt preparation, with no deferred-permission tracker or outcome
-model. The design prose below is the pre-implementation plan; Step 4/6 reconciles
-it with the reviewed implementation and complete coverage.
+### Verified facts (native 1.0.5 probes)
 
-### Verified facts (binary string survey)
-
-- Extension notification `x.ai/session_notification` wraps an internally
+- Extension notification `_x.ai/session_notification` wraps an internally
   tagged `SessionUpdate` (`sessionUpdate` key, snake_case) including
   `subagent_spawned` (`subagent_id`, `parent_session_id`,
   `child_session_id`, `subagent_type`, `capability_mode`, `persona`,
@@ -368,11 +350,10 @@ it with the reviewed implementation and complete coverage.
   (`duration_ms`, `turn_count`, `tool_call_count`, ...),
   `subagent_finished` (`tool_calls`, `turns`, ...), plus `task_backgrounded`
   and `task_completed` with `tool_call_id`.
-- Extension request `x.ai/subagent/cancel` with `subagentId`. The kill tool
+- Extension request `_x.ai/subagent/cancel` with `subagentId`. The kill tool
   sends cancel and shutdown to subagents. Nesting depth is one.
-- A turn cancel does not cancel subagents ("background tasks, subagents, and
-  the rest of the queue keep running"); `cancel_subagents_on_turn_cancel` is a
-  TUI-side preference, not agent behavior Sesori can toggle.
+- `session/cancel` on the root cancels foreground and background children on
+  the ACP seam Sesori drives. Main-agent-only stop is therefore unsupported.
 - Root and child directories persist in the normal sessions tree. A child's
   `summary.json` carries `session_kind: "subagent"` and `agent_name` but no
   parent id; the root's `updates.jsonl` carries `subagent_spawned` records with
@@ -380,24 +361,23 @@ it with the reviewed implementation and complete coverage.
 
 ### Current plugin
 
-- `acp_event_mapper.dart` routes non-`session/update` methods to
-  `mapExtension`, whose base returns `[]`; Grok uses the base mapper, so every
-  `x.ai/*` notification is dropped. Child updates, if they arrive, lack a
-  preceding `session.created` and are discarded by the bridge binding.
-- `acp_plugin.dart`: `abortSession` ignores the policy and sends
-  `session/cancel`; `getChildSessions` returns `[]`; `childSessionIds` are
-  empty; work state derives from `pending` only. `sessionParentId` is an
-  overridable hook (DeepSeek already overrides it).
-- History replays `session/load` through `AcpReplayCollector`, which knows only
-  standard updates.
+- `GrokEventMapper` parses both Grok lifecycle methods into the shared
+  `AcpChildSessionTracker`; children render live, roll into root activity, and
+  survive restart through the persisted catalog chain.
+- `GrokSessionStoreApi` already reads typed session summaries/updates for
+  catalog recovery. It never reads credential or configuration files.
+- Scoped stop remains unimplemented. History continues to use inherited ACP
+  `session/load`; this step adds extension-aware root projection without a
+  second transport.
 
 ### Design
 
 - **Ownership.** `GrokEventMapper extends AcpEventMapper` overrides
-  `mapExtension`; Freezed DTOs parse the snake_case payloads into a sealed
-  `GrokSubagentUpdate` (`spawned | progress | finished`) with a closed status
-  enum and push into `AcpChildSessionTracker` (Shared Rules, seam 1). This
-  chain introduces the five shared seams.
+  `mapExtension`; Freezed DTOs parse snake_case payloads into a sealed
+  `GrokSubagentUpdate` and push into the existing `AcpChildSessionTracker`.
+  History adds only an extension-aware ACP replay collector plus typed immutable
+  context preparation; child tracking, busy ownership, generic replay
+  replacement, and scoped-stop policy seams already exist.
 - **Tiles.** `subagent_spawned` emits the child session (`parentID` = root,
   title = description, directory = root's) and busy status; the `subtask` part
   (`agent` = subagent type, `childSessionID` = child session id, running)
@@ -405,36 +385,22 @@ it with the reviewed implementation and complete coverage.
   the spawn notification lacks and arrives under the child id right after
   the spawn (merged in PR #1270 as `appendPrompt`).
   `subagent_progress` is ignored. `subagent_finished` completes, errors, or
-  cancels and sets the child idle. Tiles are lifecycle-derived only. For the
-  earlier standard `spawn_subagent` call, which shares no id with
-  `subagent_spawned`, the Grok classifier returns seam 2's deferred outcome
-  while permission is pending. `AcpDeferredToolCallTracker` owns the buffered
-  call; the mapper delegates the same tool call's permission/tool update to
-  resolve it. Approval suppresses it before the lifecycle tile arrives, while
-  denial or cancellation emits and terminally settles the generic card because
-  no child will exist.
-  This never pairs a standard call with a lifecycle event, so concurrent spawns
-  cannot duplicate or cross-bind tiles.
-- **Child history and streaming.** Child `session/update`s flow through the
-  existing mapper once the child exists, and `session/load` accepts child ids
-  (probe). A root load replays `subagent_spawned` and `subagent_finished` as
-  `_x.ai/session/update`, but the spawn still has no prompt and the standard
-  `spawn_subagent` call shares no id. The child-history PR first adds a bounded
-  denied/cancelled `session/load` capture. If Grok replays a typed permission
-  outcome, `GrokSessionHistoryRepository` includes it in the prepared replay
-  context and the replay-local deferred tracker retains the terminal generic
-  card. If no outcome is persisted, successful and denied calls cannot be
-  correlated safely: replay suppresses every standard spawn card to preserve
-  one tile per actual child, and a denied attempt remains visible live but is
-  absent after reload. That cosmetic omission is accepted rather than adding
-  Sesori-owned persistence for Grok history. Before the collector materialises
-  the root, `GrokSessionService` asks the Layer-2
-  `GrokSessionHistoryRepository` (backed only by Layer-1
-  `GrokSessionStoreApi`) for immutable replay context containing each
-  discovered child's initial `user_message_chunk`, keyed by child id. The pure
-  Grok projection receives that context and feeds spawn, prompt, and finish
-  into its replay-local tracker. The rebuilt tile is therefore deterministic
-  and never depends on description or ordering.
+  cancels and sets the child idle. Tiles are lifecycle-derived only. The exact
+  typed `_meta["x.ai/tool"].name == spawn_subagent` classifier suppresses the
+  generic card; there is no tool-call/lifecycle id join, deferred permission
+  tracker, description matching, or ordering correlation. Denied generic-card
+  replay may therefore be absent; native denial persistence remains unverified.
+- **Child history and streaming.** Child ids use inherited `session/load` and
+  replay their own standard prompt/tool/text stream. For root replay,
+  `GrokSessionStoreApi` preserves typed persisted records in file order;
+  `GrokSessionHistoryRepository` extracts only each exact spawned child's first
+  non-empty child-owned user-message run; `GrokSessionService` resolves the
+  canonical directory and returns immutable context; and pure
+  `GrokSessionReplayCollector` inserts/settles deterministic tiles without reading
+  live state. Unknown non-user updates end the first run. Both Grok lifecycle
+  methods are consumed through the existing post-response quiet drain. Missing
+  prompts produce no tile. No permission outcome, persistence, or deferred
+  machinery is implemented.
 - **Busy accounting.** Through seam 1: root idle is deferred while
   `busyChildIds` is non-empty. `GrokEventMapper` alone parses
   `subagent_finished.will_wake` and recognizes the matching root
@@ -471,11 +437,12 @@ it with the reviewed implementation and complete coverage.
 
 | Emoji | Description | Scope |
 |---|---|---|
-| ⚙️ | `grok: parse sub-agent lifecycle notifications` | DTOs, `GrokEventMapper.mapExtension`, `AcpChildSessionTracker` (seam 1), `AcpDeferredToolCallTracker` plus deferred classification and denied/cancelled generic-card retention (seam 2), mapper/tracker lifecycle fixtures including forget/disconnect/exit cleanup |
-| ⚙️ | `acp: child sessions keep the root busy` | typed tracker-change stream and owned subscription teardown; `AcpPlugin` composes tracker statuses, idle/wake-up deferral, summary `childSessionIds`, and exit cleanup; `GrokSessionStoreApi` → `GrokSessionCatalogRepository` returns persisted children and Layer-3 `GrokSessionService` merges them with the tracker for `getChildSessions` |
-| 🌿 | `grok: child session history` | `session/load` for child ids plus denied/cancelled replay probe; seam 5 replay context and pure Grok projection; `GrokSessionStoreApi` → `GrokSessionHistoryRepository` → `GrokSessionService` prepares child prompts and any persisted permission outcomes |
-| ⚙️ | `grok: scoped stop for sub-agents` | policy in `AcpPlugin.abortSession` (seam 3), including side-effect-free unsupported-`keep` rejection and child-only `keep`; `cancelChild` seam and its Grok request (seam 4); `interruptActiveWork` uses stop |
-| 🌱 | `docs: record Grok Build sub-agent coverage` | matrix footnote ¹⁰ resolved, regression docs |
+| ⚙️ | `grok: parse sub-agent lifecycle notifications` | Historical original title unchanged (now step 1/6); DTOs, `GrokEventMapper.mapExtension`, `AcpChildSessionTracker`, exact metadata-based generic spawn suppression, and lifecycle cleanup |
+| ⚙️ | `acp: child sessions keep the root busy` | Historical original title unchanged (now step 2/6); typed tracker-change stream and owned subscription teardown, persisted children, and Layer-3 catalog/live merging |
+| 🚧 | `grok: child session history [step 3/6]` | full root/child replay production, generated DTOs, essential ACP and Grok integration/regression coverage, and supported-behavior docs |
+| 🌿 | `grok: cover child session history [step 4/6]` | supplemental collector/repository/service regressions plus detailed probe, matrix, and regression reconciliation |
+| ⚙️ | `grok: scoped stop for sub-agents [step 5/6]` | policy in `AcpPlugin.abortSession` (seam 3), including side-effect-free unsupported-`keep` rejection and child-only `keep`; `cancelChild` seam and its Grok request (seam 4); `interruptActiveWork` uses stop |
+| 🌱 | `docs: record Grok Build sub-agent coverage [step 6/6]` | final actual-plugin/client matrix and regression reconciliation |
 
 ### Probe results (Grok Build 1.0.5, 2026-09-03, details in `followups/grok-probe.md`)
 

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -11,10 +11,12 @@
   `docs/HARNESS_CAPABILITIES.md`. Codex steps 1–9 and Grok steps 1–3 are merged;
   bounded Codex Step 9 managed-0.153.4 actual-plugin policy QA passed on
   2026-09-10. Harness follow-ups remain active.
-- **Next action:** prepare Grok Step 4 under exact title
+- **Next action:** [PR #1427](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1427)
+  is current on `claude-inline-subtasks-grok-history-coverage-step4-current`
+  under exact title
   `🌿 [claude-inline-subtasks] grok: cover child session history [step 4/6]`.
   PR #1426 merged Step 3 at `517cbb9703025633efbb2658136d8aa0879daa75`;
-  Step 4 is integrated from that merge and remains unchecked until merged.
+  Step 4 remains unchecked until PR #1427 merges.
   [Policy QA](followups/codex-plugin-qa.md) verified side-effect-free
   root/named-child confirmation, root-only `keep`, named-child subtree
   isolation, root full-stop snapshot fanout, authoritative terminals plus
@@ -799,8 +801,9 @@ stop behavior changed in cleanup #1396.
 
 Grok history Step 3/6 keeps inherited ACP load/auth/drain ownership while a
 replay-local collector consumes standard updates plus both Grok lifecycle
-methods. Typed store → history repository → session service context supplies
-only exact child-owned first prompts; missing prompts emit no tile. Exact
+methods. Typed store → history repository → session service context uses each
+exact child's first child-owned user-message run only when nonblank; a blank or
+missing first run emits no tile, and later runs never substitute. Exact
 metadata-based spawn suppression leaves ordinary tools intact and no empty
 envelope, while one collector preserves deterministic identities/order around
 inserted tiles. DeepSeek's nullable replacement contract remains unchanged.
@@ -809,9 +812,11 @@ from mapper to collector, moved shared protocol classification below the
 live/replay collectors, and made history prompt discovery consume lazy typed
 records with first-run cancellation. Architecture and correctness review
 approved production at `b0d4974e`; packaging preserves that checkpoint on a
-named branch and changes no production/generated blob. Step 4 propagation is
-fulfilled on the new successor: Collector imports/names replace Mapper,
-repository/service preparation is awaited, and original plus moved collector,
-repository, service, malformed-boundary, privacy, cancellation, and
-missing-prompt coverage remain present. Original Step 4 stays untouched at
+named branch and changes no production/generated blob. Step 4 coverage is
+current on `claude-inline-subtasks-grok-history-coverage-step4-current` in PR
+#1427: Collector imports/names replace Mapper, tests use Dart `await` when
+calling asynchronous repository/service preparation, and original plus moved
+collector, repository, service, malformed-boundary, privacy, cancellation, and
+missing-prompt coverage remain present. This records completed async call
+semantics, not unfinished preparation work. Original Step 4 stays untouched at
 `fb47206bd`.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -3,32 +3,26 @@
 ## Current State
 
 - **Plan slug:** `claude-inline-subtasks`
-- **Implementation base:** `main` at `127ee3166f`, containing merged Codex
-  coverage [PR #1424](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1424)
-  at `b945755bfe`.
+- **Implementation base:** `main` at `517cbb9703`, containing merged Grok
+  history [PR #1426](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1426).
 - **Series state:** all eight original Claude steps merged, including the
   L4-found fix [#1257](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1257),
   which made scoped stop harness-neutral and added
-  `docs/HARNESS_CAPABILITIES.md`. Codex steps 1–9 are merged; bounded Step 9
-  managed-0.153.4 actual-plugin policy QA passed on 2026-09-10. Harness
-  follow-ups remain active.
-- **Next action:** [PR #1426](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1426)
-  is open/current under exact title
-  `🚧 [claude-inline-subtasks] grok: child session history [step 3/6]`.
-  Its published head is `0b0f79a859db380765359831171684cb4df65229`;
-  approved feedback head `b0d4974e116a2b413f0d0bfe9844d67d1dfe8a23`
-  is preserved on `claude-inline-subtasks-grok-history-pr1426-approved-checkpoint`,
-  while the current Step 3 branch adds packaging only. Step 4 is queued on
-  `claude-inline-subtasks-grok-history-coverage-step4-successor`; original full
-  checkpoint `704006bf8e8adbd02935fd81cfddd541d5bd9b7d` and original Step 4
-  `fb47206bd0ed4cc521dde4a0f921281d8d1a8d33` remain intact.
+  `docs/HARNESS_CAPABILITIES.md`. Codex steps 1–9 and Grok steps 1–3 are merged;
+  bounded Codex Step 9 managed-0.153.4 actual-plugin policy QA passed on
+  2026-09-10. Harness follow-ups remain active.
+- **Next action:** prepare Grok Step 4 under exact title
+  `🌿 [claude-inline-subtasks] grok: cover child session history [step 4/6]`.
+  PR #1426 merged Step 3 at `517cbb9703025633efbb2658136d8aa0879daa75`;
+  Step 4 is integrated from that merge and remains unchecked until merged.
   [Policy QA](followups/codex-plugin-qa.md) verified side-effect-free
   root/named-child confirmation, root-only `keep`, named-child subtree
   isolation, root full-stop snapshot fanout, authoritative terminals plus
   plugin settlement, false atomic acknowledgment, and runtime survival. No
   pending input surfaced, so the executed policy scope passed but the live
   matrix is partial; no phone, relay, or desktop coverage is claimed. DeepSeek #1363, #1370, and
-  live-QA crash fix #1379 are merged. Requested phone-only stop/input checks
+  live-QA crash fix #1379 are merged. Codex coverage #1424 merged at
+  `b945755bfe`; historical Codex titles remain unchanged. Requested phone-only stop/input checks
   passed; see `followups/deepseek-phone-qa.md`. Desktop remains deferred by
   user choice; overall plan stays active for Grok, DeepSeek documentation, and
   Cursor follow-ups.
@@ -188,11 +182,11 @@ post-merge E2E gates are unchanged.
 | [x] | Codex | `🚧 [claude-inline-subtasks] codex: integrate live and replay tiles [step 6/9]` | [PR #1399](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1399) merged at `db2b71134d`; full live/replay production and behavior docs; [actual-plugin QA](followups/codex-plugin-qa.md) passed bounded cases with explicit unexecuted coverage |
 | [x] | Codex | `🌿 [claude-inline-subtasks] codex: cover live tile lifecycle [step 7/9]` | [PR #1420](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1420) merged at `ae2a9297e3`; write-path/lifecycle coverage and docs |
 | [x] | Codex | `⚙️ [claude-inline-subtasks] codex: scoped stop for sub-agent threads [step 8/9]` | [PR #1421](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1421) merged at `77165f784f`; per-thread snapshot fanout, non-atomic (not native subtree cancellation); automated coverage included |
-| [x] | Codex | `🌱 [claude-inline-subtasks] docs: record Codex sub-agent coverage [step 9/9]` | [PR #1424](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1424) merged at `b945755bfe`; pending-input live case unexecuted |
+| [x] | Codex | `🌱 [claude-inline-subtasks] docs: record Codex sub-agent coverage [step 9/9]` | [PR #1424](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1424) merged at `b945755bfe`; managed-0.153.4 actual-plugin policy QA passed; pending-input live case unexecuted |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] grok: parse sub-agent lifecycle notifications` | [PR #1270](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1270) merged; historical original title unchanged (now step 1/6) |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] acp: child sessions keep the root busy` | [PR #1272](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1272) merged; historical original title unchanged (now step 2/6) |
-| [ ] | Grok | `🚧 [claude-inline-subtasks] grok: child session history [step 3/6]` | [PR #1426](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1426) open/current; updated local `claude-inline-subtasks-grok-history-step3` keeps approved production, root/direct-child integration, and no-`loadSession` coverage while moving supplemental unit coverage additively |
-| [ ] | Grok | `🌿 [claude-inline-subtasks] grok: cover child session history [step 4/6]` | Queued on new `claude-inline-subtasks-grok-history-coverage-step4-successor`; integrates original `fb47206bd` tests/docs plus moved ACP collector and Grok repository coverage against the approved Collector/async API |
+| [x] | Grok | `🚧 [claude-inline-subtasks] grok: child session history [step 3/6]` | [PR #1426](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1426) merged at `517cbb9703`; approved production, root/direct-child integration, and no-`loadSession` coverage |
+| [ ] | Grok | `🌿 [claude-inline-subtasks] grok: cover child session history [step 4/6]` | Integrated on `claude-inline-subtasks-grok-history-coverage-step4-current`; original `fb47206bd` tests/docs plus moved ACP collector and Grok repository coverage use the approved Collector/async API; remains unchecked until merged |
 | [ ] | Grok | `⚙️ [claude-inline-subtasks] grok: scoped stop for sub-agents [step 5/6]` | Not started |
 | [ ] | Grok | `🌱 [claude-inline-subtasks] docs: record Grok Build sub-agent coverage [step 6/6]` | Not started |
 | [x] | DeepSeek (adapter) | `⚙️ sessions: sub-agent lifecycle notifications and child transcripts` | [sesori-deepseek-acp #13](https://github.com/sesori-ai/sesori-deepseek-acp/pull/13) merged at `0a85fb2` |
@@ -554,11 +548,13 @@ and prompt-id conventions before invoking backend-neutral hold/release
 operations.
 
 A second follow-up `architecture-plan-review` on 2026-09-03 covered the later
-stop-policy, Grok denied-spawn, and DeepSeek prompt/settlement amendments. It
-rejected one finding, applied without re-review: deferred Grok tool-call state
-moved out of `AcpEventMapper` into a Layer-2
-`AcpDeferredToolCallTracker` with session, disconnect, and process-exit
-cleanup. The stop policy and DeepSeek adapter/plugin ownership passed.
+stop-policy, Grok denied-spawn, and DeepSeek prompt/settlement amendments. Its
+historical deferred Grok permission-state finding was superseded before
+implementation: current production has no `AcpDeferredToolCallTracker`, and the
+2026-09-10 unchanged-config probe exposed no denyable permission request or
+persisted outcome. This history step therefore keeps exact spawn suppression
+and accepts denied generic-card omission. The stop policy and DeepSeek
+adapter/plugin ownership passed.
 
 A third follow-up `architecture-plan-review` on 2026-09-03 approved the Codex
 service-owned lifecycle flow and replay replacement, the proportional Grok
@@ -792,8 +788,8 @@ passed root/named-child confirmation and scoped interruption, including
 persisted native terminals, plugin settlement, runtime survival, and the
 non-atomic `subAgentsHandled: false` acknowledgment that retains client fanout.
 The live matrix remains partial because no pending question or permission
-surfaced. Final coverage 9/9 stays unchecked until this documentation step
-merges, and the overall plan remains active for the other harness gates.
+surfaced. Final coverage 9/9 merged as PR #1424 at `b945755bfe`; the overall
+plan remains active for the other harness gates.
 Rejected tile work remains at
 `claude-inline-subtasks-codex-tiles-step4-integrated` (`c6aa29a8ce`), while
 `claude-inline-subtasks-codex-tiles-successor` (`8f9923b663`) and
@@ -801,13 +797,20 @@ Rejected tile work remains at
 untouched. No runtime pin, native source, client/shared contract, database, or
 stop behavior changed in cleanup #1396.
 
-Grok Step 3 review follow-up renamed the new stateful replay seam and Grok
-implementation from mapper to collector, moved shared protocol classification
-below the live/replay collectors, and made history prompt discovery consume
-lazy typed records with first-run cancellation. Architecture and correctness
-review approved production at `b0d4974e`; packaging preserves that checkpoint
-on a named branch and changes no production/generated blob. Step 4 propagation
-is fulfilled on the new successor: Collector imports/names replace Mapper,
+Grok history Step 3/6 keeps inherited ACP load/auth/drain ownership while a
+replay-local collector consumes standard updates plus both Grok lifecycle
+methods. Typed store → history repository → session service context supplies
+only exact child-owned first prompts; missing prompts emit no tile. Exact
+metadata-based spawn suppression leaves ordinary tools intact and no empty
+envelope, while one collector preserves deterministic identities/order around
+inserted tiles. DeepSeek's nullable replacement contract remains unchanged.
+Review follow-up renamed the new stateful replay seam and Grok implementation
+from mapper to collector, moved shared protocol classification below the
+live/replay collectors, and made history prompt discovery consume lazy typed
+records with first-run cancellation. Architecture and correctness review
+approved production at `b0d4974e`; packaging preserves that checkpoint on a
+named branch and changes no production/generated blob. Step 4 propagation is
+fulfilled on the new successor: Collector imports/names replace Mapper,
 repository/service preparation is awaited, and original plus moved collector,
 repository, service, malformed-boundary, privacy, cancellation, and
 missing-prompt coverage remain present. Original Step 4 stays untouched at

--- a/.plan/active/claude-inline-subtasks/followups/grok-probe.md
+++ b/.plan/active/claude-inline-subtasks/followups/grok-probe.md
@@ -80,12 +80,26 @@ ordering, and enum values are recorded; no prompt or transcript text.
 
 ## Replay of the extension frames
 
-`session/load` does **not** replay `_x.ai/session_notification`. The same
-sub-agent facts come back under a different method, `_x.ai/session/update`
+Persisted `session/load` facts normally replay under `_x.ai/session/update`
 (same `{sessionId, update: {sessionUpdate, ...}}` shape): a root load replays
 `subagent_spawned`, `subagent_finished`, and `turn_completed`; a child load
 replays the child's `turn_completed`. Standard frames (`user_message_chunk`,
 `tool_call` with its terminal status) replay as ordinary `session/update`.
+A bounded 2026-09-10 cancellation probe added one ordering case: after a loaded
+unfinished episode returned its load response, authoritative settlement arrived
+through `_x.ai/session_notification`. Replay therefore consumes both Grok
+methods until the existing quiet-window drain completes.
+
+## 2026-09-10 cancellation and denial follow-up
+
+A root cancelled immediately after its spawn call still persisted typed
+`subagent_spawned` and terminal `subagent_finished {status: cancelled}`. The
+cancelled child's own fresh `session/load` succeeded but replayed no
+`user_message_chunk` or `turn_completed`; without a child-owned prompt, Sesori
+must not fabricate a tile. Intended denied/cancelled-permission attempts exposed
+zero `session/request_permission` frames because the unchanged runtime/config
+resolved interaction automatically. Denial persistence is therefore unverified:
+no permission-outcome model or generic-card replay guarantee is justified.
 
 ## Consequences for the design
 

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -11,6 +11,37 @@ void main() {
   group("AcpReplayCollector", () {
     Map<String, dynamic> upd(Map<String, dynamic> body) => {"update": body};
 
+    test("collects only canonical session update notifications", () {
+      final collector = AcpReplayCollector(
+        sessionUpdateNormalizer: null,
+        sessionId: "s1",
+        agentId: "ACP",
+        initialUserMessageId: null,
+        messageIdOverride: null,
+        messageTimeResolver: null,
+        haltClassifier: null,
+        toolPartReplacement: null,
+        toolPartSuppression: null,
+      );
+      final params = {
+        "sessionId": "s1",
+        "update": {
+          "sessionUpdate": "user_message_chunk",
+          "content": {"type": "text", "text": "Prompt"},
+        },
+      };
+
+      collector
+        ..consumeNotification(
+          notification: AcpNotification(method: "foreign/update", params: params),
+        )
+        ..consumeNotification(
+          notification: AcpNotification(method: AcpMethods.sessionUpdate, params: params),
+        );
+
+      expect(collector.build(), hasLength(1));
+    });
+
     final assistantParityCases = <({String name, List<Map<String, dynamic>> updates})>[
       (
         name: "mixed content in one chunk",
@@ -1118,6 +1149,164 @@ void main() {
       final part = collector.build().single.parts.single as PluginMessagePartSubtask;
       expect(part.id, "s1-h0-assistant-tool-call-1");
       expect(part.childSessionID, "child-1");
+    });
+
+    test("suppression removes only classified tools and leaves no empty message", () {
+      final collector =
+          AcpReplayCollector(
+              sessionUpdateNormalizer: null,
+              sessionId: "s1",
+              agentId: "ACP",
+              initialUserMessageId: null,
+              messageIdOverride: null,
+              messageTimeResolver: null,
+              haltClassifier: null,
+              toolPartReplacement: null,
+              toolPartSuppression: ({required update}) => update["_meta"] == "suppress",
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call",
+                "toolCallId": "hidden",
+                "_meta": "suppress",
+              }),
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "tool_call",
+                "toolCallId": "visible",
+                "title": "ordinary",
+              }),
+            );
+
+      final messages = collector.build();
+      expect(messages, hasLength(1));
+      expect(messages.single.parts.single, isA<PluginMessagePartTool>());
+      expect((messages.single.parts.single as PluginMessagePartTool).tool, "ordinary");
+      expect(messages.every((message) => message.parts.isNotEmpty), isTrue);
+    });
+
+    test("inserted messages split an explicit assistant id into unique deterministic segments", () {
+      final collector =
+          AcpReplayCollector(
+              sessionUpdateNormalizer: null,
+              sessionId: "s1",
+              agentId: "ACP",
+              initialUserMessageId: null,
+              messageIdOverride: null,
+              messageTimeResolver: null,
+              haltClassifier: null,
+              toolPartReplacement: null,
+              toolPartSuppression: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "m1",
+                "content": {"type": "text", "text": "before"},
+              }),
+            )
+            ..upsertAssistantMessage(
+              messageId: "s1-child",
+              parts: const [],
+              time: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "m1",
+                "content": {"type": "text", "text": "after"},
+              }),
+            );
+
+      final messages = collector.build();
+      expect(
+        messages.map((message) => message.info.id),
+        ["s1-mm1-assistant", "s1-child", "s1-mm1-assistant-segment-2"],
+      );
+      expect(messages[0].parts.single.id, "s1-mm1-assistant-text");
+      expect(messages[2].parts.single.id, "s1-mm1-assistant-segment-2-text");
+      expect(messages.map((message) => message.info.id).toSet(), hasLength(3));
+    });
+
+    test("inserted messages split a user override id without replacing its identity", () {
+      final collector =
+          AcpReplayCollector(
+              sessionUpdateNormalizer: null,
+              sessionId: "s1",
+              agentId: "ACP",
+              initialUserMessageId: null,
+              messageIdOverride: ({required acpMessageId}) => "authoritative-$acpMessageId",
+              messageTimeResolver: null,
+              haltClassifier: null,
+              toolPartReplacement: null,
+              toolPartSuppression: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "user_message_chunk",
+                "messageId": "u1",
+                "content": {"type": "text", "text": "before"},
+              }),
+            )
+            ..upsertAssistantMessage(
+              messageId: "s1-child",
+              parts: const [],
+              time: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "user_message_chunk",
+                "messageId": "u1",
+                "content": {"type": "text", "text": "after"},
+              }),
+            );
+
+      final messages = collector.build();
+      expect(
+        messages.map((message) => message.info.id),
+        ["authoritative-u1", "s1-child", "authoritative-u1-segment-2"],
+      );
+      expect(messages[0].parts.single.id, "authoritative-u1-text");
+      expect(messages[2].parts.single.id, "authoritative-u1-segment-2-text");
+      expect(messages.map((message) => message.info.id).toSet(), hasLength(3));
+    });
+
+    test("inserted messages retain one collector's deterministic identity continuity", () {
+      final collector =
+          AcpReplayCollector(
+              sessionUpdateNormalizer: null,
+              sessionId: "s1",
+              agentId: "ACP",
+              initialUserMessageId: "s1-initial-user",
+              messageIdOverride: null,
+              messageTimeResolver: null,
+              haltClassifier: null,
+              toolPartReplacement: null,
+              toolPartSuppression: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "user_message_chunk",
+                "content": {"type": "text", "text": "before"},
+              }),
+            )
+            ..upsertAssistantMessage(
+              messageId: "s1-child",
+              parts: const [],
+              time: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "user_message_chunk",
+                "content": {"type": "text", "text": "after"},
+              }),
+            );
+
+      expect(
+        collector.build().map((message) => message.info.id),
+        ["s1-initial-user", "s1-child", "s1-h1-user"],
+      );
     });
   });
 }

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -23,23 +23,36 @@ void main() {
         toolPartReplacement: null,
         toolPartSuppression: null,
       );
-      final params = {
+      final foreignParams = {
         "sessionId": "s1",
         "update": {
           "sessionUpdate": "user_message_chunk",
-          "content": {"type": "text", "text": "Prompt"},
+          "content": {"type": "text", "text": "Foreign prompt"},
+        },
+      };
+      final canonicalParams = {
+        "sessionId": "s1",
+        "update": {
+          "sessionUpdate": "user_message_chunk",
+          "content": {"type": "text", "text": "Canonical prompt"},
         },
       };
 
       collector
         ..consumeNotification(
-          notification: AcpNotification(method: "foreign/update", params: params),
+          notification: AcpNotification(method: "foreign/update", params: foreignParams),
         )
         ..consumeNotification(
-          notification: AcpNotification(method: AcpMethods.sessionUpdate, params: params),
+          notification: AcpNotification(method: AcpMethods.sessionUpdate, params: canonicalParams),
         );
 
-      expect(collector.build(), hasLength(1));
+      final messages = collector.build();
+      expect(messages, hasLength(1));
+      expect(messages.single.parts, hasLength(1));
+      expect(
+        messages.single.parts.single,
+        isA<PluginMessagePartText>().having((part) => part.text, "text", "Canonical prompt"),
+      );
     });
 
     final assistantParityCases = <({String name, List<Map<String, dynamic>> updates})>[

--- a/bridge/sesori_plugin_grok/test/grok_session_history_repository_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_history_repository_test.dart
@@ -6,7 +6,6 @@ import "package:grok_plugin/src/api/grok_session_store_api.dart";
 import "package:grok_plugin/src/api/models/grok_session_notification_dto.dart";
 import "package:grok_plugin/src/api/models/grok_session_store_dto.dart";
 import "package:grok_plugin/src/repositories/grok_session_history_repository.dart";
-import "package:grok_plugin/src/repositories/models/grok_session_replay_context.dart";
 import "package:path/path.dart" as p;
 import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";

--- a/bridge/sesori_plugin_grok/test/grok_session_history_repository_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_history_repository_test.dart
@@ -18,16 +18,16 @@ void main() {
   late GrokSessionStoreApi api;
   late GrokSessionHistoryRepository repository;
 
-  String updatesPath(String sessionId) =>
+  String updatesPath({required String sessionId}) =>
       p.join(sessions.path, Uri.encodeComponent(cwd), sessionId, GrokSessionStoreApi.updatesFileName);
 
-  void writeUpdates(String sessionId, List<Object> updates) {
-    File(updatesPath(sessionId))
+  void writeUpdates({required String sessionId, required List<Object> updates}) {
+    File(updatesPath(sessionId: sessionId))
       ..createSync(recursive: true)
       ..writeAsStringSync(updates.map((update) => update is String ? update : jsonEncode(update)).join("\n"));
   }
 
-  Map<String, dynamic> spawn(String childId) => {
+  Map<String, dynamic> spawn({required String childId}) => {
     "method": GrokSessionProtocol.updateMethod,
     "params": {
       "sessionId": root,
@@ -40,7 +40,7 @@ void main() {
     },
   };
 
-  Map<String, dynamic> standard(String sessionId, Map<String, dynamic> update) => {
+  Map<String, dynamic> standard({required String sessionId, required Map<String, dynamic> update}) => {
     "method": AcpMethods.sessionUpdate,
     "params": {"sessionId": sessionId, "update": update},
   };
@@ -54,33 +54,61 @@ void main() {
   tearDown(() => sessions.deleteSync(recursive: true));
 
   test("keys exact children and concatenates only first child-owned user run", () async {
-    writeUpdates(root, [spawn("child-a"), spawn("child-b"), spawn("child-a")]);
-    writeUpdates("child-a", [
-      {"method": "foreign/before"},
-      standard("child-a", {
-        "sessionUpdate": "user_message_chunk",
-        "content": {"type": "text", "text": "first "},
-      }),
-      standard("child-a", {
-        "sessionUpdate": "user_message_chunk",
-        "content": {"type": "image", "data": "ignored"},
-      }),
-      standard("child-a", {
-        "sessionUpdate": "user_message_chunk",
-        "content": {"type": "text", "text": "prompt"},
-      }),
-      standard("child-a", {"sessionUpdate": "future_unknown_update"}),
-      standard("child-a", {
-        "sessionUpdate": "user_message_chunk",
-        "content": {"type": "text", "text": " later"},
-      }),
-    ]);
-    writeUpdates("child-b", [
-      standard("different-child", {
-        "sessionUpdate": "user_message_chunk",
-        "content": {"type": "text", "text": "wrong owner"},
-      }),
-    ]);
+    writeUpdates(
+      sessionId: root,
+      updates: [
+        spawn(childId: "child-a"),
+        spawn(childId: "child-b"),
+        spawn(childId: "child-a"),
+      ],
+    );
+    writeUpdates(
+      sessionId: "child-a",
+      updates: [
+        {"method": "foreign/before"},
+        standard(
+          sessionId: "child-a",
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": "first "},
+          },
+        ),
+        standard(
+          sessionId: "child-a",
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "image", "data": "ignored"},
+          },
+        ),
+        standard(
+          sessionId: "child-a",
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": "prompt"},
+          },
+        ),
+        standard(sessionId: "child-a", update: {"sessionUpdate": "future_unknown_update"}),
+        standard(
+          sessionId: "child-a",
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": " later"},
+          },
+        ),
+      ],
+    );
+    writeUpdates(
+      sessionId: "child-b",
+      updates: [
+        standard(
+          sessionId: "different-child",
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": "wrong owner"},
+          },
+        ),
+      ],
+    );
 
     final context = await repository.prepareReplayContext(cwd: cwd, rootSessionId: root);
     expect(context.childPrompts, {"child-a": "first prompt"});
@@ -89,18 +117,30 @@ void main() {
 
   test("malformed child record is a private diagnosed boundary between user runs", () async {
     const secretTranscriptSource = "PRIVATE_PROMPT_SHOULD_NOT_REACH_LOGS";
-    writeUpdates(root, [spawn("child")]);
-    writeUpdates("child", [
-      standard("child", {
-        "sessionUpdate": "user_message_chunk",
-        "content": {"type": "text", "text": "first prompt"},
-      }),
-      "! malformed $secretTranscriptSource",
-      standard("child", {
-        "sessionUpdate": "user_message_chunk",
-        "content": {"type": "text", "text": " fabricated continuation"},
-      }),
-    ]);
+    writeUpdates(
+      sessionId: root,
+      updates: [spawn(childId: "child")],
+    );
+    writeUpdates(
+      sessionId: "child",
+      updates: [
+        standard(
+          sessionId: "child",
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": "first prompt"},
+          },
+        ),
+        "! malformed $secretTranscriptSource",
+        standard(
+          sessionId: "child",
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": " fabricated continuation"},
+          },
+        ),
+      ],
+    );
 
     final previousLevel = Log.level;
     final stderr = BufferingStdout();
@@ -125,7 +165,7 @@ void main() {
       isA<GrokPersistedAcpSessionUpdateDto>(),
     ]);
     expect(prompts, {"child": "first prompt"});
-    expect(stderr.text, contains("${updatesPath("child")}, line 2"));
+    expect(stderr.text, contains("${updatesPath(sessionId: "child")}, line 2"));
     expect(stderr.text, contains("FormatException"));
     expect(stderr.text, contains("Unexpected character"));
     expect(stderr.text, contains("offset 0"));
@@ -133,21 +173,49 @@ void main() {
     expect(stderr.text, isNot(contains(secretTranscriptSource)));
   });
 
-  test("missing files, malformed lines, and empty prompts omit only affected children", () async {
-    writeUpdates(root, [spawn("missing"), "not json", spawn("empty"), spawn("valid")]);
-    writeUpdates("empty", [
-      standard("empty", {
-        "sessionUpdate": "user_message_chunk",
-        "content": {"type": "text", "text": "   "},
-      }),
-    ]);
-    writeUpdates("valid", [
-      "broken child line",
-      standard("valid", {
-        "sessionUpdate": "user_message_chunk",
-        "content": {"type": "text", "text": "valid prompt"},
-      }),
-    ]);
+  test("missing files, malformed lines, and blank first runs omit only affected children", () async {
+    writeUpdates(
+      sessionId: root,
+      updates: [
+        spawn(childId: "missing"),
+        "not json",
+        spawn(childId: "empty"),
+        spawn(childId: "valid"),
+      ],
+    );
+    writeUpdates(
+      sessionId: "empty",
+      updates: [
+        standard(
+          sessionId: "empty",
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": "   "},
+          },
+        ),
+        standard(sessionId: "empty", update: {"sessionUpdate": "future_unknown_update"}),
+        standard(
+          sessionId: "empty",
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": "must not replace blank first run"},
+          },
+        ),
+      ],
+    );
+    writeUpdates(
+      sessionId: "valid",
+      updates: [
+        "broken child line",
+        standard(
+          sessionId: "valid",
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": "valid prompt"},
+          },
+        ),
+      ],
+    );
 
     expect(
       (await repository.prepareReplayContext(cwd: cwd, rootSessionId: root)).childPrompts,

--- a/bridge/sesori_plugin_grok/test/grok_session_history_repository_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_history_repository_test.dart
@@ -1,0 +1,212 @@
+import "dart:convert";
+import "dart:io";
+
+import "package:acp_plugin/acp_plugin.dart" show AcpMethods;
+import "package:grok_plugin/src/api/grok_session_store_api.dart";
+import "package:grok_plugin/src/api/models/grok_session_notification_dto.dart";
+import "package:grok_plugin/src/api/models/grok_session_store_dto.dart";
+import "package:grok_plugin/src/repositories/grok_session_history_repository.dart";
+import "package:grok_plugin/src/repositories/models/grok_session_replay_context.dart";
+import "package:path/path.dart" as p;
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  const cwd = "/tmp/history-project";
+  const root = "root";
+  late Directory sessions;
+  late GrokSessionStoreApi api;
+  late GrokSessionHistoryRepository repository;
+
+  String updatesPath(String sessionId) =>
+      p.join(sessions.path, Uri.encodeComponent(cwd), sessionId, GrokSessionStoreApi.updatesFileName);
+
+  void writeUpdates(String sessionId, List<Object> updates) {
+    File(updatesPath(sessionId))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(updates.map((update) => update is String ? update : jsonEncode(update)).join("\n"));
+  }
+
+  Map<String, dynamic> spawn(String childId) => {
+    "method": GrokSessionProtocol.updateMethod,
+    "params": {
+      "sessionId": root,
+      "update": {
+        "sessionUpdate": "subagent_spawned",
+        "subagent_id": childId,
+        "child_session_id": childId,
+        "description": "Child $childId",
+      },
+    },
+  };
+
+  Map<String, dynamic> standard(String sessionId, Map<String, dynamic> update) => {
+    "method": AcpMethods.sessionUpdate,
+    "params": {"sessionId": sessionId, "update": update},
+  };
+
+  setUp(() {
+    sessions = Directory.systemTemp.createTempSync("grok-history-");
+    api = GrokSessionStoreApi(sessionsRoot: sessions.path, pluginId: "grok-test");
+    repository = GrokSessionHistoryRepository(api: api);
+  });
+
+  tearDown(() => sessions.deleteSync(recursive: true));
+
+  test("keys exact children and concatenates only first child-owned user run", () async {
+    writeUpdates(root, [spawn("child-a"), spawn("child-b"), spawn("child-a")]);
+    writeUpdates("child-a", [
+      {"method": "foreign/before"},
+      standard("child-a", {
+        "sessionUpdate": "user_message_chunk",
+        "content": {"type": "text", "text": "first "},
+      }),
+      standard("child-a", {
+        "sessionUpdate": "user_message_chunk",
+        "content": {"type": "image", "data": "ignored"},
+      }),
+      standard("child-a", {
+        "sessionUpdate": "user_message_chunk",
+        "content": {"type": "text", "text": "prompt"},
+      }),
+      standard("child-a", {"sessionUpdate": "future_unknown_update"}),
+      standard("child-a", {
+        "sessionUpdate": "user_message_chunk",
+        "content": {"type": "text", "text": " later"},
+      }),
+    ]);
+    writeUpdates("child-b", [
+      standard("different-child", {
+        "sessionUpdate": "user_message_chunk",
+        "content": {"type": "text", "text": "wrong owner"},
+      }),
+    ]);
+
+    final context = await repository.prepareReplayContext(cwd: cwd, rootSessionId: root);
+    expect(context.childPrompts, {"child-a": "first prompt"});
+    expect(() => context.childPrompts["child-c"] = "mutation", throwsUnsupportedError);
+  });
+
+  test("malformed child record is a private diagnosed boundary between user runs", () async {
+    const secretTranscriptSource = "PRIVATE_PROMPT_SHOULD_NOT_REACH_LOGS";
+    writeUpdates(root, [spawn("child")]);
+    writeUpdates("child", [
+      standard("child", {
+        "sessionUpdate": "user_message_chunk",
+        "content": {"type": "text", "text": "first prompt"},
+      }),
+      "! malformed $secretTranscriptSource",
+      standard("child", {
+        "sessionUpdate": "user_message_chunk",
+        "content": {"type": "text", "text": " fabricated continuation"},
+      }),
+    ]);
+
+    final previousLevel = Log.level;
+    final stderr = BufferingStdout();
+    late List<GrokPersistedUpdateDto> updates;
+    late Map<String, String> prompts;
+    try {
+      Log.level = LogLevel.warning;
+      await IOOverrides.runZoned(
+        () async {
+          updates = api.readUpdates(cwd: cwd, sessionId: "child");
+          prompts = (await repository.prepareReplayContext(cwd: cwd, rootSessionId: root)).childPrompts;
+        },
+        stderr: () => stderr,
+      );
+    } finally {
+      Log.level = previousLevel;
+    }
+
+    expect(updates, [
+      isA<GrokPersistedAcpSessionUpdateDto>(),
+      isA<GrokPersistedUpdateUnknownDto>(),
+      isA<GrokPersistedAcpSessionUpdateDto>(),
+    ]);
+    expect(prompts, {"child": "first prompt"});
+    expect(stderr.text, contains("${updatesPath("child")}, line 2"));
+    expect(stderr.text, contains("FormatException"));
+    expect(stderr.text, contains("Unexpected character"));
+    expect(stderr.text, contains("offset 0"));
+    expect(stderr.text, contains("_parseUpdate"), reason: "the original parse stack remains useful");
+    expect(stderr.text, isNot(contains(secretTranscriptSource)));
+  });
+
+  test("missing files, malformed lines, and empty prompts omit only affected children", () async {
+    writeUpdates(root, [spawn("missing"), "not json", spawn("empty"), spawn("valid")]);
+    writeUpdates("empty", [
+      standard("empty", {
+        "sessionUpdate": "user_message_chunk",
+        "content": {"type": "text", "text": "   "},
+      }),
+    ]);
+    writeUpdates("valid", [
+      "broken child line",
+      standard("valid", {
+        "sessionUpdate": "user_message_chunk",
+        "content": {"type": "text", "text": "valid prompt"},
+      }),
+    ]);
+
+    expect(
+      (await repository.prepareReplayContext(cwd: cwd, rootSessionId: root)).childPrompts,
+      {"valid": "valid prompt"},
+    );
+    expect(() => api.readUpdates(cwd: cwd, sessionId: "../root"), throwsArgumentError);
+  });
+
+  test("first child prompt boundary cancels lazy record iteration", () async {
+    final earlyBoundaryApi = _EarlyBoundaryStoreApi();
+    final context = await GrokSessionHistoryRepository(api: earlyBoundaryApi)
+        .prepareReplayContext(cwd: cwd, rootSessionId: root)
+        .timeout(const Duration(seconds: 1));
+
+    expect(context.childPrompts, {"child": "First prompt"});
+    expect(earlyBoundaryApi.childStreamCancelled, isTrue);
+    expect(earlyBoundaryApi.readPastBoundary, isFalse);
+  });
+}
+
+final class _EarlyBoundaryStoreApi() extends GrokSessionStoreApi {
+  this : super(sessionsRoot: null, pluginId: "grok-test");
+
+  bool childStreamCancelled = false;
+  bool readPastBoundary = false;
+
+  @override
+  Stream<GrokPersistedUpdateDto> streamUpdates({required String cwd, required String sessionId}) async* {
+    if (sessionId == "root") {
+      yield const GrokPersistedUpdateDto.grokSessionUpdate(
+        params: GrokSessionNotificationDto(
+          sessionId: "root",
+          update: GrokSubagentUpdate.subagentSpawned(
+            subagentId: "child",
+            childSessionId: "child",
+            subagentType: null,
+            description: "Child task",
+            model: null,
+          ),
+        ),
+      );
+      return;
+    }
+
+    try {
+      yield const GrokPersistedUpdateDto.acpSessionUpdate(
+        params: GrokPersistedAcpNotificationDto(
+          sessionId: "child",
+          update: GrokPersistedAcpUpdateDto.userMessageChunk(
+            content: GrokPersistedContentDto.text(text: "First prompt"),
+          ),
+        ),
+      );
+      yield const GrokPersistedUpdateDto.unknown();
+      readPastBoundary = true;
+      throw StateError("child transcript was read past its first prompt run");
+    } finally {
+      childStreamCancelled = true;
+    }
+  }
+}

--- a/bridge/sesori_plugin_grok/test/grok_session_replay_collector_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_replay_collector_test.dart
@@ -1,0 +1,221 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:grok_plugin/src/api/models/grok_session_notification_dto.dart";
+import "package:grok_plugin/src/repositories/mappers/grok_session_replay_collector.dart";
+import "package:grok_plugin/src/repositories/models/grok_session_replay_context.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  late AcpReplayCollector collector;
+  late GrokSessionReplayCollector replayCollector;
+
+  AcpNotification standard(Map<String, dynamic> update) => AcpNotification(
+    method: AcpMethods.sessionUpdate,
+    params: {"sessionId": "root", "update": update},
+  );
+
+  AcpNotification lifecycle({
+    required String method,
+    required Map<String, dynamic> update,
+  }) => AcpNotification(
+    method: method,
+    params: {"sessionId": "root", "update": update},
+  );
+
+  void createCollector({Map<String, String> prompts = const {"child-a": "Prompt A", "child-b": "Prompt B"}}) {
+    collector = AcpReplayCollector(
+      sessionUpdateNormalizer: null,
+      sessionId: "root",
+      agentId: "grok",
+      initialUserMessageId: null,
+      messageIdOverride: null,
+      messageTimeResolver: null,
+      haltClassifier: null,
+      toolPartReplacement: null,
+      toolPartSuppression: GrokSessionProtocol.isSpawnSubagentUpdate,
+    );
+    replayCollector = GrokSessionReplayCollector(
+      sessionId: "root",
+      standardCollector: collector,
+      context: GrokSessionReplayContext(childPrompts: prompts),
+    );
+  }
+
+  Map<String, dynamic> spawned(String childId, String description) => {
+    "sessionUpdate": "subagent_spawned",
+    "subagent_id": childId,
+    "child_session_id": childId,
+    "subagent_type": "general-purpose",
+    "description": description,
+  };
+
+  Map<String, dynamic> finished(String childId, String status, {String? output, String? error}) => {
+    "sessionUpdate": "subagent_finished",
+    "subagent_id": childId,
+    "child_session_id": childId,
+    "status": status,
+    "output": output,
+    "error": error,
+    "will_wake": false,
+  };
+
+  List<PluginMessageWithParts> build() => replayCollector.buildWithAssistantSelection(
+    modelId: "model-a",
+    providerId: "grok",
+    variant: "high",
+  );
+
+  setUp(createCollector);
+
+  test("suppresses typed spawn card and inserts one terminal tile in wire order", () {
+    replayCollector
+      ..consumeNotification(
+        notification: standard({
+          "sessionUpdate": "user_message_chunk",
+          "content": {"type": "text", "text": "Root prompt"},
+        }),
+      )
+      ..consumeNotification(
+        notification: standard({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "spawn-call",
+          "_meta": {
+            "x.ai/tool": {"name": "spawn_subagent", "kind": "task"},
+          },
+        }),
+      )
+      ..consumeNotification(
+        notification: lifecycle(
+          method: GrokSessionProtocol.updateMethod,
+          update: spawned("child-a", "Child A"),
+        ),
+      )
+      ..consumeNotification(
+        notification: standard({
+          "sessionUpdate": "tool_call",
+          "toolCallId": "ordinary-call",
+          "title": "Read file",
+          "status": "completed",
+        }),
+      )
+      ..consumeNotification(
+        notification: lifecycle(
+          method: GrokSessionProtocol.notificationMethod,
+          update: finished("child-a", "completed", output: "Result A"),
+        ),
+      );
+
+    final messages = build();
+    expect(messages, hasLength(3));
+    expect(messages.expand((message) => message.parts), hasLength(3));
+    expect(messages.expand((message) => message.parts).whereType<PluginMessagePartTool>(), hasLength(1));
+    final tile = messages.expand((message) => message.parts).whereType<PluginMessagePartSubtask>().single;
+    expect(tile.id, "root-subagent-child-a-subtask");
+    expect(tile.messageID, "root-subagent-child-a");
+    expect(tile.childSessionID, "child-a");
+    expect(tile.prompt, "Prompt A");
+    expect(tile.taskState!.status, PluginToolStatus.completed);
+    expect(tile.taskState!.output, "Result A");
+    expect(messages.every((message) => message.parts.isNotEmpty), isTrue);
+    final tileMessage = messages[1].info as PluginMessageAssistant;
+    expect(
+      (tileMessage.agent, tileMessage.modelID, tileMessage.providerID, tileMessage.variant),
+      ("grok", "model-a", "grok", "high"),
+    );
+  });
+
+  test("multiple children remain ordered and duplicate lifecycle updates retain identity", () {
+    replayCollector
+      ..consumeNotification(
+        notification: lifecycle(
+          method: GrokSessionProtocol.updateMethod,
+          update: spawned("child-a", "Same description"),
+        ),
+      )
+      ..consumeNotification(
+        notification: standard({
+          "sessionUpdate": "agent_message_chunk",
+          "content": {"type": "text", "text": "Between"},
+        }),
+      )
+      ..consumeNotification(
+        notification: lifecycle(
+          method: GrokSessionProtocol.notificationMethod,
+          update: spawned("child-b", "Same description"),
+        ),
+      )
+      ..consumeNotification(
+        notification: lifecycle(
+          method: GrokSessionProtocol.updateMethod,
+          update: finished("child-b", "cancelled", error: "Cancelled"),
+        ),
+      )
+      ..consumeNotification(
+        notification: lifecycle(
+          method: GrokSessionProtocol.updateMethod,
+          update: spawned("child-b", "Duplicate"),
+        ),
+      );
+
+    final messages = build();
+    expect(messages.map((message) => message.info.id), [
+      "root-subagent-child-a",
+      "root-h0-assistant",
+      "root-subagent-child-b",
+    ]);
+    final tiles = messages.expand((message) => message.parts).whereType<PluginMessagePartSubtask>().toList();
+    expect(tiles.map((tile) => tile.childSessionID), ["child-a", "child-b"]);
+    expect(tiles.last.taskState!.status, PluginToolStatus.cancelled);
+    expect(tiles.last.taskState!.error, isNull);
+  });
+
+  test("missing child prompt or description never fabricates a tile", () {
+    createCollector(prompts: const {"child-a": "Prompt A"});
+    replayCollector
+      ..consumeNotification(
+        notification: lifecycle(
+          method: GrokSessionProtocol.updateMethod,
+          update: spawned("child-missing", "Missing prompt"),
+        ),
+      )
+      ..consumeNotification(
+        notification: lifecycle(
+          method: GrokSessionProtocol.updateMethod,
+          update: spawned("child-a", ""),
+        ),
+      );
+
+    expect(build(), isEmpty);
+  });
+
+  test("foreign methods are ignored and late post-build notification settles original tile", () {
+    replayCollector.consumeNotification(
+      notification: lifecycle(
+        method: GrokSessionProtocol.updateMethod,
+        update: spawned("child-a", "Child A"),
+      ),
+    );
+    expect(
+      build().single.parts.single,
+      isA<PluginMessagePartSubtask>().having((part) => part.taskState!.status, "status", PluginToolStatus.running),
+    );
+
+    replayCollector
+      ..consumeNotification(
+        notification: lifecycle(
+          method: "foreign/method",
+          update: finished("child-a", "failed", error: "ignored"),
+        ),
+      )
+      ..consumeNotification(
+        notification: lifecycle(
+          method: GrokSessionProtocol.notificationMethod,
+          update: finished("child-a", "failed", error: "Failure"),
+        ),
+      );
+
+    final tile = build().single.parts.single as PluginMessagePartSubtask;
+    expect(tile.taskState!.status, PluginToolStatus.error);
+    expect(tile.taskState!.error, "Failure");
+  });
+}

--- a/bridge/sesori_plugin_grok/test/grok_session_replay_collector_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_replay_collector_test.dart
@@ -9,7 +9,7 @@ void main() {
   late AcpReplayCollector collector;
   late GrokSessionReplayCollector replayCollector;
 
-  AcpNotification standard(Map<String, dynamic> update) => AcpNotification(
+  AcpNotification standard({required Map<String, dynamic> update}) => AcpNotification(
     method: AcpMethods.sessionUpdate,
     params: {"sessionId": "root", "update": update},
   );
@@ -22,7 +22,7 @@ void main() {
     params: {"sessionId": "root", "update": update},
   );
 
-  void createCollector({Map<String, String> prompts = const {"child-a": "Prompt A", "child-b": "Prompt B"}}) {
+  void createCollector({required Map<String, String> prompts}) {
     collector = AcpReplayCollector(
       sessionUpdateNormalizer: null,
       sessionId: "root",
@@ -41,7 +41,7 @@ void main() {
     );
   }
 
-  Map<String, dynamic> spawned(String childId, String description) => {
+  Map<String, dynamic> spawned({required String childId, required String description}) => {
     "sessionUpdate": "subagent_spawned",
     "subagent_id": childId,
     "child_session_id": childId,
@@ -49,7 +49,12 @@ void main() {
     "description": description,
   };
 
-  Map<String, dynamic> finished(String childId, String status, {String? output, String? error}) => {
+  Map<String, dynamic> finished({
+    required String childId,
+    required String status,
+    required String? output,
+    required String? error,
+  }) => {
     "sessionUpdate": "subagent_finished",
     "subagent_id": childId,
     "child_session_id": childId,
@@ -65,43 +70,56 @@ void main() {
     variant: "high",
   );
 
-  setUp(createCollector);
+  setUp(
+    () => createCollector(prompts: const {"child-a": "Prompt A", "child-b": "Prompt B"}),
+  );
 
   test("suppresses typed spawn card and inserts one terminal tile in wire order", () {
     replayCollector
       ..consumeNotification(
-        notification: standard({
-          "sessionUpdate": "user_message_chunk",
-          "content": {"type": "text", "text": "Root prompt"},
-        }),
+        notification: standard(
+          update: {
+            "sessionUpdate": "user_message_chunk",
+            "content": {"type": "text", "text": "Root prompt"},
+          },
+        ),
       )
       ..consumeNotification(
-        notification: standard({
-          "sessionUpdate": "tool_call",
-          "toolCallId": "spawn-call",
-          "_meta": {
-            "x.ai/tool": {"name": "spawn_subagent", "kind": "task"},
+        notification: standard(
+          update: {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "spawn-call",
+            "_meta": {
+              "x.ai/tool": {"name": "spawn_subagent", "kind": "task"},
+            },
           },
-        }),
+        ),
       )
       ..consumeNotification(
         notification: lifecycle(
           method: GrokSessionProtocol.updateMethod,
-          update: spawned("child-a", "Child A"),
+          update: spawned(childId: "child-a", description: "Child A"),
         ),
       )
       ..consumeNotification(
-        notification: standard({
-          "sessionUpdate": "tool_call",
-          "toolCallId": "ordinary-call",
-          "title": "Read file",
-          "status": "completed",
-        }),
+        notification: standard(
+          update: {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "ordinary-call",
+            "title": "Read file",
+            "status": "completed",
+          },
+        ),
       )
       ..consumeNotification(
         notification: lifecycle(
           method: GrokSessionProtocol.notificationMethod,
-          update: finished("child-a", "completed", output: "Result A"),
+          update: finished(
+            childId: "child-a",
+            status: "completed",
+            output: "Result A",
+            error: null,
+          ),
         ),
       );
 
@@ -129,31 +147,38 @@ void main() {
       ..consumeNotification(
         notification: lifecycle(
           method: GrokSessionProtocol.updateMethod,
-          update: spawned("child-a", "Same description"),
+          update: spawned(childId: "child-a", description: "Same description"),
         ),
       )
       ..consumeNotification(
-        notification: standard({
-          "sessionUpdate": "agent_message_chunk",
-          "content": {"type": "text", "text": "Between"},
-        }),
+        notification: standard(
+          update: {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "Between"},
+          },
+        ),
       )
       ..consumeNotification(
         notification: lifecycle(
           method: GrokSessionProtocol.notificationMethod,
-          update: spawned("child-b", "Same description"),
+          update: spawned(childId: "child-b", description: "Same description"),
         ),
       )
       ..consumeNotification(
         notification: lifecycle(
           method: GrokSessionProtocol.updateMethod,
-          update: finished("child-b", "cancelled", error: "Cancelled"),
+          update: finished(
+            childId: "child-b",
+            status: "cancelled",
+            output: null,
+            error: "Cancelled",
+          ),
         ),
       )
       ..consumeNotification(
         notification: lifecycle(
           method: GrokSessionProtocol.updateMethod,
-          update: spawned("child-b", "Duplicate"),
+          update: spawned(childId: "child-b", description: "Duplicate"),
         ),
       );
 
@@ -175,13 +200,13 @@ void main() {
       ..consumeNotification(
         notification: lifecycle(
           method: GrokSessionProtocol.updateMethod,
-          update: spawned("child-missing", "Missing prompt"),
+          update: spawned(childId: "child-missing", description: "Missing prompt"),
         ),
       )
       ..consumeNotification(
         notification: lifecycle(
           method: GrokSessionProtocol.updateMethod,
-          update: spawned("child-a", ""),
+          update: spawned(childId: "child-a", description: ""),
         ),
       );
 
@@ -192,7 +217,7 @@ void main() {
     replayCollector.consumeNotification(
       notification: lifecycle(
         method: GrokSessionProtocol.updateMethod,
-        update: spawned("child-a", "Child A"),
+        update: spawned(childId: "child-a", description: "Child A"),
       ),
     );
     expect(
@@ -204,13 +229,13 @@ void main() {
       ..consumeNotification(
         notification: lifecycle(
           method: "foreign/method",
-          update: finished("child-a", "failed", error: "ignored"),
+          update: finished(childId: "child-a", status: "failed", output: null, error: "ignored"),
         ),
       )
       ..consumeNotification(
         notification: lifecycle(
           method: GrokSessionProtocol.notificationMethod,
-          update: finished("child-a", "failed", error: "Failure"),
+          update: finished(childId: "child-a", status: "failed", output: null, error: "Failure"),
         ),
       );
 

--- a/bridge/sesori_plugin_grok/test/grok_session_service_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_service_test.dart
@@ -19,7 +19,7 @@ void main() {
     const rootId = "root";
     const persistedChildId = "persisted-child";
 
-    String sessionDirectory(String sessionId) =>
+    String sessionDirectory({required String sessionId}) =>
         p.join(sessions.path, Uri.encodeComponent(persistedDirectory), sessionId);
 
     PluginSession rootSession() => const PluginSession(
@@ -42,14 +42,14 @@ void main() {
         liveTracker: tracker,
       );
 
-      File(p.join(sessionDirectory(rootId), "summary.json"))
+      File(p.join(sessionDirectory(sessionId: rootId), "summary.json"))
         ..createSync(recursive: true)
         ..writeAsStringSync(
           jsonEncode({
             "info": {"id": rootId, "cwd": persistedDirectory},
           }),
         );
-      File(p.join(sessionDirectory(rootId), "updates.jsonl")).writeAsStringSync(
+      File(p.join(sessionDirectory(sessionId: rootId), "updates.jsonl")).writeAsStringSync(
         jsonEncode({
           "method": "_x.ai/session/update",
           "params": {
@@ -64,7 +64,7 @@ void main() {
           },
         }),
       );
-      File(p.join(sessionDirectory(persistedChildId), "summary.json"))
+      File(p.join(sessionDirectory(sessionId: persistedChildId), "summary.json"))
         ..createSync(recursive: true)
         ..writeAsStringSync(
           jsonEncode({
@@ -112,7 +112,7 @@ void main() {
     });
 
     test("history context uses persisted directory and excludes live-only children", () async {
-      File(p.join(sessionDirectory(persistedChildId), "updates.jsonl")).writeAsStringSync(
+      File(p.join(sessionDirectory(sessionId: persistedChildId), "updates.jsonl")).writeAsStringSync(
         jsonEncode({
           "method": "session/update",
           "params": {
@@ -145,7 +145,7 @@ void main() {
     });
 
     test("derived all-session enumeration repairs a root directory even when it has no children", () {
-      File(p.join(sessionDirectory(rootId), "updates.jsonl")).writeAsStringSync("");
+      File(p.join(sessionDirectory(sessionId: rootId), "updates.jsonl")).writeAsStringSync("");
 
       final sessions = service.includeChildrenInAllSessions(sessions: [rootSession()]);
 

--- a/bridge/sesori_plugin_grok/test/grok_session_service_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_service_test.dart
@@ -111,6 +111,39 @@ void main() {
       expect(sessions.last.directory, persistedDirectory);
     });
 
+    test("history context uses persisted directory and excludes live-only children", () async {
+      File(p.join(sessionDirectory(persistedChildId), "updates.jsonl")).writeAsStringSync(
+        jsonEncode({
+          "method": "session/update",
+          "params": {
+            "sessionId": persistedChildId,
+            "update": {
+              "sessionUpdate": "user_message_chunk",
+              "content": {"type": "text", "text": "Persisted prompt"},
+            },
+          },
+        }),
+      );
+      tracker.spawn(
+        sessionId: rootId,
+        spawn: const AcpChildSpawn(
+          childSessionId: "live-only",
+          description: "Live child",
+          agent: "general-purpose",
+          prompt: "Live prompt",
+          isBackground: false,
+        ),
+        directory: persistedDirectory,
+      );
+
+      final context = await service.prepareReplayContext(
+        sessionId: rootId,
+        fallbackDirectory: "/launch-directory",
+      );
+
+      expect(context.childPrompts, {persistedChildId: "Persisted prompt"});
+    });
+
     test("derived all-session enumeration repairs a root directory even when it has no children", () {
       File(p.join(sessionDirectory(rootId), "updates.jsonl")).writeAsStringSync("");
 

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -280,8 +280,9 @@ child updates under the child id. Root `session/load` replays lifecycle as
 `_x.ai/session/update`; an unfinished loaded episode can settle later through
 `_x.ai/session_notification`, so both remain in the replay drain. Sesori exposes
 persisted/live children, loads child transcripts by exact native id, and rebuilds
-root tiles from exact child-owned first prompts without reading live tracker
-state. Missing prompts produce no tile. Permission denial persistence is
+root tiles from each exact child's first user-message run only when that run is
+nonblank, without reading live tracker state. A blank or missing first run
+produces no tile; later runs never substitute. Permission denial persistence is
 unverified and has no outcome model. Grok exposes `_x.ai/subagent/cancel` per
 child, but scoped-stop integration remains unimplemented. A root
 `session/cancel` cancels background children too, so main-agent-only is not

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -275,11 +275,17 @@ when invoked, without a Web BFF, HTTP listener, extra process, or telemetry expo
 
 ¹⁰ Grok Build (1.0.5, probed 2026-09-03 and 2026-09-10) sends
 `subagent_spawned`/`subagent_progress`/`subagent_finished` with parent and child
-session ids as extension notifications and streams child updates under the child
-id. Sesori loads exact child transcripts and rebuilds root tiles from persisted
-lifecycle plus each exact child's first prompt. Missing prompts produce no tile.
-Scoped stop remains unimplemented. A root `session/cancel` cancels background
-children too, so main-agent-only is not supported.
+session ids as `_x.ai/session_notification` extension notifications and streams
+child updates under the child id. Root `session/load` replays lifecycle as
+`_x.ai/session/update`; an unfinished loaded episode can settle later through
+`_x.ai/session_notification`, so both remain in the replay drain. Sesori exposes
+persisted/live children, loads child transcripts by exact native id, and rebuilds
+root tiles from exact child-owned first prompts without reading live tracker
+state. Missing prompts produce no tile. Permission denial persistence is
+unverified and has no outcome model. Grok exposes `_x.ai/subagent/cancel` per
+child, but scoped-stop integration remains unimplemented. A root
+`session/cancel` cancels background children too, so main-agent-only is not
+supported.
 
 ¹¹ Pi (0.84.4, probed 2026-09-05) reports it from `pi --list-models`, which
 prints one row per usable model and otherwise prints the

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -94,12 +94,20 @@ reconnect or restart.
 - Grok history uses standard ACP `session/load` on a dedicated short-lived
   connection. Historical `_x.ai/session/update` and standard `session/update`
   frames are suppressed from the live stream only during the load window;
-  extension frames received outside it remain live. Root replay rebuilds
-  deterministic child-linked tiles from typed persisted lifecycle and each
-  exact child's first non-empty user-message run;
-  child ids load their own standard transcript. Missing child prompts produce no
-  tile. Replay stamps the loaded model/provider/effort selection and never reads
-  or mutates live child state.
+  extension frames received outside it remain live. The plugin reads only typed
+  `summary.json` and `updates.jsonl` session data under the known Grok sessions
+  tree for catalog attribution and child-owned prompt context; credential and
+  configuration files remain outside the API. Root replay suppresses exact
+  metadata-identified `spawn_subagent` cards and inserts one child-linked tile
+  at the persisted lifecycle position only when that exact child's first
+  non-empty user-message run supplies the prompt. Missing prompts produce no
+  tile. Child ids use the same inherited load transport and replay their own
+  standard prompt/tool/text history. Replay initialization validates Grok
+  identity without changing live process defaults; after load, the session's
+  complete model/provider/effort selection stamps all assistant/error/tile
+  envelopes. Both persisted `_x.ai/session/update` facts and late
+  `_x.ai/session_notification` settlement remain inside the existing quiet drain
+  and never read or mutate live child state or the event stream.
 - Messages visible live but absent from the backend's replay remain visible
   after a stale re-read. Exact identities satisfy their replay occurrences
   first and anchor neighboring order by identity even when replay revises their
@@ -316,9 +324,12 @@ rules where supported.
   normalizes live and replay differently.
 - A Copilot restart prompts before `session/load`, duplicates replay as new live
   output, or reads private history files instead of the ACP replay boundary.
-- Grok replay mutates live defaults during initialize, stamps messages from an
+- Grok replay mutates live defaults or child state, stamps messages from an
   incomplete tuple, loses loaded effort/model attribution, duplicates replay as
-  live output, prompts before cold load, or reads private local files.
+  live output, prompts before cold load, reads credential/configuration files,
+  merges child prompt chunks across the first non-user boundary, renders both a
+  generic spawn card and subtask tile, or fabricates a tile without a child-owned
+  prompt.
 
 ## Known Limitations
 

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -100,9 +100,9 @@ reconnect or restart.
   configuration files remain outside the API. Root replay suppresses exact
   metadata-identified `spawn_subagent` cards and inserts one child-linked tile
   at the persisted lifecycle position only when that exact child's first
-  non-empty user-message run supplies the prompt. Missing prompts produce no
-  tile. Child ids use the same inherited load transport and replay their own
-  standard prompt/tool/text history. Replay initialization validates Grok
+  user-message run is nonblank. A blank or missing first run produces no tile;
+  later runs never substitute. Child ids use the same inherited load transport
+  and replay their own standard prompt/tool/text history. Replay initialization validates Grok
   identity without changing live process defaults; after load, the session's
   complete model/provider/effort selection stamps all assistant/error/tile
   envelopes. Both persisted `_x.ai/session/update` facts and late

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -88,12 +88,13 @@ signal that a tool changed files.
 - Grok uses that standard ACP lifecycle with exact live permission linkage.
   Root history replaces only metadata-identified `spawn_subagent` tools with one
   deterministic child-linked subtask tile, using the exact child's persisted
-  first user-message run as prompt and typed lifecycle for terminal state/output.
-  Ordinary tools remain generic and ordered around the tile; missing prompts
-  produce neither a fabricated tile nor an empty assistant message. Tool-call
-  identity, pending-to-terminal status, bounded output or error, and diff content
-  otherwise converge between live events and `session/load`; Grok tool names
-  remain presentation data and never become shared domain vocabulary.
+  first user-message run as prompt only when that run is nonblank, plus typed
+  lifecycle for terminal state/output. A blank or missing first run produces no
+  tile; later runs never substitute. Ordinary tools remain generic and ordered
+  around the tile, without an empty assistant message after spawn suppression.
+  Tool-call identity, terminal outcome (status and bounded output or error), and
+  diff content otherwise converge between live events and `session/load`; Grok
+  tool names remain presentation data and never become shared domain vocabulary.
 
 ## Regression Levels
 

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -86,12 +86,14 @@ signal that a tool changed files.
   decisions are process-local and are not part of replay. Backend tool names
   remain presentation data rather than shared behavior.
 - Grok uses that standard ACP lifecycle with exact live permission linkage.
-  Root history suppresses only metadata-identified `spawn_subagent` cards and
-  inserts one deterministic child-linked tile from exact child prompt and typed
-  lifecycle facts. Ordinary tools remain generic and ordered; missing prompts
+  Root history replaces only metadata-identified `spawn_subagent` tools with one
+  deterministic child-linked subtask tile, using the exact child's persisted
+  first user-message run as prompt and typed lifecycle for terminal state/output.
+  Ordinary tools remain generic and ordered around the tile; missing prompts
   produce neither a fabricated tile nor an empty assistant message. Tool-call
-  identity, terminal state, bounded output or error, and diff content otherwise
-  converge between live events and `session/load`.
+  identity, pending-to-terminal status, bounded output or error, and diff content
+  otherwise converge between live events and `session/load`; Grok tool names
+  remain presentation data and never become shared domain vocabulary.
 
 ## Regression Levels
 
@@ -115,7 +117,10 @@ verify permission linkage against the live call, then cold-replay the resulting
 call identity, terminal tool state, bounded output, and diff without expecting
 its process-local permission decision to replay. For Grok, compare read-only,
 mutating, failing, and long-output tools live and after `session/load`, including
-one permission-gated mutation and one repeated terminal update.
+one permission-gated mutation and one repeated terminal update. Reload a root
+with completed/cancelled children and each child transcript; verify prompt
+provenance, tile order, and both lifecycle extension methods. Denial remains
+unverified and carries no replay guarantee.
 
 ## Failure Signals
 
@@ -137,8 +142,10 @@ one permission-gated mutation and one repeated terminal update.
   terminal status, bounded output, or diff changes when reopened through ACP
   history.
 - A Grok tool loses live permission correlation, changes call identity or status
-  after replay, exposes unbounded output, loses diff content, or emits the wrong
-  number of file-change invalidations.
+  after replay, exposes unbounded output, loses diff content, emits the wrong
+  number of file-change invalidations, leaves a generic spawn beside its tile,
+  binds by description/order instead of child id, crosses the first prompt-run
+  boundary, or leaves an empty message after spawn suppression.
 - The file-change signal is missing after a real mutation, emitted for a
   read-only tool, emitted repeatedly for one call, or wrongly attributed.
 - A Claude sub-agent renders as a generic `Agent` tool card, its tile stays


### PR DESCRIPTION
## Complexity
🌿 Straightforward — supplemental tests and documentation; production unchanged from merged step 3/6.

## What
- Restore ACP collector identity, suppression and ordering regressions.
- Add Grok repository, replay collector and service coverage, including prompt ownership, lazy cancellation and privacy-safe malformed boundaries.
- Reconcile probe evidence, capability/regression docs and six-step delivery tracker.

## Why
Preserves all meaningful coverage from the reviewed full checkpoint while keeping the production PR bounded. Step 3/6 merged as #1426; this completes its supplemental coverage slice.

## Risk and test focus
Tests/docs only. Focus on truthful expectations, exact child IDs, first prompt-run boundaries, replay/live isolation and bounded coverage claims. No user-visible or database impact.

## Expected result
Merged history behavior gains complete regression coverage and accurate documentation without runtime changes. Grok scoped stop remains step 5/6; final coverage remains step 6/6. Overall harness plan stays active.

## Verification
- Review fixes at 1b403ac8: required named test helpers, stronger foreign-notification assertion and blank-first-run provenance coverage.
- ACP collector suite: 35 passed. Grok repository/collector/service suites: 12 passed. Targeted analyzers passed.
- Production matches merged #1426; no production files changed.
- Read-only review approved; whitespace/reference checks passed.
- Permission-denial persistence remains unverified. No new live-plugin, phone, relay, desktop or E2E pass claimed.
