### PR TITLE
🌿 Restore ordinary tool titles on chat cards

### DIFF
--- a/bridge/app/lib/src/repositories/mappers/plugin_to_shared_mapping.dart
+++ b/bridge/app/lib/src/repositories/mappers/plugin_to_shared_mapping.dart
@@ -78,7 +78,10 @@ extension PluginToolStateMapping on PluginToolState {
     final isShellCommand = boundedShellCommand != null;
     return ToolState(
       status: status.toShared(),
-      title: retainSummary ? _boundedToolText(text: title) : boundedShellCommand,
+      // The command is the released title alias for older clients; ordinary
+      // tools keep their bounded title (file path, pattern, skill) so the card
+      // says what the tool touched even though its output is stripped.
+      title: boundedShellCommand ?? _boundedToolText(text: title),
       shellCommand: boundedShellCommand,
       output: isShellCommand || retainSummary ? _boundedToolText(text: output) : null,
       error: isShellCommand || retainSummary ? _boundedToolText(text: error) : null,

--- a/bridge/app/test/bridge/acp_tool_projection_test.dart
+++ b/bridge/app/test/bridge/acp_tool_projection_test.dart
@@ -186,7 +186,8 @@ void main() {
           ],
         );
         expect(state.shellCommand, isNull);
-        expect(state.title, isNull);
+        // The agent's title stays a display label; it never becomes a command.
+        expect(state.title, evidence["title"]);
         expect(state.output, isNull);
         expect(state.error, isNull);
         expect(state.status, ToolStatus.error);

--- a/bridge/app/test/bridge/backend_tool_projection_test.dart
+++ b/bridge/app/test/bridge/backend_tool_projection_test.dart
@@ -63,7 +63,7 @@ void main() {
     for (final shell in [false, true]) {
       test("Claude backend content live tracker/history projection shell=$shell failed=$failed", () {
         final name = shell ? "Bash" : "Read";
-        final input = {"command": "pwd"};
+        final input = {"command": "pwd", "file_path": "lib/main.dart"};
         final content = {"type": "tool_use", "id": "c", "name": name, "input": input};
         final blocks = const ClaudeContentMapper().map(content: content);
         final block = blocks.single as ClaudeMappedToolUseContentBlock;
@@ -145,6 +145,7 @@ void main() {
         final state = _state(part: live);
         expect(state, _state(part: history));
         expect(state.shellCommand, shell ? "pwd" : null);
+        expect(state.title, shell ? "pwd" : "lib/main.dart");
         expect(state.output, shell && !failed ? "result" : null);
         expect(state.error, shell && failed ? "result" : null);
         expect(state.status, failed ? ToolStatus.error : ToolStatus.completed);
@@ -163,7 +164,7 @@ void main() {
               "type": "toolCall",
               "id": "c",
               "name": name,
-              "arguments": {"command": "pwd"},
+              "arguments": {"command": "pwd", "path": "lib/main.dart"},
             },
           ],
         };
@@ -232,6 +233,7 @@ void main() {
         final state = _state(part: live);
         expect(state, _state(part: replay));
         expect(state.shellCommand, shell ? "pwd" : null);
+        expect(state.title, shell ? "pwd" : "lib/main.dart");
         expect(state.output, shell && !failed ? "result" : null);
         expect(state.error, shell && failed ? "result" : null);
         expect(state.status, failed ? ToolStatus.error : ToolStatus.completed);
@@ -257,7 +259,16 @@ void main() {
         // Both SSE and REST use the owning generated ToolPart and MessagePartMapper.
         final state = _state(part: const MessagePartMapper().mapPart(ToolPart.fromJson(raw)));
         expect(state.shellCommand, shell ? "pwd" : null);
-        expect(state.title, shell ? "pwd" : null);
+        // OpenCode's own title is display data; only the command is authority.
+        // Its error state carries no title, so a failed ordinary tool has none.
+        expect(
+          state.title,
+          shell
+              ? "pwd"
+              : failed
+              ? null
+              : "not authority",
+        );
         expect(state.output, shell && !failed ? "result" : null);
         expect(state.error, shell && failed ? "result" : null);
         expect(state.status, failed ? ToolStatus.error : ToolStatus.completed);

--- a/bridge/app/test/bridge/codex_tool_projection_test.dart
+++ b/bridge/app/test/bridge/codex_tool_projection_test.dart
@@ -73,7 +73,8 @@ void main() {
             ),
           );
           expect(state.shellCommand, fixture.command);
-          expect(state.title, fixture.command);
+          // Non-command inputs keep Codex's argument-derived display title.
+          expect(state.title, fixture.command ?? isNotNull);
           if (line == lines.last) {
             expect(state.status, failed ? ToolStatus.error : ToolStatus.completed);
             if (fixture.command != null) {

--- a/bridge/app/test/bridge/plugin_to_shared_mapping_test.dart
+++ b/bridge/app/test/bridge/plugin_to_shared_mapping_test.dart
@@ -273,10 +273,10 @@ void main() {
       expect(ToolState.fromJson(legacy).title, state.state.shellCommand);
       expect(ToolState.fromJson(legacy).shellCommand, isNull);
     });
-    test("strips non-shell title and output while preserving status and attachments", () {
+    test("strips non-shell output while preserving title, status and attachments", () {
       const state = PluginToolState(
         status: PluginToolStatus.completed,
-        title: "Read file",
+        title: "lib/main.dart",
         shellCommand: null,
         output: "contents",
         error: null,
@@ -288,7 +288,7 @@ void main() {
       final shared = state.toShared(retainSummary: false);
 
       expect(shared.status, equals(ToolStatus.completed));
-      expect(shared.title, isNull);
+      expect(shared.title, equals("lib/main.dart"));
       expect(shared.shellCommand, isNull);
       expect(shared.output, isNull);
       expect(shared.error, isNull);

--- a/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/claude_history_mapper.dart
@@ -246,7 +246,7 @@ final class const ClaudeHistoryMapper({
       if (part case PluginMessagePartTool(:final state) when state.status != PluginToolStatus.pending) {
         if (parts[existingIndex] case final PluginMessagePartTool existing) {
           parts[existingIndex] = existing.copyWith(
-            state: state.copyWith(shellCommand: existing.state.shellCommand),
+            state: state.copyWith(title: existing.state.title, shellCommand: existing.state.shellCommand),
           );
         }
       }

--- a/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_content_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_content_mapper.dart
@@ -12,6 +12,7 @@ import "package:sesori_shared/sesori_shared.dart"
 import "../../api/models/claude_content_block_dto.dart";
 import "../../models/claude_task_notification.dart";
 import "claude_shell_command_mapper.dart";
+import "claude_tool_title_mapper.dart";
 
 sealed class const ClaudeMappedContentBlock();
 
@@ -304,7 +305,7 @@ final class const ClaudeContentMapper() {
         tool: name,
         state: PluginToolState(
           status: PluginToolStatus.pending,
-          title: null,
+          title: ClaudeToolTitleMapper.map(input: input),
           shellCommand: ClaudeShellCommandMapper.map(name: name, input: input),
           output: null,
           error: null,

--- a/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_tool_title_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_tool_title_mapper.dart
@@ -1,9 +1,9 @@
 /// Extracts the primary argument of a Claude tool input as the card title:
-/// the skill name, the file path of Read/Write/Edit, the Grep/Glob pattern,
-/// or the WebFetch/WebSearch target. Bash keeps its command through
-/// [ClaudeShellCommandMapper] and the projection uses it as the title.
+/// the skill name, the file path of Read/Write/Edit/NotebookEdit, the
+/// Grep/Glob pattern, or the WebFetch/WebSearch target. Bash keeps its command
+/// through [ClaudeShellCommandMapper] and the projection uses it as the title.
 abstract final class ClaudeToolTitleMapper() {
-  static const _keys = ["skill", "file_path", "pattern", "path", "url", "query"];
+  static const _keys = ["skill", "file_path", "notebook_path", "pattern", "path", "url", "query"];
 
   static String? map({required Object? input}) {
     if (input is! Map) return null;

--- a/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_tool_title_mapper.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/mappers/claude_tool_title_mapper.dart
@@ -1,0 +1,16 @@
+/// Extracts the primary argument of a Claude tool input as the card title:
+/// the skill name, the file path of Read/Write/Edit, the Grep/Glob pattern,
+/// or the WebFetch/WebSearch target. Bash keeps its command through
+/// [ClaudeShellCommandMapper] and the projection uses it as the title.
+abstract final class ClaudeToolTitleMapper() {
+  static const _keys = ["skill", "file_path", "pattern", "path", "url", "query"];
+
+  static String? map({required Object? input}) {
+    if (input is! Map) return null;
+    for (final key in _keys) {
+      final value = input[key];
+      if (value is String && value.isNotEmpty) return value;
+    }
+    return null;
+  }
+}

--- a/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
+++ b/bridge/sesori_plugin_claude/lib/src/repositories/trackers/claude_tool_tracker.dart
@@ -6,6 +6,7 @@ import "../../models/claude_task_status.dart";
 import "../../models/claude_tool_use_result.dart";
 import "../mappers/claude_shell_command_mapper.dart";
 import "../mappers/claude_task_status_mapping.dart";
+import "../mappers/claude_tool_title_mapper.dart";
 
 /// An immutable presentation snapshot of one Claude tool call.
 sealed class const ClaudeTrackedTool({
@@ -413,7 +414,7 @@ final class _TrackedTool({
   ClaudeTrackedTool snapshot({required bool sessionDiffRequired, bool todoRefreshRequired = false}) {
     final state = PluginToolState(
       status: status,
-      title: null,
+      title: ClaudeToolTitleMapper.map(input: input),
       shellCommand: ClaudeShellCommandMapper.map(name: name, input: input),
       output: output,
       error: error,

--- a/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
+++ b/bridge/sesori_plugin_pi/lib/src/repositories/mappers/pi_history_mapper.dart
@@ -86,6 +86,19 @@ final class PiHistoryMapper({
     return command is String && command.isNotEmpty ? _clip(command) : null;
   }
 
+  /// The primary argument shown as the card title: the search pattern of
+  /// grep/find-style tools, otherwise the path of read/write/edit/ls. Skills
+  /// load through `read` on their SKILL.md, so the path names the skill too.
+  String? titleForToolCall({required PiToolCallContentDto toolCall}) {
+    final arguments = toolCall.arguments;
+    if (arguments is! Map) return null;
+    for (final key in const ["pattern", "path"]) {
+      final value = arguments[key];
+      if (value is String && value.isNotEmpty) return _clip(value);
+    }
+    return null;
+  }
+
   PluginMessageWithParts mapAssistantMessage({
     required String sessionId,
     required String messageId,
@@ -178,7 +191,7 @@ final class PiHistoryMapper({
               tool: toolCall.name,
               state: PluginToolState(
                 status: PluginToolStatus.pending,
-                title: null,
+                title: titleForToolCall(toolCall: toolCall),
                 shellCommand: shellCommandForToolCall(toolCall: toolCall),
                 output: null,
                 error: null,

--- a/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
+++ b/bridge/sesori_plugin_pi/lib/src/services/pi_event_dispatcher.dart
@@ -263,6 +263,7 @@ final class PiEventDispatcher({
         messageId: messageId,
         toolId: part.id,
         name: part.tool ?? "tool",
+        title: part.state.title,
         shellCommand: part.state.shellCommand,
       );
       if (tracked == null) {
@@ -482,6 +483,7 @@ final class PiEventDispatcher({
       contentIndex: contentIndex,
       toolId: toolId,
       toolName: toolName,
+      title: null,
       shellCommand: null,
     );
   }
@@ -502,6 +504,7 @@ final class PiEventDispatcher({
       contentIndex: contentIndex,
       toolId: decoded.id,
       toolName: decoded.name,
+      title: _historyMapper.titleForToolCall(toolCall: decoded),
       shellCommand: _historyMapper.shellCommandForToolCall(toolCall: decoded),
     );
   }
@@ -512,6 +515,7 @@ final class PiEventDispatcher({
     required int contentIndex,
     required String toolId,
     required String toolName,
+    required String? title,
     required String? shellCommand,
   }) {
     final messageId = state.messageId;
@@ -521,6 +525,7 @@ final class PiEventDispatcher({
       messageId: messageId,
       toolId: toolId,
       name: toolName,
+      title: title,
       shellCommand: shellCommand,
     );
     // The content index identifies the streamed block. Prefer it over the

--- a/bridge/sesori_plugin_pi/lib/src/trackers/pi_tool_tracker.dart
+++ b/bridge/sesori_plugin_pi/lib/src/trackers/pi_tool_tracker.dart
@@ -16,6 +16,7 @@ final class PiToolTracker() {
     required String messageId,
     required String toolId,
     required String name,
+    required String? title,
     required String? shellCommand,
   }) {
     if (toolId.isEmpty || name.isEmpty) return null;
@@ -26,10 +27,11 @@ final class PiToolTracker() {
     );
     tool
       ..messageId = messageId
-      ..name = name;
-    if (shellCommand != null) {
-      tool.state = tool.state.copyWith(shellCommand: shellCommand);
-    }
+      ..name = name
+      ..state = tool.state.copyWith(
+        title: title ?? tool.state.title,
+        shellCommand: shellCommand ?? tool.state.shellCommand,
+      );
     return tool.snapshot(sessionDiffRequired: false);
   }
 
@@ -42,7 +44,10 @@ final class PiToolTracker() {
     final tool = _sessions[sessionId]?[toolId];
     if (tool == null || tool.isTerminal) return null;
     if (name != null && name.isNotEmpty) tool.name = name;
-    tool.state = state.copyWith(shellCommand: state.shellCommand ?? tool.state.shellCommand);
+    tool.state = state.copyWith(
+      title: state.title ?? tool.state.title,
+      shellCommand: state.shellCommand ?? tool.state.shellCommand,
+    );
     return tool.snapshot(sessionDiffRequired: false);
   }
 
@@ -55,7 +60,10 @@ final class PiToolTracker() {
     final tool = _sessions[sessionId]?[toolId];
     if (tool == null || tool.isTerminal) return null;
     if (name != null && name.isNotEmpty) tool.name = name;
-    tool.state = state.copyWith(shellCommand: state.shellCommand ?? tool.state.shellCommand);
+    tool.state = state.copyWith(
+      title: state.title ?? tool.state.title,
+      shellCommand: state.shellCommand ?? tool.state.shellCommand,
+    );
     final diff = tool.isEdit && !tool.diffEmitted;
     if (diff) tool.diffEmitted = true;
     return tool.snapshot(sessionDiffRequired: diff);

--- a/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
+++ b/bridge/sesori_plugin_pi/test/pi_event_dispatcher_test.dart
@@ -549,6 +549,44 @@ void main() {
     expect(state.output, " M file.dart");
   });
 
+  test("streamed read carries its path as the title once arguments arrive", () {
+    const path = ".agents/skills/sesori-plan-worker/SKILL.md";
+    dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_start", {"message": _assistant(content: const [], timestamp: 101)}),
+    );
+    final started = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_update", {
+        "assistantMessageEvent": {"type": "toolcall_start", "contentIndex": 0, "id": "call-1", "toolName": "read"},
+      }),
+    );
+    expect(started.whereType<BridgeSseMessagePartUpdated>().single.part.state.title, isNull);
+
+    dispatcher.map(
+      sessionId: sessionId,
+      event: _event("message_update", {
+        "assistantMessageEvent": {
+          "type": "toolcall_end",
+          "contentIndex": 0,
+          "toolCall": {
+            "id": "call-1",
+            "name": "read",
+            "arguments": {"path": path},
+          },
+        },
+      }),
+    );
+    final running = dispatcher.map(
+      sessionId: sessionId,
+      event: _event("tool_execution_start", {"toolCallId": "call-1", "toolName": "read"}),
+    );
+    final runningState = running.whereType<BridgeSseMessagePartUpdated>().single.part.state;
+    expect(runningState.status, PluginToolStatus.running);
+    expect(runningState.title, path);
+    expect(runningState.shellCommand, isNull);
+  });
+
   test("malformed tool results are omitted without ending the turn", () {
     final message = _assistant(
       content: [

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -54,7 +54,7 @@ harnesses without a dedicated skill tool, so the read path is the skill signal.
 
 | Harness | Status and title source |
 |---|---|
-| Claude | ✅ Tool input `skill`, `file_path`, `pattern`, `path`, `url`, or `query`, first present; live tracker and transcript replay. |
+| Claude | ✅ Tool input `skill`, `file_path`, `notebook_path`, `pattern`, `path`, `url`, or `query`, first present; live tracker and transcript replay. |
 | Pi | ✅ Tool-call arguments `pattern`, then `path`; live from `toolcall_end`/`message_end` and replay. `toolcall_start` carries no arguments, so the title first appears with the running or terminal update. |
 | OpenCode | ✅ Native tool part `title`. |
 | Codex | ✅ Argument-derived title (`cmd`, `command`, `path`, `filePath`, `query`, else bounded raw arguments). |

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -20,10 +20,11 @@ describe what Sesori can expose through the official ACP seam, not whether the n
 
 ## Explicit shell-command presentation
 
-Ordinary tools retain name, status and attachments; only adapter-verified shell
-commands retain command/output/error. Subtask outcome/error summaries are separate
-and remain available. All retained tool text is rune-bounded at live/history wire
-projection; the released title alias remains available to older clients.
+Ordinary tools retain name, bounded title, status and attachments; only
+adapter-verified shell commands retain command/output/error. Subtask outcome/error
+summaries are separate and remain available. All retained tool text is
+rune-bounded at live/history wire projection; the released title alias remains
+available to older clients.
 
 | Harness | Status and established command source |
 |---|---|
@@ -43,6 +44,21 @@ property in one real `tools.exec_command` invocation (single/double quotes and
 whitespace accepted). Expressions, multiple commands and other JavaScript forms
 need trustworthy correlated command-execution evidence; raw scripts never become
 commands. No general JavaScript parser or runtime execution is involved.
+
+## Ordinary tool titles
+
+Non-shell tool cards show a bounded title naming what the tool touched (file
+path, search pattern, skill, URL) instead of only the tool name; output and
+errors stay stripped. Skills load through a file read of their `SKILL.md` on
+harnesses without a dedicated skill tool, so the read path is the skill signal.
+
+| Harness | Status and title source |
+|---|---|
+| Claude | ✅ Tool input `skill`, `file_path`, `pattern`, `path`, `url`, or `query`, first present; live tracker and transcript replay. |
+| Pi | ✅ Tool-call arguments `pattern`, then `path`; live from `toolcall_end`/`message_end` and replay. `toolcall_start` carries no arguments, so the title first appears with the running or terminal update. |
+| OpenCode | ✅ Native tool part `title`. |
+| Codex | ✅ Argument-derived title (`cmd`, `command`, `path`, `filePath`, `query`, else bounded raw arguments). |
+| Grok, Antigravity, Copilot, Cursor, OMP, Hermes, DeepSeek | ✅ Agent-supplied ACP `tool_call` title, when the agent sends one; Sesori does not derive titles from ACP inputs. |
 
 ## Managed runtime
 

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -16,7 +16,7 @@ sub-agent parts, plus the signal that a tool changed files.
   output snippets and errors stop at the bridge remapping boundary and never
   enter chat history or live client events.
 - The title is the tool's primary argument: Claude reads it from the tool input
-  (`skill`, `file_path`, `pattern`, `path`, `url`, `query`), Pi from the
+  (`skill`, `file_path`, `notebook_path`, `pattern`, `path`, `url`, `query`), Pi from the
   tool-call arguments (`pattern`, then `path`), Codex from its argument-derived
   title, and OpenCode and ACP harnesses pass the harness-supplied title through.
   Skills that load through a file read of `SKILL.md` are visible by that path.

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -10,10 +10,18 @@ sub-agent parts, plus the signal that a tool changed files.
 
 - Every plugin normalizes backend tool activity into the shared tool part
   contract: stable identity, tool name, lifecycle status (pending, running,
-  completed, error, plus a forward-compatible unknown), and attachments. Shell
-  tools additionally carry the explicit command and its bounded output or error.
-  Ordinary non-shell tool titles, output snippets, and errors stop at the bridge remapping
-  boundary and never enter chat history or live client events.
+  completed, error, plus a forward-compatible unknown), a bounded title naming
+  what the tool touched, and attachments. Shell tools additionally carry the
+  explicit command and its bounded output or error. Ordinary non-shell tool
+  output snippets and errors stop at the bridge remapping boundary and never
+  enter chat history or live client events.
+- The title is the tool's primary argument: Claude reads it from the tool input
+  (`skill`, `file_path`, `pattern`, `path`, `url`, `query`), Pi from the
+  tool-call arguments (`pattern`, then `path`), Codex from its argument-derived
+  title, and OpenCode and ACP harnesses pass the harness-supplied title through.
+  Skills that load through a file read of `SKILL.md` are visible by that path.
+  Pi learns the title at `toolcall_end`, so a card announced by `toolcall_start`
+  shows it from the running or terminal update onward, live and after replay.
 - Plugin and shared message parts are sealed variants, so text, tool, subtask,
   file, agent, and retry data cannot be combined with unrelated part types. The
   shared variants retain the released `type` values and normalize known payloads
@@ -172,7 +180,9 @@ guarantee.
 ## Failure Signals
 
 - Shell output exceeds the bound, truncates mid-character, or differs between
-  live streaming and replay; or non-shell snippets reach the client.
+  live streaming and replay; non-shell snippets reach the client; or a
+  completed read/edit/skill card shows only the tool name without its path,
+  pattern, or skill.
 - A tool stays running after the backend finished, or an error renders as a
   completion.
 - Backend naming or payload shape reaches the client unnormalized, or a local


### PR DESCRIPTION
## Complexity

🌿 Straightforward: one projection rule plus argument-to-title mappers in the Pi and Claude plugins.

## What

- The common bridge projection keeps a bounded `title` for ordinary (non-shell) tool parts again. Output and errors stay stripped; shell tools still use the command as the released title alias.
- Pi derives the title from tool-call arguments (`pattern`, then `path`), live (`toolcall_end`, `message_end`) and on replay; the tracker carries it into running and terminal updates.
- Claude derives the title from tool input (`skill`, `file_path`, `pattern`, `path`, `url`, `query`) in the live tracker and transcript replay.
- OpenCode, Codex and ACP harness titles flow through unchanged.
- `docs/HARNESS_CAPABILITIES.md` gains an "Ordinary tool titles" table; the tools regression document is updated.

## Why

PR #1221 dropped titles together with output. A Pi `read` card then showed only "read": no file path, and no way to see a skill load, which Pi does by reading `SKILL.md`. The client already renders `shellCommand ?? title ?? tool`, so restoring the bounded title is enough.

## Risk and test focus

- Wire shape unchanged; `title` is an already-released field, so older clients simply see titles again. No database impact.
- Shell tools must still show the command as title; ordinary tools show path/pattern; a failed OpenCode tool has no title because its error state carries none; Codex non-command inputs keep their argument-derived title but never a command or output.

## Expected result

Read, edit and grep cards on Pi and Claude show the file path or pattern. Skill loads are visible by their `SKILL.md` path (Pi) or skill name (Claude `Skill` tool). Non-shell output remains absent.

## Verification

- `bridge/app`: projection suites (plugin_to_shared_mapping, backend/acp/codex tool projection, chat history tool finalization, SSE event mapper) pass; `dart analyze --fatal-infos` clean.
- `sesori_plugin_pi`: full suite passes, including a new streamed-read title test; analyzer clean.
- `sesori_plugin_claude`: full suite passes; analyzer clean.
- No real harness was launched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores bounded titles on ordinary (non-shell) tool cards so they show what the tool touched instead of only the tool name; PR #1221 had stripped titles along with output, which hid a Pi `read`'s file path and skill loads (reads of `SKILL.md`). Output and errors stay stripped, and shell tools keep the command as their title.

- Pi derives the title from tool-call arguments (`pattern`, then `path`); `toolcall_start` carries none, so the title first appears with the running or terminal update, live and after replay.
- Claude derives it from tool input (`skill`, `file_path`, `notebook_path`, `pattern`, `path`, `url`, `query`) in the live tracker and transcript replay.
- OpenCode, Codex, and ACP harness titles flow through unchanged; a failed OpenCode tool has no title because its error state carries none.
- Wire shape is unchanged and `title` is an already-released field, so older clients simply see titles again with no database impact.
- `docs/HARNESS_CAPABILITIES.md` gains an "Ordinary tool titles" table and the tools regression doc is updated.

<sup>Written for commit c85e026c19fce742d7e8874bd8aa76d295fb24cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

