### PR TITLE
⚙️ [claude-inline-subtasks] grok: scoped stop for sub-agents [step 5/6]

### DIFF
--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -6,9 +6,10 @@
   `.plan/active` until the four coverage PRs, Codex, Grok Build, DeepSeek,
   and Cursor, merge, then moved back)
 - **Plan date:** 2026-09-02
-- **Base:** `main` at `6e9028c4c6`
+- **Base:** `main` at merged Grok history coverage `4d0d8de7e3` (#1427).
 - **Delivery:** one open PR at a time, following current repository rules.
-  Codex now has nine steps: merged metadata, child-session, historical prompt
+  Grok Step 5 scoped-stop implementation is current; Step 6 actual-plugin and
+  phone coverage remains unexecuted. Codex has nine steps: merged metadata, child-session, historical prompt
   preparation, and cleanup remain steps 1/9–4/9. Native rollout facts are
   step 5/9, live/replay tile integration 6/9, lifecycle coverage 7/9, scoped
   stop 8/9, and coverage 9/9. Step 8 merged as PR #1421 at `77165f784f`;
@@ -102,18 +103,21 @@ confirmation, no child session or partial stop) and gets that subset.
      main turn is running but
      `mainAgentOnlySupported` is false, it returns the typed rejection before
      any side effect, so a stale or direct caller cannot silently cancel
-     children; otherwise `keep` sends `session/cancel` only. `stop` sends
-     `session/cancel` plus `cancelChild` with each child's direct parent.
-     Outcomes are typed; no `canCancel` field is invented. Foreground children
+     children; otherwise `keep` sends `session/cancel` only. Current atomic
+     opt-in `stop` either invokes declared complete native authority or snapshots
+     and fans out named plus exact child targets; released-client opt-out keeps
+     root/named cancellation and client fanout. Outcomes are typed; no
+     `canCancel` field is invented. Foreground children
      are covered by cancellation of their parent; directly targeting a child
      with no effective interrupt retains that child without cancelling siblings.
      `workKept` means retained work, not pending lifecycle delivery. Unknown-child
      responses do not fabricate either retained work or terminal state.
      `interruptActiveWork` uses `stop` and waits for authoritative lifecycle.
   4. Capability opt-in `supportsScopedStop` plus a typed `AcpPlugin.cancelChild`
-     hook matches current composition (the per-harness APIs are standalone).
-     DeepSeek supplies its typed request/response API; other ACP harnesses keep
-     their existing behavior until their transport seam lands. A child with a
+     hook matches current composition. Separate `supportsAtomicScopedStop`
+     defaults false and means complete native subtree authority; DeepSeek alone
+     opts in. Grok keeps it false and supplies its typed per-child API. Other ACP
+     harnesses keep existing behavior until their transport seam lands. A child with a
      bridge-owned standard prompt uses `session/cancel`, not its former ancestry.
   5. A narrow backend-neutral replay replacement hook on
      `AcpReplayCollector`, which consumes `session/update` frames into
@@ -342,16 +346,12 @@ confirmation, no child session or partial stop) and gets that subset.
 
 ### Verified facts (native 1.0.5 probes)
 
-- Extension notification `_x.ai/session_notification` wraps an internally
-  tagged `SessionUpdate` (`sessionUpdate` key, snake_case) including
-  `subagent_spawned` (`subagent_id`, `parent_session_id`,
-  `child_session_id`, `subagent_type`, `capability_mode`, `persona`,
-  `resumed_from`, `workflow_run_id`, ...), `subagent_progress`
-  (`duration_ms`, `turn_count`, `tool_call_count`, ...),
-  `subagent_finished` (`tool_calls`, `turns`, ...), plus `task_backgrounded`
-  and `task_completed` with `tool_call_id`.
-- Extension request `_x.ai/subagent/cancel` with `subagentId`. The kill tool
-  sends cancel and shutdown to subagents. Nesting depth is one.
+- Extension notification `_x.ai/session_notification` wraps internally tagged
+  `subagent_spawned`, `subagent_progress`, and `subagent_finished` updates.
+  Captured lifecycle carried exact parent/child ids and `will_wake`, but no
+  background flag or task-background/task-completion lifecycle variants.
+- Extension request `_x.ai/subagent/cancel` takes exact `subagentId`. The probe
+  established exact child isolation; it did not establish nested-depth support.
 - `session/cancel` on the root cancels foreground and background children on
   the ACP seam Sesori drives. Main-agent-only stop is therefore unsupported.
 - Root and child directories persist in the normal sessions tree. A child's
@@ -366,9 +366,10 @@ confirmation, no child session or partial stop) and gets that subset.
   survive restart through the persisted catalog chain.
 - `GrokSessionStoreApi` already reads typed session summaries/updates for
   catalog recovery. It never reads credential or configuration files.
-- Scoped stop remains unimplemented. History continues to use inherited ACP
-  `session/load`; this step adds extension-aware root projection without a
-  second transport.
+- Scoped stop uses ACP-owned policy and immutable snapshot fanout. Exact child
+  cancellation stays behind Grok API → control repository → session service →
+  plugin layers; native ACKs never settle lifecycle. History uses inherited ACP
+  `session/load` plus extension-aware root projection without a second transport.
 
 ### Design
 
@@ -425,13 +426,16 @@ confirmation, no child session or partial stop) and gets that subset.
   by `GrokPlugin.getChildSessions`. Replayed tiles then resolve their
   `childSessionID` to a stored session without looking for a nonexistent parent
   field in the child summary.
-- **Scoped stop.** Through seam 3; `GrokAcpApi.cancelChild` sends
+- **Scoped stop.** Through seam 3; `GrokAcpApi.cancelSubagent` sends
   `_x.ai/subagent/cancel {subagentId}` (leading underscore, as probed) with
-  the child session id, which the probe showed equals `subagent_id` in every
-  frame. `isBackground` comes from the spawn
-  payload; if it exposes no background flag and the probe shows a foreground
-  child dying with the parent tool call, every child is recorded as
-  foreground, so `mainAgentOnlySupported` is false as for OpenCode.
+  the child session id, which equalled `subagent_id` in every captured frame.
+  Lifecycle exposes no background flag, so every child is recorded as
+  foreground and active-root main-agent-only stop is unsupported. Current
+  clients get root-first cancellation plus every exact running-child request
+  from one pre-mutation snapshot; all futures are constructed before failures
+  are observed. This is non-atomic and reports `subAgentsHandled: false`.
+  `cancelled` and `already_finished` are non-retained outcomes; lifecycle alone
+  settles tracker state. Released-client `useAtomicStop: false` stays root-only.
 
 ### PRs
 
@@ -440,9 +444,9 @@ confirmation, no child session or partial stop) and gets that subset.
 | ⚙️ | `grok: parse sub-agent lifecycle notifications` | Historical original title unchanged (now step 1/6); DTOs, `GrokEventMapper.mapExtension`, `AcpChildSessionTracker`, exact metadata-based generic spawn suppression, and lifecycle cleanup |
 | ⚙️ | `acp: child sessions keep the root busy` | Historical original title unchanged (now step 2/6); typed tracker-change stream and owned subscription teardown, persisted children, and Layer-3 catalog/live merging |
 | 🚧 | `grok: child session history [step 3/6]` | full root/child replay production, generated DTOs, essential ACP and Grok integration/regression coverage, and supported-behavior docs |
-| 🌿 | `grok: cover child session history [step 4/6]` | supplemental collector/repository/service regressions plus detailed probe, matrix, and regression reconciliation |
-| ⚙️ | `grok: scoped stop for sub-agents [step 5/6]` | policy in `AcpPlugin.abortSession` (seam 3), including side-effect-free unsupported-`keep` rejection and child-only `keep`; `cancelChild` seam and its Grok request (seam 4); `interruptActiveWork` uses stop |
-| 🌱 | `docs: record Grok Build sub-agent coverage [step 6/6]` | final actual-plugin/client matrix and regression reconciliation |
+| 🌿 | `grok: cover child session history [step 4/6]` | PR #1427 merged at `4d0d8de7e3`; collector/repository/service regressions and documentation |
+| ⚙️ | `grok: scoped stop for sub-agents [step 5/6]` | Current implementation: ACP policy/atomic-authority split, root-first non-atomic snapshot fanout, typed layered Grok child cancellation, and automated isolation/failure coverage |
+| 🌱 | `docs: record Grok Build sub-agent coverage [step 6/6]` | Unexecuted: actual-plugin, phone, and any surfaced live pending-permission coverage plus final reconciliation |
 
 ### Probe results (Grok Build 1.0.5, 2026-09-03, details in `followups/grok-probe.md`)
 
@@ -467,8 +471,8 @@ confirmation, no child session or partial stop) and gets that subset.
   triggers a wake-up turn without a client prompt.
 - A root `session/cancel` cancels foreground and background children alike
   (`subagent_finished {status: cancelled}`), so every Grok child is recorded
-  as foreground and `mainAgentOnlySupported` is false. `_x.ai/subagent/cancel
-  {subagentId}` cancels one child without touching siblings or the root turn
+  as foreground and `mainAgentOnlySupported` is false. `_x.ai/subagent/cancel`
+  with `{subagentId}` cancels one child without touching siblings or the root turn
   and returns `{subagentId, cancelled, outcome: cancelled | already_finished}`.
 
 ### Open questions (resolved by the probe)
@@ -481,7 +485,7 @@ confirmation, no child session or partial stop) and gets that subset.
 3. Do `session/load` and `session/list` accept or return child ids with a
    parent marker?
 4. Fate of a foreground child on `session/cancel`; response shape of
-   `x.ai/subagent/cancel` and the resulting `subagent_finished` status.
+   `_x.ai/subagent/cancel` and the resulting `subagent_finished` status.
 5. Is `spawn_subagent` also surfaced as a standard `tool_call`; does a
    background finish trigger a wake-up turn?
 

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -113,11 +113,11 @@ confirmation, no child session or partial stop) and gets that subset.
      `workKept` means retained work, not pending lifecycle delivery. Unknown-child
      responses do not fabricate either retained work or terminal state.
      `interruptActiveWork` uses `stop` and waits for authoritative lifecycle.
-  4. Capability opt-in `supportsScopedStop` plus a typed `AcpPlugin.cancelChild`
-     hook matches current composition. Separate `supportsAtomicScopedStop`
-     defaults false and means complete native subtree authority; DeepSeek alone
-     opts in. Grok keeps it false and supplies its typed per-child API. Other ACP
-     harnesses keep existing behavior until their transport seam lands. A child with a
+  4. Closed `AcpScopedStopCapability` plus a typed `AcpPlugin.cancelChild`
+     hook matches current composition. `unsupported` is the standard ACP default,
+     `perChildSnapshot` selects exact-child fanout for Grok, and
+     `completeNativeAtomic` declares DeepSeek's complete native subtree authority.
+     Other ACP harnesses keep existing behavior until their transport seam lands. A child with a
      bridge-owned standard prompt uses `session/cancel`, not its former ancestry.
   5. A narrow backend-neutral replay replacement hook on
      `AcpReplayCollector`, which consumes `session/update` frames into

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -3,20 +3,20 @@
 ## Current State
 
 - **Plan slug:** `claude-inline-subtasks`
