### PR TITLE
⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]

### DIFF
--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -870,7 +870,7 @@ those refs. Regenerate each successor from its merged predecessor.
 | 2/6 | `🚧 [claude-inline-subtasks] cursor: settle generic Task lifecycle [step 2/6]` | PR #1438 merged at `116392cb71`: active generic-part tracking, terminal settlement, request ack, transport ordering regressions, typed-refusal plan correction, and behavior docs; no tile |
 | 3/6 | `🚧 [claude-inline-subtasks] cursor: completed foreground Task tiles [step 3/6]` | PR #1441 merged at `bb85f48148`: exact completed correlation, minimal presentation DTO fields, childless one-shot live replacement, tests, and capability/docs update |
 | 4/6 | `🚧 [claude-inline-subtasks] cursor: safe Task stop policy [step 4/6]` | Regenerated from merged main and checked locally, unpublished: exact count, process residency, typed refusal, safe root cancel/re-check, bridge/client/UI flow, tests, and docs; no replay/native QA |
-| 5/6 | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | Approximately 650–1,000 lines: configured collector/shared pure projection, stable completed projection, fallbacks, tests, and history doc |
+| 5/6 | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | Implemented and checked locally, unpublished: configured collector/shared pure projection, typed stable completed projection, fallbacks, tests, and history docs; no native QA |
 | 6/6 | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage [step 6/6]` | Approximately 60–140 lines: actual-plugin evidence and final reconciliation only; unsupported/unexecuted matrix remains explicit |
 
 ### Probe questions

--- a/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/active/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -869,8 +869,8 @@ those refs. Regenerate each successor from its merged predecessor.
 | 1/6 | `🌱 [claude-inline-subtasks] docs: record Cursor native probe and corrected plan [step 1/6]` | PR #1435 merged at `b83b64901c`; supervisor will update its GitHub title; docs only |
 | 2/6 | `🚧 [claude-inline-subtasks] cursor: settle generic Task lifecycle [step 2/6]` | PR #1438 merged at `116392cb71`: active generic-part tracking, terminal settlement, request ack, transport ordering regressions, typed-refusal plan correction, and behavior docs; no tile |
 | 3/6 | `🚧 [claude-inline-subtasks] cursor: completed foreground Task tiles [step 3/6]` | PR #1441 merged at `bb85f48148`: exact completed correlation, minimal presentation DTO fields, childless one-shot live replacement, tests, and capability/docs update |
-| 4/6 | `🚧 [claude-inline-subtasks] cursor: safe Task stop policy [step 4/6]` | Regenerated from merged main and checked locally, unpublished: exact count, process residency, typed refusal, safe root cancel/re-check, bridge/client/UI flow, tests, and docs; no replay/native QA |
-| 5/6 | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | Implemented and checked locally, unpublished: configured collector/shared pure projection, typed stable completed projection, fallbacks, tests, and history docs; no native QA |
+| 4/6 | `🚧 [claude-inline-subtasks] cursor: safe Task stop policy [step 4/6]` | PR #1442 merged at `a7d3014e1a`: exact count, process residency, typed refusal, bounded root cancel/re-check, concurrent descendant fallback, bridge/client/UI flow, tests, and docs; no replay/native QA |
+| 5/6 | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | PR #1443 open: configured collector/shared pure projection, typed stable completed projection, fallbacks, tests, and history docs; no native QA |
 | 6/6 | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage [step 6/6]` | Approximately 60–140 lines: actual-plugin evidence and final reconciliation only; unsupported/unexecuted matrix remains explicit |
 
 ### Probe questions

--- a/.plan/active/claude-inline-subtasks/PLAN.md
+++ b/.plan/active/claude-inline-subtasks/PLAN.md
@@ -10,10 +10,14 @@
   recorded in `HARNESS_FOLLOWUPS.md` and `followups/cursor-probe.md`. Cursor
   Step 1 merged as PR #1435 at `b83b64901c`; Step 2 merged as PR #1438 at
   `116392cb71`, settling generic Task lifecycle and acknowledging `cursor/task`.
-  Step 3 merged as PR #1441 at `bb85f48148`; Step 4 is reviewed on its
-  regenerated unpublished branch. Replay remains Step 5; final coverage remains Step 6.
-  Step 4 adds typed refusal, Cursor residency, named-root cancellation, repository fallback,
-  queue gate, and limitation UI; no replay/native QA. Reviewed checkpoint `5cc54ad013` is preserved by branches
+  Step 3 merged as PR #1441 at `bb85f48148`; Step 4 safe stop and Step 5 replay
+  are implemented and checked on local unpublished branches. Step 5 includes
+  configured standard replay plus Cursor-local typed replacement; final coverage
+  remains Step 6. Step 4 includes the typed refusal, Cursor-only residency,
+  named-root cancellation with mandatory post-settlement re-check/HTTP 502
+  partial failure, repository-owned concurrent descendant fallback, client queue
+  gate, and limitation UI, with no replay/native QA. Full reviewed checkpoint
+  `5cc54ad013` is preserved by branches
   `claude-inline-subtasks-cursor-tiles-step2-of5` and
   `checkpoint/cursor-step2-combined-reviewed-5cc54` as split source evidence.
   Earlier refs `c5c0def` and `ab03528` remain stale, unpublishable historical

--- a/.plan/active/claude-inline-subtasks/PLAN.md
+++ b/.plan/active/claude-inline-subtasks/PLAN.md
@@ -10,13 +10,13 @@
   recorded in `HARNESS_FOLLOWUPS.md` and `followups/cursor-probe.md`. Cursor
   Step 1 merged as PR #1435 at `b83b64901c`; Step 2 merged as PR #1438 at
   `116392cb71`, settling generic Task lifecycle and acknowledging `cursor/task`.
-  Step 3 merged as PR #1441 at `bb85f48148`; Step 4 safe stop and Step 5 replay
-  are implemented and checked on local unpublished branches. Step 5 includes
+  Step 3 merged as PR #1441 at `bb85f48148`; Step 4 safe stop merged as PR
+  #1442 at `a7d3014e1a`; Step 5 replay is open as PR #1443. Step 5 includes
   configured standard replay plus Cursor-local typed replacement; final coverage
   remains Step 6. Step 4 includes the typed refusal, Cursor-only residency,
-  named-root cancellation with mandatory post-settlement re-check/HTTP 502
-  partial failure, repository-owned concurrent descendant fallback, client queue
-  gate, and limitation UI, with no replay/native QA. Full reviewed checkpoint
+  bounded named-root cancellation with post-settlement re-check/HTTP 502 partial
+  failure, repository-owned concurrent descendant fallback, client queue gate,
+  and limitation UI, with no replay/native QA. Full reviewed checkpoint
   `5cc54ad013` is preserved by branches
   `claude-inline-subtasks-cursor-tiles-step2-of5` and
   `checkpoint/cursor-step2-combined-reviewed-5cc54` as split source evidence.

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -12,9 +12,9 @@
   bounded Codex Step 9 managed-0.153.4 actual-plugin policy QA passed on
   2026-09-10. Grok documentation is delivered, while its phone gate remains
   infrastructure-blocked. Harness follow-ups remain active.
-- **Next action:** Cursor safe Task stop Step 4/6 is implemented, reviewed,
-  regenerated from merged Step 3 on its publication branch, and ready to open
-  as a PR. No Step 5 replay or native QA is included.
+- **Next action:** Cursor replay Step 5/6 is implemented and checked locally
+  after normally merging latest unpublished Step 4 at `815756efe9`; it remains
+  unpublished. Publish in order, then run Step 6 actual-plugin coverage.
   Full reviewed checkpoint `5cc54ad013` is preserved by branches
   `claude-inline-subtasks-cursor-tiles-step2-of5` and
   `checkpoint/cursor-step2-combined-reviewed-5cc54`; the 2,038-line checkpoint
