### PR TITLE
🌱 Keep the ask-question answer indicator level with the typed answer

### DIFF
--- a/client/module_app_ui/lib/src/features/session_detail/widgets/question_modal.dart
+++ b/client/module_app_ui/lib/src/features/session_detail/widgets/question_modal.dart
@@ -904,10 +904,9 @@ class const _CustomAnswerTile({
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       onTap: onTap,
       child: Row(
-        // The field centres its text inside the decoration box, so the
-        // indicator must centre with the field too: a fixed top offset drifts
-        // away from the answer text as that box changes height (it is 28pt in
-        // the dense desktop layout and 40pt on Android).
+        // The indicator stays level with the first answer line rather than the
+        // whole field, so a wrapped answer never drags it down the tile.
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Icon(
             key: const Key("custom-answer-toggle"),
@@ -926,8 +925,10 @@ class const _CustomAnswerTile({
               decoration: InputDecoration(
                 hintText: loc.questionModalCustomHint,
                 border: InputBorder.none,
-                isDense: true,
-                contentPadding: const EdgeInsets.symmetric(vertical: 8),
+                // Collapsed rather than dense: a dense field centres its text
+                // inside a decoration box sized by the platform's visual
+                // density, which left the indicator below the typed answer.
+                isCollapsed: true,
               ),
             ),
           ),

--- a/client/module_app_ui/lib/src/features/session_detail/widgets/question_modal.dart
+++ b/client/module_app_ui/lib/src/features/session_detail/widgets/question_modal.dart
@@ -904,17 +904,17 @@ class const _CustomAnswerTile({
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       onTap: onTap,
       child: Row(
-        crossAxisAlignment: .start,
+        // The field centres its text inside the decoration box, so the
+        // indicator must centre with the field too: a fixed top offset drifts
+        // away from the answer text as that box changes height (it is 28pt in
+        // the dense desktop layout and 40pt on Android).
         children: [
-          Padding(
+          Icon(
             key: const Key("custom-answer-toggle"),
-            padding: const EdgeInsetsDirectional.only(top: 10),
-            child: Icon(
-              isMultiple
-                  ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
-                  : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
-              color: isSelected ? prego.colors.bgBrandSolid : prego.colors.borderPrimary,
-            ),
+            isMultiple
+                ? (isSelected ? Icons.check_box : Icons.check_box_outline_blank)
+                : (isSelected ? Icons.radio_button_checked : Icons.radio_button_unchecked),
+            color: isSelected ? prego.colors.bgBrandSolid : prego.colors.borderPrimary,
           ),
           const SizedBox(width: 12),
           Expanded(

--- a/client/module_app_ui/test/features/session_detail/widgets/question_modal_test.dart
+++ b/client/module_app_ui/test/features/session_detail/widgets/question_modal_test.dart
@@ -905,4 +905,34 @@ void main() {
     expect(capture.rejectedRequestId, "question-1");
     expect(find.byType(PregoBottomSheet), findsNothing);
   });
+
+  testWidgets("custom answer keeps its indicator level with the typed answer", (tester) async {
+    final capture = _ReplyCapture();
+    final router = _createRouter(
+      question: _questionAsked(
+        questions: const [
+          QuestionInfo(
+            question: "Split the work across worktrees?",
+            header: "Worktrees",
+            custom: true,
+            options: [],
+          ),
+        ],
+      ),
+      capture: capture,
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(_buildApp(router: router));
+    await _openQuestionModal(tester);
+
+    await tester.enterText(find.byType(TextField), "For the server");
+    await tester.pump();
+
+    // The field centres its text in the decoration box, so the indicator must
+    // stay centred on that box rather than on a fixed top offset.
+    final indicatorCenter = tester.getCenter(find.byKey(const Key("custom-answer-toggle")));
+    final fieldCenter = tester.getCenter(find.byType(TextField));
+    expect(indicatorCenter.dy, moreOrLessEquals(fieldCenter.dy, epsilon: 1));
+  });
 }

--- a/client/module_app_ui/test/features/session_detail/widgets/question_modal_test.dart
+++ b/client/module_app_ui/test/features/session_detail/widgets/question_modal_test.dart
@@ -906,7 +906,7 @@ void main() {
     expect(find.byType(PregoBottomSheet), findsNothing);
   });
 
-  testWidgets("custom answer keeps its indicator level with the typed answer", (tester) async {
+  testWidgets("custom answer keeps its indicator level with the first answer line", (tester) async {
     final capture = _ReplyCapture();
     final router = _createRouter(
       question: _questionAsked(
@@ -926,13 +926,21 @@ void main() {
     await tester.pumpWidget(_buildApp(router: router));
     await _openQuestionModal(tester);
 
+    double indicatorTop() => tester.getTopLeft(find.byKey(const Key("custom-answer-toggle"))).dy;
+    double answerTop() => tester.getTopLeft(find.byType(TextField)).dy;
+
     await tester.enterText(find.byType(TextField), "For the server");
     await tester.pump();
+    expect(indicatorTop(), moreOrLessEquals(answerTop(), epsilon: 1));
 
-    // The field centres its text in the decoration box, so the indicator must
-    // stay centred on that box rather than on a fixed top offset.
-    final indicatorCenter = tester.getCenter(find.byKey(const Key("custom-answer-toggle")));
-    final fieldCenter = tester.getCenter(find.byType(TextField));
-    expect(indicatorCenter.dy, moreOrLessEquals(fieldCenter.dy, epsilon: 1));
+    // A wrapped answer must keep the indicator on its first line instead of
+    // centring it against the whole field.
+    await tester.enterText(
+      find.byType(TextField),
+      "Create the relay worktree first, then the auth-server one, and keep the bridge worktree untouched.",
+    );
+    await tester.pump();
+    expect(tester.getSize(find.byType(TextField)).height, greaterThan(20));
+    expect(indicatorTop(), moreOrLessEquals(answerTop(), epsilon: 1));
   });
 }


### PR DESCRIPTION
## Complexity
🌱 Trivial — a small layout change in one row of the shared question sheet plus a regression test.

## What
The free-form answer row of the ask-questions bottom sheet (`_CustomAnswerTile`
in `question_modal.dart`) keeps its radio/checkbox indicator level with the
**first answer line**:

- the row top-aligns the indicator (`crossAxisAlignment: start`) instead of
  pushing it down with a hardcoded `top: 10` offset;
- the answer field is `isCollapsed` instead of `isDense` with vertical content
  padding, so its first line starts at the top of the row rather than centring
  inside a decoration box;
- `custom-answer-toggle` now sits on the icon itself.

## Why
The reported prompt showed the radio sitting visibly lower than the typed
answer ("For the server"). A dense field centres its text inside a decoration
box sized by the platform's visual density (28pt on macOS, 36pt on Android), so
no fixed offset can stay level — and centring the indicator against that box
drifts off the first line once the answer wraps (the field allows five lines).

Measured on macOS against the production theme and fonts (indicator ink centre
minus the first answer line's ink centre):

| layout | single-line answer | wrapped answer |
|---|---|---|
| before | +7.8pt | ~+8pt |
| centre the indicator | -0.5pt | +8pt (drifts) |
| **this PR** | **+1.5pt** | **+1.5pt** |

## Risk and test focus
- Layout-only change to one row inside the shared question sheet. The row is
  also shorter, because the field no longer reserves its dense padding: 48pt for
  a single-line answer, matching the option tiles.
- No behaviour, wire, persisted-state, or analytics change. Submission, focus,
  and selection semantics are untouched; tapping anywhere on the tile still
  focuses the answer field, so the smaller field box costs no tap target.
- The regression test types a single-line and then a wrapped answer and asserts
  the indicator starts level with the field's first line (≤1pt). It fails on the
  old layout, and on a centre-only layout once the answer wraps (8pt off).
- `flutter test` in `client/module_app_ui` (361 tests), `client/app`
  session-detail shell tests (114 tests), and `dart analyze` on the touched
  module all pass.

## Expected result
The indicator sits level with the first line of the typed answer on mobile and
desktop, and stays there as the answer wraps.
