### PR TITLE
🌱 Reword the status-bar style comment for liquid_glass_widgets 1.4.1+

### DIFF
--- a/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
+++ b/client/module_prego/lib/components/navigation/prego_glass_scaffold.dart
@@ -283,10 +283,9 @@ class _PregoGlassScaffoldState() extends State<PregoGlassScaffold> {
   Widget build(BuildContext context) {
     final backgroundColor = widget.backgroundColor ?? context.prego.colors.bgSurface1;
     // The status-bar icons have to contrast with this scaffold's surface, so
-    // they follow the active palette's brightness. GlassStatusBarStyle.auto
-    // would read the *device* brightness instead, which ignores an in-app
-    // appearance choice: picking Light on a phone in dark mode would leave
-    // white icons on a light surface (and the reverse).
+    // they follow the active palette's brightness rather than
+    // GlassStatusBarStyle.auto, which resolves through the package's theme
+    // brightness instead of the palette that paints this surface.
     final statusBarStyle = switch (context.prego.colors.brightness) {
       Brightness.dark => GlassStatusBarStyle.light,
       Brightness.light => GlassStatusBarStyle.dark,


### PR DESCRIPTION
## Complexity

🌱 Trivial: one comment reworded.

## What

Rewords the status-bar style comment in `PregoGlassScaffold`. It claimed `GlassStatusBarStyle.auto` reads the device brightness. Since `liquid_glass_widgets` 1.4.1 (main is on 1.4.3 via #1433) `.auto` resolves through the package theme brightness, so the comment now gives the reason that still holds: the icons follow the palette that paints this surface.

## Why

The upgrade investigation behind this branch found nothing else to change: a public API diff between 1.1.0 and 1.4.3 shows no removed or newly required members for any symbol we use, the changelog has no breaking changes or deprecations, and none of our wrapper code (banner slot, scroll-edge gradient, menu clamp and flat path, Android fallback) has a package equivalent yet. Keeping the stale comment would send a future reader to a limitation that no longer exists.

## Risk and test focus

Comment-only change. No user-visible, database or wire impact.

## Expected result

Unchanged behaviour; accurate comment.

## Notes from the upgrade investigation

- Fixes picked up by 1.4.3 relevant to our go_router nested routes and app-bar menus: a `StateError` during page transitions (1.3.0), immediate menu dismissal on navigation (1.4.0), menus tracking all ancestor routes (1.4.1), and the scheduler-phase assertion with declarative routers (1.4.2).
- 1.4.2 switched luminance math to Rec.709 weights, so token-tinted glass surfaces shift slightly on iOS and macOS. Android renders flat fallbacks and is unaffected.
- `LiquidGlassSettings.bodyMode: GlassBodyMode.clear` (1.4.0) renders exact token hex and alpha; worth a Figma comparison as a separate change.