@@ -209,7 +209,7 @@ post-merge E2E gates are unchanged.
 | [x] | Cursor | `🚧 [claude-inline-subtasks] cursor: settle generic Task lifecycle [step 2/6]` | [PR #1438](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1438) merged at `116392cb71`; Cursor-local active generic cards, terminal settlement, request acknowledgement, and process-exit ordering; no tile |
 | [x] | Cursor | `🚧 [claude-inline-subtasks] cursor: completed foreground Task tiles [step 3/6]` | [PR #1441](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1441) merged at `bb85f48148`; exact completed-phase correlation, childless live replacement, tests, and docs |
 | [ ] | Cursor | `🚧 [claude-inline-subtasks] cursor: safe Task stop policy [step 4/6]` | Regenerated from merged main and checked locally, unpublished: exact active mode-unknown Task count, unresolved-background process residency, typed refusal, named-root safe stop, queue-drain gate, limitation UI, tests, and docs; no replay/native QA |
-| [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | Planned; approximately 650–1,000 lines; configured ACP collector/shared pure projection, stable completed projection, fallbacks, tests, and history doc |
+| [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | Implemented and checked locally, unpublished: configured ACP collector/shared pure projection, typed stable completed projection, fallbacks, tests, and history docs; no native QA |
 | [ ] | Cursor | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage [step 6/6]` | Planned; approximately 60–140 lines; actual-plugin evidence/final reconciliation only; background stop/lifecycle and child-session gaps remain explicit |
 
 ### Cursor native probe (2026-09-11)
@@ -525,9 +525,15 @@ post-merge E2E gates are unchanged.
   from that tree (matching pre-squash `d3297ad4b9`).
 - **Cursor Step 4/6 (local, checked; unpublished):** exact Task count, process
   residency, typed refusal, bounded named-root stop, concurrent descendant
-  fallback, queue gate, and restart UI are implemented. Replay, child sessions,
-  runtime/config, native QA, push, analytics, and publication remain absent;
-  Step 5 stays blocked until merge.
+  fallback, queue gate, and restart UI are implemented. Child sessions,
+  runtime/config, native QA, push, analytics, and publication remain absent.
+- **Cursor Step 5/6 (local, checked; unpublished):** typed standard replay facts
+  replace only complete foreground Task cards through one configured collector
+  and shared pure projection; stable identity, ordering, fallbacks, and unchanged
+  configured ACP replacement behavior are focused-tested against latest Step 4
+  predecessor `815756efe9`. No analytics event: existing history rendering has
+  no bounded decision or reporting consumer. No native QA, child session,
+  wire/client/DB, runtime, timer, or poller change.
 
 ## Plan Review
 

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -3,8 +3,8 @@
 ## Current State
 
 - **Plan slug:** `claude-inline-subtasks`
-- **Implementation base:** Cursor Step 3 merged as
-  [PR #1441](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1441) at `bb85f48148`.
+- **Implementation base:** Cursor Step 4 merged as
+  [PR #1442](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1442) at `a7d3014e1a`.
 - **Series state:** all eight original Claude steps merged, including the
   L4-found fix [#1257](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1257),
   which made scoped stop harness-neutral and added
@@ -12,9 +12,9 @@
   bounded Codex Step 9 managed-0.153.4 actual-plugin policy QA passed on
   2026-09-10. Grok documentation is delivered, while its phone gate remains
   infrastructure-blocked. Harness follow-ups remain active.
-- **Next action:** Cursor replay Step 5/6 is implemented and checked locally
-  after normally merging latest unpublished Step 4 at `815756efe9`; it remains
-  unpublished. Publish in order, then run Step 6 actual-plugin coverage.
+- **Next action:** Drive Cursor replay Step 5/6
+  [PR #1443](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1443) to merge,
+  then run Step 6 actual-plugin coverage.
   Full reviewed checkpoint `5cc54ad013` is preserved by branches
   `claude-inline-subtasks-cursor-tiles-step2-of5` and
   `checkpoint/cursor-step2-combined-reviewed-5cc54`; the 2,038-line checkpoint
@@ -208,8 +208,8 @@ post-merge E2E gates are unchanged.
 | [x] | Cursor | `🌱 [claude-inline-subtasks] docs: record Cursor native probe and corrected plan [step 1/6]` | [#1435](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1435) merged at `b83b64901c` originally titled `[step 1/5]`; its GitHub title was deliberately renumbered to `[step 1/6]` after the split, matching this current table; privacy-safe evidence and original plan, with no feature implementation |
 | [x] | Cursor | `🚧 [claude-inline-subtasks] cursor: settle generic Task lifecycle [step 2/6]` | [PR #1438](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1438) merged at `116392cb71`; Cursor-local active generic cards, terminal settlement, request acknowledgement, and process-exit ordering; no tile |
 | [x] | Cursor | `🚧 [claude-inline-subtasks] cursor: completed foreground Task tiles [step 3/6]` | [PR #1441](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1441) merged at `bb85f48148`; exact completed-phase correlation, childless live replacement, tests, and docs |
-| [ ] | Cursor | `🚧 [claude-inline-subtasks] cursor: safe Task stop policy [step 4/6]` | Regenerated from merged main and checked locally, unpublished: exact active mode-unknown Task count, unresolved-background process residency, typed refusal, named-root safe stop, queue-drain gate, limitation UI, tests, and docs; no replay/native QA |
-| [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | Implemented and checked locally, unpublished: configured ACP collector/shared pure projection, typed stable completed projection, fallbacks, tests, and history docs; no native QA |
+| [x] | Cursor | `🚧 [claude-inline-subtasks] cursor: safe Task stop policy [step 4/6]` | [PR #1442](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1442) merged at `a7d3014e1a`; exact active Task count, unresolved-background residency, typed refusal, bounded named-root stop, concurrent descendant fallback, queue gate, and limitation UI; no replay/native QA |
+| [ ] | Cursor | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | [PR #1443](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1443) open: configured ACP collector/shared pure projection, typed stable completed projection, fallbacks, tests, and history docs; no native QA |
 | [ ] | Cursor | `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage [step 6/6]` | Planned; approximately 60–140 lines; actual-plugin evidence/final reconciliation only; background stop/lifecycle and child-session gaps remain explicit |
 
 ### Cursor native probe (2026-09-11)
@@ -523,17 +523,12 @@ post-merge E2E gates are unchanged.
   runtime/config change.
 - **Cursor Step 3/6:** PR #1441 merged at `bb85f48148`; Step 4 was regenerated
   from that tree (matching pre-squash `d3297ad4b9`).
-- **Cursor Step 4/6 (local, checked; unpublished):** exact Task count, process
-  residency, typed refusal, bounded named-root stop, concurrent descendant
-  fallback, queue gate, and restart UI are implemented. Child sessions,
-  runtime/config, native QA, push, analytics, and publication remain absent.
-- **Cursor Step 5/6 (local, checked; unpublished):** typed standard replay facts
-  replace only complete foreground Task cards through one configured collector
-  and shared pure projection; stable identity, ordering, fallbacks, and unchanged
-  configured ACP replacement behavior are focused-tested against latest Step 4
-  predecessor `815756efe9`. No analytics event: existing history rendering has
-  no bounded decision or reporting consumer. No native QA, child session,
-  wire/client/DB, runtime, timer, or poller change.
+- **Cursor Step 4/6:** PR #1442 merged at `a7d3014e1a`; exact Task count,
+  residency, typed refusal, bounded root stop, concurrent descendant fallback,
+  queue gate, and restart UI shipped without replay or native QA.
+- **Cursor Step 5/6:** PR #1443 is open. Complete foreground Task replay uses one
+  configured collector/shared projection with stable identity, ordering, and fallbacks.
+  No analytics event, native QA, child session, wire/client/DB, runtime, timer, or poller change.
 
 ## Plan Review
 

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -526,8 +526,7 @@ post-merge E2E gates are unchanged.
 - **Cursor Step 4/6:** PR #1442 merged at `a7d3014e1a`; exact Task count,
   residency, typed refusal, bounded root stop, concurrent descendant fallback,
   queue gate, and restart UI shipped without replay or native QA.
-- **Cursor Step 5/6:** PR #1443 is open. Complete foreground Task replay uses one
-  configured collector/shared projection with stable identity, ordering, and fallbacks.
+- **Cursor Step 5/6:** PR #1443 is open with configured collector/shared projection and stable fallbacks.
   No analytics event, native QA, child session, wire/client/DB, runtime, timer, or poller change.
 
 ## Plan Review

--- a/.plan/active/claude-inline-subtasks/TRACKER.md
+++ b/.plan/active/claude-inline-subtasks/TRACKER.md
@@ -3,8 +3,7 @@
 ## Current State
 
 - **Plan slug:** `claude-inline-subtasks`
-- **Implementation base:** Cursor Step 4 merged as
-  [PR #1442](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1442) at `a7d3014e1a`.
+- **Implementation base:** Cursor Step 4 PR #1442 merged at `a7d3014e1a`.
 - **Series state:** all eight original Claude steps merged, including the
   L4-found fix [#1257](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1257),
   which made scoped stop harness-neutral and added
@@ -12,9 +11,7 @@
   bounded Codex Step 9 managed-0.153.4 actual-plugin policy QA passed on
   2026-09-10. Grok documentation is delivered, while its phone gate remains
   infrastructure-blocked. Harness follow-ups remain active.
-- **Next action:** Drive Cursor replay Step 5/6
-  [PR #1443](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1443) to merge,
-  then run Step 6 actual-plugin coverage.
+- **Next action:** Merge Cursor Step 5 PR #1443, then run Step 6 actual-plugin coverage.
   Full reviewed checkpoint `5cc54ad013` is preserved by branches
   `claude-inline-subtasks-cursor-tiles-step2-of5` and
   `checkpoint/cursor-step2-combined-reviewed-5cc54`; the 2,038-line checkpoint
@@ -526,8 +523,7 @@ post-merge E2E gates are unchanged.
 - **Cursor Step 4/6:** PR #1442 merged at `a7d3014e1a`; exact Task count,
   residency, typed refusal, bounded root stop, concurrent descendant fallback,
   queue gate, and restart UI shipped without replay or native QA.
-- **Cursor Step 5/6:** PR #1443 is open with configured collector/shared projection and stable fallbacks.
-  No analytics event, native QA, child session, wire/client/DB, runtime, timer, or poller change.
+- **Cursor Step 5/6:** PR #1443 is open with a standard ACP collector/shared typed projection; no analytics or native QA.
 
 ## Plan Review
 

--- a/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
+++ b/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
@@ -469,7 +469,7 @@ remains at the post-settlement re-check. Background full stop remains unsupporte
 ### Replay and unsupported behavior
 
 Replay uses only typed standard Task facts. Complete foreground input plus
-`isBackground: false` may replace the generic part. `isBackground: true`,
+`isBackground: false` replaces the exact materialized generic part. `isBackground: true`,
 missing/malformed input/output, or incomplete presentation facts preserve the
 generic card. Native cancelled replay absence remains absence. Repeated loads
 reuse native replay-local identity without asserting equality to the original
@@ -512,8 +512,8 @@ source, generated serializers, tests, behavior docs, and tracker bookkeeping.
    capability docs. It remains unpublished on a branch regenerated from merged
    main; its pre-reconciliation tree matched reviewed checkpoint `eae039ca27`.
 5. `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]`
-   (expected 650–1,000 changed lines): configured collector/shared pure projection,
-   stable completed projection, fallbacks, tests, and history doc.
+   is implemented and checked locally, unpublished: configured collector/shared
+   pure projection, typed stable replacement/fallbacks, tests, and history docs.
 6. `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage [step 6/6]`
    (expected 60–140 changed lines): bounded actual-plugin evidence and final
    reconciliation only; unsupported/unexecuted boundaries remain explicit.

--- a/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
+++ b/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
@@ -510,8 +510,7 @@ source, generated serializers, tests, behavior docs, and tracker bookkeeping.
    residency, typed refusal, safe `rootSessionCancel`, and concurrent descendant
    fallback with mandatory settlement re-check; no replay/native QA.
 5. `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]`
-   is open as PR #1443 with configured collector/shared projection, typed
-   fallbacks, tests, and history docs; no native QA.
+   is open as PR #1443 with configured typed collector/projection, fallbacks, tests, history docs, and no native QA.
 6. `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage [step 6/6]`
    (expected 60–140 changed lines): bounded actual-plugin evidence and final
    reconciliation only; unsupported/unexecuted boundaries remain explicit.

--- a/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
+++ b/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
@@ -213,8 +213,8 @@ Cursor boundary and repository changes:
   any ACP child/root activity API. `CursorEventMapper` keeps the two Step 2
   terminal projections private: both preserve exact generic-card identity and
   presentation fields, and failure text is bounded. Step 3 adds its completed
-  foreground projection privately. Step 5 may extract shared pure projection
-  only when live and replay become current consumers. Complete correlated
+  foreground projection privately. Step 5 extracts one shared pure `CursorTaskMapper`
+  for the current live/replay consumers. Complete correlated
   foreground facts then produce one completed childless
   `PluginMessagePart.subtask`; pending, background, malformed, incomplete,
   cancelled, and failed cases remain generic. `agentId` is correlation data,
@@ -567,8 +567,8 @@ Step 5 automated scope:
   keep replay-local identity; live/replay fields converge without requiring
   live-id equality; background/missing/malformed facts retain generic; cancelled
   absence stays absent.
-- Composition test proves `CursorTaskReplayTracker` receives one configured
-  `AcpReplayCollector` and the shared pure projection extracted when replay lands; tracker
+- Composition tests prove `CursorTaskReplayTracker` receives one configured
+  `AcpReplayCollector` and the shared injected `CursorTaskMapper`; the tracker
   has no live state, transport, or I/O. Run Cursor/ACP replay-focused tests and
   analyzers plus `git diff --check`.
 

--- a/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
+++ b/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
@@ -506,14 +506,12 @@ source, generated serializers, tests, behavior docs, and tracker bookkeeping.
    childless replacement, tests, and live-tile capability/docs. Step 4 is based
    on that merged commit; pre-squash `d3297ad4b9` has the same tree.
 4. `🚧 [claude-inline-subtasks] cursor: safe Task stop policy [step 4/6]`
-   is implemented and checked locally: exact active count, unresolved-background
-   residency, typed refusal, safe `rootSessionCancel` with mandatory post-
-   settlement re-check, bridge/client/UI flow, tests, and stop/lifecycle/
-   capability docs. It remains unpublished on a branch regenerated from merged
-   main; its pre-reconciliation tree matched reviewed checkpoint `eae039ca27`.
+   merged as PR #1442 at `a7d3014e1a`: exact active count, unresolved-background
+   residency, typed refusal, safe `rootSessionCancel`, and concurrent descendant
+   fallback with mandatory settlement re-check; no replay/native QA.
 5. `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]`
-   is implemented and checked locally, unpublished: configured collector/shared
-   pure projection, typed stable replacement/fallbacks, tests, and history docs.
+   is open as PR #1443 with configured collector/shared projection, typed
+   fallbacks, tests, and history docs; no native QA.
 6. `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage [step 6/6]`
    (expected 60–140 changed lines): bounded actual-plugin evidence and final
    reconciliation only; unsupported/unexecuted boundaries remain explicit.

--- a/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
+++ b/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
@@ -510,7 +510,8 @@ source, generated serializers, tests, behavior docs, and tracker bookkeeping.
    residency, typed refusal, safe `rootSessionCancel`, and concurrent descendant
    fallback with mandatory settlement re-check; no replay/native QA.
 5. `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]`
-   is open as PR #1443 with configured typed collector/projection, fallbacks, tests, history docs, and no native QA.
+   is open as PR #1443 with one configured standard ACP collector and shared typed
+   `CursorTaskProjection`, fallbacks, tests, history docs, and no native QA.
 6. `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage [step 6/6]`
    (expected 60–140 changed lines): bounded actual-plugin evidence and final
    reconciliation only; unsupported/unexecuted boundaries remain explicit.

--- a/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
+++ b/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
@@ -251,15 +251,15 @@ Cursor boundary and repository changes:
   composition owner. Step 2 constructs one `CursorTaskTracker`, injects it into
   `CursorEventMapper`, and clears it from `onConnectionReset` after pending RPC
   failures have resumed their turn catch paths. Reset fabricates no terminal
-  Task event. Step 5 may compose a shared pure projection if replay creates the
-  second current consumer. Step 4 makes
+  Task event. Step 5 composes one shared pure `CursorTaskMapper` for the live and
+  replay consumers. Step 4 makes
   `CursorPlugin.scopedStopCapability` return
   `AcpScopedStopCapability.rootSessionCancel`, reaching the dedicated neutral
   ACP branch. Its `createSessionReplayCollector({required
   String sessionId, required
   AcpReplayCollectorFactory collectorFactory})` override first calls
   `collectorFactory(toolPartSuppression: null)` for one fully configured
-  standard collector, then injects that collector and the stored projection into
+  standard collector, then injects that collector and the shared mapper into
   `CursorTaskReplayTracker`. The tracker receives no factory, and neither
   mapper nor tracker constructs its peer.
 - `bridge/sesori_plugin_cursor/lib/src/runtime/cursor_plugin_descriptor.dart`

--- a/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
+++ b/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
@@ -510,8 +510,7 @@ source, generated serializers, tests, behavior docs, and tracker bookkeeping.
    residency, typed refusal, safe `rootSessionCancel`, and concurrent descendant
    fallback with mandatory settlement re-check; no replay/native QA.
 5. `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]`
-   is open as PR #1443 with one configured standard ACP collector and shared typed
-   `CursorTaskProjection`, fallbacks, tests, history docs, and no native QA.
+   is open as PR #1443 with a standard ACP collector, typed `CursorTaskProjection`, tests, docs, and no native QA.
 6. `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage [step 6/6]`
    (expected 60–140 changed lines): bounded actual-plugin evidence and final
    reconciliation only; unsupported/unexecuted boundaries remain explicit.

--- a/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
+++ b/.plan/active/claude-inline-subtasks/followups/cursor-probe.md
@@ -220,14 +220,14 @@ Cursor boundary and repository changes:
   cancelled, and failed cases remain generic. `agentId` is correlation data,
   never child identity.
 - `bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart`
-  adds the only renamed replay class,
+  adds the replay-local class,
   `CursorTaskReplayTracker({required String sessionId, required
-  AcpReplayCollector standardCollector, required CursorTaskProjection taskProjection})`.
+  AcpReplayCollector standardCollector, required CursorTaskMapper taskMapper})`.
   It implements `AcpSessionReplayCollector`, forwards each notification to the
   already-configured standard collector, and indexes typed Task input/output by
   replay-local `toolCallId`. At build it calls the collector's required
   `buildWithToolPartReplacement` seam with its own state-backed replacement,
-  which delegates presentation to the injected pure projection. It owns replay-
+  which delegates presentation to the shared injected pure mapper. It owns replay-
   local maps only: no ACP client, factory, file I/O, live tracker read, event-
   buffer write, or peer construction.
 - `bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart` keeps the
@@ -510,7 +510,7 @@ source, generated serializers, tests, behavior docs, and tracker bookkeeping.
    residency, typed refusal, safe `rootSessionCancel`, and concurrent descendant
    fallback with mandatory settlement re-check; no replay/native QA.
 5. `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]`