-- **Implementation base:** `main` at `517cbb9703`, containing merged Grok
-  history [PR #1426](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1426).
+- **Implementation base:** `main` at `4d0d8de7e3`, containing merged Grok
+  history coverage [PR #1427](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1427).
 - **Series state:** all eight original Claude steps merged, including the
   L4-found fix [#1257](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1257),
   which made scoped stop harness-neutral and added
-  `docs/HARNESS_CAPABILITIES.md`. Codex steps 1–9 and Grok steps 1–3 are merged;
+  `docs/HARNESS_CAPABILITIES.md`. Codex steps 1–9 and Grok steps 1–4 are merged;
   bounded Codex Step 9 managed-0.153.4 actual-plugin policy QA passed on
   2026-09-10. Harness follow-ups remain active.
-- **Next action:** [PR #1427](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1427)
-  is current on `claude-inline-subtasks-grok-history-coverage-step4-current`
-  under exact title
-  `🌿 [claude-inline-subtasks] grok: cover child session history [step 4/6]`.
-  PR #1426 merged Step 3 at `517cbb9703025633efbb2658136d8aa0879daa75`;
-  Step 4 remains unchecked until PR #1427 merges.
+- **Next action:** Grok Step 5 is current on
+  `claude-inline-subtasks-grok-scoped-stop-step5` under exact title
+  `⚙️ [claude-inline-subtasks] grok: scoped stop for sub-agents [step 5/6]`.
+  PR #1427 merged Step 4 at `4d0d8de7e34ad4b19ce152a4ee4091189544cb3a`.
+  Step 5 remains unchecked until its PR merges; Step 6 actual-plugin and phone
+  coverage remains unexecuted.
   [Policy QA](followups/codex-plugin-qa.md) verified side-effect-free
   root/named-child confirmation, root-only `keep`, named-child subtree
   isolation, root full-stop snapshot fanout, authoritative terminals plus
@@ -188,9 +188,9 @@ post-merge E2E gates are unchanged.
 | [x] | Grok | `⚙️ [claude-inline-subtasks] grok: parse sub-agent lifecycle notifications` | [PR #1270](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1270) merged; historical original title unchanged (now step 1/6) |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] acp: child sessions keep the root busy` | [PR #1272](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1272) merged; historical original title unchanged (now step 2/6) |
 | [x] | Grok | `🚧 [claude-inline-subtasks] grok: child session history [step 3/6]` | [PR #1426](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1426) merged at `517cbb9703`; approved production, root/direct-child integration, and no-`loadSession` coverage |
-| [ ] | Grok | `🌿 [claude-inline-subtasks] grok: cover child session history [step 4/6]` | Integrated on `claude-inline-subtasks-grok-history-coverage-step4-current`; original `fb47206bd` tests/docs plus moved ACP collector and Grok repository coverage use the approved Collector/async API; remains unchecked until merged |
-| [ ] | Grok | `⚙️ [claude-inline-subtasks] grok: scoped stop for sub-agents [step 5/6]` | Not started |
-| [ ] | Grok | `🌱 [claude-inline-subtasks] docs: record Grok Build sub-agent coverage [step 6/6]` | Not started |
+| [x] | Grok | `🌿 [claude-inline-subtasks] grok: cover child session history [step 4/6]` | [PR #1427](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1427) merged at `4d0d8de7e3`; approved collector/repository/service coverage and docs |
+| [ ] | Grok | `⚙️ [claude-inline-subtasks] grok: scoped stop for sub-agents [step 5/6]` | Current on `claude-inline-subtasks-grok-scoped-stop-step5`; implementation and focused automation complete locally, unchecked until merged |
+| [ ] | Grok | `🌱 [claude-inline-subtasks] docs: record Grok Build sub-agent coverage [step 6/6]` | Unexecuted actual-plugin/phone coverage |
 | [x] | DeepSeek (adapter) | `⚙️ sessions: sub-agent lifecycle notifications and child transcripts` | [sesori-deepseek-acp #13](https://github.com/sesori-ai/sesori-deepseek-acp/pull/13) merged at `0a85fb2` |
 | [x] | DeepSeek (adapter) | `⚙️ sessions: per-child interrupt; release v0.1.3` | [sesori-deepseek-acp #14](https://github.com/sesori-ai/sesori-deepseek-acp/pull/14) merged at `1f839c3`; release completed through #16 |
 | [x] | DeepSeek (adapter) | `🌿 protocol: carry sub-agent prompts for tile replay` | [sesori-deepseek-acp #15](https://github.com/sesori-ai/sesori-deepseek-acp/pull/15) merged at `d7a4847` |

--- a/.plan/active/claude-inline-subtasks/followups/deepseek-stop-replacement.md
+++ b/.plan/active/claude-inline-subtasks/followups/deepseek-stop-replacement.md
@@ -29,8 +29,8 @@ Native input flows through `AcpStdioClient.serverRequests -> AcpPlugin._handleAg
 DeepSeekApprovalRegistry -> DeepSeekAcpApi` parsing and the existing pending-input owner. The same prompt-write buffer
 orders old input, cancellation, and later input, including reused question IDs.
 This makes the 0.1.4 pin safe independently.
-`deepseek/session/stop` is outbound, not unsolicited: this slice has no production caller for it. Current
-`supportsScopedStop`/direct-parent cancellation, bridge/public contracts, and clients remain unchanged.
+`deepseek/session/stop` is outbound, not unsolicited: this slice has no production caller for it. Current per-child
+snapshot capability/direct-parent cancellation, bridge/public contracts, and clients remain unchanged.
 
 ## Step 5/5 — one complete ACP-owned stop
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1828,7 +1828,9 @@ abstract class AcpPlugin({
         mainAgentOnlySupported: mainOnlySupported,
       );
     }
-    if (subAgents == PluginAbortSubAgentPolicy.keep && activeSubAgentSessionIds.isNotEmpty && !mainRunning) {
+    final hasRetainedSubAgentWork =
+        activeSubAgentSessionIds.isNotEmpty || childSessionTracker.hasActiveWorkForRoot(sessionId: sessionId);
+    if (subAgents == PluginAbortSubAgentPolicy.keep && hasRetainedSubAgentWork && !mainRunning) {
       return const PluginAbortAccepted(workKept: true, subAgentsHandled: true);
     }
 

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -1752,6 +1752,9 @@ abstract class AcpPlugin({
   /// Capability opt-in: standard ACP alone cannot promise scoped child stops.
   bool get supportsScopedStop => false;
 
+  /// Complete native subtree authority, distinct from per-child cancellation.
+  bool get supportsAtomicScopedStop => false;
+
   Future<AcpChildCancelResult> cancelChild({
     required AcpStdioClient client,
     required String sessionId,
@@ -1830,32 +1833,78 @@ abstract class AcpPlugin({
     }
 
     if (useAtomicStop && subAgents != PluginAbortSubAgentPolicy.keep) {
-      for (final targetSessionId in {sessionId, ...allDescendantSessionIds}) {
-        _prepareSessionAbort(sessionId: targetSessionId, cancelBufferedInputs: false);
+      if (supportsAtomicScopedStop) {
+        for (final targetSessionId in {sessionId, ...allDescendantSessionIds}) {
+          _prepareSessionAbort(sessionId: targetSessionId, cancelBufferedInputs: false);
+        }
+        final client = _client;
+        if (client == null) {
+          return const PluginAbortAccepted(workKept: false, subAgentsHandled: true);
+        }
+        final parentSessionId = childSessionTracker.parentOf(sessionId: sessionId);
+        final targets = <AcpScopedStopTarget>[
+          if (_residentSessions.contains(sessionId))
+            AcpScopedStopSessionTarget(sessionId: sessionId)
+          else if (parentSessionId != null)
+            AcpScopedStopChildTarget(parentSessionId: parentSessionId, childSessionId: sessionId),
+          for (final descendantSessionId in independentResidentSessionIds)
+            AcpScopedStopSessionTarget(sessionId: descendantSessionId),
+        ];
+        // Calling every hook constructs and dispatches every native request before
+        // Future.wait observes a response. Its default behavior still waits for
+        // every already-dispatched request when one fails.
+        final stopFutures = [
+          for (final target in targets) stopScopedTree(client: client, target: target),
+        ];
+        final results = await Future.wait(stopFutures);
+        return PluginAbortAccepted(
+          workKept: results.any((result) => result.workKept),
+          subAgentsHandled: true,
+        );
       }
-      final client = _client;
-      if (client == null) {
-        return const PluginAbortAccepted(workKept: false, subAgentsHandled: true);
+
+      final targetBySessionId = <String, ({String sessionId, String? parentSessionId})>{
+        sessionId: (
+          sessionId: sessionId,
+          parentSessionId: childSessionTracker.parentOf(sessionId: sessionId),
+        ),
+        for (final child in children)
+          child.childSessionId: (
+            sessionId: child.childSessionId,
+            parentSessionId: child.parentSessionId,
+          ),
+      };
+      for (final residentSessionId in independentResidentSessionIds) {
+        targetBySessionId.putIfAbsent(
+          residentSessionId,
+          () => (
+            sessionId: residentSessionId,
+            parentSessionId: childSessionTracker.parentOf(sessionId: residentSessionId),
+          ),
+        );
       }
-      final parentSessionId = childSessionTracker.parentOf(sessionId: sessionId);
-      final targets = <AcpScopedStopTarget>[
-        if (_residentSessions.contains(sessionId))
-          AcpScopedStopSessionTarget(sessionId: sessionId)
-        else if (parentSessionId != null)
-          AcpScopedStopChildTarget(parentSessionId: parentSessionId, childSessionId: sessionId),
-        for (final descendantSessionId in independentResidentSessionIds)
-          AcpScopedStopSessionTarget(sessionId: descendantSessionId),
+      final targets = List<({String sessionId, String? parentSessionId})>.unmodifiable(targetBySessionId.values);
+
+      // Fence every accepted queue, prompt write, and pending interaction in
+      // the named scope before the first native cancellation is issued.
+      final preparationFutures = [
+        for (final targetSessionId in {sessionId, ...allDescendantSessionIds})
+          _abortSession(sessionId: targetSessionId, sendSessionCancel: false),
       ];
-      // Calling every hook constructs and dispatches every native request before
-      // Future.wait observes a response. Its default behavior still waits for
-      // every already-dispatched request when one fails.
-      final stopFutures = [
-        for (final target in targets) stopScopedTree(client: client, target: target),
+      await Future.wait(preparationFutures);
+      // Root is first in insertion order. Construct all futures before waiting
+      // so one failed request cannot prevent another selected target's attempt.
+      final cancelFutures = [
+        for (final target in targets)
+          _cancelPreparedScopedSession(
+            sessionId: target.sessionId,
+            parentSessionId: target.parentSessionId,
+          ),
       ];
-      final results = await Future.wait(stopFutures);
+      final results = await Future.wait(cancelFutures);
       return PluginAbortAccepted(
-        workKept: results.any((result) => result.workKept),
-        subAgentsHandled: true,
+        workKept: results.any((result) => result == AcpChildCancelResult.notCancellable),
+        subAgentsHandled: false,
       );
     }
 
@@ -1879,7 +1928,20 @@ abstract class AcpPlugin({
     final standardCancel = _residentSessions.contains(sessionId);
     await _abortSession(sessionId: sessionId, sendSessionCancel: standardCancel);
     if (standardCancel || parentSessionId == null) return AcpChildCancelResult.interrupted;
+    return await _cancelPreparedScopedSession(sessionId: sessionId, parentSessionId: parentSessionId);
+  }
+
+  Future<AcpChildCancelResult> _cancelPreparedScopedSession({
+    required String sessionId,
+    required String? parentSessionId,
+  }) async {
+    final standardCancel = _residentSessions.contains(sessionId);
     final client = _client;
+    if (standardCancel) {
+      client?.notify(method: AcpMethods.sessionCancel, params: {"sessionId": sessionId});
+      return AcpChildCancelResult.interrupted;
+    }
+    if (parentSessionId == null) return AcpChildCancelResult.interrupted;
     if (client == null) return AcpChildCancelResult.unknownChild;
     try {
       return await cancelChild(client: client, sessionId: parentSessionId, childSessionId: sessionId);

--- a/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_plugin.dart
@@ -35,6 +35,13 @@ enum AcpChildCancelResult() {
   unknownChild,
 }
 
+/// Native scoped-stop authority one ACP harness can guarantee.
+enum AcpScopedStopCapability() {
+  unsupported,
+  perChildSnapshot,
+  completeNativeAtomic,
+}
+
 /// Base [BridgeDerivedProjectsPluginApi] implementation for any ACP (Agent
 /// Client Protocol) agent driven over stdio.
 ///
@@ -1749,11 +1756,8 @@ abstract class AcpPlugin({
     return {"type": type, "mimeType": mime, "data": base64};
   }
 
-  /// Capability opt-in: standard ACP alone cannot promise scoped child stops.
-  bool get supportsScopedStop => false;
-
-  /// Complete native subtree authority, distinct from per-child cancellation.
-  bool get supportsAtomicScopedStop => false;
+  /// Standard ACP alone cannot promise scoped child stops.
+  AcpScopedStopCapability get scopedStopCapability => AcpScopedStopCapability.unsupported;
 
   Future<AcpChildCancelResult> cancelChild({
     required AcpStdioClient client,
@@ -1775,7 +1779,7 @@ abstract class AcpPlugin({
     required bool useAtomicStop,
     required Set<String> knownSubAgentSessionIds,
   }) async {
-    if (!supportsScopedStop) {
+    if (scopedStopCapability == AcpScopedStopCapability.unsupported) {
       await _abortSession(sessionId: sessionId, sendSessionCancel: true);
       return const PluginAbortAccepted(workKept: false, subAgentsHandled: false);
     }
@@ -1835,7 +1839,7 @@ abstract class AcpPlugin({
     }
 
     if (useAtomicStop && subAgents != PluginAbortSubAgentPolicy.keep) {
-      if (supportsAtomicScopedStop) {
+      if (scopedStopCapability == AcpScopedStopCapability.completeNativeAtomic) {
         for (final targetSessionId in {sessionId, ...allDescendantSessionIds}) {
           _prepareSessionAbort(sessionId: targetSessionId, cancelBufferedInputs: false);
         }
@@ -1997,7 +2001,7 @@ abstract class AcpPlugin({
   Future<Set<String>> interruptActiveWork({required Duration budget}) {
     return () async {
       final activeSessionIds = <String>{
-        if (supportsScopedStop)
+        if (scopedStopCapability != AcpScopedStopCapability.unsupported)
           for (final entry in _turnStates.entries)
             if (entry.value.pending > 0) entry.key,
         for (final summary in getActiveSessionsSummary())
@@ -2010,7 +2014,7 @@ abstract class AcpPlugin({
       };
       if (activeSessionIds.isEmpty) return const <String>{};
 
-      if (supportsScopedStop) {
+      if (scopedStopCapability != AcpScopedStopCapability.unsupported) {
         final roots = {
           for (final sessionId in activeSessionIds) childSessionTracker.rootOf(sessionId: sessionId),
         };

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -40,6 +40,9 @@ class DeepSeekPlugin({
   bool get supportsScopedStop => true;
 
   @override
+  bool get supportsAtomicScopedStop => true;
+
+  @override
   Future<AcpScopedStopResult> stopScopedTree({
     required AcpStdioClient client,
     required AcpScopedStopTarget target,

--- a/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/deepseek_plugin_impl.dart
@@ -37,10 +37,7 @@ class DeepSeekPlugin({
   );
 
   @override
-  bool get supportsScopedStop => true;
-
-  @override
-  bool get supportsAtomicScopedStop => true;
+  AcpScopedStopCapability get scopedStopCapability => AcpScopedStopCapability.completeNativeAtomic;
 
   @override
   Future<AcpScopedStopResult> stopScopedTree({

--- a/bridge/sesori_plugin_grok/lib/src/api/grok_acp_api.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/grok_acp_api.dart
@@ -4,14 +4,17 @@ import "package:acp_plugin/acp_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../grok_binary.dart";
+import "../models/grok_subagent_status.dart";
+import "models/grok_protocol_dto.dart";
 
-/// Grok's initialize-only catalog probe and legacy model-selection RPC.
+/// Grok's ACP extensions, initialize-only catalog probe, and model selection.
 class GrokAcpApi({
   required final String _binaryPath,
   required final AcpProcessFactory _processFactory,
   required final Map<String, String> _environment,
 }) {
   static const String sessionSetModelMethod = "session/set_model";
+  static const String subagentCancelMethod = "_x.ai/subagent/cancel";
   static const Set<String> headlessAuthMethodIds = {"xai.api_key", "cached_token"};
 
   Future<AcpInitializeResult> probeCatalog({
@@ -73,6 +76,45 @@ class GrokAcpApi({
     },
     timeout: timeout,
   );
+
+  Future<GrokSubagentCancelResponseDto> cancelSubagent({
+    required AcpStdioClient client,
+    required String subagentId,
+  }) async {
+    if (subagentId.trim().isEmpty) {
+      throw const FormatException("Grok sub-agent cancellation requires a nonblank subagentId");
+    }
+    final request = GrokSubagentCancelRequestDto(subagentId: subagentId);
+    final raw = await client.request(
+      method: subagentCancelMethod,
+      params: request.toJson(),
+      timeout: AcpAgentApi.defaultRequestTimeout,
+    );
+    if (raw is! Map || !raw.keys.every((key) => key is String)) {
+      throw const FormatException("Grok sub-agent cancellation returned a non-object response");
+    }
+    // ignore: no_slop_linter/prefer_specific_type, generated DTO accepts JSON maps
+    final response = GrokSubagentCancelResponseDto.fromJson(raw.cast<String, dynamic>());
+    if (response.subagentId != subagentId) {
+      throw FormatException(
+        "Grok sub-agent cancellation returned id ${response.subagentId} for requested child $subagentId",
+      );
+    }
+    final consistent = switch (response.outcome.kind) {
+      GrokSubagentCancelOutcomeKind.cancelled => response.cancelled,
+      GrokSubagentCancelOutcomeKind.alreadyFinished => !response.cancelled,
+      GrokSubagentCancelOutcomeKind.unknown => false,
+    };
+    if (!consistent) {
+      throw FormatException(
+        "Grok sub-agent cancellation returned inconsistent outcome ${response.outcome.kind.name}",
+      );
+    }
+    if (response.outcome.status == GrokSubagentStatus.unknown) {
+      throw const FormatException("Grok sub-agent cancellation returned an unknown terminal status");
+    }
+    return response;
+  }
 
   Future<AcpInitializeResult> _initialize({
     required AcpStdioClient client,

--- a/bridge/sesori_plugin_grok/lib/src/api/grok_acp_api.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/grok_acp_api.dart
@@ -4,7 +4,6 @@ import "package:acp_plugin/acp_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show Log;
 
 import "../grok_binary.dart";
-import "../models/grok_subagent_status.dart";
 import "models/grok_protocol_dto.dart";
 
 /// Grok's ACP extensions, initialize-only catalog probe, and model selection.
@@ -99,19 +98,6 @@ class GrokAcpApi({
       throw FormatException(
         "Grok sub-agent cancellation returned id ${response.subagentId} for requested child $subagentId",
       );
-    }
-    final consistent = switch (response.outcome.kind) {
-      GrokSubagentCancelOutcomeKind.cancelled => response.cancelled,
-      GrokSubagentCancelOutcomeKind.alreadyFinished => !response.cancelled,
-      GrokSubagentCancelOutcomeKind.unknown => false,
-    };
-    if (!consistent) {
-      throw FormatException(
-        "Grok sub-agent cancellation returned inconsistent outcome ${response.outcome.kind.name}",
-      );
-    }
-    if (response.outcome.status == GrokSubagentStatus.unknown) {
-      throw const FormatException("Grok sub-agent cancellation returned an unknown terminal status");
     }
     return response;
   }

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.dart
@@ -1,7 +1,48 @@
 import "package:freezed_annotation/freezed_annotation.dart";
 
+import "../../models/grok_subagent_status.dart";
+
 part "grok_protocol_dto.freezed.dart";
 part "grok_protocol_dto.g.dart";
+
+/// Exact child target accepted by Grok's sub-agent cancellation extension.
+@freezed
+sealed class GrokSubagentCancelRequestDto with _$GrokSubagentCancelRequestDto {
+  const factory({required String subagentId}) = _GrokSubagentCancelRequestDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$GrokSubagentCancelRequestDtoFromJson(json);
+}
+
+/// Closed cancellation outcomes observed from Grok Build 1.0.5.
+enum GrokSubagentCancelOutcomeKind() {
+  cancelled,
+  @JsonValue("already_finished")
+  alreadyFinished,
+  unknown,
+}
+
+/// Native outcome returned for one exact Grok child cancellation request.
+@Freezed(fromJson: true, toJson: false)
+sealed class GrokSubagentCancelOutcomeDto with _$GrokSubagentCancelOutcomeDto {
+  const factory({
+    @JsonKey(unknownEnumValue: GrokSubagentCancelOutcomeKind.unknown) required GrokSubagentCancelOutcomeKind kind,
+    @JsonKey(unknownEnumValue: GrokSubagentStatus.unknown) required GrokSubagentStatus? status,
+  }) = _GrokSubagentCancelOutcomeDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$GrokSubagentCancelOutcomeDtoFromJson(json);
+}
+
+/// Typed response from Grok's sub-agent cancellation extension.
+@Freezed(fromJson: true, toJson: false)
+sealed class GrokSubagentCancelResponseDto with _$GrokSubagentCancelResponseDto {
+  const factory({
+    required String subagentId,
+    required bool cancelled,
+    required GrokSubagentCancelOutcomeDto outcome,
+  }) = _GrokSubagentCancelResponseDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$GrokSubagentCancelResponseDtoFromJson(json);
+}
 
 /// One reasoning-effort option advertised in a Grok model's ACP metadata.
 @freezed

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.freezed.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.freezed.dart
@@ -14,6 +14,425 @@ part of 'grok_protocol_dto.dart';
 T _$identity<T>(T value) => value;
 
 /// @nodoc
+mixin _$GrokSubagentCancelRequestDto {
+
+ String get subagentId;
+/// Create a copy of GrokSubagentCancelRequestDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GrokSubagentCancelRequestDtoCopyWith<GrokSubagentCancelRequestDto> get copyWith => _$GrokSubagentCancelRequestDtoCopyWithImpl<GrokSubagentCancelRequestDto>(this as GrokSubagentCancelRequestDto, _$identity);
+
+  /// Serializes this GrokSubagentCancelRequestDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GrokSubagentCancelRequestDto&&(identical(other.subagentId, subagentId) || other.subagentId == subagentId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,subagentId);
+
+@override
+String toString() {
+  return 'GrokSubagentCancelRequestDto(subagentId: $subagentId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GrokSubagentCancelRequestDtoCopyWith<$Res>  {
+  factory $GrokSubagentCancelRequestDtoCopyWith(GrokSubagentCancelRequestDto value, $Res Function(GrokSubagentCancelRequestDto) _then) = _$GrokSubagentCancelRequestDtoCopyWithImpl;
+@useResult
+$Res call({
+ String subagentId
+});
+
+
+
+
+}
+/// @nodoc
+class _$GrokSubagentCancelRequestDtoCopyWithImpl<$Res>
+    implements $GrokSubagentCancelRequestDtoCopyWith<$Res> {
+  _$GrokSubagentCancelRequestDtoCopyWithImpl(this._self, this._then);
+
+  final GrokSubagentCancelRequestDto _self;
+  final $Res Function(GrokSubagentCancelRequestDto) _then;
+
+/// Create a copy of GrokSubagentCancelRequestDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? subagentId = null,}) {
+  return _then(GrokSubagentCancelRequestDto(
+subagentId: null == subagentId ? _self.subagentId : subagentId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable()
+
+class _GrokSubagentCancelRequestDto implements GrokSubagentCancelRequestDto {
+  const _GrokSubagentCancelRequestDto({required this.subagentId});
+  factory _GrokSubagentCancelRequestDto.fromJson(Map<String, dynamic> json) => _$GrokSubagentCancelRequestDtoFromJson(json);
+
+@override final  String subagentId;
+
+/// Create a copy of GrokSubagentCancelRequestDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GrokSubagentCancelRequestDtoCopyWith<_GrokSubagentCancelRequestDto> get copyWith => __$GrokSubagentCancelRequestDtoCopyWithImpl<_GrokSubagentCancelRequestDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GrokSubagentCancelRequestDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GrokSubagentCancelRequestDto&&(identical(other.subagentId, subagentId) || other.subagentId == subagentId));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,subagentId);
+
+@override
+String toString() {
+  return 'GrokSubagentCancelRequestDto(subagentId: $subagentId)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GrokSubagentCancelRequestDtoCopyWith<$Res> implements $GrokSubagentCancelRequestDtoCopyWith<$Res> {
+  factory _$GrokSubagentCancelRequestDtoCopyWith(_GrokSubagentCancelRequestDto value, $Res Function(_GrokSubagentCancelRequestDto) _then) = __$GrokSubagentCancelRequestDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String subagentId
+});
+
+
+
+
+}
+/// @nodoc
+class __$GrokSubagentCancelRequestDtoCopyWithImpl<$Res>
+    implements _$GrokSubagentCancelRequestDtoCopyWith<$Res> {
+  __$GrokSubagentCancelRequestDtoCopyWithImpl(this._self, this._then);
+
+  final _GrokSubagentCancelRequestDto _self;
+  final $Res Function(_GrokSubagentCancelRequestDto) _then;
+
+/// Create a copy of GrokSubagentCancelRequestDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? subagentId = null,}) {
+  return _then(_GrokSubagentCancelRequestDto(
+subagentId: null == subagentId ? _self.subagentId : subagentId // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$GrokSubagentCancelOutcomeDto {
+
+@JsonKey(unknownEnumValue: GrokSubagentCancelOutcomeKind.unknown) GrokSubagentCancelOutcomeKind get kind;@JsonKey(unknownEnumValue: GrokSubagentStatus.unknown) GrokSubagentStatus? get status;
+/// Create a copy of GrokSubagentCancelOutcomeDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GrokSubagentCancelOutcomeDtoCopyWith<GrokSubagentCancelOutcomeDto> get copyWith => _$GrokSubagentCancelOutcomeDtoCopyWithImpl<GrokSubagentCancelOutcomeDto>(this as GrokSubagentCancelOutcomeDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GrokSubagentCancelOutcomeDto&&(identical(other.kind, kind) || other.kind == kind)&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,kind,status);
+
+@override
+String toString() {
+  return 'GrokSubagentCancelOutcomeDto(kind: $kind, status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GrokSubagentCancelOutcomeDtoCopyWith<$Res>  {
+  factory $GrokSubagentCancelOutcomeDtoCopyWith(GrokSubagentCancelOutcomeDto value, $Res Function(GrokSubagentCancelOutcomeDto) _then) = _$GrokSubagentCancelOutcomeDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(unknownEnumValue: GrokSubagentCancelOutcomeKind.unknown) GrokSubagentCancelOutcomeKind kind,@JsonKey(unknownEnumValue: GrokSubagentStatus.unknown) GrokSubagentStatus? status
+});
+
+
+
+
+}
+/// @nodoc
+class _$GrokSubagentCancelOutcomeDtoCopyWithImpl<$Res>
+    implements $GrokSubagentCancelOutcomeDtoCopyWith<$Res> {
+  _$GrokSubagentCancelOutcomeDtoCopyWithImpl(this._self, this._then);
+
+  final GrokSubagentCancelOutcomeDto _self;
+  final $Res Function(GrokSubagentCancelOutcomeDto) _then;
+
+/// Create a copy of GrokSubagentCancelOutcomeDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? kind = null,Object? status = freezed,}) {
+  return _then(GrokSubagentCancelOutcomeDto(
+kind: null == kind ? _self.kind : kind // ignore: cast_nullable_to_non_nullable
+as GrokSubagentCancelOutcomeKind,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as GrokSubagentStatus?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _GrokSubagentCancelOutcomeDto implements GrokSubagentCancelOutcomeDto {
+  const _GrokSubagentCancelOutcomeDto({@JsonKey(unknownEnumValue: GrokSubagentCancelOutcomeKind.unknown) required this.kind, @JsonKey(unknownEnumValue: GrokSubagentStatus.unknown) required this.status});
+  factory _GrokSubagentCancelOutcomeDto.fromJson(Map<String, dynamic> json) => _$GrokSubagentCancelOutcomeDtoFromJson(json);
+
+@override@JsonKey(unknownEnumValue: GrokSubagentCancelOutcomeKind.unknown) final  GrokSubagentCancelOutcomeKind kind;
+@override@JsonKey(unknownEnumValue: GrokSubagentStatus.unknown) final  GrokSubagentStatus? status;
+
+/// Create a copy of GrokSubagentCancelOutcomeDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GrokSubagentCancelOutcomeDtoCopyWith<_GrokSubagentCancelOutcomeDto> get copyWith => __$GrokSubagentCancelOutcomeDtoCopyWithImpl<_GrokSubagentCancelOutcomeDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GrokSubagentCancelOutcomeDto&&(identical(other.kind, kind) || other.kind == kind)&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,kind,status);
+
+@override
+String toString() {
+  return 'GrokSubagentCancelOutcomeDto(kind: $kind, status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GrokSubagentCancelOutcomeDtoCopyWith<$Res> implements $GrokSubagentCancelOutcomeDtoCopyWith<$Res> {
+  factory _$GrokSubagentCancelOutcomeDtoCopyWith(_GrokSubagentCancelOutcomeDto value, $Res Function(_GrokSubagentCancelOutcomeDto) _then) = __$GrokSubagentCancelOutcomeDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(unknownEnumValue: GrokSubagentCancelOutcomeKind.unknown) GrokSubagentCancelOutcomeKind kind,@JsonKey(unknownEnumValue: GrokSubagentStatus.unknown) GrokSubagentStatus? status
+});
+
+
+
+
+}
+/// @nodoc
+class __$GrokSubagentCancelOutcomeDtoCopyWithImpl<$Res>
+    implements _$GrokSubagentCancelOutcomeDtoCopyWith<$Res> {
+  __$GrokSubagentCancelOutcomeDtoCopyWithImpl(this._self, this._then);
+
+  final _GrokSubagentCancelOutcomeDto _self;
+  final $Res Function(_GrokSubagentCancelOutcomeDto) _then;
+
+/// Create a copy of GrokSubagentCancelOutcomeDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? kind = null,Object? status = freezed,}) {
+  return _then(_GrokSubagentCancelOutcomeDto(
+kind: null == kind ? _self.kind : kind // ignore: cast_nullable_to_non_nullable
+as GrokSubagentCancelOutcomeKind,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as GrokSubagentStatus?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$GrokSubagentCancelResponseDto {
+
+ String get subagentId; bool get cancelled; GrokSubagentCancelOutcomeDto get outcome;
+/// Create a copy of GrokSubagentCancelResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GrokSubagentCancelResponseDtoCopyWith<GrokSubagentCancelResponseDto> get copyWith => _$GrokSubagentCancelResponseDtoCopyWithImpl<GrokSubagentCancelResponseDto>(this as GrokSubagentCancelResponseDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GrokSubagentCancelResponseDto&&(identical(other.subagentId, subagentId) || other.subagentId == subagentId)&&(identical(other.cancelled, cancelled) || other.cancelled == cancelled)&&(identical(other.outcome, outcome) || other.outcome == outcome));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,subagentId,cancelled,outcome);
+
+@override
+String toString() {
+  return 'GrokSubagentCancelResponseDto(subagentId: $subagentId, cancelled: $cancelled, outcome: $outcome)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GrokSubagentCancelResponseDtoCopyWith<$Res>  {
+  factory $GrokSubagentCancelResponseDtoCopyWith(GrokSubagentCancelResponseDto value, $Res Function(GrokSubagentCancelResponseDto) _then) = _$GrokSubagentCancelResponseDtoCopyWithImpl;
+@useResult
+$Res call({
+ String subagentId, bool cancelled, GrokSubagentCancelOutcomeDto outcome
+});
+
+
+$GrokSubagentCancelOutcomeDtoCopyWith<$Res> get outcome;
+
+}
+/// @nodoc
+class _$GrokSubagentCancelResponseDtoCopyWithImpl<$Res>
+    implements $GrokSubagentCancelResponseDtoCopyWith<$Res> {
+  _$GrokSubagentCancelResponseDtoCopyWithImpl(this._self, this._then);
+
+  final GrokSubagentCancelResponseDto _self;
+  final $Res Function(GrokSubagentCancelResponseDto) _then;
+
+/// Create a copy of GrokSubagentCancelResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? subagentId = null,Object? cancelled = null,Object? outcome = null,}) {
+  return _then(GrokSubagentCancelResponseDto(
+subagentId: null == subagentId ? _self.subagentId : subagentId // ignore: cast_nullable_to_non_nullable
+as String,cancelled: null == cancelled ? _self.cancelled : cancelled // ignore: cast_nullable_to_non_nullable
+as bool,outcome: null == outcome ? _self.outcome : outcome // ignore: cast_nullable_to_non_nullable
+as GrokSubagentCancelOutcomeDto,
+  ));
+}
+/// Create a copy of GrokSubagentCancelResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GrokSubagentCancelOutcomeDtoCopyWith<$Res> get outcome {
+  
+  return $GrokSubagentCancelOutcomeDtoCopyWith<$Res>(_self.outcome, (value) {
+    return _then(_self.copyWith(outcome: value));
+  });
+}
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _GrokSubagentCancelResponseDto implements GrokSubagentCancelResponseDto {
+  const _GrokSubagentCancelResponseDto({required this.subagentId, required this.cancelled, required this.outcome});
+  factory _GrokSubagentCancelResponseDto.fromJson(Map<String, dynamic> json) => _$GrokSubagentCancelResponseDtoFromJson(json);
+
+@override final  String subagentId;
+@override final  bool cancelled;
+@override final  GrokSubagentCancelOutcomeDto outcome;
+
+/// Create a copy of GrokSubagentCancelResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GrokSubagentCancelResponseDtoCopyWith<_GrokSubagentCancelResponseDto> get copyWith => __$GrokSubagentCancelResponseDtoCopyWithImpl<_GrokSubagentCancelResponseDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GrokSubagentCancelResponseDto&&(identical(other.subagentId, subagentId) || other.subagentId == subagentId)&&(identical(other.cancelled, cancelled) || other.cancelled == cancelled)&&(identical(other.outcome, outcome) || other.outcome == outcome));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,subagentId,cancelled,outcome);
+
+@override
+String toString() {
+  return 'GrokSubagentCancelResponseDto(subagentId: $subagentId, cancelled: $cancelled, outcome: $outcome)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GrokSubagentCancelResponseDtoCopyWith<$Res> implements $GrokSubagentCancelResponseDtoCopyWith<$Res> {
+  factory _$GrokSubagentCancelResponseDtoCopyWith(_GrokSubagentCancelResponseDto value, $Res Function(_GrokSubagentCancelResponseDto) _then) = __$GrokSubagentCancelResponseDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String subagentId, bool cancelled, GrokSubagentCancelOutcomeDto outcome
+});
+
+
+@override $GrokSubagentCancelOutcomeDtoCopyWith<$Res> get outcome;
+
+}
+/// @nodoc
+class __$GrokSubagentCancelResponseDtoCopyWithImpl<$Res>
+    implements _$GrokSubagentCancelResponseDtoCopyWith<$Res> {
+  __$GrokSubagentCancelResponseDtoCopyWithImpl(this._self, this._then);
+
+  final _GrokSubagentCancelResponseDto _self;
+  final $Res Function(_GrokSubagentCancelResponseDto) _then;
+
+/// Create a copy of GrokSubagentCancelResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? subagentId = null,Object? cancelled = null,Object? outcome = null,}) {
+  return _then(_GrokSubagentCancelResponseDto(
+subagentId: null == subagentId ? _self.subagentId : subagentId // ignore: cast_nullable_to_non_nullable
+as String,cancelled: null == cancelled ? _self.cancelled : cancelled // ignore: cast_nullable_to_non_nullable
+as bool,outcome: null == outcome ? _self.outcome : outcome // ignore: cast_nullable_to_non_nullable
+as GrokSubagentCancelOutcomeDto,
+  ));
+}
+
+/// Create a copy of GrokSubagentCancelResponseDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$GrokSubagentCancelOutcomeDtoCopyWith<$Res> get outcome {
+  
+  return $GrokSubagentCancelOutcomeDtoCopyWith<$Res>(_self.outcome, (value) {
+    return _then(_self.copyWith(outcome: value));
+  });
+}
+}
+
+
+/// @nodoc
 mixin _$GrokReasoningEffortOptionDto {
 
  String? get id; String? get value; String? get label; String? get description;@JsonKey(name: "default") bool get isDefault;

--- a/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.g.dart
+++ b/bridge/sesori_plugin_grok/lib/src/api/models/grok_protocol_dto.g.dart
@@ -6,6 +6,52 @@ part of 'grok_protocol_dto.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+_GrokSubagentCancelRequestDto _$GrokSubagentCancelRequestDtoFromJson(
+  Map json,
+) => _GrokSubagentCancelRequestDto(subagentId: json['subagentId'] as String);
+
+Map<String, dynamic> _$GrokSubagentCancelRequestDtoToJson(
+  _GrokSubagentCancelRequestDto instance,
+) => <String, dynamic>{'subagentId': instance.subagentId};
+
+_GrokSubagentCancelOutcomeDto _$GrokSubagentCancelOutcomeDtoFromJson(
+  Map json,
+) => _GrokSubagentCancelOutcomeDto(
+  kind: $enumDecode(
+    _$GrokSubagentCancelOutcomeKindEnumMap,
+    json['kind'],
+    unknownValue: GrokSubagentCancelOutcomeKind.unknown,
+  ),
+  status: $enumDecodeNullable(
+    _$GrokSubagentStatusEnumMap,
+    json['status'],
+    unknownValue: GrokSubagentStatus.unknown,
+  ),
+);
+
+const _$GrokSubagentCancelOutcomeKindEnumMap = {
+  GrokSubagentCancelOutcomeKind.cancelled: 'cancelled',
+  GrokSubagentCancelOutcomeKind.alreadyFinished: 'already_finished',
+  GrokSubagentCancelOutcomeKind.unknown: 'unknown',
+};
+
+const _$GrokSubagentStatusEnumMap = {
+  GrokSubagentStatus.completed: 'completed',
+  GrokSubagentStatus.failed: 'failed',
+  GrokSubagentStatus.cancelled: 'cancelled',
+  GrokSubagentStatus.unknown: 'unknown',
+};
+
+_GrokSubagentCancelResponseDto _$GrokSubagentCancelResponseDtoFromJson(
+  Map json,
+) => _GrokSubagentCancelResponseDto(
+  subagentId: json['subagentId'] as String,
+  cancelled: json['cancelled'] as bool,
+  outcome: GrokSubagentCancelOutcomeDto.fromJson(
+    Map<String, dynamic>.from(json['outcome'] as Map),
+  ),
+);
+
 _GrokReasoningEffortOptionDto _$GrokReasoningEffortOptionDtoFromJson(
   Map json,
 ) => _GrokReasoningEffortOptionDto(

--- a/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
+++ b/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
@@ -100,7 +100,7 @@ class GrokPlugin._({
   final GrokSessionOptionsService _grokSessionOptionsService = grokSessionOptionsService;
 
   @override
-  bool get supportsScopedStop => true;
+  AcpScopedStopCapability get scopedStopCapability => AcpScopedStopCapability.perChildSnapshot;
 
   @override
   Future<AcpChildCancelResult> cancelChild({

--- a/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
+++ b/bridge/sesori_plugin_grok/lib/src/grok_plugin_impl.dart
@@ -10,6 +10,7 @@ import "grok_identity.dart";
 import "repositories/grok_catalog_repository.dart";
 import "repositories/grok_session_catalog_repository.dart";
 import "repositories/grok_session_config_repository.dart";
+import "repositories/grok_session_control_repository.dart";
 import "repositories/grok_session_history_repository.dart";
 import "repositories/mappers/grok_session_replay_collector.dart";
 import "services/grok_session_options_service.dart";
@@ -83,6 +84,7 @@ class GrokPlugin._({
       grokSessionOptionsService: grokSessionOptionsService,
       sessionService: GrokSessionService(
         catalogRepository: sessionCatalogRepository,
+        controlRepository: GrokSessionControlRepository(api: api),
         historyRepository: GrokSessionHistoryRepository(api: sessionStoreApi),
         liveTracker: childSessionTracker,
       ),
@@ -96,6 +98,20 @@ class GrokPlugin._({
       );
 
   final GrokSessionOptionsService _grokSessionOptionsService = grokSessionOptionsService;
+
+  @override
+  bool get supportsScopedStop => true;
+
+  @override
+  Future<AcpChildCancelResult> cancelChild({
+    required AcpStdioClient client,
+    required String sessionId,
+    required String childSessionId,
+  }) => _sessionService.cancelChild(
+    client: client,
+    parentSessionId: sessionId,
+    childSessionId: childSessionId,
+  );
 
   @override
   Set<String> get authMethodAllowlist => GrokAcpApi.headlessAuthMethodIds;

--- a/bridge/sesori_plugin_grok/lib/src/repositories/grok_session_control_repository.dart
+++ b/bridge/sesori_plugin_grok/lib/src/repositories/grok_session_control_repository.dart
@@ -3,6 +3,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../api/grok_acp_api.dart";
 import "../api/models/grok_protocol_dto.dart";
+import "../models/grok_subagent_status.dart";
 
 /// Maps Grok's exact child-cancel transport outcome into ACP stop policy.
 class const GrokSessionControlRepository({required final GrokAcpApi api}) {
@@ -13,6 +14,7 @@ class const GrokSessionControlRepository({required final GrokAcpApi api}) {
   }) async {
     try {
       final response = await api.cancelSubagent(client: client, subagentId: childSessionId);
+      _validateResponse(response: response);
       return switch (response.outcome.kind) {
         GrokSubagentCancelOutcomeKind.cancelled ||
         GrokSubagentCancelOutcomeKind.alreadyFinished => AcpChildCancelResult.interrupted,
@@ -27,6 +29,22 @@ class const GrokSessionControlRepository({required final GrokAcpApi api}) {
         ),
         stackTrace,
       );
+    }
+  }
+
+  void _validateResponse({required GrokSubagentCancelResponseDto response}) {
+    final consistent = switch (response.outcome.kind) {
+      GrokSubagentCancelOutcomeKind.cancelled => response.cancelled,
+      GrokSubagentCancelOutcomeKind.alreadyFinished => !response.cancelled,
+      GrokSubagentCancelOutcomeKind.unknown => false,
+    };
+    if (!consistent) {
+      throw FormatException(
+        "Grok sub-agent cancellation returned inconsistent outcome ${response.outcome.kind.name}",
+      );
+    }
+    if (response.outcome.status == GrokSubagentStatus.unknown) {
+      throw const FormatException("Grok sub-agent cancellation returned an unknown terminal status");
     }
   }
 }

--- a/bridge/sesori_plugin_grok/lib/src/repositories/grok_session_control_repository.dart
+++ b/bridge/sesori_plugin_grok/lib/src/repositories/grok_session_control_repository.dart
@@ -1,0 +1,32 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../api/grok_acp_api.dart";
+import "../api/models/grok_protocol_dto.dart";
+
+/// Maps Grok's exact child-cancel transport outcome into ACP stop policy.
+class const GrokSessionControlRepository({required final GrokAcpApi api}) {
+  Future<AcpChildCancelResult> cancelChild({
+    required AcpStdioClient client,
+    required String parentSessionId,
+    required String childSessionId,
+  }) async {
+    try {
+      final response = await api.cancelSubagent(client: client, subagentId: childSessionId);
+      return switch (response.outcome.kind) {
+        GrokSubagentCancelOutcomeKind.cancelled ||
+        GrokSubagentCancelOutcomeKind.alreadyFinished => AcpChildCancelResult.interrupted,
+        GrokSubagentCancelOutcomeKind.unknown => throw const FormatException("Unknown Grok cancellation outcome"),
+      };
+    } on Object catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        PluginOperationException(
+          GrokAcpApi.subagentCancelMethod,
+          message: "Grok child cancellation failed for child $childSessionId under parent $parentSessionId",
+          cause: error,
+        ),
+        stackTrace,
+      );
+    }
+  }
+}

--- a/bridge/sesori_plugin_grok/lib/src/services/grok_session_service.dart
+++ b/bridge/sesori_plugin_grok/lib/src/services/grok_session_service.dart
@@ -1,18 +1,29 @@
-import "package:acp_plugin/acp_plugin.dart" show AcpChildSessionTracker;
+import "package:acp_plugin/acp_plugin.dart" show AcpChildCancelResult, AcpChildSessionTracker, AcpStdioClient;
 import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart" show normalizeProjectDirectory;
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginSession;
 
 import "../repositories/grok_session_catalog_repository.dart";
+import "../repositories/grok_session_control_repository.dart";
 import "../repositories/grok_session_history_repository.dart";
 import "../repositories/models/grok_session_replay_context.dart";
 
-/// Layer-3 coordination for Grok child-session lineage across the persisted
-/// session tree and the current ACP process's live tracker.
+/// Layer-3 coordination for Grok session control and child-session lineage.
 class GrokSessionService({
   required final GrokSessionCatalogRepository _catalogRepository,
+  required final GrokSessionControlRepository _controlRepository,
   required final GrokSessionHistoryRepository _historyRepository,
   required final AcpChildSessionTracker _liveTracker,
 }) {
+  Future<AcpChildCancelResult> cancelChild({
+    required AcpStdioClient client,
+    required String parentSessionId,
+    required String childSessionId,
+  }) => _controlRepository.cancelChild(
+    client: client,
+    parentSessionId: parentSessionId,
+    childSessionId: childSessionId,
+  );
+
   Future<GrokSessionReplayContext> prepareReplayContext({
     required String sessionId,
     required String fallbackDirectory,

--- a/bridge/sesori_plugin_grok/test/grok_acp_api_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_acp_api_test.dart
@@ -137,7 +137,37 @@ void main() {
     expect(response.outcome.status, GrokSubagentStatus.completed);
   });
 
-  test("child cancellation rejects malformed or inconsistent native outcomes", () async {
+  test("child cancellation preserves unknown native outcomes for repository validation", () async {
+    final fake = FakeAcpProcess();
+    final client = AcpStdioClient(
+      launchSpec: const AcpLaunchSpec(includeParentEnvironment: true, command: "grok", args: []),
+      processFactory: (_) async => fake,
+    );
+    addTearDown(() async {
+      await client.dispose();
+      await fake.close();
+    });
+    await client.connect();
+    final api = _api(processFactory: (_) => throw StateError("unused"));
+
+    final cancelling = api.cancelSubagent(client: client, subagentId: "child");
+    final frame = await _waitForFrame(fake: fake, method: GrokAcpApi.subagentCancelMethod);
+    fake.emit({
+      "jsonrpc": "2.0",
+      "id": frame["id"],
+      "result": {
+        "subagentId": "child",
+        "cancelled": false,
+        "outcome": {"kind": "future_outcome", "status": "future_status"},
+      },
+    });
+
+    final response = await cancelling;
+    expect(response.outcome.kind, GrokSubagentCancelOutcomeKind.unknown);
+    expect(response.outcome.status, GrokSubagentStatus.unknown);
+  });
+
+  test("child cancellation rejects malformed responses and mismatched child ids", () async {
     final fake = FakeAcpProcess();
     final client = AcpStdioClient(
       launchSpec: const AcpLaunchSpec(includeParentEnvironment: true, command: "grok", args: []),
@@ -163,26 +193,32 @@ void main() {
     });
     await expectLater(mismatched, throwsFormatException);
 
-    final inconsistent = api.cancelSubagent(client: client, subagentId: "child");
-    final inconsistentFrame = await _waitForFrame(
+    final nonObject = api.cancelSubagent(client: client, subagentId: "child");
+    final nonObjectFrame = await _waitForFrame(
       fake: fake,
       method: GrokAcpApi.subagentCancelMethod,
       afterId: mismatchFrame["id"],
     );
+    fake.emit({"jsonrpc": "2.0", "id": nonObjectFrame["id"], "result": <Object?>[]});
+    await expectLater(nonObject, throwsFormatException);
+
+    final malformed = api.cancelSubagent(client: client, subagentId: "child");
+    final malformedFrame = await _waitForFrame(
+      fake: fake,
+      method: GrokAcpApi.subagentCancelMethod,
+      afterId: nonObjectFrame["id"],
+    );
     fake.emit({
       "jsonrpc": "2.0",
-      "id": inconsistentFrame["id"],
+      "id": malformedFrame["id"],
       "result": {
         "subagentId": "child",
-        "cancelled": false,
-        "outcome": {"kind": "future_outcome"},
+        "cancelled": "yes",
+        "outcome": {"kind": "cancelled"},
       },
     });
-    await expectLater(inconsistent, throwsFormatException);
-    await expectLater(
-      api.cancelSubagent(client: client, subagentId: " "),
-      throwsFormatException,
-    );
+    await expectLater(malformed, throwsA(isA<TypeError>()));
+    await expectLater(api.cancelSubagent(client: client, subagentId: " "), throwsFormatException);
   });
 
   test("setModel sends exact model and optional reasoning metadata", () async {

--- a/bridge/sesori_plugin_grok/test/grok_acp_api_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_acp_api_test.dart
@@ -3,6 +3,8 @@ import "dart:async";
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:grok_plugin/src/api/grok_acp_api.dart";
+import "package:grok_plugin/src/api/models/grok_protocol_dto.dart";
+import "package:grok_plugin/src/models/grok_subagent_status.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show PluginAuthenticationRequiredException;
 import "package:test/test.dart";
 
@@ -86,6 +88,101 @@ void main() {
       ),
     );
     expect(await fake.exitCode, -15);
+  });
+
+  test("child cancellation sends exact params and parses settled outcomes", () async {
+    final fake = FakeAcpProcess();
+    final client = AcpStdioClient(
+      launchSpec: const AcpLaunchSpec(includeParentEnvironment: true, command: "grok", args: []),
+      processFactory: (_) async => fake,
+    );
+    addTearDown(() async {
+      await client.dispose();
+      await fake.close();
+    });
+    await client.connect();
+    final api = _api(processFactory: (_) => throw StateError("unused"));
+
+    final cancelling = api.cancelSubagent(client: client, subagentId: "child");
+    final cancel = await _waitForFrame(fake: fake, method: GrokAcpApi.subagentCancelMethod);
+    expect(cancel["params"], {"subagentId": "child"});
+    fake.emit({
+      "jsonrpc": "2.0",
+      "id": cancel["id"],
+      "result": {
+        "subagentId": "child",
+        "cancelled": true,
+        "outcome": {"kind": "cancelled"},
+      },
+    });
+    expect((await cancelling).outcome.kind, GrokSubagentCancelOutcomeKind.cancelled);
+
+    final settled = api.cancelSubagent(client: client, subagentId: "finished");
+    final alreadyFinished = await _waitForFrame(
+      fake: fake,
+      method: GrokAcpApi.subagentCancelMethod,
+      afterId: cancel["id"],
+    );
+    fake.emit({
+      "jsonrpc": "2.0",
+      "id": alreadyFinished["id"],
+      "result": {
+        "subagentId": "finished",
+        "cancelled": false,
+        "outcome": {"kind": "already_finished", "status": "completed"},
+      },
+    });
+    final response = await settled;
+    expect(response.outcome.kind, GrokSubagentCancelOutcomeKind.alreadyFinished);
+    expect(response.outcome.status, GrokSubagentStatus.completed);
+  });
+
+  test("child cancellation rejects malformed or inconsistent native outcomes", () async {
+    final fake = FakeAcpProcess();
+    final client = AcpStdioClient(
+      launchSpec: const AcpLaunchSpec(includeParentEnvironment: true, command: "grok", args: []),
+      processFactory: (_) async => fake,
+    );
+    addTearDown(() async {
+      await client.dispose();
+      await fake.close();
+    });
+    await client.connect();
+    final api = _api(processFactory: (_) => throw StateError("unused"));
+
+    final mismatched = api.cancelSubagent(client: client, subagentId: "child");
+    final mismatchFrame = await _waitForFrame(fake: fake, method: GrokAcpApi.subagentCancelMethod);
+    fake.emit({
+      "jsonrpc": "2.0",
+      "id": mismatchFrame["id"],
+      "result": {
+        "subagentId": "other",
+        "cancelled": true,
+        "outcome": {"kind": "cancelled"},
+      },
+    });
+    await expectLater(mismatched, throwsFormatException);
+
+    final inconsistent = api.cancelSubagent(client: client, subagentId: "child");
+    final inconsistentFrame = await _waitForFrame(
+      fake: fake,
+      method: GrokAcpApi.subagentCancelMethod,
+      afterId: mismatchFrame["id"],
+    );
+    fake.emit({
+      "jsonrpc": "2.0",
+      "id": inconsistentFrame["id"],
+      "result": {
+        "subagentId": "child",
+        "cancelled": false,
+        "outcome": {"kind": "future_outcome"},
+      },
+    });
+    await expectLater(inconsistent, throwsFormatException);
+    await expectLater(
+      api.cancelSubagent(client: client, subagentId: " "),
+      throwsFormatException,
+    );
   });
 
   test("setModel sends exact model and optional reasoning metadata", () async {

--- a/bridge/sesori_plugin_grok/test/grok_acp_api_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_acp_api_test.dart
@@ -292,8 +292,10 @@ Future<Map<String, dynamic>> _waitForFrame({
   Object? afterId,
 }) async {
   for (var attempt = 0; attempt < 50; attempt++) {
-    for (final frame in fake.written) {
-      if (frame["method"] == method && frame["id"] != afterId) return frame;
+    final frames = fake.written;
+    final start = afterId == null ? 0 : frames.indexWhere((frame) => frame["id"] == afterId) + 1;
+    for (final frame in frames.skip(start)) {
+      if (frame["method"] == method) return frame;
     }
     await Future<void>.delayed(Duration.zero);
   }

--- a/bridge/sesori_plugin_grok/test/grok_plugin_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_plugin_test.dart
@@ -121,6 +121,55 @@ void main() {
       expect(await connecting, isTrue);
     }
 
+    Future<Map<String, dynamic>> startPrompt({required String sessionId}) async {
+      plugin.primeSessionDirectory(sessionId: sessionId, directory: "/repo");
+      await plugin.sendPrompt(
+        promptId: "prompt-$sessionId",
+        sessionId: sessionId,
+        parts: const [PluginPromptPart.text(text: "Work")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      await respond(method: AcpMethods.sessionLoad, result: {"sessionId": sessionId, "models": _modelState});
+      return await waitForFrame(method: AcpMethods.sessionPrompt);
+    }
+
+    Future<void> spawnChild({required String parentSessionId, required String childSessionId}) async {
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": GrokSessionProtocol.notificationMethod,
+        "params": {
+          "sessionId": parentSessionId,
+          "update": {
+            "sessionUpdate": "subagent_spawned",
+            "subagent_id": childSessionId,
+            "child_session_id": childSessionId,
+            "description": "Child $childSessionId",
+          },
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+    }
+
+    Future<void> finishChild({required String parentSessionId, required String childSessionId}) async {
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": GrokSessionProtocol.notificationMethod,
+        "params": {
+          "sessionId": parentSessionId,
+          "update": {
+            "sessionUpdate": "subagent_finished",
+            "subagent_id": childSessionId,
+            "child_session_id": childSessionId,
+            "status": "cancelled",
+            "will_wake": false,
+          },
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+    }
+
     test("child sessions and parentage come from the live sub-agent tracker", () async {
       plugin.childSessionTracker.spawn(
         sessionId: "root",
@@ -755,6 +804,301 @@ void main() {
       fake.emit({
         "jsonrpc": "2.0",
         "id": prompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+    });
+
+    test("scoped confirm and unsupported keep reject without side effects", () async {
+      await connect();
+      final rootPrompt = await startPrompt(sessionId: "root");
+      await spawnChild(parentSessionId: "root", childSessionId: "child");
+
+      for (final policy in [PluginAbortSubAgentPolicy.confirm, PluginAbortSubAgentPolicy.keep]) {
+        final before = fake.written.length;
+        final result = await plugin.abortSession(
+          sessionId: "root",
+          subAgents: policy,
+          useAtomicStop: true,
+          knownSubAgentSessionIds: const {"child"},
+        );
+        expect(
+          result,
+          isA<PluginAbortRejectedSubAgentsRunning>()
+              .having((value) => value.runningSubAgentCount, "child count", 1)
+              .having((value) => value.mainAgentRunning, "main running", true)
+              .having((value) => value.mainAgentOnlySupported, "main-only support", false),
+        );
+        expect(fake.written, hasLength(before));
+      }
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": rootPrompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      await Future<void>.delayed(Duration.zero);
+      final beforeKeep = fake.written.length;
+      final idleRootKeep = await plugin.abortSession(
+        sessionId: "root",
+        subAgents: PluginAbortSubAgentPolicy.keep,
+        useAtomicStop: true,
+        knownSubAgentSessionIds: const {"child"},
+      );
+      expect(
+        idleRootKeep,
+        isA<PluginAbortAccepted>()
+            .having((value) => value.workKept, "child kept", true)
+            .having((value) => value.subAgentsHandled, "handled", true),
+      );
+      expect(fake.written, hasLength(beforeKeep));
+      expect(plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"child"});
+      await finishChild(parentSessionId: "root", childSessionId: "child");
+    });
+
+    test("named child stop is exact and lifecycle remains settlement authority", () async {
+      await connect();
+      final rootPrompt = await startPrompt(sessionId: "root");
+      await spawnChild(parentSessionId: "root", childSessionId: "child");
+      await spawnChild(parentSessionId: "root", childSessionId: "sibling");
+
+      final stopping = plugin.abortSession(
+        sessionId: "child",
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: true,
+        knownSubAgentSessionIds: const {},
+      );
+      final cancel = await waitForFrame(method: GrokAcpApi.subagentCancelMethod);
+      expect(cancel["params"], {"subagentId": "child"});
+      expect(fake.written.where((frame) => frame["method"] == AcpMethods.sessionCancel), isEmpty);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": cancel["id"],
+        "result": {
+          "subagentId": "child",
+          "cancelled": true,
+          "outcome": {"kind": "cancelled"},
+        },
+      });
+      expect(
+        await stopping,
+        isA<PluginAbortAccepted>()
+            .having((value) => value.workKept, "kept", false)
+            .having((value) => value.subAgentsHandled, "atomic authority", false),
+      );
+      expect(plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"child", "sibling"});
+
+      await finishChild(parentSessionId: "root", childSessionId: "child");
+      expect(plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"sibling"});
+      await finishChild(parentSessionId: "root", childSessionId: "sibling");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": rootPrompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+    });
+
+    test("current atomic opt-in fans out but returns false authority", () async {
+      await connect();
+      final rootPrompt = await startPrompt(sessionId: "root");
+      await spawnChild(parentSessionId: "root", childSessionId: "first");
+      await spawnChild(parentSessionId: "root", childSessionId: "second");
+
+      final stopping = plugin.abortSession(
+        sessionId: "root",
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: true,
+        knownSubAgentSessionIds: const {"first", "second"},
+      );
+      final rootCancel = await waitForFrame(method: AcpMethods.sessionCancel);
+      final firstCancel = await waitForFrame(method: GrokAcpApi.subagentCancelMethod);
+      final secondCancel = await waitForFrame(method: GrokAcpApi.subagentCancelMethod);
+      expect(
+        [firstCancel, secondCancel].map((frame) => (frame["params"] as Map)["subagentId"]),
+        unorderedEquals(["first", "second"]),
+      );
+      expect(fake.written.indexOf(rootCancel), lessThan(fake.written.indexOf(firstCancel)));
+      expect(fake.written.indexOf(rootCancel), lessThan(fake.written.indexOf(secondCancel)));
+
+      for (final frame in [firstCancel, secondCancel]) {
+        final childId = (frame["params"] as Map)["subagentId"] as String;
+        fake.emit({
+          "jsonrpc": "2.0",
+          "id": frame["id"],
+          "result": {
+            "subagentId": childId,
+            "cancelled": childId == "first",
+            "outcome": {
+              "kind": childId == "first" ? "cancelled" : "already_finished",
+              if (childId == "second") "status": "completed",
+            },
+          },
+        });
+      }
+      expect(
+        await stopping,
+        isA<PluginAbortAccepted>()
+            .having((value) => value.workKept, "kept", false)
+            .having((value) => value.subAgentsHandled, "atomic authority", false),
+      );
+      expect(plugin.childSessionTracker.busyChildIds(sessionId: "root"), {"first", "second"});
+
+      await finishChild(parentSessionId: "root", childSessionId: "first");
+      await finishChild(parentSessionId: "root", childSessionId: "second");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": rootPrompt["id"],
+        "result": {"stopReason": "cancelled"},
+      });
+    });
+
+    test("partial child failure still attempts and waits for full snapshot", () async {
+      await connect();
+      final rootPrompt = await startPrompt(sessionId: "root");
+      await spawnChild(parentSessionId: "root", childSessionId: "first");
+      await spawnChild(parentSessionId: "root", childSessionId: "second");
+      var completed = false;
+      final stopping = plugin
+          .abortSession(
+            sessionId: "root",
+            subAgents: PluginAbortSubAgentPolicy.stop,
+            useAtomicStop: true,
+            knownSubAgentSessionIds: const {"first", "second"},
+          )
+          .whenComplete(() => completed = true);
+      final failure = expectLater(stopping, throwsA(isA<PluginOperationException>()));
+      await waitForFrame(method: AcpMethods.sessionCancel);
+      final firstCancel = await waitForFrame(method: GrokAcpApi.subagentCancelMethod);
+      final secondCancel = await waitForFrame(method: GrokAcpApi.subagentCancelMethod);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": firstCancel["id"],
+        "error": {"code": -32603, "message": "cancel failed"},
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(completed, isFalse);
+      final secondId = (secondCancel["params"] as Map)["subagentId"] as String;
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": secondCancel["id"],
+        "result": {
+          "subagentId": secondId,
+          "cancelled": true,
+          "outcome": {"kind": "cancelled"},
+        },
+      });
+      await failure;
+      expect(
+        fake.written.where((frame) => frame["method"] == GrokAcpApi.subagentCancelMethod),
+        hasLength(2),
+      );
+
+      await finishChild(parentSessionId: "root", childSessionId: "first");
+      await finishChild(parentSessionId: "root", childSessionId: "second");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": rootPrompt["id"],
+        "result": {"stopReason": "cancelled"},
+      });
+    });
+
+    test("released-client opt-out preserves root-only cancellation", () async {
+      await connect();
+      final rootPrompt = await startPrompt(sessionId: "root");
+      await spawnChild(parentSessionId: "root", childSessionId: "child");
+
+      final result = await plugin.abortSession(
+        sessionId: "root",
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: false,
+        knownSubAgentSessionIds: const {"child"},
+      );
+      expect(result, isA<PluginAbortAccepted>().having((value) => value.subAgentsHandled, "handled", false));
+      expect(fake.written.where((frame) => frame["method"] == AcpMethods.sessionCancel), hasLength(1));
+      expect(fake.written.where((frame) => frame["method"] == GrokAcpApi.subagentCancelMethod), isEmpty);
+
+      await finishChild(parentSessionId: "root", childSessionId: "child");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": rootPrompt["id"],
+        "result": {"stopReason": "cancelled"},
+      });
+    });
+
+    test("named stop preserves sibling pending permission and unrelated queued turn", () async {
+      await connect();
+      final rootPrompt = await startPrompt(sessionId: "root");
+      await spawnChild(parentSessionId: "root", childSessionId: "child");
+      await spawnChild(parentSessionId: "root", childSessionId: "sibling");
+      plugin.primeSessionDirectory(sessionId: "unrelated", directory: "/repo");
+      await plugin.sendPrompt(
+        promptId: "queued-unrelated",
+        sessionId: "unrelated",
+        parts: const [PluginPromptPart.text(text: "Queued work")],
+        variant: null,
+        agent: null,
+        model: null,
+      );
+      final unrelatedLoad = await waitForFrame(method: AcpMethods.sessionLoad);
+      for (final entry in const [(id: 901, sessionId: "child"), (id: 902, sessionId: "sibling")]) {
+        fake.emit({
+          "jsonrpc": "2.0",
+          "id": entry.id,
+          "method": AcpMethods.sessionRequestPermission,
+          "params": {
+            "sessionId": entry.sessionId,
+            "toolCall": {"toolCallId": "tool-${entry.sessionId}", "title": "Run", "kind": "execute"},
+            "options": [
+              {"optionId": "allow", "name": "Allow", "kind": "allow_once"},
+              {"optionId": "reject", "name": "Reject", "kind": "reject_once"},
+            ],
+          },
+        });
+      }
+      await Future<void>.delayed(Duration.zero);
+      final siblingPermission = (await plugin.getPendingPermissions(sessionId: "sibling")).single;
+
+      final stopping = plugin.abortSession(
+        sessionId: "child",
+        subAgents: PluginAbortSubAgentPolicy.stop,
+        useAtomicStop: true,
+        knownSubAgentSessionIds: const {},
+      );
+      final cancel = await waitForFrame(method: GrokAcpApi.subagentCancelMethod);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": cancel["id"],
+        "result": {
+          "subagentId": "child",
+          "cancelled": true,
+          "outcome": {"kind": "cancelled"},
+        },
+      });
+      await stopping;
+      expect(await plugin.getPendingPermissions(sessionId: "child"), isEmpty);
+      expect(await plugin.getPendingPermissions(sessionId: "sibling"), hasLength(1));
+      expect(fake.written.singleWhere((frame) => frame["id"] == 901)["result"], {
+        "outcome": {"outcome": "cancelled"},
+      });
+      expect(fake.written.where((frame) => frame["id"] == 902), isEmpty);
+
+      await plugin.replyToPermission(
+        requestId: siblingPermission.id,
+        sessionId: "sibling",
+        reply: PluginPermissionReply.once,
+      );
+      fake.emit({"jsonrpc": "2.0", "id": unrelatedLoad["id"], "result": const <String, dynamic>{}});
+      final unrelatedPrompt = await waitForFrame(method: AcpMethods.sessionPrompt);
+      expect((unrelatedPrompt["params"] as Map)["sessionId"], "unrelated");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": unrelatedPrompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      await finishChild(parentSessionId: "root", childSessionId: "child");
+      await finishChild(parentSessionId: "root", childSessionId: "sibling");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": rootPrompt["id"],
         "result": {"stopReason": "end_turn"},
       });
     });

--- a/bridge/sesori_plugin_grok/test/grok_plugin_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_plugin_test.dart
@@ -855,6 +855,66 @@ void main() {
       await finishChild(parentSessionId: "root", childSessionId: "child");
     });
 
+    test("keep retains a terminal child's autonomous root hold", () async {
+      await connect();
+      final rootPrompt = await startPrompt(sessionId: "root");
+      await spawnChild(parentSessionId: "root", childSessionId: "child");
+      fake.emit({
+        "jsonrpc": "2.0",
+        "id": rootPrompt["id"],
+        "result": {"stopReason": "end_turn"},
+      });
+      await Future<void>.delayed(Duration.zero);
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": GrokSessionProtocol.notificationMethod,
+        "params": {
+          "sessionId": "root",
+          "update": {
+            "sessionUpdate": "subagent_finished",
+            "subagent_id": "child",
+            "child_session_id": "child",
+            "status": "completed",
+            "will_wake": true,
+          },
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(plugin.childSessionTracker.busyChildIds(sessionId: "root"), isEmpty);
+      expect(plugin.childSessionTracker.hasRootHold(sessionId: "root"), isTrue);
+
+      final beforeKeep = fake.written.length;
+      final result = await plugin.abortSession(
+        sessionId: "root",
+        subAgents: PluginAbortSubAgentPolicy.keep,
+        useAtomicStop: true,
+        knownSubAgentSessionIds: const {"child"},
+      );
+      expect(
+        result,
+        isA<PluginAbortAccepted>()
+            .having((value) => value.workKept, "hold kept", true)
+            .having((value) => value.subAgentsHandled, "handled", true),
+      );
+      expect(fake.written, hasLength(beforeKeep));
+      expect(plugin.childSessionTracker.hasRootHold(sessionId: "root"), isTrue);
+
+      fake.emit({
+        "jsonrpc": "2.0",
+        "method": GrokSessionProtocol.updateMethod,
+        "params": {
+          "sessionId": "root",
+          "update": {
+            "sessionUpdate": "turn_completed",
+            "prompt_id": "${GrokSessionProtocol.autonomousTurnPromptPrefix}child",
+          },
+        },
+      });
+      await Future<void>.delayed(Duration.zero);
+      expect(plugin.childSessionTracker.hasRootHold(sessionId: "root"), isFalse);
+      expect((await plugin.getSessionStatuses())["root"], const PluginSessionStatus.idle());
+    });
+
     test("named child stop is exact and lifecycle remains settlement authority", () async {
       await connect();
       final rootPrompt = await startPrompt(sessionId: "root");

--- a/bridge/sesori_plugin_grok/test/grok_session_control_repository_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_control_repository_test.dart
@@ -1,0 +1,145 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:grok_plugin/src/api/grok_acp_api.dart";
+import "package:grok_plugin/src/api/models/grok_protocol_dto.dart";
+import "package:grok_plugin/src/models/grok_subagent_status.dart";
+import "package:grok_plugin/src/repositories/grok_session_control_repository.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+void main() {
+  const client = _FakeAcpStdioClient();
+
+  GrokSubagentCancelResponseDto response({
+    required GrokSubagentCancelOutcomeKind kind,
+    required bool cancelled,
+    required GrokSubagentStatus? status,
+  }) => GrokSubagentCancelResponseDto(
+    subagentId: "child",
+    cancelled: cancelled,
+    outcome: GrokSubagentCancelOutcomeDto(kind: kind, status: status),
+  );
+
+  Future<AcpChildCancelResult> cancel({required GrokSubagentCancelResponseDto response}) =>
+      GrokSessionControlRepository(api: _FakeGrokAcpApi(cancellation: () async => response)).cancelChild(
+        client: client,
+        parentSessionId: "parent",
+        childSessionId: "child",
+      );
+
+  test("maps consistent cancelled and already-finished outcomes", () async {
+    expect(
+      await cancel(
+        response: response(
+          kind: GrokSubagentCancelOutcomeKind.cancelled,
+          cancelled: true,
+          status: null,
+        ),
+      ),
+      AcpChildCancelResult.interrupted,
+    );
+    expect(
+      await cancel(
+        response: response(
+          kind: GrokSubagentCancelOutcomeKind.alreadyFinished,
+          cancelled: false,
+          status: GrokSubagentStatus.completed,
+        ),
+      ),
+      AcpChildCancelResult.interrupted,
+    );
+  });
+
+  test("rejects cancellation kind and cancelled inconsistencies", () async {
+    for (final invalidResponse in [
+      response(
+        kind: GrokSubagentCancelOutcomeKind.cancelled,
+        cancelled: false,
+        status: null,
+      ),
+      response(
+        kind: GrokSubagentCancelOutcomeKind.alreadyFinished,
+        cancelled: true,
+        status: GrokSubagentStatus.completed,
+      ),
+      response(
+        kind: GrokSubagentCancelOutcomeKind.unknown,
+        cancelled: false,
+        status: null,
+      ),
+    ]) {
+      await expectLater(
+        cancel(response: invalidResponse),
+        throwsA(
+          isA<PluginOperationException>()
+              .having((error) => error.operation, "operation", GrokAcpApi.subagentCancelMethod)
+              .having((error) => error.cause, "cause", isA<FormatException>()),
+        ),
+      );
+    }
+  });
+
+  test("rejects an unknown terminal status", () async {
+    await expectLater(
+      cancel(
+        response: response(
+          kind: GrokSubagentCancelOutcomeKind.alreadyFinished,
+          cancelled: false,
+          status: GrokSubagentStatus.unknown,
+        ),
+      ),
+      throwsA(
+        isA<PluginOperationException>().having(
+          (error) => error.cause,
+          "cause",
+          isA<FormatException>().having(
+            (error) => error.message,
+            "message",
+            "Grok sub-agent cancellation returned an unknown terminal status",
+          ),
+        ),
+      ),
+    );
+  });
+
+  test("wraps transport failures with parent-child context and original cause", () async {
+    final cause = StateError("transport failed");
+    final repository = GrokSessionControlRepository(
+      api: _FakeGrokAcpApi(cancellation: () async => throw cause),
+    );
+
+    await expectLater(
+      repository.cancelChild(
+        client: client,
+        parentSessionId: "parent",
+        childSessionId: "child",
+      ),
+      throwsA(
+        isA<PluginOperationException>()
+            .having((error) => error.cause, "cause", same(cause))
+            .having(
+              (error) => error.message,
+              "message",
+              "Grok child cancellation failed for child child under parent parent",
+            ),
+      ),
+    );
+  });
+}
+
+class _FakeGrokAcpApi({
+  required final Future<GrokSubagentCancelResponseDto> Function() cancellation,
+}) implements GrokAcpApi {
+  @override
+  Future<GrokSubagentCancelResponseDto> cancelSubagent({
+    required AcpStdioClient client,
+    required String subagentId,
+  }) => cancellation();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class const _FakeAcpStdioClient() implements AcpStdioClient {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_options_service_test.dart
@@ -338,6 +338,10 @@ Map<String, dynamic> _jsonFixture({required String name}) {
 }
 
 class _FakeGrokAcpApi() implements GrokAcpApi {
+  @override
+  Future<Never> cancelSubagent({required AcpStdioClient client, required String subagentId}) =>
+      throw StateError("unused");
+
   final List<Future<AcpInitializeResult> Function()> probes = [];
   final List<({String sessionId, String modelId, String? reasoningEffort})> selections = [];
   int probeCount = 0;

--- a/bridge/sesori_plugin_grok/test/grok_session_service_test.dart
+++ b/bridge/sesori_plugin_grok/test/grok_session_service_test.dart
@@ -2,8 +2,10 @@ import "dart:convert";
 import "dart:io";
 
 import "package:acp_plugin/acp_plugin.dart";
+import "package:grok_plugin/src/api/grok_acp_api.dart";
 import "package:grok_plugin/src/api/grok_session_store_api.dart";
 import "package:grok_plugin/src/repositories/grok_session_catalog_repository.dart";
+import "package:grok_plugin/src/repositories/grok_session_control_repository.dart";
 import "package:grok_plugin/src/repositories/grok_session_history_repository.dart";
 import "package:grok_plugin/src/services/grok_session_service.dart";
 import "package:path/path.dart" as p;
@@ -38,6 +40,13 @@ void main() {
       final repository = GrokSessionCatalogRepository(api: storeApi);
       service = GrokSessionService(
         catalogRepository: repository,
+        controlRepository: GrokSessionControlRepository(
+          api: GrokAcpApi(
+            binaryPath: "grok",
+            processFactory: (_) => throw StateError("unused"),
+            environment: const {},
+          ),
+        ),
         historyRepository: GrokSessionHistoryRepository(api: storeApi),
         liveTracker: tracker,
       );

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -193,9 +193,9 @@ prompt, and skill commands remain available.
 | Stop the sub-agents only while the main agent is idle (`stop`) | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅¹⁰ |
 | Stop the main agent only while it runs, keeping its sub-agents | 🚫¹ | 🚫² | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | 🚫¹⁰ |
 
-Plugins that report a scoped-stop rejection declare whether "main agent only"
-is honored through `mainAgentOnlySupported`; the app offers the action only
-when it is true.
+ACP plugins declare one closed scoped-stop capability: `unsupported`, `perChildSnapshot` (Grok), or
+`completeNativeAtomic` (DeepSeek). Plugins that report a scoped-stop rejection declare whether "main agent only" is
+honored through `mainAgentOnlySupported`; the app offers the action only when it is true.
 
 ¹ Claude Code's only stop primitive (`interrupt`, verified on 2.1.257) stops
 background sub-agents together with the running main turn.

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -189,8 +189,8 @@ prompt, and skill commands remain available.
 |---|---|---|---|---|---|---|---|---|---|---|
 | Sub-agents rendered as inline subtask tiles | ✅ | ✅ | ✅³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅¹⁰ |
 | Sub-agent transcripts exposed as child sessions | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅¹⁰ |
-| Scoped stop: confirmation while sub-agents run, `stop` cancels them all | ✅ | ✅ | ✅ (snapshot)³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ⬜¹⁰ |
-| Stop the sub-agents only while the main agent is idle (`stop`) | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ⬜¹⁰ |
+| Scoped stop: confirmation while sub-agents run, `stop` cancels them all | ✅ | ✅ | ✅ (snapshot)³ | 🚫⁴ | ⬜⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅ (snapshot)¹⁰ |
+| Stop the sub-agents only while the main agent is idle (`stop`) | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅¹⁰ |
 | Stop the main agent only while it runs, keeping its sub-agents | 🚫¹ | 🚫² | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | 🚫¹⁰ |
 
 Plugins that report a scoped-stop rejection declare whether "main agent only"
@@ -283,10 +283,16 @@ persisted/live children, loads child transcripts by exact native id, and rebuild
 root tiles from each exact child's first user-message run only when that run is
 nonblank, without reading live tracker state. A blank or missing first run
 produces no tile; later runs never substitute. Permission denial persistence is
-unverified and has no outcome model. Grok exposes `_x.ai/subagent/cancel` per
-child, but scoped-stop integration remains unimplemented. A root
-`session/cancel` cancels background children too, so main-agent-only is not
-supported.
+unverified and has no outcome model. Grok scoped stop snapshots the named
+scope before mutation, sends root `session/cancel` first, and fans out exact
+`_x.ai/subagent/cancel {subagentId}` requests for its running children. This is
+not complete native subtree authority: accepted results deliberately report
+`subAgentsHandled: false` and retain current-client fallback. Main-agent-only
+stop is unsupported because root cancellation stopped every observed child;
+idle-root child-only `keep` remains side-effect free. Automated coverage proves
+rejection, fanout, outcome mapping, lifecycle-only settlement, and exact pending
+permission/queue isolation. Actual-plugin, phone, and live pending-input coverage
+remain unexecuted for Step 6; Grok question support is not claimed.
 
 ¹¹ Pi (0.84.4, probed 2026-09-05) reports it from `pi --list-models`, which
 prints one row per usable model and otherwise prints the

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -82,8 +82,14 @@ reaches the backend so the turn continues.
   Standard ACP permissions preserve the exact session, tool call, and offered
   option IDs; Once, Reject, and every scope the request actually advertises stay
   phone-mediated unless an existing explicit bridge auto-approval rule applies.
-  Abort, process exit, and disposal cancel pending Grok requests rather than
-  broadening or silently approving them.
+  Scoped-stop preflight preserves pending Grok requests when `confirm` rejects,
+  when active-root `keep` is unsupported, and when idle-root child-only `keep`
+  succeeds. Accepted named-child stop cancels only that child's pending ACP
+  interaction; full snapshot stop cancels root and selected-child interactions.
+  Process exit and disposal also cancel pending Grok requests rather than
+  broadening or silently approving them. These guarantees have automated
+  fixture coverage only; actual-plugin pending input remains unexecuted, and no
+  native Grok question channel is claimed.
 - A sessionless ACP request first resolves its top-level or nested
   `toolCall.toolCallId` against tracked calls. An exact match retains its session;
   an ambiguous match cancels rather than falling back to another active turn.

--- a/docs/regression/questions-and-permissions.md
+++ b/docs/regression/questions-and-permissions.md
@@ -86,6 +86,8 @@ reaches the backend so the turn continues.
   when active-root `keep` is unsupported, and when idle-root child-only `keep`
   succeeds. Accepted named-child stop cancels only that child's pending ACP
   interaction; full snapshot stop cancels root and selected-child interactions.
+  This input cleanup stays scoped; completion suppression for a fully stopped
+  named child records the root ID and applies to the root session group.
   Process exit and disposal also cancel pending Grok requests rather than
   broadening or silently approving them. These guarantees have automated
   fixture coverage only; actual-plugin pending input remains unexecuted, and no

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -141,15 +141,15 @@ defaults and queued client sends coherent.
   matching subtask and are never rendered as user messages, while user text
   that merely discusses the envelope stays visible. Forwarded sub-agent frames
   render in the sub-agent's child session, never as a root turn.
-- Claude tasks and OpenCode child sessions expose scoped stop. The client
-  first asks with `confirm`; while sub-agents
+- Claude tasks, OpenCode child sessions, and Grok children expose scoped stop.
+  The client first asks with `confirm`; while sub-agents
   run the bridge refuses with the running count and whether the main agent is
   mid-turn, and the app shows a confirmation: with the main agent idle, "Stop N
   sub-agents"; with the main agent running, "Stop main agent and N sub-agents".
   Dismissing leaves everything running. "Stop main agent only" (`keep`) is
   offered only when the rejection declares `mainAgentOnlySupported`; neither
   of these harnesses can interrupt a running main agent without its sub-agents,
-  so both report false and refuse `keep` during a live main turn with the
+  so all three report false and refuse `keep` during a live main turn with the
   running count. With the main agent idle `keep` is honored: the Claude process
   stays resident, the sub-agents continue, their later wake-up turn renders,
   and the completion push is not suppressed. `stop` interrupts and tears
@@ -157,7 +157,12 @@ defaults and queued client sends coherent.
   as before with no dialog. An older app stops everything; an older bridge
   ignores the scope.
   OpenCode retains legacy client fallback: its observed-child snapshot does not
-  prove atomic subtree completion across separate HTTP/SSE channels.
+  prove atomic subtree completion across separate HTTP/SSE channels. Grok also
+  reports false atomic authority: current clients receive root-first native
+  cancellation plus exact per-child snapshot fanout, then retain their fallback.
+  `cancelled` and `already_finished` ACKs mean work was not retained, but only
+  native `subagent_finished` and turn completion settle lifecycle state. Named
+  child stop excludes its root and siblings.
 - Codex supports the same side-effect-free `confirm` preflight for any named
   root or child thread. It reports the exact active descendant count, including
   pending-input-only work, plus the named thread's own running state, and offers
@@ -298,8 +303,12 @@ defaults and queued client sends coherent.
   matching `turn_completed` prompt `subagent-completed-<child id>`. A new user
   prompt cancels that autonomous turn and waits for the hold to clear before its
   ACP prompt frame is dispatched. Spawn and non-final finish changes invalidate
-  the project summary. Deletion refuses a running child or root with active
-  child work until that work is stopped or finishes; global interruption,
+  the project summary. Scoped `confirm` and unsupported active-root `keep`
+  reject before cancellation or local input mutation. Idle-root child-only
+  `keep` writes nothing. Named stop fences only that child's queue and pending
+  ACP interaction; full stop fences the immutable named scope before root-first
+  and per-child cancellation. Deletion refuses a running child or root with
+  active child work until that work is stopped or finishes; global interruption,
   process exit, and disposal cancel or clear child activity and holds without
   leaving the root busy or delivering tracker changes to a closed event stream.
 - Existing-session ACP prompts remain bridge-queued while an earlier same-session

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -147,7 +147,7 @@ defaults and queued client sends coherent.
   mid-turn, and the app shows a confirmation: with the main agent idle, "Stop N
   sub-agents"; with the main agent running, "Stop main agent and N sub-agents".
   Dismissing leaves everything running. "Stop main agent only" (`keep`) is
-  offered only when the rejection declares `mainAgentOnlySupported`; neither
+  offered only when the rejection declares `mainAgentOnlySupported`; none
   of these harnesses can interrupt a running main agent without its sub-agents,
   so all three report false and refuse `keep` during a live main turn with the
   running count. With the main agent idle `keep` is honored: the Claude process


### PR DESCRIPTION
## Complexity
⚙️ Moderate — narrow shared ACP authority split plus typed Grok cancellation through existing layers.

## What
- Model unsupported, per-child snapshot and complete native atomic authority with one capability enum; DeepSeek retains its native path.
- Opt Grok into existing ACP policy with typed exact-child cancellation.
- Dispatch root-first immutable snapshot cancellation and retain native lifecycle as settlement authority.
- Preserve terminal-child autonomous root holds on idle-root keep.

## Why
Grok root cancellation cannot preserve active descendants, and its per-child primitive is not complete atomic subtree authority. Policy must reflect those limits without duplicating ACP orchestration or weakening DeepSeek.

## Risk and test focus
Focus on no-effect rejection, exact scope, queued/pending-input fencing, complete attempted fanout on partial failure, outcome mapping and lifecycle-only settlement. Full snapshot stop returns subAgentsHandled:false, preserving client fallback. Existing useAtomicStop:false behavior is unchanged.

User-visible impact: Grok supports scope confirmation and full stop; active-root keep with descendants is rejected honestly. Idle-root keep retains descendant or autonomous-held work without cancellation. No database, client/shared wire, runtime pin or auth changes.

## Expected result
Confirm and unsupported keep do not mutate work. Named-child stop excludes ancestor/sibling. Full stop targets the captured scope, while native lifecycle—not ACK—settles status. DeepSeek retains complete-native authority; Grok does not claim it.

## Verification
- Grok package suite/analyzer, targeted ACP suites/analyzer and affected DeepSeek scoped-stop tests/analyzer passed during implementation.
- Final hold fix: Grok plugin tests30 and ACP serialization tests31 passed; both analyzers clean.
- Architecture review approved; correctness finding fixed and focused review approved 14c8452636.
- Latest capability/outcome-layer fixes approved in architecture and correctness reviews; ACP, Grok and DeepSeek tests/analyzers passed.
- Whitespace checks passed; 1,597-line scope including generated output/tests/docs.
- No repeated native probes or new actual-plugin/phone QA claimed. Those remain step6/6; permission-denial and Grok question support remain unclaimed.
