### PR TITLE
🌿 Keep strongest effort options at the bottom of the chat picker

### DIFF
--- a/client/app/test/core/widgets/agent_model_buttons_test.dart
+++ b/client/app/test/core/widgets/agent_model_buttons_test.dart
@@ -48,7 +48,112 @@ Widget _buildApp({required List<AgentInfo> agents, required void Function(String
   );
 }
 
+const _variants = [
+  SessionVariant(id: "max"),
+  SessionVariant(id: "xhigh"),
+  SessionVariant(id: "high"),
+  SessionVariant(id: "medium"),
+  SessionVariant(id: "low"),
+  SessionVariant(id: "minimal"),
+];
+
+Widget _buildVariantApp({required ValueChanged<SessionVariant> onVariantSelected}) {
+  return MaterialApp(
+    theme: ThemeData(extensions: [PregoDesignSystem.light]),
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          AgentModelButtons(
+            surfaceStyle: PregoComposerSurfaceStyle.subtle,
+            agents: const [],
+            selectedAgent: null,
+            onAgentSelected: (_) {},
+            providers: const [],
+            // The menu opens at the strongest end even if a low effort is selected.
+            selectedAgentModel: const AgentModel(providerID: "example", modelID: "model", variant: "minimal"),
+            onModelSelected: ({required providerID, required modelID}) {},
+            availableVariants: _variants,
+            onVariantSelected: onVariantSelected,
+          ),
+          // The prompt field sits below the picker row in the chat composer.
+          const SizedBox(height: 120),
+        ],
+      ),
+    ),
+  );
+}
+
 void main() {
+  group("Variant picker", () {
+    const platforms = TargetPlatformVariant({TargetPlatform.iOS, TargetPlatform.android, TargetPlatform.macOS});
+
+    testWidgets("lists efforts lowest to highest with the heading at the top", (tester) async {
+      tester.view.physicalSize = const Size(390, 844);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+      final selected = <SessionVariant>[];
+      await tester.pumpWidget(_buildVariantApp(onVariantSelected: selected.add));
+      await tester.tap(find.widgetWithText(PregoPickerButton, "minimal"));
+      await tester.pumpAndSettle();
+
+      final displayOrder = _variants.reversed.toList();
+      for (var index = 1; index < displayOrder.length; index++) {
+        expect(
+          tester.getTopLeft(_menuItem(displayOrder[index - 1].id)).dy,
+          lessThan(tester.getTopLeft(_menuItem(displayOrder[index].id)).dy),
+        );
+      }
+      final loc = AppLocalizations.of(tester.element(find.byType(AgentModelButtons)))!;
+      expect(
+        tester.getBottomLeft(find.text(loc.sessionDetailPickerVariant.toUpperCase())).dy,
+        lessThanOrEqualTo(tester.getTopLeft(_menuItem("minimal")).dy),
+      );
+      expect(tester.state<ScrollableState>(find.byType(Scrollable)).position.maxScrollExtent, 0);
+      expect(find.descendant(of: _menuItem("minimal"), matching: find.byIcon(Icons.check)), findsOneWidget);
+
+      await tester.tap(_menuItem("xhigh"));
+      await tester.pumpAndSettle();
+      expect(selected, [const SessionVariant(id: "xhigh")]);
+      expect(_menuItem("max"), findsNothing);
+    }, variant: platforms);
+
+    testWidgets("opens cramped menus at max and scrolls toward the lowest efforts", (tester) async {
+      tester.view.physicalSize = const Size(320, 568);
+      tester.view.devicePixelRatio = 1;
+      tester.view.viewInsets = const FakeViewPadding(bottom: 216);
+      addTearDown(tester.view.reset);
+      final selected = <SessionVariant>[];
+      await tester.pumpWidget(_buildVariantApp(onVariantSelected: selected.add));
+      await tester.tap(find.widgetWithText(PregoPickerButton, "minimal"));
+      await tester.pumpAndSettle();
+
+      final scrollView = find.byType(SingleChildScrollView);
+      final position = tester.state<ScrollableState>(find.byType(Scrollable)).position;
+      expect(position.maxScrollExtent, greaterThan(0));
+      expect(_menuItem("max").hitTestable(), findsOneWidget);
+      expect(_menuItem("xhigh").hitTestable(), findsOneWidget);
+      expect(_menuItem("minimal").hitTestable(), findsNothing);
+      expect(tester.getRect(_menuItem("max")).bottom, tester.getRect(scrollView).bottom);
+
+      await tester.drag(scrollView, const Offset(0, 500));
+      await tester.pumpAndSettle();
+      expect(_menuItem("minimal").hitTestable(), findsOneWidget);
+      await tester.tap(_menuItem("minimal"));
+      await tester.pumpAndSettle();
+      expect(selected, [const SessionVariant(id: "minimal")]);
+      expect(_menuItem("max"), findsNothing);
+
+      // Scrolling a previous opening does not hide the strongest end next time.
+      await tester.tap(find.widgetWithText(PregoPickerButton, "minimal"));
+      await tester.pumpAndSettle();
+      expect(_menuItem("max").hitTestable(), findsOneWidget);
+      expect(_menuItem("minimal").hitTestable(), findsNothing);
+    }, variant: platforms);
+  });
+
   group("Agent picker", () {
     testWidgets("shows every agent, with none clipped out of reach", (tester) async {
       await tester.pumpWidget(_buildApp(agents: _agents, onAgentSelected: (_) {}));

--- a/client/module_app_ui/lib/src/features/session_detail/widgets/agent_model_buttons.dart
+++ b/client/module_app_ui/lib/src/features/session_detail/widgets/agent_model_buttons.dart
@@ -240,6 +240,7 @@ class const _VariantMenu({
       flat: true,
       menuWidth: 220,
       menuMaxHeight: _pickerMaxHeight,
+      reverseScroll: true,
       triggerBuilder: (context, toggle) => PregoPickerButton(
         leadingIcon: Icons.speed_outlined,
         label: selectedVariant ?? availableVariants.first.id,
@@ -248,7 +249,8 @@ class const _VariantMenu({
       ),
       entriesBuilder: () => [
         PregoMenuLabel(text: loc.sessionDetailPickerVariant),
-        for (final variant in availableVariants)
+        // Catalogs are strongest-first; keep those efforts nearest the composer.
+        for (final variant in availableVariants.reversed)
           PregoMenuItem(
             title: variant.id,
             subtitle: null,

--- a/client/module_prego/lib/components/menus/anchored_flat_panel.dart
+++ b/client/module_prego/lib/components/menus/anchored_flat_panel.dart
@@ -40,6 +40,9 @@ class const AnchoredFlatPanel({
   /// Minimum gap kept between the bubble and the screen edges.
   required final EdgeInsets screenPadding,
 
+  /// Starts overflow at the bottom without changing the body's visual order.
+  final bool reverseScroll = false,
+
   /// Builds the bubble body. The `close` callback dismisses the popup. The panel
   /// scrolls this content when it exceeds the available height, so it need not
   /// provide its own scroll view.
@@ -87,7 +90,7 @@ class const AnchoredFlatPanel({
         // (the delegate's maxHeight cap) scrolls instead of overflowing, so
         // callers can hand in arbitrary content without each wrapping its own
         // scroll view. Shorter content shrink-wraps as before.
-        child: SingleChildScrollView(child: childBuilder(context, close)),
+        child: SingleChildScrollView(reverse: reverseScroll, child: childBuilder(context, close)),
       ),
     );
 

--- a/client/module_prego/lib/components/menus/prego_anchor_menu.dart
+++ b/client/module_prego/lib/components/menus/prego_anchor_menu.dart
@@ -170,6 +170,11 @@ class const PregoAnchorMenu({
   /// flat on Android.
   final bool flat = false,
 
+  /// Starts a scrollable flat menu at the bottom, keeping the last entries
+  /// visible when the rows do not fit. Entries still render top to bottom in
+  /// [entriesBuilder] order. Requires [flat]; the glass menu owns its scroll.
+  final bool reverseScroll = false,
+
   /// When set, the open menu blurs and dims the page behind it while keeping the
   /// trigger sharp. Null (the default) leaves the backdrop untouched — right for
   /// a menu hung off a button, where the page behind it is not the subject.
@@ -181,7 +186,8 @@ class const PregoAnchorMenu({
         spotlight == null || flat,
         "A spotlight needs the flat path (flat: true): GlassMenu hides its trigger while the "
         "popup is up, so there is no trigger left to keep sharp.",
-      );
+      ),
+      assert(!reverseScroll || flat, "Reverse scrolling requires the flat menu path (flat: true).");
 
   @override
   State<PregoAnchorMenu> createState() => _PregoAnchorMenuState();
@@ -366,6 +372,7 @@ class _PregoAnchorMenuState() extends State<PregoAnchorMenu> {
       maxHeight: widget.menuMaxHeight,
       borderRadius: widget.menuBorderRadius,
       screenPadding: widget.menuScreenPadding,
+      reverseScroll: widget.reverseScroll,
       // Menu items meet the panel clip so their ink reaches its outer edges.
       // Labels, dividers, and custom content keep the original edge breathing
       // room when they bookend the menu.

--- a/client/module_prego/test/components/prego_anchor_menu_test.dart
+++ b/client/module_prego/test/components/prego_anchor_menu_test.dart
@@ -7,6 +7,7 @@ import "package:theme_prego/module_prego.dart";
 Widget _harness(
   List<PregoMenuEntry> entries, {
   bool flat = false,
+  bool reverseScroll = false,
   PregoMenuSpotlight? spotlight,
   double? maxHeight,
 }) {
@@ -18,6 +19,7 @@ Widget _harness(
           menuWidth: 240,
           menuMaxHeight: maxHeight,
           flat: flat,
+          reverseScroll: reverseScroll,
           spotlight: spotlight,
           entriesBuilder: () => entries,
           triggerBuilder: (context, toggle) => ElevatedButton(
@@ -44,8 +46,7 @@ List<PregoMenuEntry> _agentEntries(List<String> names, {void Function(String nam
 ];
 
 /// The scroll position of the open glass popup.
-ScrollPosition _popupScroll(WidgetTester tester) =>
-    tester.state<ScrollableState>(find.byType(Scrollable)).position;
+ScrollPosition _popupScroll(WidgetTester tester) => tester.state<ScrollableState>(find.byType(Scrollable)).position;
 
 void main() {
   group("Android (flat) path", () {
@@ -87,6 +88,42 @@ void main() {
       // Selecting an item closes the menu.
       expect(find.text("Alpha"), findsNothing);
     }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+
+    testWidgets("reverse scrolling opens at the last entries without reordering rows", (tester) async {
+      await tester.pumpWidget(
+        _harness(
+          [
+            for (final name in ["First", "Second", "Third", "Last"])
+              PregoMenuItem(title: name, subtitle: null, isSelected: false, onTap: () {}),
+          ],
+          flat: true,
+          reverseScroll: true,
+          maxHeight: 120,
+        ),
+      );
+      await tester.tap(find.text("Open"));
+      await tester.pumpAndSettle();
+
+      final first = find.widgetWithText(InkWell, "First");
+      final last = find.widgetWithText(InkWell, "Last");
+      expect(last.hitTestable(), findsOneWidget);
+      expect(first.hitTestable(), findsNothing);
+      expect(tester.getTopLeft(first).dy, lessThan(tester.getTopLeft(last).dy));
+      await tester.drag(find.byType(SingleChildScrollView), const Offset(0, 300));
+      await tester.pumpAndSettle();
+      expect(first.hitTestable(), findsOneWidget);
+    });
+
+    test("reverse scrolling requires the flat path", () {
+      expect(
+        () => PregoAnchorMenu(
+          reverseScroll: true,
+          entriesBuilder: () => [],
+          triggerBuilder: (context, toggle) => const SizedBox.shrink(),
+        ),
+        throwsAssertionError,
+      );
+    });
 
     testWidgets("first and last item highlights reach the panel edges", (tester) async {
       await tester.pumpWidget(

--- a/docs/regression/session-creation-and-options.md
+++ b/docs/regression/session-creation-and-options.md
@@ -35,6 +35,12 @@ variant, and worktree mode, and creating the session with its first input.
   otherwise the variant the backend listed first, so reordering never changes
   what runs. Hermes exposes none, and Claude and Pi drop names outside their
   own closed level sets before ordering.
+- Chat and New Session composer effort pickers display that catalog in reverse:
+  lowest efforts at the top, strongest efforts (`max`, `xhigh`) at the bottom,
+  nearest the trigger. A constrained-height popup opens at the bottom regardless
+  of the selected effort; scrolling toward the top reveals the lowest options
+  and heading. Selection/checkmarks, declared defaults, and agent/model picker
+  ordering are unchanged on mobile and desktop.
 - Every plugin ranks Anthropic and OpenAI models strongest first from the model
   id through one shared rule: newest generation first, then Fable, Opus,
   Sonnet, Haiku, or Astra, Sol, Terra, Luna, the bare GPT model, then other
@@ -283,6 +289,10 @@ selection rejection, and authentication failure during discovery. For Grok,
 vary default and explicit model/effort tuples, model-only and effort-only
 changes, changing catalogs, malformed optional entries, stale rejection,
 refresh failure with a last-good catalog, and headless-auth discovery failure.
+For composer effort pickers, vary full-height and small/keyboard-constrained
+viewports, a selected low effort, and reopening after scrolling: the strongest
+options start visible at the bottom, the lowest remain reachable above, and
+selection still dispatches the exact variant that was tapped.
 
 ## Failure Signals
 
@@ -291,6 +301,9 @@ refresh failure with a last-good catalog, and headless-auth discovery failure.
   cache, Create remains enabled, Refresh becomes unavailable, the plugin runtime
   becomes globally blocked, or Pi reports no models without local `/login` guidance.
 - Options are stale where a discovery failure should be an explicit error.
+- An effort popup puts the strongest levels at the top, opens with them hidden
+  below the fold, makes the lowest levels unreachable by scrolling toward the
+  top, or selects a different level from the tapped row.
 - A model the backend reports unavailable is selectable or offers variants on
   one surface but not another, an agent's declared model is adopted without
   being checked against the catalog, or a screen's variant list describes a
@@ -395,7 +408,8 @@ refresh failure with a last-good catalog, and headless-auth discovery failure.
   `client/module_app_ui/lib/src/features/new_session/`,
   `client/app/lib/features/new_session/new_session_screen.dart`, and
   `client/desktop/lib/features/new_session/desktop_new_session_screen.dart`
-- Client tests: `client/app/test/features/new_session/new_session_screen_test.dart`,
+- Client tests: `client/app/test/core/widgets/agent_model_buttons_test.dart`,
+  `client/app/test/features/new_session/new_session_screen_test.dart`,
   `client/desktop/test/features/new_session/desktop_new_session_screen_test.dart`,
   and `client/desktop/test/core/routing/desktop_router_test.dart`
 - Plans (discovery only): `.plan/completed/multi-plugin-release-prep`,


### PR DESCRIPTION
## Complexity
🌿 Straightforward — reverse the composer's effort presentation and opt its existing flat popup into bottom-starting scrolling.

## What
- List efforts lowest to highest, with `xhigh` and `max` at the bottom nearest the composer.
- Open overflowing effort menus at the bottom, regardless of the selected effort; scroll toward the top to reach lower efforts.
- Keep the heading at the top and preserve exact selection callbacks/checkmarks.
- Add focused widget coverage and update the session-options regression guide.

## Why
The strongest efforts should remain immediately reachable on small screens rather than being hidden below the fold after reversing the list.

## Risk and test focus
Low-risk, shared presentation-only change: mobile and desktop chat/New Session composers consume the same picker. Agent/model menus and popovers retain their existing order and initial scroll position. Plugin catalogs, defaults, analytics, and selection reconciliation are unchanged. No database or wire-contract impact.

Focus: ascending row order, initial bottom visibility with a low selected effort, small/keyboard-constrained viewports, scrolling to the lowest effort, reopening, and exact tap selection on iOS/Android/macOS widget targets.

## Expected result
Users see `max` and `xhigh` at the bottom immediately when opening the effort picker. If options do not fit, they scroll toward the top to see lower efforts.

## Verification
- 9 composer-picker widget cases passed, including 6 new iOS/Android/macOS cases.
- 29 anchored-menu/popover tests passed.
- 10 existing New Session/chat model, variant, and picker tests passed.
- 2 rendered chat-screen screenshot fixtures passed; regular and compact before/after screenshots plus compact scrolled states saved outside the repository. Screenshots and temporary capture source are not committed. This is widget-fixture evidence, not live-device E2E.
- New variant regressions failed against the unchanged implementation before the fix.
- `dart analyze` passed in `client/module_app_ui` and `client/module_prego`; the changed app test also analyzes cleanly.
- Architecture plan and implementation reviews approved.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverses the composer's effort picker so the strongest efforts (`max`, `xhigh`) sit at the bottom nearest the input. Overflowing menus now open at the bottom regardless of the selected effort, scrolling up to reveal lower efforts and the heading; this is presentation-only with no database or wire-contract impact.

- `PregoAnchorMenu` and `AnchoredFlatPanel` gain a `reverseScroll` option that starts flat menus at the bottom; it requires `flat: true`.
- Agent/model pickers keep their existing order and scroll position, and selection callbacks, checkmarks, and defaults are unchanged.
- Adds widget tests for iOS, Android, and macOS covering ascending order, bottom visibility on small viewports, and reopening after scrolling.

<sup>Written for commit 7d5e2f5ce4ee0830352d899734ec83d4c0d77e45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