-   is open as PR #1443 with a standard ACP collector, typed `CursorTaskProjection`, tests, docs, and no native QA.
+   PR #1443 uses one configured standard ACP collector and shared injected `CursorTaskMapper`; tests pass; no native QA.
 6. `🌱 [claude-inline-subtasks] docs: record Cursor sub-agent coverage [step 6/6]`
    (expected 60–140 changed lines): bounded actual-plugin evidence and final
    reconciliation only; unsupported/unexecuted boundaries remain explicit.

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -107,7 +107,7 @@ class AcpReplayCollector({
       case "user_message_chunk":
         _consumeUserContent(update: update, time: time);
       case "tool_call":
-        final id = update["toolCallId"] as String?;
+        final id = _asString(value: update["toolCallId"]);
         if (id == null) return;
         final contentMutation = _contentMapper.toolContent(update: update);
         final draft = _findTool(id);
@@ -145,7 +145,7 @@ class AcpReplayCollector({
           draft.hasExplicitStatus = draft.hasExplicitStatus || mappedStatus != null;
         }
       case "tool_call_update":
-        final id = update["toolCallId"] as String?;
+        final id = _asString(value: update["toolCallId"]);
         if (id == null) return;
         final contentMutation = _contentMapper.toolContent(update: update);
         final draft = _findTool(id);
@@ -676,6 +676,8 @@ class AcpReplayCollector({
     if (value is Map) return value.cast<String, dynamic>();
     return null;
   }
+
+  String? _asString({required Object? value}) => value is String ? value : null;
 
   Object? _stripUserImageUris(Object? content) {
     if (content is List) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -107,7 +107,7 @@ class AcpReplayCollector({
       case "user_message_chunk":
         _consumeUserContent(update: update, time: time);
       case "tool_call":
-        final id = _asString(value: update["toolCallId"]);
+        final id = _toolCallId(value: update["toolCallId"]);
         if (id == null) return;
         final contentMutation = _contentMapper.toolContent(update: update);
         final draft = _findTool(id);
@@ -145,7 +145,7 @@ class AcpReplayCollector({
           draft.hasExplicitStatus = draft.hasExplicitStatus || mappedStatus != null;
         }
       case "tool_call_update":
-        final id = _asString(value: update["toolCallId"]);
+        final id = _toolCallId(value: update["toolCallId"]);
         if (id == null) return;
         final contentMutation = _contentMapper.toolContent(update: update);
         final draft = _findTool(id);
@@ -677,7 +677,11 @@ class AcpReplayCollector({
     return null;
   }
 
-  String? _asString({required Object? value}) => value is String ? value : null;
+  String? _toolCallId({required Object? value}) {
+    if (value is String) return value;
+    if (value != null) Log.w("[acp] malformed replay tool-call ID ignored");
+    return null;
+  }
 
   Object? _stripUserImageUris(Object? content) {
     if (content is List) {

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -283,6 +283,7 @@ class AcpReplayCollector({
   /// Materializes replay without model-selection metadata.
   List<PluginMessageWithParts> build() => _build(
     selection: (modelId: null, providerId: null, variant: null),
+    materializationToolPartReplacement: toolPartReplacement,
   );
 
   /// Materializes replay with one authoritative assistant selection tuple.
@@ -294,14 +295,37 @@ class AcpReplayCollector({
     required String? modelId,
     required String? providerId,
     required String? variant,
-  }) => _build(selection: (modelId: modelId, providerId: providerId, variant: variant));
+  }) => _build(
+    selection: (modelId: modelId, providerId: providerId, variant: variant),
+    materializationToolPartReplacement: toolPartReplacement,
+  );
 
-  List<PluginMessageWithParts> _build({required _AcpReplayAssistantSelection selection}) {
+  /// Materializes replay through the same ordered path with a caller-owned
+  /// replay-local tool replacement. Constructor configuration remains intact
+  /// for every other materialization method.
+  List<PluginMessageWithParts> buildWithToolPartReplacement({
+    required String? modelId,
+    required String? providerId,
+    required String? variant,
+    required AcpReplayToolPartReplacement toolPartReplacement,
+  }) => _build(
+    selection: (modelId: modelId, providerId: providerId, variant: variant),
+    materializationToolPartReplacement: toolPartReplacement,
+  );
+
+  List<PluginMessageWithParts> _build({
+    required _AcpReplayAssistantSelection selection,
+    required AcpReplayToolPartReplacement? materializationToolPartReplacement,
+  }) {
     final messages = <PluginMessageWithParts>[];
     for (final entry in _entries) {
       switch (entry) {
         case _Draft():
-          final message = _buildMessage(draft: entry, selection: selection);
+          final message = _buildMessage(
+            draft: entry,
+            selection: selection,
+            materializationToolPartReplacement: materializationToolPartReplacement,
+          );
           if (message != null) messages.add(message);
         case _InsertedAssistantMessage():
           messages.add(
@@ -327,6 +351,7 @@ class AcpReplayCollector({
   PluginMessageWithParts? _buildMessage({
     required _Draft draft,
     required _AcpReplayAssistantSelection selection,
+    required AcpReplayToolPartReplacement? materializationToolPartReplacement,
   }) {
     // A recognized halt notice (e.g. Cursor's account/plan gate, streamed as a
     // lone assistant message) is surfaced as an error message so a reloaded
@@ -365,7 +390,12 @@ class AcpReplayCollector({
     if (draft.text.isNotEmpty) {
       parts.add(_textPart(draft, "text", PluginMessagePartType.text, draft.text.toString()));
     }
-    parts.addAll(_chronologicalAssistantParts(draft: draft));
+    parts.addAll(
+      _chronologicalAssistantParts(
+        draft: draft,
+        materializationToolPartReplacement: materializationToolPartReplacement,
+      ),
+    );
     if (parts.isEmpty && draft.tools.values.any((tool) => tool.suppressed)) return null;
     return PluginMessageWithParts(
       info: _message(draft: draft, selection: selection),
@@ -393,7 +423,10 @@ class AcpReplayCollector({
 
   bool _hasAssistantImageCandidate({required _Draft draft}) => draft.contentTracker.snapshot.imageCandidateCount > 0;
 
-  List<PluginMessagePart> _chronologicalAssistantParts({required _Draft draft}) {
+  List<PluginMessagePart> _chronologicalAssistantParts({
+    required _Draft draft,
+    required AcpReplayToolPartReplacement? materializationToolPartReplacement,
+  }) {
     final parts = <PluginMessagePart>[];
     String? textPartIdSuffix;
     StringBuffer? textBuffer;
@@ -438,7 +471,12 @@ class AcpReplayCollector({
           }
         case _AssistantToolEntry(:final toolId, :final tool):
           flushText();
-          final part = _toolPart(draft: draft, toolId: toolId, tool: tool);
+          final part = _toolPart(
+            draft: draft,
+            toolId: toolId,
+            tool: tool,
+            materializationToolPartReplacement: materializationToolPartReplacement,
+          );
           if (part != null) parts.add(part);
       }
     }
@@ -508,6 +546,7 @@ class AcpReplayCollector({
     required _Draft draft,
     required String toolId,
     required _ToolDraft tool,
+    required AcpReplayToolPartReplacement? materializationToolPartReplacement,
   }) {
     if (tool.suppressed) return null;
     final content = tool.contentTracker.snapshot;
@@ -525,7 +564,7 @@ class AcpReplayCollector({
         attachments: content.attachments,
       ),
     );
-    return toolPartReplacement?.call(toolCallId: toolId, toolPart: toolPart) ?? toolPart;
+    return materializationToolPartReplacement?.call(toolCallId: toolId, toolPart: toolPart) ?? toolPart;
   }
 
   void _retainTime({required _Draft draft, required PluginMessageTime? time}) {

--- a/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_session_loader_test.dart
@@ -1228,6 +1228,63 @@ void main() {
       expect(messages.every((message) => message.parts.isNotEmpty), isTrue);
     });
 
+    test("build-time tool replacement keeps ordered materialization and constructor behavior", () {
+      final collector =
+          AcpReplayCollector(
+              sessionUpdateNormalizer: null,
+              shellCommandResolver: null,
+              sessionId: "s1",
+              agentId: "ACP",
+              initialUserMessageId: null,
+              messageIdOverride: null,
+              messageTimeResolver: null,
+              haltClassifier: null,
+              toolPartReplacement: ({required toolCallId, required toolPart}) =>
+                  toolPart.copyWith(tool: "configured-$toolCallId"),
+              toolPartSuppression: null,
+            )
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "m1",
+                "content": {"type": "text", "text": "before"},
+              }),
+            )
+            ..consume(upd({"sessionUpdate": "tool_call", "toolCallId": "task-1", "status": "completed"}))
+            ..consume(
+              upd({
+                "sessionUpdate": "agent_message_chunk",
+                "messageId": "m1",
+                "content": {"type": "text", "text": "after"},
+              }),
+            );
+
+      final configured = collector.buildWithAssistantSelection(modelId: "m", providerId: "p", variant: "v");
+      final overridden = collector.buildWithToolPartReplacement(
+        modelId: "m",
+        providerId: "p",
+        variant: "v",
+        toolPartReplacement: ({required toolCallId, required toolPart}) =>
+            toolPart.copyWith(tool: "override-$toolCallId"),
+      );
+
+      expect(configured.single.parts.map((part) => part.type), [
+        PluginMessagePartType.text,
+        PluginMessagePartType.tool,
+        PluginMessagePartType.text,
+      ]);
+      expect((configured.single.parts[1] as PluginMessagePartTool).tool, "configured-task-1");
+      expect((overridden.single.parts[1] as PluginMessagePartTool).tool, "override-task-1");
+      expect(overridden.single.parts.map((part) => part.id), configured.single.parts.map((part) => part.id));
+      final assistant = overridden.single.info as PluginMessageAssistant;
+      expect((assistant.modelID, assistant.providerID, assistant.variant), ("m", "p", "v"));
+      expect(
+        (collector.build().single.parts[1] as PluginMessagePartTool).tool,
+        "configured-task-1",
+        reason: "override does not mutate configuration",
+      );
+    });
+
     test("inserted messages split an explicit assistant id into unique deterministic segments", () {
       final collector =
           AcpReplayCollector(

--- a/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_task_dto.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_task_dto.dart
@@ -17,6 +17,28 @@ enum CursorSubagentType() {
   unknown,
 }
 
+enum CursorTaskReplayUpdateKind() {
+  @JsonValue("tool_call")
+  toolCall,
+  @JsonValue("tool_call_update")
+  toolCallUpdate,
+  @JsonValue("unknown")
+  unknown,
+}
+
+enum CursorTaskReplayStatus() {
+  @JsonValue("pending")
+  pending,
+  @JsonValue("in_progress")
+  inProgress,
+  @JsonValue("completed")
+  completed,
+  @JsonValue("failed")
+  failed,
+  @JsonValue("unknown")
+  unknown,
+}
+
 /// Cursor-owned boundary model for identifying standard Task calls.
 @Freezed(fromJson: true, toJson: false)
 sealed class CursorTaskInputDto with _$CursorTaskInputDto {
@@ -47,6 +69,35 @@ sealed class CursorSubagentTypeDto with _$CursorSubagentTypeDto {
   }) = _CursorSubagentTypeDto;
 
   factory fromJson(Map<String, dynamic> json) => _$CursorSubagentTypeDtoFromJson(json);
+}
+
+/// Full standard Task input persisted by Cursor for history replay.
+@Freezed(fromJson: true, toJson: false)
+sealed class CursorTaskReplayInputDto with _$CursorTaskReplayInputDto {
+  const factory({
+    @JsonKey(
+      name: "_toolName",
+      unknownEnumValue: CursorTaskTool.unknown,
+    )
+    required CursorTaskTool toolName,
+    required String? prompt,
+    required String? description,
+    required CursorSubagentTypeDto? subagentType,
+  }) = _CursorTaskReplayInputDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CursorTaskReplayInputDtoFromJson(json);
+}
+
+/// Minimal standard update envelope used to establish replay Task identity.
+@Freezed(fromJson: true, toJson: false)
+sealed class CursorTaskReplayUpdateDto with _$CursorTaskReplayUpdateDto {
+  const factory({
+    @JsonKey(unknownEnumValue: CursorTaskReplayUpdateKind.unknown) required CursorTaskReplayUpdateKind sessionUpdate,
+    required String? toolCallId,
+    @JsonKey(unknownEnumValue: CursorTaskReplayStatus.unknown) required CursorTaskReplayStatus? status,
+  }) = _CursorTaskReplayUpdateDto;
+
+  factory fromJson(Map<String, dynamic> json) => _$CursorTaskReplayUpdateDtoFromJson(json);
 }
 
 /// Presentation and exact tool correlation from Cursor's terminal

--- a/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_task_dto.freezed.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_task_dto.freezed.dart
@@ -422,6 +422,317 @@ as CursorSubagentType?,
 
 
 /// @nodoc
+mixin _$CursorTaskReplayInputDto {
+
+@JsonKey(name: "_toolName", unknownEnumValue: CursorTaskTool.unknown) CursorTaskTool get toolName; String? get prompt; String? get description; CursorSubagentTypeDto? get subagentType;
+/// Create a copy of CursorTaskReplayInputDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CursorTaskReplayInputDtoCopyWith<CursorTaskReplayInputDto> get copyWith => _$CursorTaskReplayInputDtoCopyWithImpl<CursorTaskReplayInputDto>(this as CursorTaskReplayInputDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  final _this = this as CursorTaskReplayInputDto;
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CursorTaskReplayInputDto&&(identical(other.toolName, _this.toolName) || other.toolName == _this.toolName)&&(identical(other.prompt, _this.prompt) || other.prompt == _this.prompt)&&(identical(other.description, _this.description) || other.description == _this.description)&&(identical(other.subagentType, _this.subagentType) || other.subagentType == _this.subagentType));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode {
+  final _this = this as CursorTaskReplayInputDto;
+  return Object.hash(runtimeType,_this.toolName,_this.prompt,_this.description,_this.subagentType);
+}
+
+@override
+String toString() {
+  final _this = this as CursorTaskReplayInputDto;
+  return 'CursorTaskReplayInputDto(toolName: ${_this.toolName}, prompt: ${_this.prompt}, description: ${_this.description}, subagentType: ${_this.subagentType})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CursorTaskReplayInputDtoCopyWith<$Res>  {
+  factory $CursorTaskReplayInputDtoCopyWith(CursorTaskReplayInputDto value, $Res Function(CursorTaskReplayInputDto) _then) = _$CursorTaskReplayInputDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(name: "_toolName", unknownEnumValue: CursorTaskTool.unknown) CursorTaskTool toolName, String? prompt, String? description, CursorSubagentTypeDto? subagentType
+});
+
+
+$CursorSubagentTypeDtoCopyWith<$Res>? get subagentType;
+
+}
+/// @nodoc
+class _$CursorTaskReplayInputDtoCopyWithImpl<$Res>
+    implements $CursorTaskReplayInputDtoCopyWith<$Res> {
+  _$CursorTaskReplayInputDtoCopyWithImpl(this._self, this._then);
+
+  final CursorTaskReplayInputDto _self;
+  final $Res Function(CursorTaskReplayInputDto) _then;
+
+/// Create a copy of CursorTaskReplayInputDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? toolName = null,Object? prompt = freezed,Object? description = freezed,Object? subagentType = freezed,}) {
+  return _then(CursorTaskReplayInputDto(
+toolName: null == toolName ? _self.toolName : toolName // ignore: cast_nullable_to_non_nullable
+as CursorTaskTool,prompt: freezed == prompt ? _self.prompt : prompt // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,subagentType: freezed == subagentType ? _self.subagentType : subagentType // ignore: cast_nullable_to_non_nullable
+as CursorSubagentTypeDto?,
+  ));
+}
+/// Create a copy of CursorTaskReplayInputDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CursorSubagentTypeDtoCopyWith<$Res>? get subagentType {
+    if (_self.subagentType == null) {
+    return null;
+  }
+
+  return $CursorSubagentTypeDtoCopyWith<$Res>(_self.subagentType!, (value) {
+    return _then(_self.copyWith(subagentType: value));
+  });
+}
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CursorTaskReplayInputDto implements CursorTaskReplayInputDto {
+  const _CursorTaskReplayInputDto({@JsonKey(name: "_toolName", unknownEnumValue: CursorTaskTool.unknown) required this.toolName, required this.prompt, required this.description, required this.subagentType});
+  factory _CursorTaskReplayInputDto.fromJson(Map<String, dynamic> json) => _$CursorTaskReplayInputDtoFromJson(json);
+
+@override@JsonKey(name: "_toolName", unknownEnumValue: CursorTaskTool.unknown) final  CursorTaskTool toolName;
+@override final  String? prompt;
+@override final  String? description;
+@override final  CursorSubagentTypeDto? subagentType;
+
+/// Create a copy of CursorTaskReplayInputDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CursorTaskReplayInputDtoCopyWith<_CursorTaskReplayInputDto> get copyWith => __$CursorTaskReplayInputDtoCopyWithImpl<_CursorTaskReplayInputDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+    return identical(this, other) || (other.runtimeType == runtimeType&&other is _CursorTaskReplayInputDto&&(identical(other.toolName, toolName) || other.toolName == toolName)&&(identical(other.prompt, prompt) || other.prompt == prompt)&&(identical(other.description, description) || other.description == description)&&(identical(other.subagentType, subagentType) || other.subagentType == subagentType));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode {
+    return Object.hash(runtimeType,toolName,prompt,description,subagentType);
+}
+
+@override
+String toString() {
+    return 'CursorTaskReplayInputDto(toolName: $toolName, prompt: $prompt, description: $description, subagentType: $subagentType)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CursorTaskReplayInputDtoCopyWith<$Res> implements $CursorTaskReplayInputDtoCopyWith<$Res> {
+  factory _$CursorTaskReplayInputDtoCopyWith(_CursorTaskReplayInputDto value, $Res Function(_CursorTaskReplayInputDto) _then) = __$CursorTaskReplayInputDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(name: "_toolName", unknownEnumValue: CursorTaskTool.unknown) CursorTaskTool toolName, String? prompt, String? description, CursorSubagentTypeDto? subagentType
+});
+
+
+@override $CursorSubagentTypeDtoCopyWith<$Res>? get subagentType;
+
+}
+/// @nodoc
+class __$CursorTaskReplayInputDtoCopyWithImpl<$Res>
+    implements _$CursorTaskReplayInputDtoCopyWith<$Res> {
+  __$CursorTaskReplayInputDtoCopyWithImpl(this._self, this._then);
+
+  final _CursorTaskReplayInputDto _self;
+  final $Res Function(_CursorTaskReplayInputDto) _then;
+
+/// Create a copy of CursorTaskReplayInputDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? toolName = null,Object? prompt = freezed,Object? description = freezed,Object? subagentType = freezed,}) {
+  return _then(_CursorTaskReplayInputDto(
+toolName: null == toolName ? _self.toolName : toolName // ignore: cast_nullable_to_non_nullable
+as CursorTaskTool,prompt: freezed == prompt ? _self.prompt : prompt // ignore: cast_nullable_to_non_nullable
+as String?,description: freezed == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String?,subagentType: freezed == subagentType ? _self.subagentType : subagentType // ignore: cast_nullable_to_non_nullable
+as CursorSubagentTypeDto?,
+  ));
+}
+
+/// Create a copy of CursorTaskReplayInputDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$CursorSubagentTypeDtoCopyWith<$Res>? get subagentType {
+    if (_self.subagentType == null) {
+    return null;
+  }
+
+  return $CursorSubagentTypeDtoCopyWith<$Res>(_self.subagentType!, (value) {
+    return _then(_self.copyWith(subagentType: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$CursorTaskReplayUpdateDto {
+
+@JsonKey(unknownEnumValue: CursorTaskReplayUpdateKind.unknown) CursorTaskReplayUpdateKind get sessionUpdate; String? get toolCallId;@JsonKey(unknownEnumValue: CursorTaskReplayStatus.unknown) CursorTaskReplayStatus? get status;
+/// Create a copy of CursorTaskReplayUpdateDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CursorTaskReplayUpdateDtoCopyWith<CursorTaskReplayUpdateDto> get copyWith => _$CursorTaskReplayUpdateDtoCopyWithImpl<CursorTaskReplayUpdateDto>(this as CursorTaskReplayUpdateDto, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  final _this = this as CursorTaskReplayUpdateDto;
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CursorTaskReplayUpdateDto&&(identical(other.sessionUpdate, _this.sessionUpdate) || other.sessionUpdate == _this.sessionUpdate)&&(identical(other.toolCallId, _this.toolCallId) || other.toolCallId == _this.toolCallId)&&(identical(other.status, _this.status) || other.status == _this.status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode {
+  final _this = this as CursorTaskReplayUpdateDto;
+  return Object.hash(runtimeType,_this.sessionUpdate,_this.toolCallId,_this.status);
+}
+
+@override
+String toString() {
+  final _this = this as CursorTaskReplayUpdateDto;
+  return 'CursorTaskReplayUpdateDto(sessionUpdate: ${_this.sessionUpdate}, toolCallId: ${_this.toolCallId}, status: ${_this.status})';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CursorTaskReplayUpdateDtoCopyWith<$Res>  {
+  factory $CursorTaskReplayUpdateDtoCopyWith(CursorTaskReplayUpdateDto value, $Res Function(CursorTaskReplayUpdateDto) _then) = _$CursorTaskReplayUpdateDtoCopyWithImpl;
+@useResult
+$Res call({
+@JsonKey(unknownEnumValue: CursorTaskReplayUpdateKind.unknown) CursorTaskReplayUpdateKind sessionUpdate, String? toolCallId,@JsonKey(unknownEnumValue: CursorTaskReplayStatus.unknown) CursorTaskReplayStatus? status
+});
+
+
+
+
+}
+/// @nodoc
+class _$CursorTaskReplayUpdateDtoCopyWithImpl<$Res>
+    implements $CursorTaskReplayUpdateDtoCopyWith<$Res> {
+  _$CursorTaskReplayUpdateDtoCopyWithImpl(this._self, this._then);
+
+  final CursorTaskReplayUpdateDto _self;
+  final $Res Function(CursorTaskReplayUpdateDto) _then;
+
+/// Create a copy of CursorTaskReplayUpdateDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? sessionUpdate = null,Object? toolCallId = freezed,Object? status = freezed,}) {
+  return _then(CursorTaskReplayUpdateDto(
+sessionUpdate: null == sessionUpdate ? _self.sessionUpdate : sessionUpdate // ignore: cast_nullable_to_non_nullable
+as CursorTaskReplayUpdateKind,toolCallId: freezed == toolCallId ? _self.toolCallId : toolCallId // ignore: cast_nullable_to_non_nullable
+as String?,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as CursorTaskReplayStatus?,
+  ));
+}
+
+}
+
+
+
+/// @nodoc
+@JsonSerializable(createToJson: false)
+
+class _CursorTaskReplayUpdateDto implements CursorTaskReplayUpdateDto {
+  const _CursorTaskReplayUpdateDto({@JsonKey(unknownEnumValue: CursorTaskReplayUpdateKind.unknown) required this.sessionUpdate, required this.toolCallId, @JsonKey(unknownEnumValue: CursorTaskReplayStatus.unknown) required this.status});
+  factory _CursorTaskReplayUpdateDto.fromJson(Map<String, dynamic> json) => _$CursorTaskReplayUpdateDtoFromJson(json);
+
+@override@JsonKey(unknownEnumValue: CursorTaskReplayUpdateKind.unknown) final  CursorTaskReplayUpdateKind sessionUpdate;
+@override final  String? toolCallId;
+@override@JsonKey(unknownEnumValue: CursorTaskReplayStatus.unknown) final  CursorTaskReplayStatus? status;
+
+/// Create a copy of CursorTaskReplayUpdateDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$CursorTaskReplayUpdateDtoCopyWith<_CursorTaskReplayUpdateDto> get copyWith => __$CursorTaskReplayUpdateDtoCopyWithImpl<_CursorTaskReplayUpdateDto>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+    return identical(this, other) || (other.runtimeType == runtimeType&&other is _CursorTaskReplayUpdateDto&&(identical(other.sessionUpdate, sessionUpdate) || other.sessionUpdate == sessionUpdate)&&(identical(other.toolCallId, toolCallId) || other.toolCallId == toolCallId)&&(identical(other.status, status) || other.status == status));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode {
+    return Object.hash(runtimeType,sessionUpdate,toolCallId,status);
+}
+
+@override
+String toString() {
+    return 'CursorTaskReplayUpdateDto(sessionUpdate: $sessionUpdate, toolCallId: $toolCallId, status: $status)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$CursorTaskReplayUpdateDtoCopyWith<$Res> implements $CursorTaskReplayUpdateDtoCopyWith<$Res> {
+  factory _$CursorTaskReplayUpdateDtoCopyWith(_CursorTaskReplayUpdateDto value, $Res Function(_CursorTaskReplayUpdateDto) _then) = __$CursorTaskReplayUpdateDtoCopyWithImpl;
+@override @useResult
+$Res call({
+@JsonKey(unknownEnumValue: CursorTaskReplayUpdateKind.unknown) CursorTaskReplayUpdateKind sessionUpdate, String? toolCallId,@JsonKey(unknownEnumValue: CursorTaskReplayStatus.unknown) CursorTaskReplayStatus? status
+});
+
+
+
+
+}
+/// @nodoc
+class __$CursorTaskReplayUpdateDtoCopyWithImpl<$Res>
+    implements _$CursorTaskReplayUpdateDtoCopyWith<$Res> {
+  __$CursorTaskReplayUpdateDtoCopyWithImpl(this._self, this._then);
+
+  final _CursorTaskReplayUpdateDto _self;
+  final $Res Function(_CursorTaskReplayUpdateDto) _then;
+
+/// Create a copy of CursorTaskReplayUpdateDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? sessionUpdate = null,Object? toolCallId = freezed,Object? status = freezed,}) {
+  return _then(_CursorTaskReplayUpdateDto(
+sessionUpdate: null == sessionUpdate ? _self.sessionUpdate : sessionUpdate // ignore: cast_nullable_to_non_nullable
+as CursorTaskReplayUpdateKind,toolCallId: freezed == toolCallId ? _self.toolCallId : toolCallId // ignore: cast_nullable_to_non_nullable
+as String?,status: freezed == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as CursorTaskReplayStatus?,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
 mixin _$CursorTaskRequestDto {
 
  String get toolCallId; String get description; String get prompt; CursorSubagentTypeDto get subagentType;

--- a/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_task_dto.g.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/api/models/cursor_task_dto.g.dart
@@ -37,6 +37,51 @@ const _$CursorSubagentTypeEnumMap = {
   CursorSubagentType.unknown: 'unknown',
 };
 
+_CursorTaskReplayInputDto _$CursorTaskReplayInputDtoFromJson(Map json) =>
+    _CursorTaskReplayInputDto(
+      toolName: $enumDecode(
+        _$CursorTaskToolEnumMap,
+        json['_toolName'],
+        unknownValue: CursorTaskTool.unknown,
+      ),
+      prompt: json['prompt'] as String?,
+      description: json['description'] as String?,
+      subagentType: json['subagentType'] == null
+          ? null
+          : CursorSubagentTypeDto.fromJson(
+              Map<String, dynamic>.from(json['subagentType'] as Map),
+            ),
+    );
+
+_CursorTaskReplayUpdateDto _$CursorTaskReplayUpdateDtoFromJson(Map json) =>
+    _CursorTaskReplayUpdateDto(
+      sessionUpdate: $enumDecode(
+        _$CursorTaskReplayUpdateKindEnumMap,
+        json['sessionUpdate'],
+        unknownValue: CursorTaskReplayUpdateKind.unknown,
+      ),
+      toolCallId: json['toolCallId'] as String?,
+      status: $enumDecodeNullable(
+        _$CursorTaskReplayStatusEnumMap,
+        json['status'],
+        unknownValue: CursorTaskReplayStatus.unknown,
+      ),
+    );
+
+const _$CursorTaskReplayUpdateKindEnumMap = {
+  CursorTaskReplayUpdateKind.toolCall: 'tool_call',
+  CursorTaskReplayUpdateKind.toolCallUpdate: 'tool_call_update',
+  CursorTaskReplayUpdateKind.unknown: 'unknown',
+};
+
+const _$CursorTaskReplayStatusEnumMap = {
+  CursorTaskReplayStatus.pending: 'pending',
+  CursorTaskReplayStatus.inProgress: 'in_progress',
+  CursorTaskReplayStatus.completed: 'completed',
+  CursorTaskReplayStatus.failed: 'failed',
+  CursorTaskReplayStatus.unknown: 'unknown',
+};
+
 _CursorTaskRequestDto _$CursorTaskRequestDtoFromJson(Map json) =>
     _CursorTaskRequestDto(
       toolCallId: json['toolCallId'] as String,

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -4,6 +4,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "api/models/cursor_task_dto.dart";
 import "repositories/cursor_generated_image_reader.dart";
+import "repositories/mappers/cursor_task_projection.dart";
 import "trackers/cursor_task_tracker.dart";
 
 /// Cursor's event mapper: the standard ACP `session/update` handling from
@@ -22,6 +23,7 @@ class CursorEventMapper({
   required super.childSessions,
   required final CursorGeneratedImageReader _generatedImageReader,
   required final CursorTaskTracker _taskTracker,
+  required final CursorTaskProjection _taskProjection,
 
   /// The plugin's active-turn resolver ([AcpPlugin.activeTurnSessionId]) — the
   /// last-resort attribution for Cursor extension payloads that omit
@@ -184,42 +186,13 @@ class CursorEventMapper({
       toolCallId: request.toolCallId,
     );
     if (genericPart == null) return const [];
-    final replacement = _mapCompletedForeground(
+    final replacement = _taskProjection.completedForeground(
       genericPart: genericPart,
-      request: request,
+      prompt: request.prompt,
+      description: request.description,
+      subagentType: request.subagentType,
     );
     return replacement == null ? const [] : [BridgeSseMessagePartUpdated(part: replacement)];
-  }
-
-  PluginMessagePart? _mapCompletedForeground({
-    required PluginMessagePartTool genericPart,
-    required CursorTaskRequestDto request,
-  }) {
-    final prompt = _nonblank(request.prompt);
-    final description = _nonblank(request.description);
-    final agent = switch (request.subagentType.custom) {
-      CursorSubagentType.unspecified => CursorSubagentType.unspecified.name,
-      CursorSubagentType.unknown || null => null,
-    };
-    if (prompt == null || description == null || agent == null) return null;
-
-    return PluginMessagePart.subtask(
-      id: genericPart.id,
-      sessionID: genericPart.sessionID,
-      messageID: genericPart.messageID,
-      prompt: prompt,
-      description: description,
-      agent: agent,
-      taskState: PluginToolState(
-        status: PluginToolStatus.completed,
-        title: genericPart.state.title,
-        shellCommand: null,
-        output: genericPart.state.output,
-        error: null,
-        attachments: genericPart.state.attachments,
-      ),
-      childSessionID: null,
-    );
   }
 
   PluginMessagePart _mapTerminalGeneric({
@@ -273,8 +246,6 @@ class CursorEventMapper({
       return null;
     }
   }
-
-  static String? _nonblank(String value) => value.trim().isEmpty ? null : value;
 
   static Map<String, dynamic>? _map(Object? raw) => raw is Map ? raw.cast<String, dynamic>() : null;
 

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_event_mapper.dart
@@ -4,7 +4,7 @@ import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "api/models/cursor_task_dto.dart";
 import "repositories/cursor_generated_image_reader.dart";
-import "repositories/mappers/cursor_task_projection.dart";
+import "repositories/mappers/cursor_task_mapper.dart";
 import "trackers/cursor_task_tracker.dart";
 
 /// Cursor's event mapper: the standard ACP `session/update` handling from
@@ -23,7 +23,7 @@ class CursorEventMapper({
   required super.childSessions,
   required final CursorGeneratedImageReader _generatedImageReader,
   required final CursorTaskTracker _taskTracker,
-  required final CursorTaskProjection _taskProjection,
+  required final CursorTaskMapper _taskMapper,
 
   /// The plugin's active-turn resolver ([AcpPlugin.activeTurnSessionId]) — the
   /// last-resort attribution for Cursor extension payloads that omit
@@ -186,7 +186,7 @@ class CursorEventMapper({
       toolCallId: request.toolCallId,
     );
     if (genericPart == null) return const [];
-    final replacement = _taskProjection.completedForeground(
+    final replacement = _taskMapper.completedForeground(
       genericPart: genericPart,
       prompt: request.prompt,
       description: request.description,

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -11,6 +11,8 @@ import "cursor_event_mapper.dart";
 import "models/cursor_catalog_models.dart";
 import "repositories/cursor_catalog_repository.dart";
 import "repositories/cursor_generated_image_reader.dart";
+import "repositories/mappers/cursor_task_projection.dart";
+import "repositories/trackers/cursor_task_replay_tracker.dart";
 import "services/cursor_catalog_service.dart";
 import "services/cursor_session_cleanup_service.dart";
 import "services/cursor_session_options_service.dart";
@@ -34,6 +36,7 @@ class CursorPlugin._({
   required CursorSessionOptionsService cursorSessionOptionsService,
   required final AcpSessionConfigurationTracker _configurationTracker,
   required final CursorTaskTracker _taskTracker,
+  required final CursorTaskProjection _taskProjection,
   required super.commandTracker,
   required super.sessionOptionsService,
   required final CursorSessionCleanupService _sessionCleanupService,
@@ -72,6 +75,7 @@ class CursorPlugin._({
     final stagedCommandTracker = AcpCommandTracker();
     final configurationTracker = AcpSessionConfigurationTracker();
     final taskTracker = CursorTaskTracker();
+    const taskProjection = CursorTaskProjection();
     final acpSessionOptionsService = AcpSessionOptionsService(
       configurationTracker: configurationTracker,
       commandTracker: commandTracker,
@@ -107,6 +111,7 @@ class CursorPlugin._({
       childSessions: childSessionTracker,
       generatedImageReader: const CursorGeneratedImageReader(),
       taskTracker: taskTracker,
+      taskProjection: taskProjection,
       activeSessionResolver: () => plugin.activeTurnSessionId,
     );
     return plugin = CursorPlugin._(
@@ -121,6 +126,7 @@ class CursorPlugin._({
       cursorSessionOptionsService: cursorSessionOptionsService,
       configurationTracker: configurationTracker,
       taskTracker: taskTracker,
+      taskProjection: taskProjection,
       commandTracker: commandTracker,
       sessionOptionsService: acpSessionOptionsService,
       sessionCleanupService: sessionCleanupService,
@@ -143,6 +149,19 @@ class CursorPlugin._({
 
   @override
   String? get authMethodId => CursorBinary.acpAuthMethodId;
+
+  @override
+  Future<AcpSessionReplayCollector> createSessionReplayCollector({
+    required String sessionId,
+    required AcpReplayCollectorFactory collectorFactory,
+  }) async {
+    final standardCollector = collectorFactory(toolPartSuppression: null);
+    return CursorTaskReplayTracker(
+      sessionId: sessionId,
+      standardCollector: standardCollector,
+      taskProjection: _taskProjection,
+    );
+  }
 
   @override
   AcpScopedStopCapability get scopedStopCapability => AcpScopedStopCapability.rootSessionCancel;

--- a/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/cursor_plugin_impl.dart
@@ -11,7 +11,7 @@ import "cursor_event_mapper.dart";
 import "models/cursor_catalog_models.dart";
 import "repositories/cursor_catalog_repository.dart";
 import "repositories/cursor_generated_image_reader.dart";
-import "repositories/mappers/cursor_task_projection.dart";
+import "repositories/mappers/cursor_task_mapper.dart";
 import "repositories/trackers/cursor_task_replay_tracker.dart";
 import "services/cursor_catalog_service.dart";
 import "services/cursor_session_cleanup_service.dart";
@@ -36,7 +36,7 @@ class CursorPlugin._({
   required CursorSessionOptionsService cursorSessionOptionsService,
   required final AcpSessionConfigurationTracker _configurationTracker,
   required final CursorTaskTracker _taskTracker,
-  required final CursorTaskProjection _taskProjection,
+  required final CursorTaskMapper _taskMapper,
   required super.commandTracker,
   required super.sessionOptionsService,
   required final CursorSessionCleanupService _sessionCleanupService,
@@ -75,7 +75,7 @@ class CursorPlugin._({
     final stagedCommandTracker = AcpCommandTracker();
     final configurationTracker = AcpSessionConfigurationTracker();
     final taskTracker = CursorTaskTracker();
-    const taskProjection = CursorTaskProjection();
+    const taskMapper = CursorTaskMapper();
     final acpSessionOptionsService = AcpSessionOptionsService(
       configurationTracker: configurationTracker,
       commandTracker: commandTracker,
@@ -111,7 +111,7 @@ class CursorPlugin._({
       childSessions: childSessionTracker,
       generatedImageReader: const CursorGeneratedImageReader(),
       taskTracker: taskTracker,
-      taskProjection: taskProjection,
+      taskMapper: taskMapper,
       activeSessionResolver: () => plugin.activeTurnSessionId,
     );
     return plugin = CursorPlugin._(
@@ -126,7 +126,7 @@ class CursorPlugin._({
       cursorSessionOptionsService: cursorSessionOptionsService,
       configurationTracker: configurationTracker,
       taskTracker: taskTracker,
-      taskProjection: taskProjection,
+      taskMapper: taskMapper,
       commandTracker: commandTracker,
       sessionOptionsService: acpSessionOptionsService,
       sessionCleanupService: sessionCleanupService,
@@ -159,7 +159,7 @@ class CursorPlugin._({
     return CursorTaskReplayTracker(
       sessionId: sessionId,
       standardCollector: standardCollector,
-      taskProjection: _taskProjection,
+      taskMapper: _taskMapper,
     );
   }
 

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/mappers/cursor_task_mapper.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/mappers/cursor_task_mapper.dart
@@ -4,7 +4,7 @@ import "../../api/models/cursor_task_dto.dart";
 
 /// Pure completed-foreground Cursor Task presentation shared by live mapping
 /// and replay-local history projection.
-final class const CursorTaskProjection() {
+final class const CursorTaskMapper() {
   PluginMessagePart? completedForeground({
     required PluginMessagePartTool genericPart,
     required String prompt,

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/mappers/cursor_task_projection.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/mappers/cursor_task_projection.dart
@@ -1,0 +1,43 @@
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../../api/models/cursor_task_dto.dart";
+
+/// Pure completed-foreground Cursor Task presentation shared by live mapping
+/// and replay-local history projection.
+final class const CursorTaskProjection() {
+  PluginMessagePart? completedForeground({
+    required PluginMessagePartTool genericPart,
+    required String prompt,
+    required String description,
+    required CursorSubagentTypeDto subagentType,
+  }) {
+    if (genericPart.state.status != PluginToolStatus.completed) return null;
+    final usefulPrompt = _nonblank(prompt);
+    final usefulDescription = _nonblank(description);
+    final agent = switch (subagentType.custom) {
+      CursorSubagentType.unspecified => CursorSubagentType.unspecified.name,
+      CursorSubagentType.unknown || null => null,
+    };
+    if (usefulPrompt == null || usefulDescription == null || agent == null) return null;
+
+    return PluginMessagePart.subtask(
+      id: genericPart.id,
+      sessionID: genericPart.sessionID,
+      messageID: genericPart.messageID,
+      prompt: usefulPrompt,
+      description: usefulDescription,
+      agent: agent,
+      taskState: PluginToolState(
+        status: PluginToolStatus.completed,
+        title: genericPart.state.title,
+        shellCommand: null,
+        output: genericPart.state.output,
+        error: null,
+        attachments: genericPart.state.attachments,
+      ),
+      childSessionID: null,
+    );
+  }
+
+  static String? _nonblank(String value) => value.trim().isEmpty ? null : value;
+}

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
@@ -2,14 +2,13 @@ import "package:acp_plugin/acp_plugin.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 import "../../api/models/cursor_task_dto.dart";
-import "../mappers/cursor_task_projection.dart";
+import "../mappers/cursor_task_mapper.dart";
 
-/// Replay-local Cursor Task fact index around one fully configured standard ACP
-/// collector. It owns no transport, process, file, live-tracker, or event state.
+/// Replay-local Task facts around one configured ACP collector; owns no transport, process, file, or live state.
 final class CursorTaskReplayTracker({
   required final String sessionId,
   required final AcpReplayCollector standardCollector,
-  required final CursorTaskProjection taskProjection,
+  required final CursorTaskMapper taskMapper,
 }) implements AcpSessionReplayCollector {
   final Map<String, _CursorReplayTask> _tasksByToolCallId = {};
 
@@ -17,7 +16,6 @@ final class CursorTaskReplayTracker({
   void consumeNotification({required AcpNotification notification}) {
     standardCollector.consumeNotification(notification: notification);
     if (notification.method != AcpMethods.sessionUpdate) return;
-
     if (notification.params["sessionId"] != sessionId) return;
     final updateJson = _asMap(notification.params["update"]);
     if (updateJson == null) return;
@@ -31,7 +29,6 @@ final class CursorTaskReplayTracker({
       Log.w("[cursor] malformed replay update envelope ignored", error, stackTrace);
       return;
     }
-
     final toolCallId = envelope.toolCallId;
     if (toolCallId == null || toolCallId.isEmpty) return;
     switch (envelope.sessionUpdate) {
@@ -79,13 +76,13 @@ final class CursorTaskReplayTracker({
     variant: variant,
     toolPartReplacement: ({required toolCallId, required toolPart}) {
       final task = _tasksByToolCallId[toolCallId];
-      if (task == null || !task.hasCompleted || (task.isBackground ?? true)) return null;
+      if (task == null || task.lifecycle != _Lifecycle.completed || task.mode != _Mode.foreground) return null;
       final input = task.input;
       final prompt = input.prompt;
       final description = input.description;
       final subagentType = input.subagentType;
       if (prompt == null || description == null || subagentType == null) return null;
-      return taskProjection.completedForeground(
+      return taskMapper.completedForeground(
         genericPart: toolPart,
         prompt: prompt,
         description: description,
@@ -99,7 +96,7 @@ final class CursorTaskReplayTracker({
     required CursorTaskReplayUpdateDto update,
     required Map<String, dynamic> updateJson,
   }) {
-    if (update.status == CursorTaskReplayStatus.completed) task.hasCompleted = true;
+    if (update.status == CursorTaskReplayStatus.completed) task.lifecycle = _Lifecycle.completed;
     final rawOutput = updateJson["rawOutput"];
     if (rawOutput == null) return;
     final outputJson = _asMap(rawOutput);
@@ -108,7 +105,8 @@ final class CursorTaskReplayTracker({
       return;
     }
     try {
-      task.isBackground = CursorTaskOutputDto.fromJson({"isBackground": outputJson["isBackground"]}).isBackground;
+      final output = CursorTaskOutputDto.fromJson({"isBackground": outputJson["isBackground"]});
+      task.mode = output.isBackground ? _Mode.background : _Mode.foreground;
     } on Object catch (error, stackTrace) {
       Log.w("[cursor] malformed replay Task output ignored", error, stackTrace);
     }
@@ -123,15 +121,24 @@ final class CursorTaskReplayTracker({
     }
   }
 
-  static void _logMalformedTaskFact() {
-    // Task input may contain transcript text. Do not attach parser errors.
-    Log.w("[cursor] malformed replay Task fact ignored");
-  }
+  // A complete Task fact may contain transcript text. Do not attach parser errors.
+  static void _logMalformedTaskFact() => Log.w("[cursor] malformed replay Task fact ignored");
 
   static Map<String, dynamic>? _asMap(Object? value) => value is Map ? value.cast<String, dynamic>() : null;
 }
 
+enum _Lifecycle() {
+  active,
+  completed,
+}
+
+enum _Mode() {
+  unknown,
+  foreground,
+  background,
+}
+
 final class _CursorReplayTask({required final CursorTaskReplayInputDto input}) {
-  bool hasCompleted = false;
-  bool? isBackground;
+  _Lifecycle lifecycle = _Lifecycle.active;
+  _Mode mode = _Mode.unknown;
 }

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
@@ -11,7 +11,6 @@ final class CursorTaskReplayTracker({
   required final CursorTaskMapper taskMapper,
 }) implements AcpSessionReplayCollector {
   final Map<String, _CursorReplayTask> _tasksByToolCallId = {};
-
   @override
   void consumeNotification({required AcpNotification notification}) {
     standardCollector.consumeNotification(notification: notification);
@@ -76,7 +75,7 @@ final class CursorTaskReplayTracker({
     variant: variant,
     toolPartReplacement: ({required toolCallId, required toolPart}) {
       final task = _tasksByToolCallId[toolCallId];
-      if (task == null || task.lifecycle != _Lifecycle.completed || task.mode != _Mode.foreground) return null;
+      if (task == null || task.status != CursorTaskReplayStatus.completed || task.mode != _Mode.foreground) return null;
       final input = task.input;
       final prompt = input.prompt;
       final description = input.description;
@@ -90,13 +89,12 @@ final class CursorTaskReplayTracker({
       );
     },
   );
-
   void _mergeTerminalOutput({
     required _CursorReplayTask task,
     required CursorTaskReplayUpdateDto update,
     required Map<String, dynamic> updateJson,
   }) {
-    if (update.status == CursorTaskReplayStatus.completed) task.lifecycle = _Lifecycle.completed;
+    task.status = update.status ?? task.status;
     final rawOutput = updateJson["rawOutput"];
     if (rawOutput == null) return;
     final outputJson = _asMap(rawOutput);
@@ -127,11 +125,6 @@ final class CursorTaskReplayTracker({
   static Map<String, dynamic>? _asMap(Object? value) => value is Map ? value.cast<String, dynamic>() : null;
 }
 
-enum _Lifecycle() {
-  active,
-  completed,
-}
-
 enum _Mode() {
   unknown,
   foreground,
@@ -139,6 +132,6 @@ enum _Mode() {
 }
 
 final class _CursorReplayTask({required final CursorTaskReplayInputDto input}) {
-  _Lifecycle lifecycle = _Lifecycle.active;
+  CursorTaskReplayStatus status = CursorTaskReplayStatus.pending;
   _Mode mode = _Mode.unknown;
 }

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
@@ -1,0 +1,140 @@
+import "package:acp_plugin/acp_plugin.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+
+import "../../api/models/cursor_task_dto.dart";
+import "../mappers/cursor_task_projection.dart";
+
+/// Replay-local Cursor Task fact index around one fully configured standard ACP
+/// collector. It owns no transport, process, file, live-tracker, or event state.
+final class CursorTaskReplayTracker({
+  required final String sessionId,
+  required final AcpReplayCollector standardCollector,
+  required final CursorTaskProjection taskProjection,
+}) implements AcpSessionReplayCollector {
+  final Map<String, _CursorReplayTask> _tasksByToolCallId = {};
+
+  @override
+  void consumeNotification({required AcpNotification notification}) {
+    standardCollector.consumeNotification(notification: notification);
+    if (notification.method != AcpMethods.sessionUpdate) return;
+
+    if (notification.params["sessionId"] != sessionId) return;
+    final updateJson = _asMap(notification.params["update"]);
+    if (updateJson == null) return;
+    final CursorTaskReplayUpdateDto envelope;
+    try {
+      envelope = CursorTaskReplayUpdateDto.fromJson({
+        "sessionUpdate": updateJson["sessionUpdate"],
+        "toolCallId": updateJson["toolCallId"],
+      });
+    } on Object {
+      return;
+    }
+
+    final toolCallId = _nonblank(envelope.toolCallId);
+    if (toolCallId == null) return;
+    switch (envelope.sessionUpdate) {
+      case CursorTaskReplayUpdateKind.toolCall:
+        final inputJson = _asMap(updateJson["rawInput"]);
+        if (inputJson == null) return;
+        final CursorTaskInputDto identity;
+        try {
+          identity = CursorTaskInputDto.fromJson(inputJson);
+        } on Object {
+          return;
+        }
+        if (identity.toolName != CursorTaskTool.task) return;
+        final CursorTaskReplayInputDto input;
+        try {
+          input = CursorTaskReplayInputDto.fromJson(inputJson);
+        } on Object {
+          _logMalformedTaskFact();
+          return;
+        }
+        final update = _parseTaskUpdate(updateJson);
+        if (update == null) return;
+        final task = _CursorReplayTask(input: input);
+        _tasksByToolCallId[toolCallId] = task;
+        _mergeTerminalOutput(task: task, update: update, updateJson: updateJson);
+      case CursorTaskReplayUpdateKind.toolCallUpdate:
+        final task = _tasksByToolCallId[toolCallId];
+        if (task == null) return;
+        final update = _parseTaskUpdate(updateJson);
+        if (update != null) _mergeTerminalOutput(task: task, update: update, updateJson: updateJson);
+      case CursorTaskReplayUpdateKind.unknown:
+        break;
+    }
+  }
+
+  @override
+  List<PluginMessageWithParts> buildWithAssistantSelection({
+    required String? modelId,
+    required String? providerId,
+    required String? variant,
+  }) => standardCollector.buildWithToolPartReplacement(
+    modelId: modelId,
+    providerId: providerId,
+    variant: variant,
+    toolPartReplacement: ({required toolCallId, required toolPart}) {
+      final task = _tasksByToolCallId[toolCallId];
+      if (task == null || !task.hasCompleted || (task.isBackground ?? true)) return null;
+      final input = task.input;
+      final prompt = input.prompt;
+      final description = input.description;
+      final subagentType = input.subagentType;
+      if (prompt == null || description == null || subagentType == null) return null;
+      return taskProjection.completedForeground(
+        genericPart: toolPart,
+        prompt: prompt,
+        description: description,
+        subagentType: subagentType,
+      );
+    },
+  );
+
+  void _mergeTerminalOutput({
+    required _CursorReplayTask task,
+    required CursorTaskReplayUpdateDto update,
+    required Map<String, dynamic> updateJson,
+  }) {
+    if (update.status == CursorTaskReplayStatus.completed) task.hasCompleted = true;
+    final rawOutput = updateJson["rawOutput"];
+    if (rawOutput == null) return;
+    final outputJson = _asMap(rawOutput);
+    if (outputJson == null) {
+      _logMalformedTaskFact();
+      return;
+    }
+    try {
+      task.isBackground = CursorTaskOutputDto.fromJson(outputJson).isBackground;
+    } on Object {
+      _logMalformedTaskFact();
+    }
+  }
+
+  static CursorTaskReplayUpdateDto? _parseTaskUpdate(Map<String, dynamic> updateJson) {
+    try {
+      return CursorTaskReplayUpdateDto.fromJson(updateJson);
+    } on Object {
+      _logMalformedTaskFact();
+      return null;
+    }
+  }
+
+  static void _logMalformedTaskFact() {
+    // Task input may contain transcript text. Do not attach parser errors.
+    Log.w("[cursor] malformed replay Task fact ignored");
+  }
+
+  static Map<String, dynamic>? _asMap(Object? value) => value is Map ? value.cast<String, dynamic>() : null;
+
+  static String? _nonblank(String? value) {
+    final normalized = value?.trim();
+    return normalized == null || normalized.isEmpty ? null : normalized;
+  }
+}
+
+final class _CursorReplayTask({required final CursorTaskReplayInputDto input}) {
+  bool hasCompleted = false;
+  bool? isBackground;
+}

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
@@ -108,9 +108,9 @@ final class CursorTaskReplayTracker({
       return;
     }
     try {
-      task.isBackground = CursorTaskOutputDto.fromJson(outputJson).isBackground;
-    } on Object {
-      _logMalformedTaskFact();
+      task.isBackground = CursorTaskOutputDto.fromJson({"isBackground": outputJson["isBackground"]}).isBackground;
+    } on Object catch (error, stackTrace) {
+      Log.w("[cursor] malformed replay Task output ignored", error, stackTrace);
     }
   }
 

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
@@ -32,8 +32,8 @@ final class CursorTaskReplayTracker({
       return;
     }
 
-    final toolCallId = _nonblank(envelope.toolCallId);
-    if (toolCallId == null) return;
+    final toolCallId = envelope.toolCallId;
+    if (toolCallId == null || toolCallId.isEmpty) return;
     switch (envelope.sessionUpdate) {
       case CursorTaskReplayUpdateKind.toolCall:
         final inputJson = _asMap(updateJson["rawInput"]);
@@ -129,11 +129,6 @@ final class CursorTaskReplayTracker({
   }
 
   static Map<String, dynamic>? _asMap(Object? value) => value is Map ? value.cast<String, dynamic>() : null;
-
-  static String? _nonblank(String? value) {
-    final normalized = value?.trim();
-    return normalized == null || normalized.isEmpty ? null : normalized;
-  }
 }
 
 final class _CursorReplayTask({required final CursorTaskReplayInputDto input}) {

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
@@ -94,7 +94,7 @@ final class CursorTaskReplayTracker({
     required CursorTaskReplayUpdateDto update,
     required Map<String, dynamic> updateJson,
   }) {
-    task.status = update.status ?? task.status;
+    if (update.status == CursorTaskReplayStatus.completed) task.status = CursorTaskReplayStatus.completed;
     final rawOutput = updateJson["rawOutput"];
     if (rawOutput == null) return;
     final outputJson = _asMap(rawOutput);

--- a/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
+++ b/bridge/sesori_plugin_cursor/lib/src/repositories/trackers/cursor_task_replay_tracker.dart
@@ -27,7 +27,8 @@ final class CursorTaskReplayTracker({
         "sessionUpdate": updateJson["sessionUpdate"],
         "toolCallId": updateJson["toolCallId"],
       });
-    } on Object {
+    } on Object catch (error, stackTrace) {
+      Log.w("[cursor] malformed replay update envelope ignored", error, stackTrace);
       return;
     }
 
@@ -39,8 +40,9 @@ final class CursorTaskReplayTracker({
         if (inputJson == null) return;
         final CursorTaskInputDto identity;
         try {
-          identity = CursorTaskInputDto.fromJson(inputJson);
-        } on Object {
+          identity = CursorTaskInputDto.fromJson({"_toolName": inputJson["_toolName"]});
+        } on Object catch (error, stackTrace) {
+          Log.w("[cursor] malformed replay tool identity ignored", error, stackTrace);
           return;
         }
         if (identity.toolName != CursorTaskTool.task) return;

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -5,6 +5,7 @@ import "dart:typed_data";
 import "package:acp_plugin/acp_plugin.dart";
 import "package:cursor_plugin/cursor_plugin.dart";
 import "package:cursor_plugin/src/repositories/cursor_generated_image_reader.dart";
+import "package:cursor_plugin/src/repositories/mappers/cursor_task_projection.dart";
 import "package:cursor_plugin/src/trackers/cursor_task_tracker.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
@@ -22,6 +23,7 @@ void main() {
         childSessions: AcpChildSessionTracker(),
         generatedImageReader: const CursorGeneratedImageReader(),
         taskTracker: taskTracker ?? CursorTaskTracker(),
+        taskProjection: const CursorTaskProjection(),
         activeSessionResolver: activeSessionResolver ?? () => null,
       );
     }
@@ -163,6 +165,7 @@ void main() {
         childSessions: childSessions,
         generatedImageReader: const CursorGeneratedImageReader(),
         taskTracker: CursorTaskTracker(),
+        taskProjection: const CursorTaskProjection(),
         activeSessionResolver: () => "other-root",
       );
       target.beginTurn(sessionId: "root", messageId: "turn-1");

--- a/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_event_mapper_test.dart
@@ -5,7 +5,7 @@ import "dart:typed_data";
 import "package:acp_plugin/acp_plugin.dart";
 import "package:cursor_plugin/cursor_plugin.dart";
 import "package:cursor_plugin/src/repositories/cursor_generated_image_reader.dart";
-import "package:cursor_plugin/src/repositories/mappers/cursor_task_projection.dart";
+import "package:cursor_plugin/src/repositories/mappers/cursor_task_mapper.dart";
 import "package:cursor_plugin/src/trackers/cursor_task_tracker.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
@@ -23,7 +23,7 @@ void main() {
         childSessions: AcpChildSessionTracker(),
         generatedImageReader: const CursorGeneratedImageReader(),
         taskTracker: taskTracker ?? CursorTaskTracker(),
-        taskProjection: const CursorTaskProjection(),
+        taskMapper: const CursorTaskMapper(),
         activeSessionResolver: activeSessionResolver ?? () => null,
       );
     }
@@ -165,7 +165,7 @@ void main() {
         childSessions: childSessions,
         generatedImageReader: const CursorGeneratedImageReader(),
         taskTracker: CursorTaskTracker(),
-        taskProjection: const CursorTaskProjection(),
+        taskMapper: const CursorTaskMapper(),
         activeSessionResolver: () => "other-root",
       );
       target.beginTurn(sessionId: "root", messageId: "turn-1");

--- a/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_plugin_test.dart
@@ -5,6 +5,7 @@ import "dart:io";
 import "package:acp_plugin/acp_plugin.dart";
 import "package:acp_plugin/acp_testing.dart";
 import "package:cursor_plugin/cursor_plugin.dart";
+import "package:cursor_plugin/src/repositories/trackers/cursor_task_replay_tracker.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 import "package:test/test.dart";
 
@@ -198,6 +199,35 @@ void main() {
       await pump();
       return prompt;
     }
+
+    test("replay composition configures one standard collector without suppression", () async {
+      var factoryCalls = 0;
+      AcpReplayToolPartSuppression? receivedSuppression;
+
+      final collector = await plugin.createSessionReplayCollector(
+        sessionId: "replay-root",
+        collectorFactory: ({required toolPartSuppression}) {
+          factoryCalls++;
+          receivedSuppression = toolPartSuppression;
+          return AcpReplayCollector(
+            sessionUpdateNormalizer: null,
+            shellCommandResolver: null,
+            sessionId: "replay-root",
+            agentId: CursorPlugin.pluginId,
+            initialUserMessageId: null,
+            messageIdOverride: null,
+            messageTimeResolver: null,
+            haltClassifier: null,
+            toolPartReplacement: null,
+            toolPartSuppression: toolPartSuppression,
+          );
+        },
+      );
+
+      expect(collector, isA<CursorTaskReplayTracker>());
+      expect(factoryCalls, 1);
+      expect(receivedSuppression, isNull);
+    });
 
     test("delegates persisted session cleanup", () async {
       expect(plugin, isA<PersistedSessionCleanupApi>());

--- a/bridge/sesori_plugin_cursor/test/cursor_task_dto_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_task_dto_test.dart
@@ -22,6 +22,46 @@ void main() {
     });
   });
 
+  group("Cursor replay Task DTOs", () {
+    test("parses the update envelope and Task-specific nested facts separately", () {
+      final update = CursorTaskReplayUpdateDto.fromJson(const {
+        "sessionUpdate": "tool_call",
+        "toolCallId": "task-1",
+        "status": "pending",
+      });
+      final input = CursorTaskReplayInputDto.fromJson(const {
+        "_toolName": "task",
+        "prompt": "Inspect code",
+        "description": "Inspect",
+        "subagentType": {"custom": "unspecified"},
+      });
+      final output = CursorTaskOutputDto.fromJson(const {"isBackground": false});
+
+      expect(
+        (update.sessionUpdate, update.status, input.subagentType?.custom),
+        (CursorTaskReplayUpdateKind.toolCall, CursorTaskReplayStatus.pending, CursorSubagentType.unspecified),
+      );
+      expect(output.isBackground, isFalse);
+    });
+
+    test("preserves nullable enums and rejects malformed known fields", () {
+      final unknown = CursorTaskReplayUpdateDto.fromJson(const {
+        "sessionUpdate": "future_update",
+        "status": "future_status",
+      });
+      expect(
+        (unknown.sessionUpdate, unknown.status),
+        (CursorTaskReplayUpdateKind.unknown, CursorTaskReplayStatus.unknown),
+      );
+      expect(CursorSubagentTypeDto.fromJson(const {}).custom, isNull);
+      expect(
+        () => CursorTaskReplayInputDto.fromJson(const {"_toolName": "task", "prompt": 7}),
+        throwsA(anything),
+      );
+      expect(() => CursorTaskReplayUpdateDto.fromJson(const {}), throwsA(anything));
+    });
+  });
+
   group("Cursor completed Task DTOs", () {
     test("parses explicit foreground output and observed request presentation", () {
       expect(CursorTaskOutputDto.fromJson(const {"isBackground": false}).isBackground, isFalse);

--- a/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
@@ -41,7 +41,7 @@ void main() {
           ..consumeNotification(notification: _notification(update: _toolCall()..["toolCallId"] = 42));
       }, stderr: () => CapturingStdout(lines: stderrLines));
       expect(stderrLines.join(), allOf(contains("malformed replay Task output"), isNot(contains("secret"))));
-      expect(stderrLines.join(), contains("malformed replay update envelope"));
+      expect(stderrLines.join(), contains("malformed replay tool-call ID"));
       expect(
         _build(tracker: tracker),
         standard.buildWithAssistantSelection(modelId: "model", providerId: "cursor", variant: "high"),
@@ -64,6 +64,7 @@ void main() {
             },
           ],
         ),
+        _terminal(status: "future"),
         _text(text: "after"),
       ];
       final first = _build(tracker: _load(updates: updates));
@@ -135,25 +136,14 @@ void main() {
     test("update-only, unmatched, foreign-session, and absent facts never synthesize tiles", () {
       final updateOnly = _load(
         updates: [
-          {
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "task-1",
-            "status": "completed",
-            "rawInput": _input(),
-            "rawOutput": {"isBackground": false},
-          },
+          _terminal(rawOutput: {"isBackground": false}),
         ],
       );
       expect(_build(tracker: updateOnly).single.parts.single, isA<PluginMessagePartTool>());
       final unmatched = _load(
         updates: [
           _toolCall(),
-          {
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "other",
-            "status": "completed",
-            "rawOutput": {"isBackground": false},
-          },
+          _terminal(rawOutput: {"isBackground": false})..["toolCallId"] = "other",
         ],
       );
       expect(_build(tracker: unmatched).expand((message) => message.parts), everyElement(isA<PluginMessagePartTool>()));

--- a/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
@@ -1,7 +1,7 @@
 import "dart:io";
 
 import "package:acp_plugin/acp_plugin.dart";
-import "package:cursor_plugin/src/repositories/mappers/cursor_task_projection.dart";
+import "package:cursor_plugin/src/repositories/mappers/cursor_task_mapper.dart";
 import "package:cursor_plugin/src/repositories/trackers/cursor_task_replay_tracker.dart";
 import "package:sesori_plugin_interface/plugin_interface_testing.dart";
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
@@ -16,13 +16,11 @@ void main() {
       final tracker = _tracker(standardCollector: standard);
       const foreign = AcpNotification(method: "cursor/task", params: {"toolCallId": "task-1"});
       final task = _notification(update: _toolCall());
-
       tracker
         ..consumeNotification(notification: foreign)
         ..consumeNotification(notification: task);
       expect(standard.notifications, [foreign, task]);
     });
-
     test("preserves non-Task output and safely diagnoses malformed Task output", () {
       final update = _toolCall(input: const {"_toolName": "shell"}, status: "completed")
         ..["rawOutput"] = const {"stdout": "done"};
@@ -31,7 +29,6 @@ void main() {
       final tracker = _tracker();
       final malformedTracker = _tracker();
       final stderrLines = <String>[];
-
       IOOverrides.runZoned(() {
         tracker.consumeNotification(notification: notification);
         malformedTracker
@@ -40,10 +37,11 @@ void main() {
             notification: _notification(
               update: _terminal(rawOutput: {"isBackground": "false", "transcript": "secret"}),
             ),
-          );
+          )
+          ..consumeNotification(notification: _notification(update: _toolCall()..["toolCallId"] = 42));
       }, stderr: () => CapturingStdout(lines: stderrLines));
-
       expect(stderrLines.join(), allOf(contains("malformed replay Task output"), isNot(contains("secret"))));
+      expect(stderrLines.join(), contains("malformed replay update envelope"));
       expect(
         _build(tracker: tracker),
         standard.buildWithAssistantSelection(modelId: "model", providerId: "cursor", variant: "high"),
@@ -69,7 +67,6 @@ void main() {
         ),
         _text(text: "after"),
       ];
-
       final first = _build(tracker: _load(updates: updates));
       final second = _build(tracker: _load(updates: updates));
       expect(second, first, reason: "independent loads use equivalent replay-local fields");
@@ -108,7 +105,6 @@ void main() {
       ];
       expect(_build(tracker: _load(updates: updates)).single.parts.single, isA<PluginMessagePartSubtask>());
     });
-
     test("background, incomplete, malformed, unknown, and nonterminal facts stay generic", () {
       final foreground = {"isBackground": false};
       final cases = <(String, Object, Map<String, dynamic>?)>[
@@ -126,7 +122,6 @@ void main() {
         ("failed", _input(), _terminal(status: "failed")),
         ("unknown status", _input(), _terminal(status: "future")),
       ];
-
       for (final taskCase in cases) {
         final part = _build(
           tracker: _load(
@@ -139,7 +134,6 @@ void main() {
         expect(part, isA<PluginMessagePartTool>(), reason: taskCase.$1);
       }
     });
-
     test("update-only, unmatched, foreign-session, and absent facts never synthesize tiles", () {
       final updateOnly = _load(
         updates: [
@@ -153,7 +147,6 @@ void main() {
         ],
       );
       expect(_build(tracker: updateOnly).single.parts.single, isA<PluginMessagePartTool>());
-
       final unmatched = _load(
         updates: [
           _toolCall(),
@@ -166,7 +159,6 @@ void main() {
         ],
       );
       expect(_build(tracker: unmatched).expand((message) => message.parts), everyElement(isA<PluginMessagePartTool>()));
-
       final foreign = _tracker()
         ..consumeNotification(
           notification: _notification(
@@ -191,7 +183,6 @@ Map<String, dynamic> _input({
   "description": description,
   "subagentType": subagentType,
 };
-
 Map<String, dynamic> _toolCall({Object? input, String title = "Task", String status = "pending"}) => {
   "sessionUpdate": "tool_call",
   "toolCallId": "task-1",
@@ -200,7 +191,6 @@ Map<String, dynamic> _toolCall({Object? input, String title = "Task", String sta
   "rawInput": input ?? _input(),
   if (status == "completed") "rawOutput": {"isBackground": false},
 };
-
 Map<String, dynamic> _terminal({String status = "completed", Object? rawOutput, Object? content}) => {
   "sessionUpdate": "tool_call_update",
   "toolCallId": "task-1",
@@ -208,24 +198,20 @@ Map<String, dynamic> _terminal({String status = "completed", Object? rawOutput, 
   "rawOutput": ?rawOutput,
   "content": ?content,
 };
-
 Map<String, dynamic> _text({required String text}) => {
   "sessionUpdate": "agent_message_chunk",
   "messageId": "m1",
   "content": {"type": "text", "text": text},
 };
-
 AcpNotification _notification({required Map<String, dynamic> update, String sessionId = _sessionId}) => AcpNotification(
   method: AcpMethods.sessionUpdate,
   params: {"sessionId": sessionId, "update": update},
 );
-
 CursorTaskReplayTracker _tracker({AcpReplayCollector? standardCollector}) => CursorTaskReplayTracker(
   sessionId: _sessionId,
   standardCollector: standardCollector ?? _collector(),
-  taskProjection: const CursorTaskProjection(),
+  taskMapper: const CursorTaskMapper(),
 );
-
 CursorTaskReplayTracker _load({required List<Map<String, dynamic>> updates}) {
   final tracker = _tracker();
   for (final update in updates) {
@@ -239,7 +225,6 @@ List<PluginMessageWithParts> _build({required CursorTaskReplayTracker tracker}) 
   providerId: "cursor",
   variant: "high",
 );
-
 AcpReplayCollector _collector() => AcpReplayCollector(
   sessionUpdateNormalizer: null,
   shellCommandResolver: null,
@@ -267,9 +252,7 @@ final class _RecordingReplayCollector() extends AcpReplayCollector {
         toolPartReplacement: null,
         toolPartSuppression: null,
       );
-
   final List<AcpNotification> notifications = [];
-
   @override
   void consumeNotification({required AcpNotification notification}) {
     notifications.add(notification);

--- a/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
@@ -23,20 +23,27 @@ void main() {
       expect(standard.notifications, [foreign, task]);
     });
 
-    test("preserves completed non-Task generic output without a malformed Task warning", () {
+    test("preserves non-Task output and safely diagnoses malformed Task output", () {
       final update = _toolCall(input: const {"_toolName": "shell"}, status: "completed")
         ..["rawOutput"] = const {"stdout": "done"};
       final notification = _notification(update: update);
       final standard = _collector()..consumeNotification(notification: notification);
       final tracker = _tracker();
+      final malformedTracker = _tracker();
       final stderrLines = <String>[];
 
-      IOOverrides.runZoned(
-        () => tracker.consumeNotification(notification: notification),
-        stderr: () => CapturingStdout(lines: stderrLines),
-      );
+      IOOverrides.runZoned(() {
+        tracker.consumeNotification(notification: notification);
+        malformedTracker
+          ..consumeNotification(notification: _notification(update: _toolCall()))
+          ..consumeNotification(
+            notification: _notification(
+              update: _terminal(rawOutput: {"isBackground": "false", "transcript": "secret"}),
+            ),
+          );
+      }, stderr: () => CapturingStdout(lines: stderrLines));
 
-      expect(stderrLines, isEmpty);
+      expect(stderrLines.join(), allOf(contains("malformed replay Task output"), isNot(contains("secret"))));
       expect(
         _build(tracker: tracker),
         standard.buildWithAssistantSelection(modelId: "model", providerId: "cursor", variant: "high"),

--- a/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
@@ -1,0 +1,271 @@
+import "dart:io";
+
+import "package:acp_plugin/acp_plugin.dart";
+import "package:cursor_plugin/src/repositories/mappers/cursor_task_projection.dart";
+import "package:cursor_plugin/src/repositories/trackers/cursor_task_replay_tracker.dart";
+import "package:sesori_plugin_interface/plugin_interface_testing.dart";
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
+import "package:test/test.dart";
+
+const _sessionId = "root";
+
+void main() {
+  group("CursorTaskReplayTracker", () {
+    test("forwards every notification before replay-local indexing", () {
+      final standard = _RecordingReplayCollector();
+      final tracker = _tracker(standardCollector: standard);
+      const foreign = AcpNotification(method: "cursor/task", params: {"toolCallId": "task-1"});
+      final task = _notification(update: _toolCall());
+
+      tracker
+        ..consumeNotification(notification: foreign)
+        ..consumeNotification(notification: task);
+      expect(standard.notifications, [foreign, task]);
+    });
+
+    test("preserves completed non-Task generic output without a malformed Task warning", () {
+      final update = _toolCall(input: const {"_toolName": "shell"}, status: "completed")
+        ..["rawOutput"] = const {"stdout": "done"};
+      final notification = _notification(update: update);
+      final standard = _collector()..consumeNotification(notification: notification);
+      final tracker = _tracker();
+      final stderrLines = <String>[];
+
+      IOOverrides.runZoned(
+        () => tracker.consumeNotification(notification: notification),
+        stderr: () => CapturingStdout(lines: stderrLines),
+      );
+
+      expect(stderrLines, isEmpty);
+      expect(
+        _build(tracker: tracker),
+        standard.buildWithAssistantSelection(modelId: "model", providerId: "cursor", variant: "high"),
+      );
+    });
+
+    test("replaces one complete foreground generic part in order with stable replay identity", () {
+      final updates = [
+        _text(text: "before"),
+        _toolCall(title: "Task: Inspect"),
+        _terminal(
+          rawOutput: {"durationMs": 42, "isBackground": false},
+          content: const [
+            {
+              "type": "content",
+              "content": {"type": "text", "text": "final report"},
+            },
+            {
+              "type": "content",
+              "content": {"type": "image", "data": "AA==", "mimeType": "image/png", "uri": null},
+            },
+          ],
+        ),
+        _text(text: "after"),
+      ];
+
+      final first = _build(tracker: _load(updates: updates));
+      final second = _build(tracker: _load(updates: updates));
+      expect(second, first, reason: "independent loads use equivalent replay-local fields");
+      expect(first.single.parts.map((part) => part.type), [
+        PluginMessagePartType.text,
+        PluginMessagePartType.subtask,
+        PluginMessagePartType.text,
+      ]);
+      final message = first.single;
+      final tile = message.parts[1] as PluginMessagePartSubtask;
+      expect((message.info.id, tile.id), ("root-mm1-assistant", "root-mm1-assistant-tool-task-1"));
+      expect((tile.sessionID, tile.messageID), (_sessionId, message.info.id));
+      expect((tile.prompt, tile.description, tile.agent), ("Inspect code", "Inspect", "unspecified"));
+      expect(tile.childSessionID, isNull);
+      expect(
+        (
+          tile.taskState?.status,
+          tile.taskState?.title,
+          tile.taskState?.output,
+          tile.taskState?.attachments.length,
+        ),
+        (PluginToolStatus.completed, "Task: Inspect", "final report", 1),
+      );
+      expect(message.parts.whereType<PluginMessagePartTool>(), isEmpty);
+    });
+
+    test("merges separately replayed completion and foreground facts", () {
+      final updates = [
+        _toolCall(),
+        {"sessionUpdate": "tool_call_update", "toolCallId": "task-1", "status": "completed"},
+        {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "task-1",
+          "rawOutput": {"isBackground": false},
+        },
+      ];
+      expect(_build(tracker: _load(updates: updates)).single.parts.single, isA<PluginMessagePartSubtask>());
+    });
+
+    test("background, incomplete, malformed, unknown, and nonterminal facts stay generic", () {
+      final foreground = {"isBackground": false};
+      final cases = <(String, Object, Map<String, dynamic>?)>[
+        ("background", _input(), _terminal(rawOutput: {"isBackground": true})),
+        ("missing output", _input(), _terminal()),
+        ("malformed output", _input(), _terminal(rawOutput: {"isBackground": "false"})),
+        ("missing enum", _input(subagentType: const <String, Object?>{}), _terminal(rawOutput: foreground)),
+        ("unknown enum", _input(subagentType: const {"custom": "future"}), _terminal(rawOutput: foreground)),
+        ("blank prompt", _input(prompt: " "), _terminal(rawOutput: foreground)),
+        ("blank description", _input(description: ""), _terminal(rawOutput: foreground)),
+        ("malformed input", _input(prompt: 7), _terminal(rawOutput: foreground)),
+        ("unknown tool", _input(toolName: "future"), _terminal(rawOutput: foreground)),
+        ("pending", _input(), null),
+        ("running", _input(), _terminal(status: "in_progress")),
+        ("failed", _input(), _terminal(status: "failed")),
+        ("unknown status", _input(), _terminal(status: "future")),
+      ];
+
+      for (final taskCase in cases) {
+        final part = _build(
+          tracker: _load(
+            updates: [
+              _toolCall(input: taskCase.$2, title: taskCase.$1),
+              ?taskCase.$3,
+            ],
+          ),
+        ).single.parts.single;
+        expect(part, isA<PluginMessagePartTool>(), reason: taskCase.$1);
+      }
+    });
+
+    test("update-only, unmatched, foreign-session, and absent facts never synthesize tiles", () {
+      final updateOnly = _load(
+        updates: [
+          {
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "task-1",
+            "status": "completed",
+            "rawInput": _input(),
+            "rawOutput": {"isBackground": false},
+          },
+        ],
+      );
+      expect(_build(tracker: updateOnly).single.parts.single, isA<PluginMessagePartTool>());
+
+      final unmatched = _load(
+        updates: [
+          _toolCall(),
+          {
+            "sessionUpdate": "tool_call_update",
+            "toolCallId": "other",
+            "status": "completed",
+            "rawOutput": {"isBackground": false},
+          },
+        ],
+      );
+      expect(_build(tracker: unmatched).expand((message) => message.parts), everyElement(isA<PluginMessagePartTool>()));
+
+      final foreign = _tracker()
+        ..consumeNotification(
+          notification: _notification(
+            update: _toolCall(status: "completed"),
+            sessionId: "other",
+          ),
+        );
+      expect(_build(tracker: foreign).single.parts.single, isA<PluginMessagePartTool>());
+      expect(_build(tracker: _tracker()), isEmpty, reason: "native cancelled replay absence remains absence");
+    });
+  });
+}
+
+Map<String, dynamic> _input({
+  String toolName = "task",
+  Object? prompt = "Inspect code",
+  Object? description = "Inspect",
+  Object? subagentType = const {"custom": "unspecified"},
+}) => {
+  "_toolName": toolName,
+  "prompt": prompt,
+  "description": description,
+  "subagentType": subagentType,
+};
+
+Map<String, dynamic> _toolCall({Object? input, String title = "Task", String status = "pending"}) => {
+  "sessionUpdate": "tool_call",
+  "toolCallId": "task-1",
+  "title": title,
+  "status": status,
+  "rawInput": input ?? _input(),
+  if (status == "completed") "rawOutput": {"isBackground": false},
+};
+
+Map<String, dynamic> _terminal({String status = "completed", Object? rawOutput, Object? content}) => {
+  "sessionUpdate": "tool_call_update",
+  "toolCallId": "task-1",
+  "status": status,
+  "rawOutput": ?rawOutput,
+  "content": ?content,
+};
+
+Map<String, dynamic> _text({required String text}) => {
+  "sessionUpdate": "agent_message_chunk",
+  "messageId": "m1",
+  "content": {"type": "text", "text": text},
+};
+
+AcpNotification _notification({required Map<String, dynamic> update, String sessionId = _sessionId}) => AcpNotification(
+  method: AcpMethods.sessionUpdate,
+  params: {"sessionId": sessionId, "update": update},
+);
+
+CursorTaskReplayTracker _tracker({AcpReplayCollector? standardCollector}) => CursorTaskReplayTracker(
+  sessionId: _sessionId,
+  standardCollector: standardCollector ?? _collector(),
+  taskProjection: const CursorTaskProjection(),
+);
+
+CursorTaskReplayTracker _load({required List<Map<String, dynamic>> updates}) {
+  final tracker = _tracker();
+  for (final update in updates) {
+    tracker.consumeNotification(notification: _notification(update: update));
+  }
+  return tracker;
+}
+
+List<PluginMessageWithParts> _build({required CursorTaskReplayTracker tracker}) => tracker.buildWithAssistantSelection(
+  modelId: "model",
+  providerId: "cursor",
+  variant: "high",
+);
+
+AcpReplayCollector _collector() => AcpReplayCollector(
+  sessionUpdateNormalizer: null,
+  shellCommandResolver: null,
+  sessionId: _sessionId,
+  agentId: "cursor",
+  initialUserMessageId: null,
+  messageIdOverride: null,
+  messageTimeResolver: null,
+  haltClassifier: null,
+  toolPartReplacement: null,
+  toolPartSuppression: null,
+);
+
+final class _RecordingReplayCollector() extends AcpReplayCollector {
+  this
+    : super(
+        sessionUpdateNormalizer: null,
+        shellCommandResolver: null,
+        sessionId: _sessionId,
+        agentId: "cursor",
+        initialUserMessageId: null,
+        messageIdOverride: null,
+        messageTimeResolver: null,
+        haltClassifier: null,
+        toolPartReplacement: null,
+        toolPartSuppression: null,
+      );
+
+  final List<AcpNotification> notifications = [];
+
+  @override
+  void consumeNotification({required AcpNotification notification}) {
+    notifications.add(notification);
+    super.consumeNotification(notification: notification);
+  }
+}

--- a/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
@@ -89,13 +89,13 @@ void main() {
       expect(message.parts.whereType<PluginMessagePartTool>(), isEmpty);
     });
 
-    test("merges separately replayed completion and foreground facts", () {
+    test("merges separately replayed facts using an opaque tool-call ID", () {
       final updates = [
-        _toolCall(),
-        {"sessionUpdate": "tool_call_update", "toolCallId": "task-1", "status": "completed"},
+        _toolCall()..["toolCallId"] = " task-1 ",
+        {"sessionUpdate": "tool_call_update", "toolCallId": " task-1 ", "status": "completed"},
         {
           "sessionUpdate": "tool_call_update",
-          "toolCallId": "task-1",
+          "toolCallId": " task-1 ",
           "rawOutput": {"isBackground": false},
         },
       ];

--- a/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
@@ -47,7 +47,6 @@ void main() {
         standard.buildWithAssistantSelection(modelId: "model", providerId: "cursor", variant: "high"),
       );
     });
-
     test("replaces one complete foreground generic part in order with stable replay identity", () {
       final updates = [
         _text(text: "before"),
@@ -92,7 +91,6 @@ void main() {
       );
       expect(message.parts.whereType<PluginMessagePartTool>(), isEmpty);
     });
-
     test("merges separately replayed facts using an opaque tool-call ID", () {
       final updates = [
         _toolCall()..["toolCallId"] = " task-1 ",

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -294,25 +294,26 @@ foreground invocation's completion is also sub-agent completion; a background
 invocation completes at launch and exposes `isBackground: true`, while the
 background work continues without a later terminal lifecycle or child
 transcript. `session/load` replays stable full standard Task input/result facts,
-not `cursor/task`, so completed foreground tiles are planned without a child
-session. Pending/in-progress calls lack presentation facts and `isBackground`, so their
+not `cursor/task`; Sesori now replaces an exact completed foreground replay card
+with the same childless tile while preserving replay-local identity and order. Pending/in-progress calls lack presentation facts and `isBackground`, so their
 mode is unknown and they remain generic; cancelled foreground calls also remain
 generic cancelled cards because no `cursor/task` follows cancellation. Sesori
 now replaces only an exact live standard completion with explicit
 `isBackground: false` plus a complete correlated request, producing one
 completed childless tile with stable part identity. Missing/unknown/malformed,
-unmatched, background, failed, and cancelled cases stay generic. Replay remains
-unimplemented. Standard `session/cancel` authoritatively cancels an active root
-prompt. Safe Task confirmation is side-effect-free with exact active count;
-named-root stop waits up to 20 seconds, then rechecks background and active work.
-Timeout or survivors yield HTTP 502 after cancellation, never false success. A
-background Task survives root cancel, so “`stop` cancels them all” remains **not
-supported**. While that observation is unresolved, every policy returns concrete
-HTTP 409 `notPerformed` before input or cancellation. Client drain pauses; that
-variant retains queued prompts and shows restart recovery even for unknown reasons.
-Malformed bodies, unknown variants, and post-cancel failures remain ambiguous.
-The observation keeps only ACP process work state busy until session cleanup or
-process reset; root `end_turn` and UI idle never claim background completion.
+unmatched, background, failed, and cancelled cases stay generic; cancelled Task
+replay remains absent when Cursor emits no frames. Standard `session/cancel`
+authoritatively cancels an active root prompt. Safe Task confirmation is
+side-effect-free with exact active count; named-root stop waits up to 20 seconds,
+then rechecks background and active work. Timeout or survivors yield HTTP 502
+after cancellation, never false success. A background Task survives root cancel,
+so “`stop` cancels them all” remains **not supported**. While that observation is
+unresolved, every policy returns concrete HTTP 409 `notPerformed` before input or
+cancellation. Client drain pauses; that variant retains queued prompts and shows
+restart recovery even for unknown reasons. Malformed bodies, unknown variants,
+and post-cancel failures remain ambiguous. The observation keeps only ACP process
+work state busy until session cleanup or process reset; root `end_turn` and UI
+idle never claim background completion.
 
 ⁶ Hermes (hermes-agent 0.19.0) has `delegate_task`, but its ACP adapter
 flattens delegation into an ordinary tool call and maps `session/cancel` to a

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -301,8 +301,8 @@ generic cancelled cards because no `cursor/task` follows cancellation. Sesori
 now replaces only an exact live standard completion with explicit
 `isBackground: false` plus a complete correlated request, producing one
 completed childless tile with stable part identity. Missing/unknown/malformed,
-unmatched, background, failed, and cancelled cases stay generic; cancelled Task
-replay remains absent when Cursor emits no frames. Standard `session/cancel`
+unmatched, background, and failed cases with standard facts stay generic. A cancelled
+Task is absent from replay when Cursor emits no standard frame; no completed tile is synthesized. Standard `session/cancel`
 authoritatively cancels an active root prompt. Safe Task confirmation is
 side-effect-free with exact active count; named-root stop waits up to 20 seconds,
 then rechecks background and active work. Timeout or survivors yield HTTP 502

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -112,6 +112,12 @@ reconnect or restart.
   link, one root tile linked to that child, and a nonblank child-owned prompt in
   child replay. Phone automation did not reach visible history or the read-only
   child view, so neither client path is claimed.
+- Cursor `session/load` replaces only a fully typed completed foreground Task's
+  generic card, preserving its replay-local part identity, title, output,
+  attachments, and transcript order. Background, incomplete, malformed,
+  unknown, nonterminal, unmatched, and update-only facts remain generic; an
+  omitted cancelled Task remains absent. Independent loads produce equivalent
+  fields without requiring equality with the earlier live id.
 - Messages visible live but absent from the backend's replay remain visible
   after a stale re-read. Exact identities satisfy their replay occurrences
   first and anchor neighboring order by identity even when replay revises their
@@ -271,6 +277,9 @@ rules where supported.
   belong to a different transcript than its messages, or misreports freshness in
   either direction — a current store flagged as awaiting sync, or a stale one
   served as complete.
+- Cursor replay duplicates a generic Task card and tile, changes replay-local
+  identity or order across loads, or turns incomplete/background facts into a
+  completed subtask.
 - DeepSeek replay duplicates a generic delegation card and child tile, attributes
   a nested tile to the root instead of its direct parent, changes live child
   activity, loses latest terminal metadata across pages, or collapses/reorders
@@ -368,5 +377,5 @@ SSE replay window, and routed request dispatch; database and audit compatibility
 tests under `bridge/app/test/bridge/services/`; client session-detail load/cubit
 code and focused metadata, blocking, reload-race and event-buffer tests; Pi
 session process repository, storage API, and history mapper; shared ACP event mapper, turn serialization,
-and session loader plus Antigravity, Copilot and Grok plugins and package tests; shared
+and session loader plus Antigravity, Copilot, Cursor, and Grok plugins and package tests; shared
 pagination cursor; client detail load service and cubit.


### PR DESCRIPTION
## Complexity
⚙️ Moderate: this slice adds Cursor-specific replay correlation around the existing ACP history collector while preserving one ordered generic materialization path.

## What
- Add a build-time ACP tool-part replacement hook without changing existing constructor-configured replacement or suppression behavior.
- Add a replay-local Cursor Task tracker that forwards every standard notification first, then indexes only exactly correlated typed Task facts.
- Share one injected pure `CursorTaskMapper` between live mapping and history replay.
- Replace only a completed generic Task part with explicit `isBackground: false`; preserve its identity, message/session ownership, title, output, attachments, and transcript position.
- Keep background, incomplete, malformed, unknown, nonterminal, update-only, unmatched, foreign-session, and absent facts generic or absent.
- Keep lifecycle and mode as independent non-null replay states; parse identity before Task payloads so non-Task output is not misdiagnosed.
- Update capability, regression, and active-plan truth for replay behavior and remaining limitations.

## Why
Cursor `session/load` replays standard Task updates but does not replay the live `cursor/task` request. Complete foreground history can still be reconstructed from typed standard facts. The reconstruction must remain replay-local and must not invent child sessions, background completion, cancelled history, or runtime state.

## Risk and test focus
Focus on notification-forwarding order, exact initial Task identity, split completion/output merging, foreground-only replacement, stable repeated loads, generic-card fallback, full field/order fidelity, and unchanged DeepSeek/Grok collector behavior. Malformed handling must not expose prompts, transcripts, or raw payloads.

## Expected result
A reloaded Cursor session renders fully correlated completed foreground Tasks as the same childless completed tiles used live. Unsupported or incomplete facts retain the generic ACP representation without false warnings. No database, client/wire, runtime/configuration, model, auth, native-process, background-stop, or child-session change.

## Verification
- Regenerated from merged Step 4 (`a7d3014e1a`); initial implementation blobs matched the reviewed checkpoint except an unrelated additive `main` documentation section retained during application, then publication state was updated.
- Final diff: 19 files, 1,103 additions and 95 deletions (1,198 changed lines).
- Cursor DTO/replay/event/plugin focused suites passed; final parser-order suites passed 14 tests and the complete plugin suite passed 40.
- ACP loader/history replay suites passed 47 tests; the affected loader suite passed 36 tests again after malformed-ID hardening.
- DeepSeek history replay and Grok replay-collector regression suites passed unchanged.
- Cursor, ACP, DeepSeek, and Grok owning fatal-info analyzers passed.
- Cursor generated Freezed/JSON output was regenerated from source; formatting, `git diff --check`, privacy, scope, and clean-index checks passed.
- Architecture implementation review approved; independent correctness/simplicity review passed after the generic-output parsing finding was fixed.
- Step 6 native/client coverage remains intentionally deferred.