### PR TITLE
🌱 Record Antigravity sub-agent seam disposition

### DIFF
--- a/.plan/completed/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
+++ b/.plan/completed/claude-inline-subtasks/HARNESS_FOLLOWUPS.md
@@ -13,8 +13,13 @@
   rows on each side because live final text was an empty snapshot. The anchored
   empty-prefix correction is implemented. Final build `493bab1483` passed one
   exact four-row child sequence on two cold opens and two private backfills; the
-  Grok gate and overall follow-up plan are complete.
-- **Plan date:** 2026-09-02; Cursor probe/design refreshed 2026-09-11.
+  Grok gate and overall follow-up plan are complete. A post-completion
+  Antigravity assessment on 2026-09-12 found native delegation but no
+  authoritative child identity or lifecycle over the official ACP seam, so its
+  Sesori inline-subtask capabilities are explicitly unsupported rather than
+  omitted or unfinished.
+- **Plan date:** 2026-09-02; Cursor probe/design refreshed 2026-09-11;
+  Antigravity disposition added 2026-09-12.
 - **Base:** `main` at merged DeepSeek coverage documentation `7dd323d1d7`
   ([#1431](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1431)).
 - **Delivery:** one open PR at a time, following current repository rules.
@@ -26,7 +31,7 @@
   unclaimed; questions remain unsupported. DeepSeek final coverage
   documentation now records its passed phone stop/input scope and explicitly
   deferred desktop scope. Codex has nine steps: merged metadata,
-  child-session, historical prompt preparation, and cleanup remain steps
+  child-session, historical prompt preparation, and cleanup occupy steps
   1/9–4/9. Native rollout facts are
   step 5/9, live/replay tile integration 6/9, lifecycle coverage 7/9, scoped
   stop 8/9, and coverage 9/9. Step 8 merged as PR #1421 at `77165f784f`;
@@ -50,12 +55,16 @@ seam can carry it, per `docs/HARNESS_CAPABILITIES.md`:
   contract, and `mainAgentOnlySupported` is declared honestly per harness.
 
 The contract, bridge translation, sweep, client tile, and dialog already exist
-and are not changed here. Every follow-up is plugin-internal work plus, for
-DeepSeek, work in Sesori's own adapter repository.
+and are not changed here. Every implementation follow-up is plugin-internal
+work plus, for DeepSeek, work in Sesori's own adapter repository. Antigravity's
+post-completion item is an assessment and documentation update only.
 
-Harnesses verified as not supportable over the seam Sesori drives (Copilot,
-Hermes, Pi, Oh My Pi) are out of scope; their verdicts and versions are
-recorded in the capability matrix. Cursor's planned subset is completed
+Harnesses verified as not supportable over the seam Sesori drives (Antigravity,
+Copilot, Hermes, Pi, Oh My Pi) are out of implementation scope; their verdicts
+and versions are recorded in the capability matrix. Antigravity's native runtime
+can delegate, but its ACP projection does not expose trustworthy child identity,
+lifecycle, child-session replay, or sub-agent-scoped cancellation semantics.
+Standard root replay and turn-wide cancellation remain available. Cursor's planned subset is completed
 foreground tiles plus safe Task confirmation/root stop when no background
 observation is unresolved. Active pending/in-progress Task mode is unknown; it
 has no child session or full scoped stop.
@@ -111,8 +120,8 @@ has no child session or full scoped stop.
      tracker or permission-outcome model exists; a denied Grok generic card may
      be absent after replay. Replay has a separate typed suppression callback,
      while DeepSeek's existing nullable replacement callback keeps null meaning
-     “retain generic.” Cursor's future tile-only mapping must land with its own
-     production need rather than prebuilding unused classification machinery.
+     “retain generic.” Cursor's tile-only mapping landed with its own production
+     need rather than prebuilding unused classification machinery.
   3. The scoped-stop policy, once, in `AcpPlugin.abortSession`: `confirm` with
      running children is side-effect free and rejects with their count,
      `mainAgentRunning` from pending prompts or an active named child, and `mainAgentOnlySupported` true only
@@ -540,7 +549,7 @@ has no child session or full scoped stop.
   non-growing shape. The otherwise exact anchored window now accepts its empty
   live final text as a strict prefix only when replay text is nonempty; phone
   confirmation then passed on `493bab1483`. Background completion notification
-  was attempted in the earlier full run but not delivered or claimed. Owned
+  was attempted in the earlier full run but not observed and remains unclaimed. Owned
   resources were cleaned
   and protected resources were untouched.
 
@@ -627,17 +636,17 @@ has no child session or full scoped stop.
 | monorepo | ⚙️ | `[claude-inline-subtasks] DeepSeek scoped sub-agent stops [step 1/2]` | #1346 merged at `2cc1485d7c`; historical title retained |
 | adapter | 🚧 | `[claude-inline-subtasks] DeepSeek atomic subtree cancellation [step 2/3]` | #17 merged at `5eecdf68a3`; historical title retained |
 | adapter | 🌱 | `release: prepare v0.1.4 for atomic-stop consumer` | #18 merged at `e2ea207f21`; v0.1.4 and six archives verified |
-| monorepo | ⚙️ | `[claude-inline-subtasks] DeepSeek native stop contract and input ordering [step 4/5]` | Frozen native corpus, ordered input cancel, initialize floor, target and digests; no stop-policy change |
-| monorepo | 🚧 | `[claude-inline-subtasks] DeepSeek completes ACP-owned scoped stop [step 5/5]` | Replace direct-child fanout with complete native authority at the existing ACP owner |
+| monorepo | ⚙️ | `[claude-inline-subtasks] DeepSeek native stop contract and input ordering [step 4/5]` | #1363 merged at `b13d197d51`; frozen native corpus, ordered input cancel, initialize floor, target and digests; no stop-policy change |
+| monorepo | 🚧 | `[claude-inline-subtasks] DeepSeek completes ACP-owned scoped stop [step 5/5]` | #1370 merged at `c88d4ade82`; replaced direct-child fanout with complete native authority at the existing ACP owner |
 | monorepo | 🌱 | `docs: record DeepSeek sub-agent coverage` | Current reconciliation: requested phone stop/input scope passed; desktop explicitly deferred; other unexecuted client matrices remain explicit |
 
 ### Scoped-stop replacement
 
 The [replacement design](followups/deepseek-stop-replacement.md) fixes both slices' ownership and compatibility flow.
 PR #1356 closed without merge; its former step 4/4 is superseded. Step 4/5
-lands only the verified native contract/input consumer and keeps current scoped
-stop behavior. Step 5/5 will use one ACP-owned operation, native atomic authority,
-and no residual-ID handshake or new long-lived state. Requested phone stop/input
+landed only the verified native contract/input consumer and kept then-current
+scoped-stop behavior. Step 5/5 then used one ACP-owned operation, native atomic
+authority, and no residual-ID handshake or new long-lived state. Requested phone stop/input
 E2E passed after #1379; desktop remains explicitly deferred. Final documentation
 records that partial matrix without reopening native probes. Automatic managed-runtime
 upgrade machinery remains outside this series.
@@ -902,12 +911,12 @@ those refs. Regenerate each successor from its merged predecessor.
 
 | Step | Exact title | Target and scope |
 |---|---|---|
-| 1/6 | `🌱 [claude-inline-subtasks] docs: record Cursor native probe and corrected plan [step 1/6]` | PR #1435 merged at `b83b64901c`; supervisor will update its GitHub title; docs only |
+| 1/6 | `🌱 [claude-inline-subtasks] docs: record Cursor native probe and corrected plan [step 1/6]` | PR #1435 merged at `b83b64901c`; GitHub title was renumbered from step 1/5 to step 1/6 after the split; docs only |
 | 2/6 | `🚧 [claude-inline-subtasks] cursor: settle generic Task lifecycle [step 2/6]` | PR #1438 merged at `116392cb71`: active generic-part tracking, terminal settlement, request ack, transport ordering regressions, typed-refusal plan correction, and behavior docs; no tile |
 | 3/6 | `🚧 [claude-inline-subtasks] cursor: completed foreground Task tiles [step 3/6]` | PR #1441 merged at `bb85f48148`: exact completed correlation, minimal presentation DTO fields, childless one-shot live replacement, tests, and capability/docs update |
 | 4/6 | `🚧 [claude-inline-subtasks] cursor: safe Task stop policy [step 4/6]` | PR #1442 merged at `a7d3014e1a`: exact count, process residency, typed refusal, bounded root cancel/re-check, concurrent descendant fallback, bridge/client/UI flow, tests, and docs; no replay/native QA |
 | 5/6 | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | PR #1443 merged at `f5e4e7f67a`: configured collector/shared `CursorTaskMapper`, typed stable completed replacement, fallbacks, tests, and history docs; no native QA |
-| 6/6 | `⚙️ [claude-inline-subtasks] cursor: reconcile native Task coverage [step 6/6]` | PR #1444 open: actual-plugin executed scope passed; exact distinct live/replay presentation tags repaired with typed generated DTOs; unsupported/unexecuted matrix remains explicit |
+| 6/6 | `⚙️ [claude-inline-subtasks] cursor: reconcile native Task coverage [step 6/6]` | PR #1444 merged at `67e173be1a`: actual-plugin executed scope passed; exact distinct live/replay presentation tags repaired with typed generated DTOs; unsupported/unexecuted matrix remains explicit |
 
 ### Probe questions
 
@@ -920,6 +929,46 @@ those refs. Regenerate each successor from its merged predecessor.
    output, not `cursor/task`; completed foreground replay can project a typed
    tile, while background/cancelled cases use honest generic/absent fallbacks.
 
+## Antigravity (official ACP package 1.0.0)
+
+### Post-completion verified facts
+
+- The 2026-09-12 bounded probe used pinned runtime identity
+  `agy_acp_server_20260818_01_RC01`, existing authenticated isolated profile,
+  mode `default`, and an owned temporary workspace. It read or copied no token,
+  changed no runtime pin/model/global configuration, and touched no existing
+  bridge process. Every local probe session/database, workspace, script, and
+  process was removed; Google-side conversation residue may remain under the
+  user's accepted provider terms.
+- Two root turns requested exactly one native internal sub-agent and returned
+  the expected deterministic result. Each invocation requested permission; the
+  probe selected exactly one warning-free `allow_once` and never selected
+  persistent approval.
+- ACP emitted only standard `session/update` frames under the root session ID.
+  `invoke_subagent` input carried one `Subagents` item with model, prompt, role,
+  and type fields, but no child ID. Nested activity appeared as separate generic
+  parent-local tool calls. No child session, lifecycle extension, background
+  discriminator, or child-cancel method appeared, and `session/list` grew only
+  by the created root.
+- Live `invoke_subagent` moved from `pending` to `failed` after the permission
+  decision even though the root returned the requested result. Cold
+  `session/load` instead replayed that invocation as `completed`, encoded its
+  structured input as a JSON string, and supplied blank raw output. Replay also
+  exposed no child identity or transcript.
+
+### Disposition
+
+Antigravity native delegation exists, but official ACP projection is not an
+authoritative inline-subtask seam. Sesori keeps these records as generic tools
+and does not infer lifecycle, child history, descendant busy state, or scoped
+cancellation from order, prompts, assistant claims, or replay's contradictory
+status. Standard turn-wide `session/cancel` remains available, but it cannot
+implement any sub-agent-specific stop policy. No production follow-up is
+planned. Reassess only if a later official runtime exposes stable typed child
+identity plus lifecycle/replay semantics; cancellation support additionally
+requires an exact child or native subtree stop authority. Full privacy-safe
+facts live in [the probe record](followups/antigravity-probe.md).
+
 ## Non-Goals
 
 - Per-child stop from the tile, progress rendering, per-subtask usage.
@@ -927,3 +976,5 @@ those refs. Regenerate each successor from its merged predecessor.
 - Migrating Codex children already imported as roots.
 - Cursor child sessions or partial stops, and any work for Copilot, Hermes,
   Pi, Oh My Pi.
+- Inferring Antigravity child identity or lifecycle from generic parent-local
+  tool order, prompt text, assistant output, or contradictory replay status.

--- a/.plan/completed/claude-inline-subtasks/PLAN.md
+++ b/.plan/completed/claude-inline-subtasks/PLAN.md
@@ -31,17 +31,23 @@
   count/copy and dismissal, full stop, same-session/runtime reuse, cold root
   reload, read-only child controls, and normal one-time permission handling.
   Cold child history stably duplicated its assistant/tool/final sequence under
-  distinct rows. Push was attempted while backgrounded but not delivered. A
+  distinct rows. Push delivery was attempted while backgrounded but not observed and remains unclaimed. A
   fixed-build rerun at `0187bb2b10` deduplicated the exact tool anchor, but two
   assistant rows remained on each side because live retained an empty final text
   snapshot. The anchored predicate now accepts that exact empty-prefix case.
   Final QA at `493bab1483` passed exact cold convergence twice and two private
   backfills. Grok phone coverage now passes its bounded matrix and the plan is
-  retired.
-- **Plan date:** 2026-08-22
+  retired. A post-completion 2026-09-12 audit added newly registered Antigravity:
+  its official runtime delegated internally, but the ACP seam exposed only
+  contradictory generic parent-local tool records without child identity,
+  lifecycle, child history, background state, or sub-agent-scoped cancellation.
+  Standard root replay and turn-wide cancellation remain available. Antigravity's
+  inline-subtask rows are therefore explicitly unsupported rather than an open
+  implementation task; details are in `followups/antigravity-probe.md`.
+- **Plan date:** 2026-08-22; Antigravity disposition added 2026-09-12
 - **Repository:** `sesori-ai/sesori_apps_monorepo`
 - **Historical original implementation base:** `main` at `ba725ec84`
-- **Current Cursor series base after Step 1 merge:** `main` at `b83b64901c`
+- **Historical Cursor series base after Step 1 merge:** `main` at `b83b64901c`
 - **Plan branch:** `inline-subtask-plan`
 - **Plan PR:** [#1027](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1027)
 - **Delivery:** eight PRs: plan, contract + client tile, Claude lifecycle,
@@ -65,7 +71,10 @@
   Status section above and `followups/grok-probe.md`; no duplicate matrix is
   maintained here. DeepSeek's final documentation reconciles the passed phone
   stop/input scope and user-deferred desktop matrix without changing adapter
-  0.1.4 evidence. Grok and Cursor follow-ups are complete; the plan is retired.
+  0.1.4 evidence. Grok and Cursor follow-ups are complete. Antigravity was added
+  after retirement and now has a completed bounded seam assessment with an
+  explicit unsupported disposition; no production follow-up is justified by
+  the observed ACP facts. The plan remains retired.
 
 ## Goal
 

--- a/.plan/completed/claude-inline-subtasks/TRACKER.md
+++ b/.plan/completed/claude-inline-subtasks/TRACKER.md
@@ -3,7 +3,10 @@
 ## Current State
 
 - **Plan slug:** `claude-inline-subtasks`
-- **Implementation base:** completed rollout merged to `main` at `e4dfd480ab` through PR #1445.
+- **Implementation base:** completed rollout merged to `main` as
+  [PR #1445](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1445) at `e4dfd480ab`.
+- **Post-completion Antigravity assessment:**
+  [PR #1447](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1447).
 - **Series state:** all eight original Claude steps merged, including the
   L4-found fix [#1257](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1257),
   which made scoped stop harness-neutral and added
@@ -224,7 +227,7 @@ post-merge E2E gates are unchanged.
 | [x] | Cursor | `🚧 [claude-inline-subtasks] cursor: safe Task stop policy [step 4/6]` | [PR #1442](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1442) merged at `a7d3014e1a`; exact active Task count, unresolved-background residency, typed refusal, bounded named-root stop, concurrent descendant fallback, queue gate, and limitation UI; no replay/native QA |
 | [x] | Cursor | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | PR #1443 merged at `f5e4e7f67a`: configured ACP collector/shared `CursorTaskMapper`, typed stable completed replacement, fallbacks, tests, and history docs; no native QA |
 | [x] | Cursor | `⚙️ [claude-inline-subtasks] cursor: reconcile native Task coverage [step 6/6]` | PR #1444 merged at `67e173be1a`; actual-plugin executed scope passed; distinct exact native live/replay presentation shapes repaired and generated; background stop/lifecycle and child-session gaps remain explicit |
-| [x] | Antigravity | `🌱 [claude-inline-subtasks] docs: record Antigravity sub-agent seam disposition` | 2026-09-12 bounded authenticated probe completed; native internal delegation observed, but official ACP exposed no trustworthy child identity/lifecycle, child-session replay, or sub-agent-scoped stop seam; standard root replay/cancel remain available; no production implementation |
+| [x] | Antigravity | `🌱 [claude-inline-subtasks] docs: record Antigravity sub-agent seam disposition` | [PR #1447](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1447); 2026-09-12 bounded authenticated probe completed; native internal delegation observed, but official ACP exposed no trustworthy child identity/lifecycle, child-session replay, or sub-agent-scoped stop seam; standard root replay/cancel remain available; no production implementation |
 
 ### Antigravity native ACP probe (2026-09-12)
 

--- a/.plan/completed/claude-inline-subtasks/TRACKER.md
+++ b/.plan/completed/claude-inline-subtasks/TRACKER.md
@@ -3,7 +3,7 @@
 ## Current State
 
 - **Plan slug:** `claude-inline-subtasks`
-- **Implementation base:** Cursor Step 5 merged at `f5e4e7f67a`.
+- **Implementation base:** completed rollout merged to `main` at `e4dfd480ab` through PR #1445.
 - **Series state:** all eight original Claude steps merged, including the
   L4-found fix [#1257](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1257),
   which made scoped stop harness-neutral and added
@@ -39,7 +39,10 @@
   #1431. Overall plan is **COMPLETED** after build `493bab1483` passed the
   bounded Grok cold-history phone gate. Earlier WebDriverAgent,
   stale-authentication, and history-convergence blocks are superseded. Grok and
-  Cursor follow-ups are complete.
+  Cursor follow-ups are complete. A 2026-09-12 post-completion audit added the
+  newly registered Antigravity harness and recorded its official ACP seam as
+  insufficient for Sesori inline subtasks despite native internal delegation;
+  standard root replay and turn-wide cancellation remain available.
 - **Pinned facts source:** `PLAN.md` "Claude Code CLI 2.1.237 facts" plus the
   Step 3 capture below (CLI 2.1.257); the completed
   `claude-code-plugin/PROTOCOL.md` is historical and is not edited
@@ -203,7 +206,7 @@ post-merge E2E gates are unchanged.
 | [x] | Grok | `🌿 [claude-inline-subtasks] grok: cover child session history [step 4/6]` | [PR #1427](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1427) merged at `4d0d8de7e3`; historical title unchanged (now step 4/7); approved collector/repository/service coverage and docs |
 | [x] | Grok | `⚙️ [claude-inline-subtasks] grok: scoped stop for sub-agents [step 5/6]` | [PR #1428](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1428) merged at `3934f32ec9`; historical title unchanged (now step 5/7) |
 | [x] | Grok | `🌿 [claude-inline-subtasks] grok: decode child-cancel response envelope [step 6/7]` | [PR #1429](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1429) merged at `2ebcc7d01a`; exact title unchanged |
-| [x] | Grok | `🌱 [claude-inline-subtasks] docs: record Grok sub-agent coverage [step 7/7]` | [PR #1430](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1430) merged at `a28e860557`; actual-plugin scope passed; subsequent owned-phone matrix passed, including genuine permission Once and fixed cold child history; notification unavailable and questions unsupported |
+| [x] | Grok | `🌱 [claude-inline-subtasks] docs: record Grok sub-agent coverage [step 7/7]` | [PR #1430](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1430) merged at `a28e860557`; actual-plugin scope passed; subsequent owned-phone matrix passed, including genuine permission Once and fixed cold child history; notification delivery unobserved/unclaimed and questions unsupported |
 | [x] | DeepSeek (adapter) | `⚙️ sessions: sub-agent lifecycle notifications and child transcripts` | [sesori-deepseek-acp #13](https://github.com/sesori-ai/sesori-deepseek-acp/pull/13) merged at `0a85fb2` |
 | [x] | DeepSeek (adapter) | `⚙️ sessions: per-child interrupt; release v0.1.3` | [sesori-deepseek-acp #14](https://github.com/sesori-ai/sesori-deepseek-acp/pull/14) merged at `1f839c3`; release completed through #16 |
 | [x] | DeepSeek (adapter) | `🌿 protocol: carry sub-agent prompts for tile replay` | [sesori-deepseek-acp #15](https://github.com/sesori-ai/sesori-deepseek-acp/pull/15) merged at `d7a4847` |
@@ -221,6 +224,29 @@ post-merge E2E gates are unchanged.
 | [x] | Cursor | `🚧 [claude-inline-subtasks] cursor: safe Task stop policy [step 4/6]` | [PR #1442](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1442) merged at `a7d3014e1a`; exact active Task count, unresolved-background residency, typed refusal, bounded named-root stop, concurrent descendant fallback, queue gate, and limitation UI; no replay/native QA |
 | [x] | Cursor | `⚙️ [claude-inline-subtasks] cursor: replay completed foreground Task tiles [step 5/6]` | PR #1443 merged at `f5e4e7f67a`: configured ACP collector/shared `CursorTaskMapper`, typed stable completed replacement, fallbacks, tests, and history docs; no native QA |
 | [x] | Cursor | `⚙️ [claude-inline-subtasks] cursor: reconcile native Task coverage [step 6/6]` | PR #1444 merged at `67e173be1a`; actual-plugin executed scope passed; distinct exact native live/replay presentation shapes repaired and generated; background stop/lifecycle and child-session gaps remain explicit |
+| [x] | Antigravity | `🌱 [claude-inline-subtasks] docs: record Antigravity sub-agent seam disposition` | 2026-09-12 bounded authenticated probe completed; native internal delegation observed, but official ACP exposed no trustworthy child identity/lifecycle, child-session replay, or sub-agent-scoped stop seam; standard root replay/cancel remain available; no production implementation |
+
+### Antigravity native ACP probe (2026-09-12)
+
+- [x] Used only official managed package 1.0.0/runtime
+  `agy_acp_server_20260818_01_RC01`, existing isolated authenticated profile,
+  default mode, and owned temporary work. Token contents were never read or
+  copied; runtime pin, model, global configuration, and existing bridge process
+  remained unchanged.
+- [x] Two deterministic single-sub-agent turns completed at root level after one
+  warning-free `allow_once` each. All ACP updates carried only the parent session
+  ID; no child session/ID, lifecycle extension, background fact, or child-cancel
+  method appeared. Session listing gained only the created root.
+- [x] Live `invoke_subagent` reported `pending` then `failed` while the root still
+  returned the expected result. Replay reported the invocation `completed`,
+  string-encoded its structured input, returned blank raw output, and exposed no
+  child transcript. Nested activity remained uncorrelated generic parent tools.
+- [x] Recorded unsupported Sesori tile, child-session, descendant-lifecycle, and
+  scoped-stop cells in `docs/HARNESS_CAPABILITIES.md`; generic turn cancellation
+  remains distinct. No speculative mapper/tracker was added.
+- [x] Removed owned local session/database files, scratch workspace, scripts, and
+  processes. Existing profile/runtime and protected bridge stayed untouched;
+  accepted Google-side conversation residue may remain.
 
 ### Cursor native probe (2026-09-11)
 
@@ -290,7 +316,7 @@ post-merge E2E gates are unchanged.
   HTTP 409 variant. Client-local exceptions, cubit outcome, queue gate, and UI
   trust only that variant; unknown reasons retain the queue, while unknown kinds
   and malformed bodies remain ambiguous. Active mode-unknown
-  confirmation/count and safe named-root stop remain planned: `confirm`/`keep`
+  confirmation/count and safe named-root stop are implemented: `confirm`/`keep`
   map exact `activeTaskCount` through the existing
   `PluginAbortRejectedSubAgentsRunning`/`SessionAbortRejection` path with
   main-only false and no wire change;

--- a/.plan/completed/claude-inline-subtasks/followups/antigravity-probe.md
+++ b/.plan/completed/claude-inline-subtasks/followups/antigravity-probe.md
@@ -1,0 +1,111 @@
+# Antigravity Sub-Agent ACP Probe
+
+## Status and disposition
+
+Completed 2026-09-12 against Google's official managed Antigravity ACP package
+`1.0.0`, exact runtime identity `agy_acp_server_20260818_01_RC01`.
+
+Native internal delegation was observed, but the official ACP projection does
+not expose enough authoritative state for Sesori inline subtasks. Antigravity
+therefore remains generic-tool-only for this feature: no inline subtask tile,
+child transcript, descendant lifecycle/busy state, or scoped sub-agent stop.
+This is a completed unsupported disposition, not unfinished implementation and
+not a claim that native Antigravity lacks sub-agents.
+
+## Authorization, isolation, and cleanup
+
+The user authorized one bounded live probe using Sesori's existing authenticated
+Antigravity profile, accepted provider quota use, and accepted Google-side
+conversation residue that Sesori cannot delete. Token contents were never read,
+printed, copied, or changed.
+
+- Used only pinned server/harness siblings already installed beneath Sesori's
+  Antigravity state.
+- Preserved production runtime pin, account-selected model, approval policy,
+  global configuration, and existing bridge processes.
+- Used mode `default`, a sanitized no-inheritance environment, and an owned
+  temporary workspace. Browser launch was suppressed.
+- Accepted only one exact warning-free `allow_once` option per invocation. No
+  persistent approval was selected; unsupported requests would have been
+  cancelled.
+- Captured only bounded structural facts. No prompt, transcript, token, raw ID,
+  permission payload, provider response, screenshot, or private log was
+  published.
+- Removed every owned local conversation metadata/database file, temporary
+  workspace, probe script, and process. One unrelated existing conversation and
+  the installed runtime/profile remained untouched. No owned probe process
+  remained. Google-side residue may remain under the accepted provider boundary.
+
+## Executed cases
+
+1. Initialized and authenticated the pinned ACP pair with the existing isolated
+   profile, created one owned root session, forced mode `default`, and requested
+   exactly one bounded reasoning-only sub-agent.
+2. Resumed that same root on a fresh ACP process and requested exactly one
+   built-in `self` sub-agent for a second deterministic reasoning task.
+3. Replayed the first turn through standard `session/load` on a fresh process.
+4. Listed sessions before and after root creation to detect independently
+   exposed child sessions.
+
+Both live root prompts returned `stopReason: end_turn`; assistant output included
+the expected deterministic result after sub-agent-labelled tool activity. This
+proves that native delegation was attempted and produced a usable root result.
+It does not make assistant text lifecycle authority.
+
+No child-cancellation case was run. The seam exposed no child target, child
+listing, or child-cancel method to exercise. Standard root `session/cancel` is
+already available through shared ACP, but whole-turn cancellation cannot prove
+or implement any sub-agent-specific stop policy.
+
+## Privacy-safe wire facts
+
+- `initialize` advertised standard ACP load/list/resume capabilities and no
+  child-session or sub-agent extension.
+- Every observed notification was standard `session/update`; every update used
+  only the root session ID. No extension notification appeared.
+- Live `invoke_subagent` input contained one `Subagents` item with `Model`,
+  `Prompt`, `Role`, and `TypeName`; it contained no child ID. Both invocations
+  transitioned `pending` → `failed` after permission resolution even though the
+  root returned the requested result.
+- Nested activity appeared as additional generic parent-local `other` tool
+  calls. One case also exposed a generic `manage_subagents` call and a nested
+  read. No field correlated these calls to a child identity or authoritative
+  lifecycle.
+- `session/list` grew by exactly one: the owned root. No child session appeared.
+- `session/load` replayed the recorded `invoke_subagent`, nested generic call,
+  and read as `completed`. Replay string-encoded structured raw input and
+  supplied blank raw output. It exposed no child identity, child transcript, or
+  lifecycle extension.
+- Live and replay therefore disagree on invocation status and raw shape. Neither
+  form exposes background/foreground mode, independent completion, child
+  ancestry, or cancellation authority.
+
+## Capability decision
+
+| Capability | Disposition | Reason |
+|---|---|---|
+| Inline subtask tile | Not supported | Generic parent-local calls lack authoritative child identity/lifecycle; live and replay status conflict. |
+| Child transcript/session | Not supported | No child ID/session/list row or child-scoped replay target crosses ACP. |
+| Descendant busy/root residency | Not supported | Root prompt lifetime is observable; independent descendant lifetime is not. |
+| Confirm/count running sub-agents | Not supported | No authoritative running-child set exists. |
+| Stop all sub-agents | Not supported as scoped policy | Only whole-root `session/cancel` is available; descendant settlement is unobservable. |
+| Stop child only | Not supported | No child target or child-cancel method crosses ACP. |
+| Stop root while retaining children | Not supported | No background/independent child lifecycle is exposed. |
+
+Keep native calls generic. Do not infer support from binary symbols, public
+Antigravity SDK/CLI documentation, tool names, prompt-bearing raw input, call
+order, assistant claims, replay's `completed` status, or the shared ACP child
+tracker existing in Sesori. Reassess only when a later official ACP runtime
+exposes stable typed child identity plus lifecycle and replay semantics;
+sub-agent stop additionally needs exact-child or native-subtree cancellation
+authority.
+
+## Records updated
+
+- `docs/HARNESS_CAPABILITIES.md`
+- `docs/ANTIGRAVITY.md`
+- `docs/regression/antigravity-live-replay-updates.md`
+- `docs/regression/tools-and-file-changes.md`
+- `docs/regression/session-turns.md`
+- `docs/regression/session-history-and-recovery.md`
+- `.plan/completed/claude-inline-subtasks/{PLAN.md,HARNESS_FOLLOWUPS.md,TRACKER.md}`

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -104,7 +104,12 @@ needs no browser of its own, but does need a current connected client for initia
   over recovered fallback metadata. Sesori never parses private Google SQLite/brain content.
 - **Images and tools:** prompt and returned image content use the shared bounded attachment path. Provider-local image
   filenames are metadata only: Sesori does not open or fetch them. Model/account rejection remains visible. Tool
-  output is bounded and normalized consistently for live/replay; a nonzero exit note is not an ACP protocol failure.
+  output is bounded and normalized consistently for equivalent live/replay source envelopes; a nonzero exit note is not
+  an ACP protocol failure.
+- **Sub-agents:** Antigravity can delegate internally, but its official ACP projection exposes that work only as generic
+  parent-local tool calls. It supplies no trustworthy child identity or lifecycle, and live versus replayed invocation
+  status disagrees. Sesori therefore does not show Antigravity inline subtask tiles or child transcripts and cannot
+  offer sub-agent-scoped stop. Normal turn-wide cancellation still applies.
 - **Deletion:** the pinned runtime has no standard close/delete capability. Deleting in Sesori removes its own catalog
   and transcript data and retains a tombstone against re-import; it does not erase Google's conversation/profile files.
 - **Presentation:** shared harness settings and chooser surfaces show **Antigravity** with Google's official full-colour
@@ -114,9 +119,10 @@ needs no browser of its own, but does need a current connected client for initia
 
 Implementation is not a claim of completed cross-platform end-to-end verification. Official archive integrity was
 checked for all five targets. Native initialize-only and managed-pipeline correctness has been exercised on macOS arm64
-in disposable state. Native Linux/Windows installation, real personal OAuth, authenticated discovery-session
-creation/resume, full session/image/history flows and the final cumulative L1–L5 matrix remain unverified.
-Missing test infrastructure is a blocked result, not a pass.
+in disposable state. One bounded authenticated ACP probe verified only the generic sub-agent projection described
+above. Native Linux/Windows installation, real personal OAuth, authenticated discovery-session creation/resume, full
+ordinary session/image/history flows and the final cumulative L1–L5 matrix remain unverified. Missing test
+infrastructure is a blocked result, not a pass.
 
 The implementation plan was retired under the owner's
 [explicitly accepted verification reduction](../.plan/completed/antigravity-harness/PLAN.md).

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -7,8 +7,8 @@ capability lands for some harnesses but not others, or a harness limitation is
 verified or lifted.
 
 Capability tables include registered plugins where the relevant integration behavior has been verified. Antigravity is
-included below for local runtime, options, setup, login, and permission behavior; its upstream sub-agent behavior has
-not been verified, so the sub-agent table makes no claim about it.
+included below, including the bounded authenticated sub-agent assessment completed on 2026-09-12. Its sub-agent cells
+describe what Sesori can expose through the official ACP seam, not whether the native runtime delegates internally.
 
 ## Legend
 
@@ -228,13 +228,13 @@ reconciliation when connected to an older bridge.
 
 ## Sub-agents
 
-| Capability | Claude | OpenCode | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |
-|---|---|---|---|---|---|---|---|---|---|---|
-| Sub-agents rendered as inline subtask tiles | ✅ | ✅ | ✅³ | 🚫⁴ | ✅⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅¹⁰ |
-| Sub-agent transcripts exposed as child sessions | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅¹⁰ |
-| Scoped stop: confirmation while sub-agents run, `stop` cancels them all | ✅ | ✅ | ✅ (snapshot)³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅ (snapshot)¹⁰ |
-| Stop the sub-agents only while the main agent is idle (`stop`) | ✅ | ✅ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅¹⁰ |
-| Stop the main agent only while it runs, keeping its sub-agents | 🚫¹ | 🚫² | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | 🚫¹⁰ |
+| Capability | Claude | OpenCode | Antigravity | Codex | Copilot | Cursor | Hermes | Pi | OMP | DeepSeek | Grok |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Sub-agents rendered as inline subtask tiles | ✅ | ✅ | 🚫¹⁹ | ✅³ | 🚫⁴ | ✅⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅¹⁰ |
+| Sub-agent transcripts exposed as child sessions | ✅ | ✅ | 🚫¹⁹ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅¹⁰ |
+| Scoped stop: confirmation while sub-agents run, `stop` cancels them all | ✅ | ✅ | 🚫¹⁹ | ✅ (snapshot)³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅ (snapshot)¹⁰ |
+| Stop the sub-agents only while the main agent is idle (`stop`) | ✅ | ✅ | 🚫¹⁹ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | ✅¹⁰ |
+| Stop the main agent only while it runs, keeping its sub-agents | 🚫¹ | 🚫² | 🚫¹⁹ | ✅³ | 🚫⁴ | 🚫⁵ | 🚫⁶ | 🚫⁷ | 🚫⁸ | ✅⁹ | 🚫¹⁰ |
 
 ACP plugins declare one closed scoped-stop capability: `unsupported`, `rootSessionCancel` (Cursor),
 `perChildSnapshot` (Grok), or `completeNativeAtomic` (DeepSeek). Plugins that report a scoped-stop rejection declare
@@ -391,6 +391,26 @@ history, and exact read-only child navigation. Final fixed-build QA showed one
 stable child-owned initial row plus one assistant/tool/assistant sequence on two
 opens. Background completion delivery was attempted, but no OS notification was
 observed; notification and push delivery remain unclaimed.
+
+¹⁹ Antigravity's official managed ACP pair (package 1.0.0, runtime
+`agy_acp_server_20260818_01_RC01`, probed 2026-09-12) can invoke native internal
+sub-agents. Two authenticated default-mode turns returned the expected bounded
+reasoning result after `invoke_subagent` activity and one warning-free
+`allow_once` decision each. The official ACP projection does not expose a
+trustworthy Sesori subtask seam, however: every update carried only the parent
+session id; no child session, child id, child lifecycle extension, background
+fact, or child-cancel method appeared. Live `invoke_subagent` calls moved from
+`pending` to `failed` even though the root reported the delegated result, while
+`session/load` replayed those same calls as `completed`, string-encoded their
+structured input, and supplied blank raw output. Nested work appeared only as
+additional generic parent-local tool calls without correlation to the invocation.
+Sesori therefore keeps these calls generic and does not infer tiles, child
+history, descendant busy state, or scoped stop from call order, prompt text, or
+replay's contradictory status. Standard turn-wide `session/cancel` remains
+available, but it cannot implement any sub-agent-specific stop row above. This
+is a limitation of the ACP projection Sesori drives, not a claim that native
+Antigravity lacks delegation. Details:
+[completed probe record](../.plan/completed/claude-inline-subtasks/followups/antigravity-probe.md).
 
 ¹¹ Pi (0.84.4, probed 2026-09-05) reports it from `pi --list-models`, which
 prints one row per usable model and otherwise prints the

--- a/docs/regression/antigravity-live-replay-updates.md
+++ b/docs/regression/antigravity-live-replay-updates.md
@@ -26,7 +26,8 @@ credential access or history mutation.
   truncation marker. Do not classify a nonzero exit as an ACP tool/protocol failure. Genuine failed tool status stays
   failed; successful/completed status stays completed. Exit-only partial terminal updates preserve earlier tool output:
   they do not replace it with empty text or an exit note. No second output cache is introduced to append that note.
-  Live and replay must produce identical tool state.
+  Equivalent source envelopes must produce identical normalized tool state live and on replay; this does not assert that
+  the upstream runtime emits equivalent source envelopes for every native tool.
 - Deduplicate standard text only on exact equality with native output, including text split across blocks. Retain
   differing standard/native text together, reserving bounded space for both tails and the exit note. Accept direct
   map/string content as well as lists, matching existing shared ACP handling. Preserve original non-text content entries,
@@ -37,6 +38,11 @@ credential access or history mutation.
   image data/blob/data-image URI copies and formatted output identical to combined output; retain useful metadata.
   Sanitized-away fields cannot reappear from merging the original envelope. Standard content attachments remain
   governed by ACP's existing separate limits rather than the raw-payload budget.
+- Native `invoke_subagent` and its nested work remain ordinary parent-local ACP tool calls. The pinned runtime exposes
+  no child session ID, child lifecycle extension, background discriminator, or child cancellation method through ACP.
+  Its live invocation status and replayed status also disagree. Sesori therefore does not reinterpret these calls as
+  subtask parts, child sessions, descendant busy state, or scoped-stop targets. Call order, prompt-bearing raw input,
+  assistant claims, and replay completion are not lifecycle authority.
 - Malformed native aliases degrade to bounded raw data with an original error/stack log, not invented command policy.
   Generated envelope decoding failures log and retain existing ACP handling. Malformed known content blocks log and
   preserve their original entries for the shared mapper's bounded degradation, rather than aborting live/replay.
@@ -49,7 +55,9 @@ credential access or history mutation.
   failure, a genuine tool failure becoming success, or differing live/replay output is a regression. Overlapping or
   repeated/legacy text remains best-effort within the display cap; do not mistake cosmetic repetition for lost output.
 - Lost supported standard images, retained redundant raw image bytes, original fields reappearing after sanitation,
-  caller-envelope mutation, or unbounded raw metadata indicates normalization regression.
+  caller-envelope mutation, or unbounded raw metadata indicates normalization regression. So does promoting an
+  Antigravity `invoke_subagent` call into a subtask or child from generic parent-local facts without a new authoritative
+  upstream identity and lifecycle seam.
 - `antigravity_protocol_mapper_updates_test.dart`: 24 tests cover exact aliases, identity, live/replay equality,
   nonzero/empty/success/failure output with and without standard content, update-only replay, tail/note bounds, valid
   inline images and retained metadata, raw-copy removal, aggregate budgets and observable malformed-native fallback;
@@ -57,5 +65,8 @@ credential access or history mutation.
   preservation without duplication, and exit-only terminal updates retaining earlier output.
 - `acp_session_loader_test.dart`, `acp_tool_content_integration_test.dart`, and `acp_history_replay_test.dart` exercise
   standard identity behavior and production replay; DeepSeek history/time tests cover its direct collector path.
-- Owning ACP/Antigravity and changed DeepSeek analyses are the static boundary. Authenticated native sessions, real
-  Google-generated images and the full L5 integration matrix remain unverified.
+- Owning ACP/Antigravity and changed DeepSeek analyses are the static boundary. One bounded authenticated native probe
+  on 2026-09-12 verified only Antigravity's generic sub-agent wire projection and replay mismatch; it changed no
+  production runtime or code state. This documentation records the resulting support-boundary decision. Real
+  Google-generated images, ordinary end-to-end sessions, and the full L5 integration matrix remain unverified. See the
+  [privacy-safe probe record](../../.plan/completed/claude-inline-subtasks/followups/antigravity-probe.md).

--- a/docs/regression/session-history-and-recovery.md
+++ b/docs/regression/session-history-and-recovery.md
@@ -378,8 +378,9 @@ rules where supported.
   discovery can also still start a stopped backend.
 - Client session-detail refresh triggers are still under diagnosis; only the
   diagnostic logging is in place and any refresh correction is unfinished.
-- Antigravity's native personal-authenticated history, cold bridge restart, retained-history import/tombstone behavior,
-  and cross-target pairs remain unverified.
+- Antigravity's native personal-authenticated history beyond the bounded 2026-09-12 ACP sub-agent replay probe, cold
+  bridge restart, retained-history import/tombstone behavior, and cross-target pairs remain unverified. That probe found
+  contradictory generic live/replay invocation status and no child history seam; it is not bridge-history coverage.
 - The final DeepSeek phone gate did not cold-reload a root or child, open a
   read-only child transcript, restart the bridge/plugin, or test reconnect
   convergence. Existing package tests remain the evidence for replay identity

--- a/docs/regression/session-turns.md
+++ b/docs/regression/session-turns.md
@@ -767,8 +767,9 @@ and require authoritative lifecycle plus plugin settlement before claiming pass.
   shape. Cold replay therefore shows only the slash-command token to avoid
   exposing bridge-owned arguments; live API-command presentation retains only
   the exact user-authored arguments.
-- Antigravity native turn behavior, personal OAuth and cross-target reconnect remain unverified; synthetic ACP
-  composition does not substitute for them.
+- Beyond the bounded 2026-09-12 authenticated ACP sub-agent projection probe, Antigravity native turn behavior,
+  personal OAuth and cross-target reconnect remain unverified; synthetic ACP composition does not substitute for them.
+  The probe establishes no inline-subtask, child-session, descendant-lifecycle, or scoped-stop support.
 - Grok does not advertise ACP image prompt capability in the supported release;
   image attachments are not Grok turn coverage.
 - Copilot reasoning is model/account dependent; absence is not a failure unless

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -118,6 +118,9 @@ sub-agent parts, plus the signal that a tool changed files.
   shared ACP live or replay mapper retains tool state. Raw provider payloads and canonical output are independently
   bounded; local image paths remain metadata and are never read. Exact duplicate text is removed, differing standard
   and provider text is retained within the shared display cap, and a nonzero exit note never changes ACP tool status.
+  Native `invoke_subagent` activity remains generic: the official ACP seam supplies no child identity or authoritative
+  lifecycle, and its live terminal status conflicts with replay. Sesori does not manufacture a tile, child transcript,
+  descendant busy state, or scoped-stop target from prompt-bearing input, call order, or assistant output.
 - GitHub Copilot uses the same standard ACP tool lifecycle. Permission linkage
   must be exact while the request is live. Call identity, terminal state, and
   diff content then converge after `session/load`; permission
@@ -186,8 +189,9 @@ guarantee.
   generic Task running; live/replay tagged sub-agent shapes are conflated; or
   either exact known shape fails replacement.
 - Antigravity changes ACP status from an exit code, loses an exit note to truncation, leaks an image path as a fetched
-  attachment, retains unbounded/redundant raw fields, drops differing text, or
-  produces different live/replay tool state.
+  attachment, retains unbounded/redundant raw fields, drops differing text, or produces different normalized state from
+  equivalent live/replay source envelopes. Its upstream `invoke_subagent` status mismatch is retained as generic data;
+  promoting that call into a child or subtask without a new authoritative seam is also a regression.
 - A Copilot tool loses permission correlation while live, or its call identity,
   terminal status, or diff changes when reopened through ACP history.
 - A Grok tool loses live permission correlation, changes call identity or status
@@ -227,8 +231,10 @@ guarantee.
 - ACP permission decisions and pending requests are process-local interaction
   state. Cold replay restores the resulting tool lifecycle and diff, not the
   earlier decision or its linkage event.
-- Real Antigravity tool execution and generated-image output remain unverified; synthetic normalization
-  establishes the boundary contract only.
+- Real Antigravity file/shell execution and generated-image output remain unverified; synthetic normalization
+  establishes those boundary contracts only. A bounded authenticated 2026-09-12 probe verified native internal
+  delegation but found only contradictory generic parent-local ACP tool records, so Antigravity inline subtasks and
+  child sessions remain unsupported in Sesori.
 - Attachment presentation is being reworked toward referenced images; only the
   shipped build counts.
 - An older client does not tolerate an unknown message-part `type` from a newer


### PR DESCRIPTION
## Complexity

🌱 Trivial — documentation and bounded verification evidence only; no production code or contract change.

## What

- Adds Antigravity to the inline-subtask capability matrix.
- Records a bounded authenticated probe against official managed package `1.0.0` / runtime `agy_acp_server_20260818_01_RC01`.
- Distinguishes native internal delegation from capabilities Sesori can safely expose through ACP.
- Reconciles the completed `claude-inline-subtasks` plan, tracker, follow-up record, operator guide, and affected regression documents.
- Corrects stale completed-plan wording for Grok notification evidence, merged Cursor PR state, and completed DeepSeek stop slices.

## Why

Antigravity was registered after the inline-subtask rollout was retired, so the completed plan had no Antigravity disposition. Live probing showed native `invoke_subagent` activity, but only generic parent-local ACP tools: no child identity/session/lifecycle, no child-scoped replay or cancellation authority, and contradictory live versus replay invocation status. Inferring a tile or child from those facts would be unreliable.

## Risk and test focus

Low risk. No user-visible runtime behavior, database, wire, authentication, model, approval-policy, runtime-pin, or configuration impact. Review focus is documentation accuracy, unsupported-versus-unverified wording, privacy boundaries, and completed-plan consistency.

Probe used the existing isolated authenticated profile with user authorization. Token contents were not read or copied. Only warning-free `allow_once` choices were selected. Owned local session/database files, scratch work, scripts, and probe processes were removed; unrelated runtime/profile and existing bridge processes remained untouched. Accepted Google-side conversation residue may remain.

## Expected result

Capability matrix states that Antigravity can delegate internally but Sesori does not expose inline subtask tiles, child transcripts, descendant lifecycle, or sub-agent-scoped stop from the current official ACP seam. Standard root replay and turn-wide cancellation remain documented. Completed plan stays retired with this gap classified as intentionally unsupported, not unfinished implementation.

## Verification

- Two bounded deterministic root turns returned `end_turn` with expected results after native sub-agent-labelled activity.
- `session/list` added only the root; all notifications used the root ID.
- Live invocation reported `pending` → `failed`; `session/load` replay reported `completed` with string-encoded input and blank output.
- Relative-link validation: pass.
- Sub-agent matrix column-count and footnote validation: pass.
- Sensitive-pattern and stale active-plan reference checks: pass.
- `git diff --cached --check`: pass.
- Independent read-only correctness review findings applied.
- Dart/Flutter suites not run: documentation-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records Antigravity's official ACP seam disposition after a bounded probe, so the completed inline-subtask plan and capability matrix now classify its Sesori subtask features as unsupported.

- Adds an Antigravity column to the sub-agent capability matrix with tiles, child sessions, lifecycle, and scoped stop marked unsupported.
- Adds a privacy-safe probe record and updates the completed plan, tracker, follow-up, and regression docs.
- Corrects stale completed-plan wording for Grok notifications, Cursor PR state, and DeepSeek stop slices.
- Notes that Antigravity can delegate internally, but ACP exposes only generic parent-local calls, and live and replay invocation status disagree.
- No production code, runtime, wire, or configuration changes.

<sup>Written for commit 9181863431f7a017bfb1766fc5158c839650e804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

