### PR TITLE
🌿 Match chat messages to the Figma design

### DIFF
--- a/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
+++ b/client/app/test/features/session_detail/widgets/session_detail_body_test.dart
@@ -521,7 +521,7 @@ void main() {
     expect(find.text("Cold-start prompt"), findsOneWidget);
   });
 
-  testWidgets("settled user text renders Markdown inside the shared brand bubble", (tester) async {
+  testWidgets("settled user text renders Markdown inside the shared neutral bubble", (tester) async {
     final state = _loadedState(
       pendingQuestions: const [],
       pendingPermissions: const [],

--- a/client/module_app_ui/lib/src/features/session_detail/widgets/text_part_widget.dart
+++ b/client/module_app_ui/lib/src/features/session_detail/widgets/text_part_widget.dart
@@ -30,7 +30,7 @@ class const TextPartWidget({
           uri: uri,
           semanticLabel: alt,
         ),
-        styleSheet: buildSessionMarkdownStyleSheet(prego: context.prego),
+        styleSheet: buildChatMessageMarkdownStyleSheet(prego: context.prego),
         blockSyntaxes: sessionMarkdownBlockSyntaxes,
         builders: buildSessionMarkdownBuilders(
           highlightEnabled: !isStreaming,

--- a/client/module_app_ui/lib/src/features/session_detail/widgets/user_message_card.dart
+++ b/client/module_app_ui/lib/src/features/session_detail/widgets/user_message_card.dart
@@ -46,58 +46,57 @@ class const UserMessageBubble({
     final prego = context.prego;
     final markdown = this.markdown;
 
-    return Align(
-      alignment: .centerRight,
-      child: AnimatedContainer(
-        duration: transitionDuration,
-        curve: Curves.easeInOutCubic,
-        margin: const EdgeInsets.symmetric(
-          horizontal: PregoSpacing.xl,
-          vertical: PregoSpacing.xs,
-        ),
-        padding: const EdgeInsets.symmetric(
-          horizontal: PregoSpacing.xl,
-          vertical: PregoSpacing.lg,
-        ),
-        constraints: BoxConstraints(
-          maxWidth: MediaQuery.sizeOf(context).width * 0.85,
-        ),
-        decoration: BoxDecoration(
-          color: prego.colors.bgBrandPrimary,
-          borderRadius: BorderRadius.circular(PregoRadius.x2l),
-        ),
-        foregroundDecoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(PregoRadius.x2l),
-          border: Border.all(
-            color: prego.colors.borderBrand.withValues(alpha: outlined ? 0.55 : 0),
+    return LayoutBuilder(
+      builder: (context, constraints) => Align(
+        alignment: .centerRight,
+        child: AnimatedContainer(
+          duration: transitionDuration,
+          curve: Curves.easeInOutCubic,
+          margin: const EdgeInsets.symmetric(
+            horizontal: PregoSpacing.xl,
+            vertical: PregoSpacing.xs,
           ),
-        ),
-        child: Column(
-          crossAxisAlignment: .end,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ...attachments,
-            if (markdown != null)
-              PregoReadableSelectionArea(
-                child: MarkdownBody(
-                  data: markdown,
-                  selectable: false,
-                  softLineBreak: true,
-                  onTapLink: buildSessionDetailMarkdownLinkTapHandler(context: context),
-                  imageBuilder: (uri, title, alt) => _userMarkdownImage(
-                    context: context,
-                    uri: uri,
-                    semanticLabel: alt,
-                  ),
-                  styleSheet: buildUserMessageMarkdownStyleSheet(prego: prego),
-                  blockSyntaxes: sessionMarkdownBlockSyntaxes,
-                  builders: buildSessionMarkdownBuilders(
-                    highlightEnabled: true,
-                    copyTooltip: context.loc.sessionDetailCopy,
+          padding: const EdgeInsets.all(10),
+          constraints: BoxConstraints(
+            maxWidth: (constraints.maxWidth - PregoSpacing.xl * 2) * 0.76,
+          ),
+          decoration: BoxDecoration(
+            color: prego.colors.bgSurface2,
+            borderRadius: BorderRadius.circular(PregoRadius.xl),
+          ),
+          foregroundDecoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(PregoRadius.xl),
+            border: Border.all(
+              color: prego.colors.borderBrand.withValues(alpha: outlined ? 0.55 : 0),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: .end,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ...attachments,
+              if (markdown != null)
+                PregoReadableSelectionArea(
+                  child: MarkdownBody(
+                    data: markdown,
+                    selectable: false,
+                    softLineBreak: true,
+                    onTapLink: buildSessionDetailMarkdownLinkTapHandler(context: context),
+                    imageBuilder: (uri, title, alt) => _userMarkdownImage(
+                      context: context,
+                      uri: uri,
+                      semanticLabel: alt,
+                    ),
+                    styleSheet: buildChatMessageMarkdownStyleSheet(prego: prego),
+                    blockSyntaxes: sessionMarkdownBlockSyntaxes,
+                    builders: buildSessionMarkdownBuilders(
+                      highlightEnabled: true,
+                      copyTooltip: context.loc.sessionDetailCopy,
+                    ),
                   ),
                 ),
-              ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -125,8 +124,8 @@ class const UserMessageBubble({
       icon: const Icon(TablerRegular.photo, size: 16),
       label: Text(label, maxLines: 1, overflow: TextOverflow.ellipsis),
       style: TextButton.styleFrom(
-        foregroundColor: prego.colors.textBrandPrimary,
-        backgroundColor: prego.colors.textBrandPrimary.withValues(alpha: 0.08),
+        foregroundColor: prego.colors.textPrimary,
+        backgroundColor: prego.colors.textPrimary.withValues(alpha: 0.08),
         minimumSize: const Size(44, 44),
         padding: const EdgeInsetsDirectional.symmetric(
           horizontal: PregoSpacing.lg,
@@ -136,7 +135,7 @@ class const UserMessageBubble({
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(PregoRadius.md),
           side: BorderSide(
-            color: prego.colors.textBrandPrimary.withValues(alpha: 0.24),
+            color: prego.colors.textPrimary.withValues(alpha: 0.24),
           ),
         ),
       ),

--- a/client/module_app_ui/lib/src/widgets/markdown_styles.dart
+++ b/client/module_app_ui/lib/src/widgets/markdown_styles.dart
@@ -49,10 +49,13 @@ MarkdownStyleSheet buildSessionMarkdownStyleSheet({
   );
 }
 
-/// Session Markdown styled for the brand surface of an outgoing user bubble.
-MarkdownStyleSheet buildUserMessageMarkdownStyleSheet({required PregoDesignSystem prego}) {
-  final foreground = prego.colors.textBrandPrimary;
-  final body = prego.textTheme.textSm.regular.copyWith(color: foreground);
+/// Figma chat typography shared by outgoing bubbles and assistant responses.
+MarkdownStyleSheet buildChatMessageMarkdownStyleSheet({required PregoDesignSystem prego}) {
+  final foreground = prego.colors.textPrimary;
+  final body = prego.textTheme.textSm.regular.copyWith(
+    color: foreground,
+    letterSpacing: 0.14,
+  );
   final base = buildSessionMarkdownStyleSheet(
     prego: prego,
     paragraphStyle: body,
@@ -71,12 +74,12 @@ MarkdownStyleSheet buildUserMessageMarkdownStyleSheet({required PregoDesignSyste
     h5: prego.textTheme.textSm.bold.copyWith(color: foreground),
     h6: prego.textTheme.textSm.bold.copyWith(color: foreground),
     em: body.copyWith(fontStyle: FontStyle.italic),
-    strong: prego.textTheme.textSm.bold.copyWith(color: foreground),
+    strong: body.copyWith(fontWeight: FontWeight.bold),
     del: body.copyWith(decoration: TextDecoration.lineThrough),
     blockquote: body,
     checkbox: body,
     listBullet: body,
-    tableHead: prego.textTheme.textSm.bold.copyWith(color: foreground),
+    tableHead: body.copyWith(fontWeight: FontWeight.bold),
     tableBody: body,
   );
 }

--- a/client/module_app_ui/test/features/session_detail/widgets/chat_message_style_test.dart
+++ b/client/module_app_ui/test/features/session_detail/widgets/chat_message_style_test.dart
@@ -1,0 +1,94 @@
+import "package:flutter_markdown_plus/flutter_markdown_plus.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:material_ui/material_ui.dart";
+import "package:sesori_app_ui/sesori_app_ui.dart";
+import "package:theme_prego/module_prego.dart";
+
+void main() {
+  for (final brightness in Brightness.values) {
+    final prego = brightness == Brightness.light ? PregoDesignSystem.light : PregoDesignSystem.dark;
+
+    for (final paneWidth in [402.0, 600.0]) {
+      testWidgets("${brightness.name} user bubble fits a $paneWidth transcript pane", (tester) async {
+        tester.view.physicalSize = const Size(1200, 900);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        for (final outlined in [false, true]) {
+          await tester.pumpWidget(
+            _app(
+              brightness: brightness,
+              child: Center(
+                child: SizedBox(
+                  key: const Key("pane"),
+                  width: paneWidth,
+                  child: UserMessageBubble(
+                    markdown:
+                        "Search codebase for relevant files, checking type definitions and resolving import paths.",
+                    attachments: const [],
+                    outlined: outlined,
+                    transitionDuration: Duration.zero,
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final surface = tester.widget<AnimatedContainer>(find.byType(AnimatedContainer));
+          final decoration = surface.decoration as BoxDecoration?;
+          final foreground = surface.foregroundDecoration as BoxDecoration?;
+          expect(decoration?.color, prego.colors.bgSurface2);
+          expect(decoration?.borderRadius, BorderRadius.circular(12));
+          expect(surface.padding, const EdgeInsets.all(10));
+          expect(foreground?.borderRadius, decoration?.borderRadius);
+          expect(
+            foreground?.border?.top.color,
+            prego.colors.borderBrand.withValues(alpha: outlined ? 0.55 : 0),
+          );
+
+          final bubbleRect = tester.getRect(
+            find.byWidgetPredicate((widget) => widget is DecoratedBox && widget.decoration == decoration),
+          );
+          final paneRect = tester.getRect(find.byKey(const Key("pane")));
+          expect(bubbleRect.width, closeTo((paneWidth - 32) * 0.76, 0.01));
+          expect(bubbleRect.right, closeTo(paneRect.right - 16, 0.01));
+          final markdown = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+          expect(markdown.styleSheet?.p?.color, prego.colors.textPrimary);
+          expect(markdown.styleSheet?.p?.letterSpacing, 0.14);
+          expect(tester.takeException(), isNull);
+        }
+      });
+    }
+
+    testWidgets("${brightness.name} assistant keeps chat typography while streaming and settled", (tester) async {
+      for (final streaming in [true, false]) {
+        await tester.pumpWidget(
+          _app(
+            brightness: brightness,
+            child: TextPartWidget(
+              text: "A **response** with a [link](https://example.com).\n\n- First item\n- Second item",
+              isStreaming: streaming,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final markdown = tester.widget<MarkdownBody>(find.byType(MarkdownBody));
+        final expected = buildChatMessageMarkdownStyleSheet(prego: prego);
+        expect(markdown.styleSheet?.p, expected.p);
+        expect(markdown.styleSheet?.listBullet, expected.listBullet);
+        expect(markdown.styleSheet?.a, expected.a);
+        expect(tester.takeException(), isNull);
+      }
+    });
+  }
+}
+
+Widget _app({required Brightness brightness, required Widget child}) => MaterialApp(
+  theme: buildPregoThemeData(brightness: brightness),
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(body: child),
+);

--- a/client/module_app_ui/test/widgets/markdown_styles_test.dart
+++ b/client/module_app_ui/test/widgets/markdown_styles_test.dart
@@ -38,15 +38,33 @@ void main() {
     expect(styleSheet.p, paragraphStyle);
   });
 
-  test("buildUserMessageMarkdownStyleSheet keeps Markdown legible on the brand surface", () {
-    final styleSheet = buildUserMessageMarkdownStyleSheet(prego: prego);
+  for (final brightness in Brightness.values) {
+    final theme = brightness == Brightness.light ? PregoDesignSystem.light : PregoDesignSystem.dark;
+    test("chat Markdown uses Figma typography and neutral foreground in ${brightness.name}", () {
+      final styleSheet = buildChatMessageMarkdownStyleSheet(prego: theme);
 
-    expect(styleSheet.p?.color, prego.colors.textBrandPrimary);
-    expect(styleSheet.a?.color, prego.colors.textBrandPrimary);
-    expect(styleSheet.strong?.color, prego.colors.textBrandPrimary);
-    expect(styleSheet.listBullet?.color, prego.colors.textBrandPrimary);
-    expect(styleSheet.code?.color, prego.colors.textBrandPrimary);
-  });
+      for (final style in [
+        styleSheet.p,
+        styleSheet.a,
+        styleSheet.strong,
+        styleSheet.listBullet,
+        styleSheet.tableBody,
+      ]) {
+        expect(style?.fontFamily, PregoTextTheme.fontFamily);
+        expect(style?.fontSize, 14);
+        expect(style?.height, 20 / 14);
+        expect(style?.letterSpacing, 0.14);
+        expect(style?.color, theme.colors.textPrimary);
+      }
+      expect(styleSheet.p?.fontWeight, FontWeight.w400);
+      expect(styleSheet.strong?.fontWeight, FontWeight.bold);
+      expect(styleSheet.a?.decoration, TextDecoration.underline);
+      expect(styleSheet.a?.decorationColor, theme.colors.textPrimary);
+      expect(styleSheet.code?.color, theme.colors.textPrimary);
+      expect(styleSheet.code?.fontFamily, "monospace");
+      expect(styleSheet.code?.fontSize, 13);
+    });
+  }
 
   test("sessionMarkdownBlockSyntaxes keeps raw HTML visible as a code block", () {
     const message =

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -446,10 +446,17 @@ defaults and queued client sends coherent.
   by the next snapshot instead.
 - Queued and sending text render as the newest rows inside the scrollable
   transcript, never as controls pinned above the composer. They use the same
-  brand bubble and Markdown rendering as settled user text; a compact status
+  neutral bubble and Markdown rendering as settled user text; a compact status
   rail and subtle queued outline carry the transient state, with the outline
   change animated when reduced motion is not requested. A turn started on one
   client is visible to every other client of that bridge.
+- Outgoing message bubbles use the neutral raised surface, 12px corners and
+  10px padding, aligned right and sized against the available transcript width
+  (including desktop split panes). Both user and assistant Markdown use Prego
+  14px/20px regular primary text with 1% letter spacing, matching list markers
+  and underlined primary-color links in light and dark themes. Streaming and
+  settled responses share the same typography; code remains monospace and
+  Markdown emphasis, selection, attachments and queued-state cues stay usable.
 - User and assistant message text containing a raw HTML block renders that
   markup as a literal code block, so a pasted page or error body stays visible
   and copyable instead of being swallowed by the Markdown renderer.


### PR DESCRIPTION
## Complexity
🌿 Straightforward shared-widget styling and focused regression coverage; no new production classes, dependencies, or architecture changes.

## What
- Match outgoing messages to the [Figma chat reference](https://www.figma.com/design/NILKXLD9cwuWHhLnGqPqeJ/Sesori?node-id=5669-45206): neutral raised surface, 12px corners, 10px padding, and a narrower right-aligned bubble sized to its transcript pane.
- Share Prego 14px/20px regular primary-color typography with 1% letter spacing between user and assistant Markdown, including list markers and underlined links.
- Preserve queued outlines, streaming behavior, Markdown emphasis/code, selection, attachments, and explicit remote-image opening.
- Update the session-turn regression documentation and add light/dark and narrow-pane styling tests.

## Why
Bring chat messages closer to the current design while keeping mobile, desktop, and every harness consistent through the existing shared UI widgets. The change is limited to messages, not the composer, navigation, or tool cards.

## Risk and test focus
Low-risk presentation change. Focus on light/dark contrast, wrapping within desktop split panes, queued/sending/settled consistency, streaming text, Markdown readability, and attachments. No database, wire-contract, authentication, analytics, or backend impact.

## Expected result
Users see compact neutral outgoing bubbles and consistent, readable assistant responses. No database impact.

## Verification
- `client/module_app_ui`: 24 focused Markdown, message-style, and assistant-card tests passed.
- `client/app`: all 114 `session_detail_body_test.dart` tests passed.
- `dart analyze` in `client/module_app_ui`: no issues; Dart LSP also clean for changed shared files.
- iOS simulator debug build passed; installed over the signed-in app without erasing data.
- Identical production-widget fixtures captured before/after in light and dark with actual fonts. Screenshots and temporary capture code remain in an ignored build folder and are not committed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Matches outgoing chat bubbles and shared Markdown typography to the Figma chat reference so messages render consistently across light/dark themes and transcript pane widths.

- Outgoing bubbles move from the brand-colored surface to a neutral raised surface with 12px corners, 10px padding, and a narrower right-aligned width sized against the transcript pane.
- User and assistant Markdown now share Prego 14px/20px regular primary-color type with 1% letter spacing, including list markers and underlined links.
- Attachment buttons now use primary text colors instead of brand primary.
- Adds light/dark and narrow-pane style tests and updates the session-turn regression documentation.

No database, backend, or contract impact; queued outlines, streaming, selection, and attachments behave as before.

<sup>Written for commit 1141a7bfdf1f6b1d5db775501a682cb4cbc53c4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

