### PR TITLE
🌿 Update Flutter and compatible project dependencies

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.47.3-stable
+flutter 3.47.4-stable

--- a/bridge/pubspec.lock
+++ b/bridge/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: fe18c7e37d5acb3b43224fa255281dec007970d6fd01f6d76fcd88ed3777a117
+      sha256: fdcd9f70f9eb80df3bc5ed0fa67280df2595fd481948df8a9ab082e6a40ad04b
       url: "https://pub.dev"
     source: hosted
-    version: "107.0.0"
+    version: "108.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f2dde9e50c23fc95b846b4ef334e98c3ae8c0effd5d2453b02fc9fb3f8939791
+      sha256: a51c769bff3b6dfbe9d60199b8606d808290702a296bef0c26a4ca391d414e46
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.4.0"
   analyzer_buffer:
     dependency: transitive
     description:

--- a/client/app/android/Gemfile.lock
+++ b/client/app/android/Gemfile.lock
@@ -8,8 +8,8 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1285.0)
-    aws-sdk-core (3.255.0)
+    aws-partitions (1.1286.0)
+    aws-sdk-core (3.256.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -18,11 +18,11 @@ GEM
       jmespath (~> 1, >= 1.6.1)
       logger
       rexml (~> 3.4, >= 3.4.2)
-    aws-sdk-kms (1.131.0)
-      aws-sdk-core (~> 3, >= 3.255.0)
+    aws-sdk-kms (1.132.0)
+      aws-sdk-core (~> 3, >= 3.256.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.231.0)
-      aws-sdk-core (~> 3, >= 3.255.0)
+    aws-sdk-s3 (1.232.0)
+      aws-sdk-core (~> 3, >= 3.256.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
@@ -170,7 +170,7 @@ GEM
       reline (>= 0.4.2)
     jmespath (1.6.2)
     json (2.21.2)
-    jwt (3.2.0)
+    jwt (3.3.0)
       base64
     logger (1.7.0)
     mini_magick (4.13.2)
@@ -265,10 +265,10 @@ CHECKSUMS
   artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
   atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
-  aws-partitions (1.1285.0) sha256=db3bdc741ecdd529d9a2e96c2a96ddf32e13e4337bcb10db060d87e93ece2485
-  aws-sdk-core (3.255.0) sha256=2bac7fbc8796e4e2eb8e6a6edebcb880d7023a922af97b15d2a8a26c9283343f
-  aws-sdk-kms (1.131.0) sha256=b60d28045cd93c604142cb691b15c7ddc1e6738c4ee5a90db4f2b91f0ada1d15
-  aws-sdk-s3 (1.231.0) sha256=a9fc98c6f03f0e71c7215d48ff8844d436421df7f9486301d56bdf1f368a3364
+  aws-partitions (1.1286.0) sha256=955672fb6cbeccff69b4566a32147d9b8b899afe59220ca786dc60a798f18950
+  aws-sdk-core (3.256.0) sha256=54680a6818323ad1a977dd2aab88a98f294f11fd603852af53e5718e9ce11a12
+  aws-sdk-kms (1.132.0) sha256=094b0097bb3be9d5c1ac87e971ca7f5aebb746801dfb5f0f576480bf98dca69c
+  aws-sdk-s3 (1.232.0) sha256=3899ee76a776761001a22b0e6992d2f4683e03c08f2399835b8ea32c0bb44ee7
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   babosa (1.0.4) sha256=18dea450f595462ed7cb80595abd76b2e535db8c91b350f6c4b3d73986c5bc99
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
@@ -314,7 +314,7 @@ CHECKSUMS
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
-  jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  jwt (3.3.0) sha256=44cc34fbc341c148233cf66641522b4bce0dfb1ce55e8073f05c56f44f4ee546
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef

--- a/client/app/ios/Gemfile.lock
+++ b/client/app/ios/Gemfile.lock
@@ -23,8 +23,8 @@ GEM
     artifactory (3.0.17)
     atomos (0.1.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1285.0)
-    aws-sdk-core (3.255.0)
+    aws-partitions (1.1286.0)
+    aws-sdk-core (3.256.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -33,11 +33,11 @@ GEM
       jmespath (~> 1, >= 1.6.1)
       logger
       rexml (~> 3.4, >= 3.4.2)
-    aws-sdk-kms (1.131.0)
-      aws-sdk-core (~> 3, >= 3.255.0)
+    aws-sdk-kms (1.132.0)
+      aws-sdk-core (~> 3, >= 3.256.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.231.0)
-      aws-sdk-core (~> 3, >= 3.255.0)
+    aws-sdk-s3 (1.232.0)
+      aws-sdk-core (~> 3, >= 3.256.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
@@ -237,7 +237,7 @@ GEM
       reline (>= 0.4.2)
     jmespath (1.6.2)
     json (2.21.2)
-    jwt (3.2.0)
+    jwt (3.3.0)
       base64
     logger (1.7.0)
     mini_magick (4.13.2)
@@ -346,10 +346,10 @@ CHECKSUMS
   artifactory (3.0.17) sha256=3023d5c964c31674090d655a516f38ca75665c15084140c08b7f2841131af263
   atomos (0.1.3) sha256=7d43b22f2454a36bace5532d30785b06de3711399cb1c6bf932573eda536789f
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
-  aws-partitions (1.1285.0) sha256=db3bdc741ecdd529d9a2e96c2a96ddf32e13e4337bcb10db060d87e93ece2485
-  aws-sdk-core (3.255.0) sha256=2bac7fbc8796e4e2eb8e6a6edebcb880d7023a922af97b15d2a8a26c9283343f
-  aws-sdk-kms (1.131.0) sha256=b60d28045cd93c604142cb691b15c7ddc1e6738c4ee5a90db4f2b91f0ada1d15
-  aws-sdk-s3 (1.231.0) sha256=a9fc98c6f03f0e71c7215d48ff8844d436421df7f9486301d56bdf1f368a3364
+  aws-partitions (1.1286.0) sha256=955672fb6cbeccff69b4566a32147d9b8b899afe59220ca786dc60a798f18950
+  aws-sdk-core (3.256.0) sha256=54680a6818323ad1a977dd2aab88a98f294f11fd603852af53e5718e9ce11a12
+  aws-sdk-kms (1.132.0) sha256=094b0097bb3be9d5c1ac87e971ca7f5aebb746801dfb5f0f576480bf98dca69c
+  aws-sdk-s3 (1.232.0) sha256=3899ee76a776761001a22b0e6992d2f4683e03c08f2399835b8ea32c0bb44ee7
   aws-sigv4 (1.12.1) sha256=6973ff95cb0fd0dc58ba26e90e9510a2219525d07620c8babeb70ef831826c00
   babosa (1.0.4) sha256=18dea450f595462ed7cb80595abd76b2e535db8c91b350f6c4b3d73986c5bc99
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
@@ -414,7 +414,7 @@ CHECKSUMS
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
-  jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  jwt (3.3.0) sha256=44cc34fbc341c148233cf66641522b4bce0dfb1ce55e8073f05c56f44f4ee546
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef

--- a/client/app/pubspec.yaml
+++ b/client/app/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   material_ui: ^1.2.0
   cupertino_ui: ^1.0.2
 
-  liquid_glass_widgets: ^1.4.3
+  liquid_glass_widgets: ^1.4.4
   http: ^1.6.0
   freezed_annotation: ^3.1.0
   rxdart: ^0.28.0
@@ -52,7 +52,7 @@ dependencies:
     path: ../module_app_ui
   theme_prego:
     path: ../module_prego
-  flutter_secure_storage: ^11.1.0
+  flutter_secure_storage: ^11.1.1
   app_links: ^7.2.1
   url_launcher: ^6.3.2
   share_plus: ^13.3.0

--- a/client/design_catalog/pubspec.yaml
+++ b/client/design_catalog/pubspec.yaml
@@ -5,7 +5,7 @@ resolution: workspace
 
 environment:
   sdk: ^3.13.3
-  flutter: ">=3.47.3 <3.48.0"
+  flutter: ">=3.47.4 <3.48.0"
 
 dependencies:
   flutter:

--- a/client/desktop/pubspec.yaml
+++ b/client/desktop/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
     sdk: flutter
   flutter_bloc: ^9.1.1
   flutter_local_notifications: ^22.3.0
-  flutter_secure_storage: ^11.1.0
+  flutter_secure_storage: ^11.1.1
   get_it: ^9.2.1
   go_router: ^18.0.1
   http: ^1.6.0

--- a/client/module_app_ui/pubspec.yaml
+++ b/client/module_app_ui/pubspec.yaml
@@ -6,7 +6,7 @@ resolution: workspace
 
 environment:
   sdk: ^3.13.3
-  flutter: ">=3.47.3 <3.48.0"
+  flutter: ">=3.47.4 <3.48.0"
 
 dependencies:
   flutter:

--- a/client/module_app_ui/pubspec.yaml
+++ b/client/module_app_ui/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   flutter_markdown_plus: ^1.0.12
   go_router: ^18.0.1
   intl: any
-  liquid_glass_widgets: ^1.4.3
+  liquid_glass_widgets: ^1.4.4
   markdown: ^7.3.1
   material_ui: ^1.2.0
   path: any

--- a/client/module_prego/pubspec.yaml
+++ b/client/module_prego/pubspec.yaml
@@ -6,7 +6,7 @@ resolution: workspace
 
 environment:
   sdk: ^3.13.3
-  flutter: ">=3.47.3"
+  flutter: ">=3.47.4"
 
 dependencies:
   clock: ^1.1.3
@@ -18,7 +18,7 @@ dependencies:
     path: ../../shared/sesori_shared
   flutter_svg: ^2.3.0
   universal_platform: ^1.1.0
-  liquid_glass_widgets: ^1.4.3
+  liquid_glass_widgets: ^1.4.4
   cue: ^0.3.1
 
 flutter:

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -748,10 +748,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: "76fa9c841b3b1619fc5b5bc36efc7d158fa2356f223b6caeb1d0c80a54168546"
+      sha256: caa75bd78f017422912e3a904933113b2428eb79f981ac37acd2dd2a700458ea
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
@@ -1136,10 +1136,10 @@ packages:
     dependency: transitive
     description:
       name: liquid_glass_widgets
-      sha256: bd767b4b7886350ff84262159572b8dceb91ad588c290e3c43592d160b0eb0dc
+      sha256: b00e51b4b72f4164fac39aa75b8072ea97d1955d91b703d1f354464b082f5b98
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.3"
+    version: "1.4.4"
   logging:
     dependency: transitive
     description:
@@ -1488,18 +1488,18 @@ packages:
     dependency: transitive
     description:
       name: record_web
-      sha256: f53d3da48de3618a331868aec73261d5a75eddd9c09409afd9ec6d66b25db532
+      sha256: "7f6950be87abacb05cf77eb6ca200b60f2c2a6af5d50236b5f4baf53f92e755e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   record_windows:
     dependency: transitive
     description:
       name: record_windows
-      sha256: e6884f91be4370f122111aca3c04291ae5fe6d8fd045f87afa967635a02dbbac
+      sha256: "8195489a47b5e8246985d6213ff65aae1b14e32a0ca45dc5f680e8d503296e1b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.0"
   resizable_widget:
     dependency: transitive
     description:
@@ -2074,4 +2074,4 @@ packages:
     version: "2.2.4"
 sdks:
   dart: ">=3.13.3 <4.0.0"
-  flutter: ">=3.47.3 <3.48.0"
+  flutter: ">=3.47.4 <3.48.0"

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ^3.13.3
-  flutter: ">=3.47.3 <3.48.0"
+  flutter: ">=3.47.4 <3.48.0"
 
 workspace:
   - app

--- a/shared/sesori_shared/pubspec.lock
+++ b/shared/sesori_shared/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: fe18c7e37d5acb3b43224fa255281dec007970d6fd01f6d76fcd88ed3777a117
+      sha256: fdcd9f70f9eb80df3bc5ed0fa67280df2595fd481948df8a9ab082e6a40ad04b
       url: "https://pub.dev"
     source: hosted
-    version: "107.0.0"
+    version: "108.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: f2dde9e50c23fc95b846b4ef334e98c3ae8c0effd5d2453b02fc9fb3f8939791
+      sha256: a51c769bff3b6dfbe9d60199b8606d808290702a296bef0c26a4ca391d414e46
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.4.0"
   analyzer_buffer:
     dependency: transitive
     description:


### PR DESCRIPTION
## Complexity
🌿 Straightforward dependency/toolchain maintenance: 12 manifest/lock/config files; no production or generated-code changes.

## What
- Upgrade Flutter 3.47.3 → 3.47.4 and align existing Flutter environment constraints. Dart remains 3.13.3.
- Raise `liquid_glass_widgets` to ^1.4.4 and `flutter_secure_storage` to ^11.1.1 in all consumers. Refresh client recording/secure-storage platform transitives.
- Regenerate shared and bridge locks with analyzer 14.4.0 / `_fe_analyzer_shared` 108.0.0; their direct/dev dependency minima were already current.
- Refresh AWS SDK and JWT transitives in both Fastlane bundles; Fastlane 2.239.0 is already latest.
- Configure and freshly resolve app iOS/macOS and desktop macOS SwiftPM graphs. All four app lockfiles were already current, with identical project/workspace pins; desktop remains local-only and emits no lockfile.
- Preserve `shared/no_slop_linter/pubspec.yaml` and its standalone lock byte-for-byte, as required by the update-dependencies skill.

## Why
Apply the dependency-update workflow across every discovered source package and native graph without forcing blocked upgrades or unrelated migrations.

## Risk and test focus
Dependency-only changes; focus on glass widgets, secure storage, recording plugins, analyzer/codegen compatibility, and release tooling. No intentional user-visible behavior change, database/schema impact, or wire-contract change. No backend harness runtime changes.

Native checks configure/resolve packages, not signed compilation or device smoke tests. Windows/Linux/web runtime plugin behavior was not exercised on this macOS host.

## Expected result
All workspaces resolve and verify with the latest compatible dependencies and Flutter patch release while retaining existing app/bridge behavior.

## Verification
- Discovered 28 source pubspecs: 27 audited for updates plus the explicitly excluded linter. Per-member outdated checks accounted for all three editable resolution roots.
- `make pub-get`, `make analyze`, `make test`, and `make codegen` passed in each of `shared`, `bridge`, and `client`; 10,284 tests passed, and codegen produced no tracked changes.
- Independent read-only review found no P0/P1/P2 issues after checking inventory, every versioned dependency declaration, locks, native pin parity, linter bytes, and captured command evidence.
- Initial bridge E2E failure traced to an old local compiled helper. `bridge/app: make build-host` rebuilt it; the full failed bridge test target then passed. Two existing PowerShell-only tests skipped because PowerShell is unavailable.
- Flutter config-only release setup and fresh scratch-cache workspace resolution passed for app iOS/macOS and desktop macOS. App project/workspace pin arrays match exactly.
- Both `bundle update` and `bundle exec fastlane --version` passed.
- SDK latest confirmed by asdf and upstream Flutter release tag; an optional release-index HTTP request failed, without affecting installation or verification.

## Conflicts / deferred
No forced overrides or breaking migrations added.

| Dependency | Current → latest | Blocker / next step |
|---|---|---|
| `cli_util` (bridge) | 0.5.2 → 0.6.0 | `drift_dev` requires <0.6.0; await upstream constraint update. |
| `analyzer` (client) | 13.3.0 → 14.4.0 | Human-managed linter/plugin graph caps analyzer below 14. |
| `_fe_analyzer_shared` (client) | 103.0.0 → 108.0.0 | Analyzer selection and `lean_builder` bounds; coordinated upstream support needed. |
| `analysis_server_plugin` / `analyzer_plugin` | 0.3.18 → 0.3.23 / 0.14.12 → 0.14.17 | Excluded linter's deliberate upper bounds; manual human migration. |
| `source_gen` (client) | 4.2.4 → 4.3.0 | Latest requires analyzer >=14. |
| `test` / `test_api` / `test_core` (client) | 1.31.1 → 1.32.0 / 0.7.12 → 0.7.14 / 0.6.18 → 0.6.20 | Flutter's exact test API pin; await stable SDK update. |
| `package_config` (client) | 2.2.0 → 3.0.0 | Selected test packages require ^2. |
| `material_color_utilities` | 0.13.0 → 0.13.1 | Flutter SDK exact pin. |
| `accessibility_tools` | 2.8.0 → 3.0.0 | `widgetbook` requires ^2.6.0; await migration support. |
| `window_to_front` | 0.0.4 → 1.0.0 | `flutter_web_auth_2` requires ^0.0.3. |

The standalone linter dependency graph remains intentionally unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades Flutter to 3.47.4 and refreshes Dart, Fastlane, and native dependency graphs across the workspace; Dart stays at 3.13.3. Raises `liquid_glass_widgets` to ^1.4.4 and `flutter_secure_storage` to ^11.1.1 in all consumers, refreshes shared/bridge locks with analyzer 14.4.0 and `_fe_analyzer_shared` 108.0.0, and bumps AWS SDK and JWT transitives in both Fastlane bundles. No production code, generated sources, or user-visible behavior changes; all workspace `pub-get`, `analyze`, `test`, and `codegen` targets pass.

**Deferred upgrades**
- Client's `cli_util`, `source_gen`, `test`/`test_api`/`test_core`, `package_config`, `accessibility_tools`, and `window_to_front` stay pinned by `drift_dev`, the analyzer/minion linter, Flutter's test API pin, `widgetbook`, and `flutter_web_auth_2` upstream constraints.
- The standalone `no_slop_linter` lockfile and pubspec remain byte-for-byte unchanged.

<sup>Written for commit 6b2b3037a68cdd6dfe60e508a81c590531d655a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

