### PR TITLE
⚙️ Synchronize AI sparkles with a 40 fps Flutter loop

### DIFF
--- a/client/app/test/playbook/thread_state_motion_playbook.dart
+++ b/client/app/test/playbook/thread_state_motion_playbook.dart
@@ -125,7 +125,7 @@ class _ThreadStateMotionPlaybookState() extends State<ThreadStateMotionPlaybook>
             onChanged: (value) => setState(() => _showThreads = value),
           ),
           Text(
-            "Scroll the threads beneath the glass header.",
+            "Scroll the threads beneath the glass header; working sparkles stay synchronized.",
             style: prego.textTheme.textSm.regular.copyWith(color: prego.colors.textTertiary),
           ),
           const SizedBox(height: 12),

--- a/client/module_app_ui/lib/src/features/project_list/widgets/project_tile.dart
+++ b/client/module_app_ui/lib/src/features/project_list/widgets/project_tile.dart
@@ -335,7 +335,7 @@ class const _StatusRow({
           if (activeSessions > 0)
             Flexible(
               child: _StatusLabel(
-                icon: PregoAiLoader(phase: PregoAiLoader.phaseFor(project.id)),
+                icon: const PregoAiLoader(),
                 label: loc.projectListRunning(activeSessions),
               ),
             )

--- a/client/module_app_ui/lib/src/features/session_list/session_tile.dart
+++ b/client/module_app_ui/lib/src/features/session_list/session_tile.dart
@@ -314,7 +314,7 @@ class const SessionTile({
     if (isActive) {
       return (
         label: context.loc.sessionListRunning,
-        sparkle: PregoAiLoader(size: _stateIconSize, phase: PregoAiLoader.phaseFor(session.id)),
+        sparkle: const PregoAiLoader(size: _stateIconSize),
       );
     }
     if (unseen) {

--- a/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
+++ b/client/module_prego/darwin/theme_prego/Sources/theme_prego/ThemePregoPlugin.swift
@@ -70,11 +70,10 @@ private struct ActivityIndicatorCreationParams {
   }
 }
 
-/// Theme colours, initial state, and phase supplied by the Flutter decoration.
+/// Theme colours and initial state supplied by the Flutter decoration.
 private struct AiLoaderCreationParams {
   let solid: CGColor
   let outline: CGColor
-  let phase: Double
   let loading: Bool
 
   init?(from args: Any?) {
@@ -82,12 +81,10 @@ private struct AiLoaderCreationParams {
       let dictionary = args as? [String: Any],
       let solid = dictionary["solid"] as? NSNumber,
       let outline = dictionary["outline"] as? NSNumber,
-      let phase = dictionary["phase"] as? NSNumber,
       let loading = dictionary["loading"] as? Bool
     else { return nil }
     self.solid = ColorComponents(fromARGB: solid.int64Value).cgColor
     self.outline = ColorComponents(fromARGB: outline.int64Value).cgColor
-    self.phase = phase.doubleValue
     self.loading = loading
   }
 }
@@ -98,6 +95,7 @@ private enum AiLoaderSparkle {
   static let viewBox: CGFloat = 20
   static let period: CFTimeInterval = 2
   static let completionDuration: CFTimeInterval = 0.7
+  static let resumeDuration: CFTimeInterval = 0.15
   static let clear = ColorComponents(fromARGB: 0x00b2d1ff).cgColor
   static let completionHighlight = ColorComponents(fromARGB: 0xffb2d1ff).cgColor
   static let colourTiming = CAMediaTimingFunction(controlPoints: 0.5, 0, 0.5, 1)
@@ -111,24 +109,32 @@ private enum AiLoaderSparkle {
     layer.lineCap = .round
     layer.fillColor = params.loading ? clear : params.solid
     layer.strokeColor = params.loading ? params.outline : params.solid
-    if params.loading {
-      layer.setValue(params.phase * .pi * 2, forKeyPath: "transform.rotation.z")
-    }
     return layer
   }
 
-  /// Capture the displayed angle and colours before replacing animations, so
-  /// finishing and a rapid restart never jump to a different visual frame.
-  static func animate(layer: CAShapeLayer, params: AiLoaderCreationParams, loading: Bool) {
+  /// Capture displayed geometry and colours before replacing animations, so
+  /// finishing and rapid restart never jump to a different visual frame.
+  static func animate(
+    layer: CAShapeLayer,
+    params: AiLoaderCreationParams,
+    loading: Bool,
+    loadingTransitionCompleted: (() -> Void)? = nil
+  ) {
     let displayed = layer.presentation() ?? layer
     let angle = (displayed.value(forKeyPath: "transform.rotation.z") as? NSNumber)?.doubleValue ?? 0
     let fill = displayed.fillColor ?? clear
     let stroke = displayed.strokeColor ?? params.outline
     let quarterTurn = Double.pi / 2
-    let target = loading ? angle : ceil((angle + 0.593) / quarterTurn) * quarterTurn
+    let synchronizedTarget = synchronizedAngle(at: Date(timeIntervalSinceNow: resumeDuration))
+    let target = loading
+      ? synchronizedTarget + round((angle - synchronizedTarget) / (.pi * 2)) * .pi * 2
+      : ceil((angle + 0.593) / quarterTurn) * quarterTurn
 
     CATransaction.begin()
     CATransaction.setDisableActions(true)
+    if loading {
+      CATransaction.setCompletionBlock(loadingTransitionCompleted)
+    }
     layer.removeAllAnimations()
     layer.setValue(target, forKeyPath: "transform.rotation.z")
     layer.fillColor = loading ? clear : params.solid
@@ -136,30 +142,56 @@ private enum AiLoaderSparkle {
 
     let rotation = CABasicAnimation(keyPath: "transform.rotation.z")
     rotation.fromValue = angle
-    rotation.toValue = loading ? angle + .pi * 2 : target
-    rotation.duration = loading ? period : completionDuration
+    rotation.toValue = target
+    rotation.duration = loading ? resumeDuration : completionDuration
     rotation.timingFunction = loading
       ? CAMediaTimingFunction(name: .linear)
       : CAMediaTimingFunction(controlPoints: 0.45, 1.45, 0.833, 1.368)
-    if loading {
-      rotation.repeatCount = .infinity
-    }
     layer.add(rotation, forKey: loading ? "loading" : "completion")
 
     let fillAnimation = CAKeyframeAnimation(keyPath: "fillColor")
     fillAnimation.values = loading ? [fill, clear] : [fill, completionHighlight, params.solid]
     fillAnimation.keyTimes = loading ? [0, 1] : [0, 0.5, 1]
     fillAnimation.timingFunctions = loading ? [colourTiming] : [colourTiming, colourTiming]
-    fillAnimation.duration = loading ? 0.15 : completionDuration
+    fillAnimation.duration = loading ? resumeDuration : completionDuration
     layer.add(fillAnimation, forKey: "fill")
 
     let strokeAnimation = CABasicAnimation(keyPath: "strokeColor")
     strokeAnimation.fromValue = stroke
     strokeAnimation.toValue = loading ? params.outline : params.solid
-    strokeAnimation.duration = loading ? 0.15 : completionDuration
+    strokeAnimation.duration = loading ? resumeDuration : completionDuration
     strokeAnimation.timingFunction = colourTiming
     layer.add(strokeAnimation, forKey: "stroke")
     CATransaction.commit()
+  }
+
+  /// Start an unthrottled Core Animation loop at current Unix-clock phase.
+  /// Sampling here, rather than from Flutter creation arguments, also aligns
+  /// views mounted later and views resuming after suspension.
+  static func startSynchronizedLoading(layer: CAShapeLayer, params: AiLoaderCreationParams) {
+    let localNow = layer.convertTime(CACurrentMediaTime(), from: nil)
+    let epochOffset = Date().timeIntervalSince1970.truncatingRemainder(dividingBy: period)
+
+    CATransaction.begin()
+    CATransaction.setDisableActions(true)
+    layer.removeAllAnimations()
+    layer.setValue(synchronizedAngle(at: Date()), forKeyPath: "transform.rotation.z")
+    layer.fillColor = clear
+    layer.strokeColor = params.outline
+
+    let rotation = CABasicAnimation(keyPath: "transform.rotation.z")
+    rotation.fromValue = 0
+    rotation.toValue = Double.pi * 2
+    rotation.duration = period
+    rotation.repeatCount = .infinity
+    rotation.timingFunction = CAMediaTimingFunction(name: .linear)
+    rotation.beginTime = localNow - epochOffset
+    layer.add(rotation, forKey: "loading")
+    CATransaction.commit()
+  }
+
+  private static func synchronizedAngle(at date: Date) -> Double {
+    date.timeIntervalSince1970.truncatingRemainder(dividingBy: period) / period * .pi * 2
   }
 
   static func showStatic(layer: CAShapeLayer, params: AiLoaderCreationParams, loading: Bool) {
@@ -464,7 +496,11 @@ private enum AiLoaderSparkle {
       guard self.loading != loading else { return }
       self.loading = loading
       if canAnimate {
-        AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: loading)
+        if loading {
+          startLoading()
+        } else {
+          AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: false)
+        }
       } else {
         AiLoaderSparkle.showStatic(layer: sparkleLayer, params: params, loading: loading)
       }
@@ -474,7 +510,14 @@ private enum AiLoaderSparkle {
       if !canAnimate {
         AiLoaderSparkle.showStatic(layer: sparkleLayer, params: params, loading: loading)
       } else if loading && sparkleLayer.animation(forKey: "loading") == nil {
-        AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: true)
+        AiLoaderSparkle.startSynchronizedLoading(layer: sparkleLayer, params: params)
+      }
+    }
+
+    private func startLoading() {
+      AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: true) { [weak self] in
+        guard let self, self.loading, self.canAnimate else { return }
+        AiLoaderSparkle.startSynchronizedLoading(layer: self.sparkleLayer, params: self.params)
       }
     }
   }
@@ -715,7 +758,11 @@ private enum AiLoaderSparkle {
       guard self.loading != loading else { return }
       self.loading = loading
       if canAnimate {
-        AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: loading)
+        if loading {
+          startLoading()
+        } else {
+          AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: false)
+        }
       } else {
         AiLoaderSparkle.showStatic(layer: sparkleLayer, params: params, loading: loading)
       }
@@ -725,7 +772,14 @@ private enum AiLoaderSparkle {
       if !canAnimate {
         AiLoaderSparkle.showStatic(layer: sparkleLayer, params: params, loading: loading)
       } else if loading && sparkleLayer.animation(forKey: "loading") == nil {
-        AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: true)
+        AiLoaderSparkle.startSynchronizedLoading(layer: sparkleLayer, params: params)
+      }
+    }
+
+    private func startLoading() {
+      AiLoaderSparkle.animate(layer: sparkleLayer, params: params, loading: true) { [weak self] in
+        guard let self, self.loading, self.canAnimate else { return }
+        AiLoaderSparkle.startSynchronizedLoading(layer: self.sparkleLayer, params: self.params)
       }
     }
   }

--- a/client/module_prego/lib/components/loaders/prego_ai_loader.dart
+++ b/client/module_prego/lib/components/loaders/prego_ai_loader.dart
@@ -4,6 +4,7 @@ library;
 import "dart:async";
 import "dart:math" as math;
 
+import "package:clock/clock.dart";
 import "package:flutter/foundation.dart";
 import "package:flutter/rendering.dart";
 import "package:flutter/services.dart";
@@ -12,6 +13,56 @@ import "package:material_ui/material_ui.dart";
 import "../../motion/prego_reduced_motion.dart";
 import "../../theme/prego_theme.dart";
 import "../../utils/lerp_utils.dart";
+
+/// One device-clock-aligned repaint source shared by all Flutter sparkles.
+///
+/// A recursive one-shot timer avoids `Timer.periodic` drift. It exists only
+/// while at least one visible, motion-enabled working sparkle listens.
+final class _AiLoaderLoopClock._() extends ChangeNotifier {
+  static final instance = _AiLoaderLoopClock._();
+  static const _period = Duration(seconds: 2);
+  static const _step = Duration(milliseconds: 25);
+
+  Timer? _timer;
+  double _angle = 0;
+
+  double get angle => _angle;
+
+  @override
+  void addListener(VoidCallback listener) {
+    final needsTimer = !hasListeners;
+    super.addListener(listener);
+    if (needsTimer) {
+      _sampleClock();
+      _scheduleNextStep();
+    }
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    super.removeListener(listener);
+    if (!hasListeners) {
+      _timer?.cancel();
+      _timer = null;
+    }
+  }
+
+  void _scheduleNextStep() {
+    final remainder = clock.now().millisecondsSinceEpoch % _step.inMilliseconds;
+    _timer = Timer(Duration(milliseconds: _step.inMilliseconds - remainder), () {
+      _timer = null;
+      _sampleClock();
+      notifyListeners();
+      if (hasListeners) _scheduleNextStep();
+    });
+  }
+
+  void _sampleClock() {
+    final now = clock.now().millisecondsSinceEpoch;
+    final sampled = now - now % _step.inMilliseconds;
+    _angle = (sampled % _period.inMilliseconds) / _period.inMilliseconds * 2 * math.pi;
+  }
+}
 
 /// How the sparkle's interior is painted.
 enum PregoAiLoaderFillMode() {
@@ -41,12 +92,7 @@ class const PregoAiLoader({
 
   /// Overrides both states, for a caller-owned timeline such as Deep Scan.
   final Color? color,
-
-  /// Initial fraction of a rotation, stable per row across rebuilds.
-  final double phase = 0,
 }) extends StatefulWidget {
-  static double phaseFor(String seed) => (seed.hashCode % 100) / 100;
-
   @override
   State<PregoAiLoader> createState() => _PregoAiLoaderState();
 }
@@ -55,7 +101,6 @@ class _PregoAiLoaderState()
     extends State<PregoAiLoader>
     with TickerProviderStateMixin, WidgetsBindingObserver, PregoReducedMotionStateMixin {
   static const _nativeViewType = "sesori/native-ai-loader";
-  static const _period = Duration(seconds: 2);
 
   // The Figma example contains several seconds of loading and a long idle
   // hold. Only the finish is a UI transition: preserve its fill and rotational
@@ -65,11 +110,12 @@ class _PregoAiLoaderState()
   static const _resumeDuration = Duration(milliseconds: 150);
   static const _settleCurve = Cubic(0.45, 1.45, 0.833, 1.368);
 
-  late final _rotation = AnimationController.unbounded(
-    vsync: this,
-    value: widget.animate ? widget.phase * 2 * math.pi : 0,
-  );
-  late final _fill = AnimationController(vsync: this, value: 1);
+  late final _rotation = AnimationController.unbounded(vsync: this);
+  late final _fill = AnimationController(vsync: this, value: 1)..addListener(_updateLoopAngle);
+  final _loopClock = _AiLoaderLoopClock.instance;
+  double _loopAngle = 0;
+  double _loopOffset = 0;
+  bool _listeningToLoop = false;
   late ({Color fill, Color stroke}) _fillOrigin = (
     fill: const Color(0x00B2D1FF),
     stroke: context.prego.colors.textPrimary,
@@ -82,19 +128,25 @@ class _PregoAiLoaderState()
       widget.fillMode == .keyframed &&
       widget.color == null;
 
+  bool get _appIsVisible {
+    final lifecycle = WidgetsBinding.instance.lifecycleState;
+    return lifecycle == null || lifecycle == AppLifecycleState.resumed || lifecycle == AppLifecycleState.inactive;
+  }
+
   @override
-  bool get motionEnabled => !_usesNativeRenderer && TickerMode.valuesOf(context).enabled;
+  bool get motionEnabled => !_usesNativeRenderer && TickerMode.valuesOf(context).enabled && _appIsVisible;
 
   @override
   void startMotion() {
     if (widget.animate) {
-      if (!_rotation.isAnimating) {
-        _rotation.repeat(min: _rotation.value, max: _rotation.value + 2 * math.pi, period: _period);
+      _startLoop(rejoin: _fill.value < 1);
+    } else {
+      _stopLoop();
+      if (_fill.value < 1 && !_rotation.isAnimating) {
+        const quarterTurn = math.pi / 2;
+        final target = ((_rotation.value + 0.593) / quarterTurn).ceil() * quarterTurn;
+        _rotation.animateTo(target, duration: _settleDuration, curve: _settleCurve);
       }
-    } else if (_fill.value < 1 && !_rotation.isAnimating) {
-      const quarterTurn = math.pi / 2;
-      final target = ((_rotation.value + 0.593) / quarterTurn).ceil() * quarterTurn;
-      _rotation.animateTo(target, duration: _settleDuration, curve: _settleCurve);
     }
     if (_fill.value < 1 && !_fill.isAnimating) {
       _fill.animateTo(1, duration: widget.animate ? _resumeDuration : _settleDuration);
@@ -103,10 +155,40 @@ class _PregoAiLoaderState()
 
   @override
   void stopMotion() {
+    _stopLoop();
     _rotation.stop();
     _rotation.value = 0;
     _fill.stop();
     _fill.value = 1;
+  }
+
+  void _startLoop({required bool rejoin}) {
+    if (_listeningToLoop) return;
+    _listeningToLoop = true;
+    _loopClock.addListener(_updateLoopAngle);
+    final phaseAngle = _loopClock.angle;
+    _loopAngle = phaseAngle + ((_rotation.value - phaseAngle) / (2 * math.pi)).round() * 2 * math.pi;
+    _loopOffset = rejoin ? _rotation.value - _loopAngle : 0;
+    _updateLoopAngle();
+  }
+
+  void _stopLoop() {
+    if (!_listeningToLoop) return;
+    _loopClock.removeListener(_updateLoopAngle);
+    _listeningToLoop = false;
+  }
+
+  void _updateLoopAngle() {
+    if (!_listeningToLoop) return;
+    final phaseAngle = _loopClock.angle;
+    _loopAngle = phaseAngle + ((_loopAngle - phaseAngle) / (2 * math.pi)).round() * 2 * math.pi;
+    _rotation.value = _loopAngle + _loopOffset * (1 - _fill.value);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    syncMotion();
   }
 
   @override
@@ -124,6 +206,7 @@ class _PregoAiLoaderState()
         outline: widget.color ?? colors.textPrimary,
         bloom: widget.color ?? const Color(0xFFB2D1FF),
       );
+      _stopLoop();
       _rotation.stop();
       _fill.stop();
       _fill.value = 0;
@@ -161,6 +244,7 @@ class _PregoAiLoaderState()
 
   @override
   void dispose() {
+    _stopLoop();
     _rotation.dispose();
     _fill.dispose();
     super.dispose();
@@ -192,12 +276,11 @@ class _PregoAiLoaderState()
   }
 
   Widget _nativeSparkle({required PregoColors colors}) {
-    // StandardMessageCodec carries ARGB integers, a double phase, and a bool.
+    // StandardMessageCodec carries ARGB integers and a bool.
     // ignore: no_slop_linter/prefer_specific_type, heterogeneous native codec payload
     final params = <String, Object>{
       "solid": colors.textPrimaryOnBrand.toARGB32(),
       "outline": colors.textPrimary.toARGB32(),
-      "phase": widget.phase,
       "loading": widget.animate,
     };
     final nativeView = defaultTargetPlatform == TargetPlatform.iOS
@@ -217,7 +300,7 @@ class _PregoAiLoaderState()
           );
     return SizedBox.square(
       dimension: widget.size,
-      // State and phase must not replace the renderer at completion. Colours
+      // State must not replace the renderer at completion. Colours
       // are creation-time data, so a theme change does create the new palette.
       child: KeyedSubtree(
         key: ValueKey(Object.hash(params["solid"], params["outline"])),

--- a/client/module_prego/pubspec.yaml
+++ b/client/module_prego/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   flutter: ">=3.47.3"
 
 dependencies:
+  clock: ^1.1.3
   flutter:
     sdk: flutter
   material_ui: ^1.2.0

--- a/client/module_prego/test/components/prego_ai_loader_test.dart
+++ b/client/module_prego/test/components/prego_ai_loader_test.dart
@@ -1,5 +1,7 @@
 import "dart:ui" as ui;
 
+import "package:clock/clock.dart";
+import "package:flutter/foundation.dart";
 import "package:flutter/rendering.dart";
 import "package:flutter/services.dart";
 import "package:flutter_test/flutter_test.dart";
@@ -8,14 +10,26 @@ import "package:theme_prego/module_prego.dart";
 
 /// Behavioural guards for the AI activity sparkle.
 ///
-/// The rotation is an infinite repeating animation, so these tests pump fixed
-/// durations and never `pumpAndSettle` — it would pump to its timeout and throw.
+/// The rotation has a repeating 25ms timer, so these tests pump fixed
+/// durations and never `pumpAndSettle` — the loop would keep it from settling.
 ///
 /// The painter tests pin a platform without a native rotation renderer (Linux):
 /// on iOS and macOS the animated sparkle is a platform view, which cannot
 /// paint pixels in a widget test. The `native rotation` group covers those
 /// branches and the deliberate Android fallback explicitly.
 void main() {
+  void clockTestWidgets(
+    String description,
+    WidgetTesterCallback callback, {
+    TestVariant<Object?> variant = const DefaultTestVariant(),
+  }) {
+    testWidgets(
+      description,
+      (tester) => withClock(Clock(() => tester.binding.clock.now()), () => callback(tester)),
+      variant: variant,
+    );
+  }
+
   Widget harness(Widget child, {bool disableAnimations = false}) {
     return MaterialApp(
       theme: ThemeData(extensions: [PregoDesignSystem.light]),
@@ -66,30 +80,146 @@ void main() {
     return visiblePixels;
   }
 
+  Future<Uint8List> sparklePixels(WidgetTester tester, Finder loader) async {
+    final boundary = tester.renderObject<RenderRepaintBoundary>(
+      find.descendant(of: loader, matching: find.byType(RepaintBoundary)),
+    );
+    late Uint8List pixels;
+    await tester.runAsync(() async {
+      final image = await boundary.toImage(pixelRatio: 3);
+      pixels = (await image.toByteData(format: ui.ImageByteFormat.rawRgba))!.buffer.asUint8List();
+      image.dispose();
+    });
+    return pixels;
+  }
+
   /// A non-cardinal rotation, so a jump to the resting angle is visible.
   const loadingSample = Duration(milliseconds: 250);
 
-  group("phaseFor", () {
-    test("derives a stable phase in [0, 1) from a seed", () {
-      final phase = PregoAiLoader.phaseFor("session-42");
-
-      expect(phase, PregoAiLoader.phaseFor("session-42"));
-      expect(phase, greaterThanOrEqualTo(0));
-      expect(phase, lessThan(1));
-    });
-
-    test("staggers different seeds apart", () {
-      // Not a hash-quality proof — just a guard that two neighbouring ids
-      // don't collapse onto one phase, which is the whole point of the offset.
-      expect(PregoAiLoader.phaseFor("session-1"), isNot(PregoAiLoader.phaseFor("session-2")));
-    });
-  });
-
-  testWidgets("rotates by default", (tester) async {
+  clockTestWidgets("steps the synchronized loop at 40 FPS without a repeating ticker", (tester) async {
     await tester.pumpWidget(harness(const PregoAiLoader()));
-    await tester.pump(const Duration(milliseconds: 200));
+    final painter = tester
+        .widget<CustomPaint>(
+          find.descendant(of: find.byType(PregoAiLoader), matching: find.byType(CustomPaint)),
+        )
+        .painter!;
+    var repaints = 0;
+    void countRepaint() => repaints++;
+    painter.addListener(countRepaint);
+    addTearDown(() => painter.removeListener(countRepaint));
 
-    expect(tester.hasRunningAnimations, isTrue);
+    // Reach one device-clock boundary, then measure from that known boundary.
+    await tester.pump(const Duration(milliseconds: 25));
+    repaints = 0;
+    await tester.pump(const Duration(milliseconds: 24));
+    expect(repaints, 0);
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(repaints, 1);
+    await tester.pump(const Duration(milliseconds: 225));
+
+    expect(repaints, 10);
+    expect(tester.hasRunningAnimations, isFalse);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+
+  clockTestWidgets("staggered mounts share one synchronized loop phase", (tester) async {
+    const first = PregoAiLoader(key: ValueKey("first"));
+    await tester.pumpWidget(harness(const Row(mainAxisSize: MainAxisSize.min, children: [first])));
+    await tester.pump(const Duration(milliseconds: 137));
+    await tester.pumpWidget(
+      harness(
+        const Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            first,
+            PregoAiLoader(key: ValueKey("second")),
+          ],
+        ),
+      ),
+    );
+
+    final firstPainter = tester
+        .widget<CustomPaint>(
+          find.descendant(of: find.byKey(const ValueKey("first")), matching: find.byType(CustomPaint)),
+        )
+        .painter!;
+    final secondPainter = tester
+        .widget<CustomPaint>(
+          find.descendant(of: find.byKey(const ValueKey("second")), matching: find.byType(CustomPaint)),
+        )
+        .painter!;
+    var firstRepaints = 0;
+    var secondRepaints = 0;
+    void countFirst() => firstRepaints++;
+    void countSecond() => secondRepaints++;
+    firstPainter.addListener(countFirst);
+    secondPainter.addListener(countSecond);
+    addTearDown(() {
+      firstPainter.removeListener(countFirst);
+      secondPainter.removeListener(countSecond);
+    });
+
+    await tester.pump(const Duration(milliseconds: 25));
+    firstRepaints = 0;
+    secondRepaints = 0;
+    await tester.pump(const Duration(milliseconds: 100));
+    expect((firstRepaints, secondRepaints), (4, 4));
+
+    final firstPixels = await sparklePixels(tester, find.byKey(const ValueKey("first")));
+    final secondPixels = await sparklePixels(tester, find.byKey(const ValueKey("second")));
+    expect(listEquals(firstPixels, secondPixels), isTrue);
+    expect(tester.hasRunningAnimations, isFalse);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+
+  clockTestWidgets("a restarted sparkle rejoins the synchronized phase after its smooth clear", (tester) async {
+    const restartingKey = ValueKey("restarting");
+    const synchronizedKey = ValueKey("synchronized");
+    await tester.pumpWidget(
+      harness(
+        const Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            PregoAiLoader(key: restartingKey, animate: false),
+            PregoAiLoader(key: synchronizedKey),
+          ],
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pumpWidget(
+      harness(
+        const Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            PregoAiLoader(key: restartingKey),
+            PregoAiLoader(key: synchronizedKey),
+          ],
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 151));
+
+    final restarted = await sparklePixels(tester, find.byKey(restartingKey));
+    final synchronized = await sparklePixels(tester, find.byKey(synchronizedKey));
+    expect(listEquals(restarted, synchronized), isTrue);
+    expect(tester.hasRunningAnimations, isFalse);
+  }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
+
+  clockTestWidgets("stops loop scheduling while backgrounded and after disposal", (tester) async {
+    await tester.pumpWidget(harness(const PregoAiLoader()));
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    await tester.binding.delayed(const Duration(milliseconds: 100));
+    expect(tester.binding.hasScheduledFrame, isFalse);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    await tester.binding.delayed(const Duration(milliseconds: 30));
+    expect(tester.binding.hasScheduledFrame, isTrue);
+    await tester.pumpWidget(harness(const SizedBox.shrink()));
+    await tester.pump();
+    await tester.binding.delayed(const Duration(milliseconds: 100));
+    expect(tester.binding.hasScheduledFrame, isFalse);
   }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
   testWidgets("rests on the solid brand sparkle", (tester) async {
@@ -151,20 +281,6 @@ void main() {
     expect(tester.hasRunningAnimations, isFalse);
   }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
-  testWidgets("a phase offset moves it through the loop, but never off its resting frame", (tester) async {
-    await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.4)));
-    await tester.pump();
-
-    // Loading is hollow at every phase, including the first visible frame.
-    expect((await sparkleCentre(tester)).a, 0);
-
-    await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 700));
-
-    expect(await sparkleCentre(tester), PregoColorsLight.textPrimaryOnBrand);
-  }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
-
   testWidgets("holds still when the platform removes animations", (tester) async {
     await tester.pumpWidget(harness(const PregoAiLoader(), disableAnimations: true));
     await tester.pump(const Duration(milliseconds: 200));
@@ -201,7 +317,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 200));
 
-    expect(tester.hasRunningAnimations, isTrue);
+    expect(tester.hasRunningAnimations, isFalse);
   }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
   testWidgets("is decorative, and isolates its repaints from the surrounding layer", (tester) async {
@@ -224,9 +340,11 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 175));
     final beforeRestart = await sparkleCentre(tester);
+    final beforeRestartPixels = await sparklePixels(tester, find.byType(PregoAiLoader));
 
     await tester.pumpWidget(harness(const PregoAiLoader()));
     expect(await sparkleCentre(tester), beforeRestart);
+    expect(listEquals(await sparklePixels(tester, find.byType(PregoAiLoader)), beforeRestartPixels), isTrue);
     await tester.pump(const Duration(milliseconds: 75));
     final clearing = await sparkleCentre(tester);
     expect(clearing.a, greaterThan(0));
@@ -250,7 +368,7 @@ void main() {
     expect(clearing.a, lessThan(1));
     await tester.pump(const Duration(milliseconds: 76));
     expect((await sparkleCentre(tester)).a, 0);
-    expect(tester.hasRunningAnimations, isTrue);
+    expect(tester.hasRunningAnimations, isFalse);
   }, variant: TargetPlatformVariant.only(TargetPlatform.linux));
 
   testWidgets("changing Reduce Motion during completion settles without replay", (tester) async {
@@ -277,13 +395,13 @@ void main() {
     });
     addTearDown(() => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null));
 
-    await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.4)));
+    await tester.pumpWidget(harness(const PregoAiLoader()));
     final original = tester.state(find.byType(AppKitView));
     tester.widget<AppKitView>(find.byType(AppKitView)).onPlatformViewCreated!(99);
     await tester.pump();
     await tester.pumpWidget(harness(const PregoAiLoader(animate: false)));
     await tester.pump();
-    await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.4)));
+    await tester.pumpWidget(harness(const PregoAiLoader()));
     await tester.pump();
 
     expect(tester.state(find.byType(AppKitView)), same(original));
@@ -296,14 +414,13 @@ void main() {
     final expectedParams = <String, Object>{
       "solid": PregoColorsLight.textPrimaryOnBrand.toARGB32(),
       "outline": PregoColorsLight.textPrimary.toARGB32(),
-      "phase": 0.25,
       "loading": true,
     };
 
     Finder painter() => find.descendant(of: find.byType(PregoAiLoader), matching: find.byType(CustomPaint));
 
     testWidgets("animates natively on macOS without scheduling Flutter frames", (tester) async {
-      await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.25)));
+      await tester.pumpWidget(harness(const PregoAiLoader()));
 
       final platformView = tester.widget<AppKitView>(find.byType(AppKitView));
       expect(platformView.viewType, "sesori/native-ai-loader");
@@ -314,7 +431,7 @@ void main() {
     }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
 
     testWidgets("animates natively on iOS without scheduling Flutter frames", (tester) async {
-      await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.25)));
+      await tester.pumpWidget(harness(const PregoAiLoader()));
 
       final platformView = tester.widget<UiKitView>(find.byType(UiKitView));
       expect(platformView.viewType, "sesori/native-ai-loader");
@@ -327,13 +444,13 @@ void main() {
     testWidgets("Android keeps the animated Flutter painter in list rows", (tester) async {
       // Deliberate: a platform view per visible session row wrecks Android
       // scroll performance (measured on-device), so Android rotations in Flutter.
-      await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.25)));
+      await tester.pumpWidget(harness(const PregoAiLoader()));
       await tester.pump(const Duration(milliseconds: 200));
 
       expect(find.byType(AppKitView), findsNothing);
       expect(find.byType(UiKitView), findsNothing);
       expect(painter(), findsOneWidget);
-      expect(tester.hasRunningAnimations, isTrue);
+      expect(tester.hasRunningAnimations, isFalse);
     }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
     testWidgets("reduced motion keeps the static painter, not a platform view", (tester) async {
@@ -366,8 +483,8 @@ void main() {
       expect(tester.hasRunningAnimations, isFalse);
     }, variant: TargetPlatformVariant.only(TargetPlatform.macOS));
 
-    testWidgets("retains the native view when the unread caller drops its phase", (tester) async {
-      await tester.pumpWidget(harness(const PregoAiLoader(phase: 0.25)));
+    testWidgets("retains the native view through completion", (tester) async {
+      await tester.pumpWidget(harness(const PregoAiLoader()));
       final firstKey = tester
           .widget<KeyedSubtree>(
             find.ancestor(of: find.byType(AppKitView), matching: find.byType(KeyedSubtree)).first,

--- a/docs/regression/native-activity-indicators.md
+++ b/docs/regression/native-activity-indicators.md
@@ -15,9 +15,13 @@ indicator at the native medium size, stepped by a plain timer instead of a
 ticker. Its picture only changes when the active tick advances, so it repaints
 exactly eight times per second, registers no ticker, schedules no frame between
 steps, and stops its timer while the app is not visible (paused, hidden, or
-detached; an unfocused but visible window keeps spinning). The sparkle
-keeps its animated Flutter fallback there. Reduced motion and disabled tickers
-replace the native views with static Flutter frames (the spinner rests on one
+detached; an unfocused but visible window keeps spinning). The sparkle uses a
+private, device-clock-aligned 40 FPS timer there: all visible working sparkles
+share one timer and phase, no repeating ticker runs, and the steady loop
+schedules no frame between 25ms steps. Its timer also stops when no eligible
+sparkle listens. Finite completion and 150ms restart/rejoin transitions keep
+display-rate updates.
+Reduced motion and disabled tickers replace the native views with static Flutter frames (the spinner rests on one
 stepped frame; the sparkle is a hollow working mark or a solid unread mark), the spinner owns loading-spinner semantics on every
 platform, and the sparkle stays decorative.
 The sparkle matches Figma `2506:20093`: a 14px Tabler glyph in a 20px slot,
@@ -30,9 +34,11 @@ read thread removes the status mark through the existing row state rules.
 
 Apple views retain their renderer through working/unread changes and receive
 `setLoading` on a per-view channel; both the loop and completion use Core
-Animation, without continuous Flutter frames. Native and Flutter renderers
-share the same geometry, colours, timing, and per-row initial phase. Theme
-changes rebuild the native palette. Reduced motion and disabled TickerMode
+Animation, without continuous Flutter frames or per-frame channel traffic.
+Native Core Animation remains unthrottled. Apple and Flutter renderers sample
+the same two-second Unix device-clock phase when starting or resuming, so
+working sparkles mounted at different times rotate together. They share the
+same geometry, colours, and timing. Theme changes rebuild the native palette. Reduced motion and disabled TickerMode
 settle immediately, retaining the hollow/solid state distinction. Caller-owned
 outline mode and explicit colours remain available for Deep Scan.
 
@@ -40,7 +46,7 @@ outline mode and explicit colours remain available for Deep Scan.
 
 | Level | Additional coverage |
 |---|---|
-| L1 Smoke | Automated: the owning widget test suite proves per-platform widget selection, creation parameters, semantics role, the reduced-motion and disabled-ticker fallbacks, and that the stepped spinner schedules one repaint per step, none between, no ticker, and nothing while the app is backgrounded. |
+| L1 Smoke | Automated: the owning widget test suite proves per-platform widget selection, creation parameters, semantics role, and reduced-motion and disabled-ticker fallbacks. It also proves staggered sparkle mounts share one phase and 40 FPS cadence, restarted sparkles rejoin after their finite transition, no repeating ticker or inter-step frames run, and scheduling stops while backgrounded or disposed. Stepped-spinner cadence remains covered independently. |
 | L2 Routine | Client end to end (release-target client platform): a screen with a spinning indicator renders correctly while the app shows no continuous Flutter UI/raster work attributable to the spinner; list scrolling stays smooth with indicators on screen. |
 | L3 Release | Client end to end: repeat on the alternate mobile platform and macOS desktop (include a session list with working-session sparkles on iOS and macOS); scroll an indicator through a list, insert and remove it repeatedly, and overlap it with glass/blur without crashes or scene corruption. |
 | L4 Extended | Client end to end: toggle system reduce motion mid-spin; background and foreground the app while an indicator is animating. |
@@ -70,8 +76,8 @@ request no brand tint, so every spinner shows its platform's natural colour
 for the app's resolved brightness (native views receive that brightness and
 surfaces that invert the page ask for the opposite natural grey) while the
 tint capability stays available;
-sparkles in a list rotating in lockstep despite distinct phases; the native
-sparkle motion visibly diverging from the Flutter fallback; completion
+working sparkles rotating out of sync or the Flutter fallback's steady working
+loop exceeding 40 repaints per second; the native sparkle motion visibly diverging from the Flutter fallback; completion
 restarting on rebuild or looping after work ends; a visible angle/fill jump
 when another turn starts during completion; a stale native loading state after
 a row update; reduce motion still animating or making working look unread.


### PR DESCRIPTION
## Complexity
⚙️ Moderate — shared Flutter animation timing plus synchronized iOS/macOS Core Animation, with focused lifecycle and presentation tests.

## What
- Synchronize working AI sparkles using a common two-second device-clock phase instead of per-session/project offsets.
- Drive the steady Flutter loop at 40 fps (25 ms) through one shared timer, with no repeating ticker or inter-step frame scheduling.
- Keep native animation cadence unchanged and preserve the finite 700 ms completion and 150 ms restart/rejoin transitions.
- Remove the internal row-phase API and update regression documentation and preview copy. Cupertino/activity spinners and the caller-owned Deep Scan timeline remain unchanged.

## Why
Multiple working sessions should rotate together rather than distract with staggered indicators. The lower Flutter loop cadence reduces scheduled animation work while keeping a higher cadence than the initially proposed 30 fps.

## Risk and test focus
UI-only, medium regression risk around staggered mounts, interrupted completion, background/resume, reduced motion, and native view lifecycle. No database, transport, backend, or account-state impact.

Device-level visual smoothness, native compositing/lifecycle behavior, and battery savings were not measured here. The existing thread-state motion playbook is the manual review target; the 40 fps cap applies only to the steady Flutter loop, not finite transitions.

## Expected result
Working sparkles in session/project lists visibly stay in sync, including rows mounted later. Flutter's steady loop updates at 40 fps; Apple keeps unthrottled Core Animation. Unread, reduced-motion, and inactive indicators retain their existing meaning. Other indicator types remain independent.

## Verification
Using repository-pinned Flutter 3.47.3 / Dart 3.13.3:
- `client/module_prego`: AI loader and activity indicator widget suites passed.
- `client/module_app_ui`: session tile state and catalog scan row widget suites passed.
- `flutter analyze`: `module_prego`, `module_app_ui`, and the app thread-state motion playbook passed.
- Native `ThemePregoPlugin.swift` type-check passed for macOS and iOS Simulator against the matching Flutter frameworks (not a full app build or GUI run).
- Architecture plan and implementation reviews approved; `git diff --check` passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronizes working AI sparkles so rows rotate together instead of at staggered per-row phase offsets.

**Refactors**
- Flutter's steady loop now runs at 40 fps from one shared device-clock-aligned timer; no repeating ticker or inter-step frames, and the 700 ms completion and 150 ms restart/rejoin transitions are unchanged.
- Native iOS/macOS Core Animation keeps its unthrottled cadence.
- Removes `PregoAiLoader.phase` and `phaseFor`; session and project tiles no longer seed a phase.
- Adds the `clock` package for deterministic device-clock sampling in tests.

<sup>Written for commit c62b104458c1eb51aae46027fb535f36a20ea467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

