### PR TITLE
🌿 [deepseek-user-profile] Pin managed adapter 0.1.6 [step 2/2]

### DIFF
--- a/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_runtime_manifest.dart
+++ b/bridge/sesori_plugin_deepseek/lib/src/runtime/deepseek_runtime_manifest.dart
@@ -11,61 +11,61 @@ class const DeepSeekRuntimeManifest() extends RuntimeManifest {
   static final SemanticRuntimeVersion _minPathVersion = SemanticRuntimeVersion.parse(value: minimumVersion);
 
   /// The latest stable adapter release targeted by this plugin.
-  static const String targetVersion = "0.1.5";
+  static const String targetVersion = "0.1.6";
 
   static final SemanticRuntimeVersion _bundledVersion = SemanticRuntimeVersion.parse(value: targetVersion);
 
   static const Map<PlatformOs, Map<PlatformArch, RuntimeAsset>> _assets = {
     PlatformOs.macos: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.5-darwin-arm64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.6-darwin-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "4741d1e58b912a0d15018c956c4484b2b04be4dd5cd58710508d094ac604c254",
+        sha256: "c0763ea25a2ebe85bfa0327e4d75492fc2d3e40c7af6694f3fdf8b1eee8befce",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.5-darwin-x64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.6-darwin-x64.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "c985bae87b7fc3f8b6ca01f27dd47e36725e9da496c08bf01e7a0a285458fb86",
+        sha256: "54eb6d599307b16808ed47322b48b93fb94083d90816fb32de93c393042414b9",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
     PlatformOs.linux: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.5-linux-arm64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.6-linux-arm64.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "5551a82f11838e4a3e73646283eed0c888547061428caab682c59a62fe72121b",
+        sha256: "eae26c2091cca61d9aeea363caea425bbad7c5b7b8bcab9df5ff77d26e817047",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.5-linux-x64.tar.gz",
+        assetName: "sesori-deepseek-acp-v0.1.6-linux-x64.tar.gz",
         format: ArchiveFormat.tarGz,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "0675af1b24be0b8c35983b866a0624532767217db8a4254efb6e91e311a7d237",
+        sha256: "7746c6d6a9dfb142c8f7c7f5d1c849dc82cea0de34b29ce6703c9e7dca3afea1",
         archiveBinaryName: "sesori-deepseek-acp",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
     },
     PlatformOs.windows: {
       PlatformArch.arm64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.5-windows-arm64.zip",
+        assetName: "sesori-deepseek-acp-v0.1.6-windows-arm64.zip",
         format: ArchiveFormat.zip,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "390e593ab24f37ca00f52543997c876d90a59affd080e01c3cb8979b744c92c7",
+        sha256: "591eb5fb1105672e64845770e6db86604431d0fdcb54328fcd49a5452da5e24c",
         archiveBinaryName: "sesori-deepseek-acp.cmd",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),
       PlatformArch.x64: ArchiveRuntimeAsset(
-        assetName: "sesori-deepseek-acp-v0.1.5-windows-x64.zip",
+        assetName: "sesori-deepseek-acp-v0.1.6-windows-x64.zip",
         format: ArchiveFormat.zip,
         archiveCommandTimeout: Duration(minutes: 2),
-        sha256: "013cd4a261bcf99fe3438645b19fa610cc565f94694d74c674df83f90cb4ea1e",
+        sha256: "0fc4a31940cb61798d79fd849b469b7f2484e78fc58091cceeec392748bce660",
         archiveBinaryName: "sesori-deepseek-acp.cmd",
         layout: RuntimeArchiveLayout.packageDirectory,
       ),

--- a/bridge/sesori_plugin_deepseek/test/deepseek_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_plugin_descriptor_test.dart
@@ -35,8 +35,8 @@ void main() {
       );
     });
 
-    test("asks for an upgrade when a superseded version is installed", () {
-      installedVersion("0.1.4");
+    test("asks for an upgrade when the preceding managed version is installed", () {
+      installedVersion("0.1.5");
 
       expect(
         const DeepSeekPluginDescriptor().needsManagedRuntimeUpgrade(
@@ -48,7 +48,7 @@ void main() {
     });
 
     test("declines with an explicit binary override", () {
-      installedVersion("0.1.4");
+      installedVersion("0.1.5");
 
       expect(
         const DeepSeekPluginDescriptor().needsManagedRuntimeUpgrade(
@@ -83,7 +83,7 @@ void main() {
         _ProbeProcess(
           pid: 1,
           stdoutBytes: utf8.encode(
-            "sesori-deepseek-acp/${DeepSeekPluginDescriptor.targetVersion} deepseek-harness/0.1.1-rc.2 acp/1\n",
+            "sesori-deepseek-acp/${DeepSeekPluginDescriptor.minVersion} deepseek-harness/0.1.1-rc.2 acp/1\n",
           ),
           stderrBytes: const [],
           exitCodeValue: 0,
@@ -101,6 +101,35 @@ void main() {
         .toList();
 
     expect(events.last, isA<ProvisionReady>().having((event) => event.binaryPath, "binaryPath", "/custom/deepseek"));
+    expect(processes.spawnedArguments, [
+      const ["--version"],
+    ]);
+  });
+
+  test("ensureRuntime keeps a compatible preceding PATH adapter", () async {
+    final processes = _ProcessService(
+      probes: [
+        _ProbeProcess(
+          pid: 1,
+          stdoutBytes: utf8.encode(
+            "sesori-deepseek-acp/${DeepSeekPluginDescriptor.minVersion} deepseek-harness/0.1.5-rc.2 acp/1\n",
+          ),
+          stderrBytes: const [],
+          exitCodeValue: 0,
+        ),
+      ],
+    );
+
+    final events = await const DeepSeekPluginDescriptor()
+        .ensureRuntime(
+          host: _PluginHost(processes: processes, config: config, provisionedRuntimePath: null),
+        )
+        .toList();
+
+    expect(
+      events.last,
+      isA<ProvisionReady>().having((event) => event.binaryPath, "binaryPath", DeepSeekBinary.defaultBinary),
+    );
     expect(processes.spawnedArguments, [
       const ["--version"],
     ]);

--- a/bridge/sesori_plugin_deepseek/test/deepseek_runtime_manifest_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_runtime_manifest_test.dart
@@ -8,7 +8,7 @@ import "package:test/test.dart";
 void main() {
   const manifest = DeepSeekRuntimeManifest();
 
-  test("pins the stable adapter as the PATH floor and managed release", () {
+  test("pins the compatible PATH floor and latest managed release", () {
     expect(manifest.runtimeId, "deepseek");
     expect(manifest.pathExecutableName, "sesori-deepseek-acp");
     expect(
@@ -17,7 +17,7 @@ void main() {
     );
     expect(manifest.minPathVersion.raw, "0.1.5");
     expect(manifest.minPathVersion.raw, DeepSeekPluginDescriptor.minVersion);
-    expect(manifest.bundledVersion.raw, "0.1.5");
+    expect(manifest.bundledVersion.raw, "0.1.6");
     expect(manifest.parseVersion(value: "sesori-deepseek-acp/0.1.0")?.raw, "0.1.0");
   });
 
@@ -37,18 +37,18 @@ void main() {
     expect(
       {for (final asset in assets) asset.assetName: asset.sha256},
       {
-        "sesori-deepseek-acp-v0.1.5-darwin-arm64.tar.gz":
-            "4741d1e58b912a0d15018c956c4484b2b04be4dd5cd58710508d094ac604c254",
-        "sesori-deepseek-acp-v0.1.5-darwin-x64.tar.gz":
-            "c985bae87b7fc3f8b6ca01f27dd47e36725e9da496c08bf01e7a0a285458fb86",
-        "sesori-deepseek-acp-v0.1.5-linux-arm64.tar.gz":
-            "5551a82f11838e4a3e73646283eed0c888547061428caab682c59a62fe72121b",
-        "sesori-deepseek-acp-v0.1.5-linux-x64.tar.gz":
-            "0675af1b24be0b8c35983b866a0624532767217db8a4254efb6e91e311a7d237",
-        "sesori-deepseek-acp-v0.1.5-windows-arm64.zip":
-            "390e593ab24f37ca00f52543997c876d90a59affd080e01c3cb8979b744c92c7",
-        "sesori-deepseek-acp-v0.1.5-windows-x64.zip":
-            "013cd4a261bcf99fe3438645b19fa610cc565f94694d74c674df83f90cb4ea1e",
+        "sesori-deepseek-acp-v0.1.6-darwin-arm64.tar.gz":
+            "c0763ea25a2ebe85bfa0327e4d75492fc2d3e40c7af6694f3fdf8b1eee8befce",
+        "sesori-deepseek-acp-v0.1.6-darwin-x64.tar.gz":
+            "54eb6d599307b16808ed47322b48b93fb94083d90816fb32de93c393042414b9",
+        "sesori-deepseek-acp-v0.1.6-linux-arm64.tar.gz":
+            "eae26c2091cca61d9aeea363caea425bbad7c5b7b8bcab9df5ff77d26e817047",
+        "sesori-deepseek-acp-v0.1.6-linux-x64.tar.gz":
+            "7746c6d6a9dfb142c8f7c7f5d1c849dc82cea0de34b29ce6703c9e7dca3afea1",
+        "sesori-deepseek-acp-v0.1.6-windows-arm64.zip":
+            "591eb5fb1105672e64845770e6db86604431d0fdcb54328fcd49a5452da5e24c",
+        "sesori-deepseek-acp-v0.1.6-windows-x64.zip":
+            "0fc4a31940cb61798d79fd849b469b7f2484e78fc58091cceeec392748bce660",
       },
     );
     expect(
@@ -68,7 +68,7 @@ void main() {
     )!;
     expect(
       manifest.downloadUrlFor(asset: asset),
-      "https://github.com/sesori-ai/sesori-deepseek-acp/releases/download/v0.1.5/sesori-deepseek-acp-v0.1.5-darwin-arm64.tar.gz",
+      "https://github.com/sesori-ai/sesori-deepseek-acp/releases/download/v0.1.6/sesori-deepseek-acp-v0.1.6-darwin-arm64.tar.gz",
     );
   });
 }

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -357,8 +357,8 @@ generic `tool_call` with no ids or lifecycle notifications; those exist only in
 `--mode rpc`, which Sesori does not drive. `session/cancel` aborts the whole
 turn.
 
-⁹ DeepSeek's published adapter 0.1.5 over dsh 0.1.5-rc.2 is the managed target
-and minimum accepted runtime. ACP uses native subtree stop for the named scope
+⁹ DeepSeek's published adapter 0.1.6 over dsh 0.1.5-rc.2 is the managed target;
+adapter 0.1.5 remains the minimum accepted runtime. ACP uses native subtree stop for the named scope
 and every independently resident descendant root, while ordered input cancel,
 exact-child authority, lifecycle, tiles, and child catalogs remain native-backed.
 Released clients retain their own child fanout. Phone QA on unchanged published
@@ -371,7 +371,12 @@ and surviving root-owned shell jobs do not imply failed descendant cancellation 
 broader process-stop support. Cold tile/history reload, read-only child navigation,
 push delivery, restart/reconnect, multiple clients, alternate mobile platforms,
 and macOS desktop remain unexecuted in this gate; desktop was deferred by explicit
-user choice. This 0.1.4 evidence does not requalify the current 0.1.5 managed target.
+user choice. This 0.1.4 evidence does not requalify the current 0.1.6 managed target.
+Adapter 0.1.6 loads explicitly installed local plugins from only the application-owned
+`$DSH_HOME/profiles/sesori` profile on startup, then reapplies Sesori's mandatory
+runtime constraints; profile changes require restart and profile failure falls back
+to the pinned in-memory graph. These plugins are trusted local in-process code, not a
+trust grant for future cloud or otherwise managed-trust runtimes.
 The native model catalog includes `deepseek-flash` (DeepSeek V4.1 Flash) with
 image input and reasoning controls. Refresh rereads the installed harness's
 configured catalog; it does not upgrade that harness or fetch a live provider catalog.

--- a/docs/regression/plugin-setup-and-lifecycle.md
+++ b/docs/regression/plugin-setup-and-lifecycle.md
@@ -64,7 +64,7 @@ idle suspension, the management snapshot, and lifecycle commands.
 - DeepSeek is an ACP harness with six-platform managed package archives. Its
   descriptor honors an explicit `--deepseek-bin` path before a compatible PATH
   release (`>=0.1.5`) and then a managed release at or above that minimum,
-  preferring the pinned `0.1.5` target. An outdated explicit
+  preferring the pinned `0.1.6` target. An outdated explicit
   binary is rejected; an old or malformed PATH candidate falls through to managed
   selection. It performs bounded parseable-version and
   side-effect-free `check --state-dir` probes, advertises install only on a
@@ -78,14 +78,23 @@ idle suspension, the management snapshot, and lifecycle commands.
   0.1.4 verified that the bridge and native runtime survived atomic cancellation
   of an independently resumed child and its grandchild after #1379, and accepted
   a successful follow-up turn. That evidence does not requalify current managed
-  target 0.1.5 or cover setup selection, crash reconnect, idle suspension/reap,
+  target 0.1.6 or cover setup selection, crash reconnect, idle suspension/reap,
   bridge restart, desktop, or another platform.
 - Standard ACP owns DeepSeek lifecycle, prompts, config options, and permissions;
   `deepseek/*` adds catalog, detached history, rename, questions, bounded statuses,
   and correlated sub-agent lifecycle on that same connection. Normal `DSH_HOME` remains the source
   of settings, credentials, providers, and skills but its session root is never
-  scanned. Session, attachment, query, and spill mutations stay below plugin
-  state, and session-local model/reasoning writes never modify user settings.
+  scanned. Adapter 0.1.6 initializes and loads only the application-owned
+  `$DSH_HOME/profiles/sesori` profile at startup, so explicitly installed bundle and
+  patch plugins run after restart. The adapter resolves one immutable entry snapshot,
+  then reapplies its pinned storage, telemetry, hot-reload, sandbox, approval,
+  agent/sub-agent, and transport constraints. An unavailable, invalid, or failing
+  profile falls back once to the pinned in-memory graph without changing active ACP
+  sessions. Profile plugins are trusted local in-process code with access to prompts,
+  files, credentials, Node APIs, and the network; this local trust grant does not
+  extend to a future cloud or otherwise managed-trust runtime. Session, attachment,
+  query, and spill mutations stay below plugin state, and session-local
+  model/reasoning writes never modify user settings.
 - Antigravity is an ACP v1 harness over Google's official proprietary runtime pair. An explicit
   `--antigravity-bin` server is authoritative and requires its matching sibling harness; otherwise PATH then the
   installed managed pair are checked. Setup inspection is static and inert, reports personal-auth readiness from
@@ -451,7 +460,11 @@ owned-process exit; and restart.
 - A DeepSeek setup probe creates a session or mutates runtime state, accepts an
   old/malformed adapter version, selects managed runtime ahead of a supported
   PATH release, offers install with an explicit path or on an unsupported
-  platform, or keeps using a dead stdio child after an unexpected exit.
+  platform, or keeps using a dead stdio child after an unexpected exit. A DeepSeek
+  adapter loads an unrelated profile, hot-applies profile changes to active sessions,
+  lets profile rows replace mandatory runtime constraints, lets plugin stdout corrupt
+  ACP framing, or fails startup instead of using its pinned fallback after a profile
+  composition or plugin-boot error.
 - Copilot setup accepts unbranded version output, falls back from a provisioned
   runtime during start, mutates the user's configuration, offers in-app login,
   or leaves another harness unavailable after Copilot exits.


### PR DESCRIPTION
## Complexity
🌿 Straightforward managed-runtime pin, compatibility coverage, and regression documentation. The adapter implementation shipped separately in [step 1/2](https://github.com/sesori-ai/sesori-deepseek-acp/pull/20).

## What
- Pin published [adapter v0.1.6](https://github.com/sesori-ai/sesori-deepseek-acp/releases/tag/v0.1.6) across all six supported targets using independently verified archive hashes.
- Preserve adapter `0.1.5` as the compatible explicit/PATH minimum while selecting `0.1.6` for managed installs and upgrades.
- Cover replacement of the preceding managed `0.1.5` runtime and continued acceptance of a compatible `0.1.5` PATH adapter.
- Document the application-owned `$DSH_HOME/profiles/sesori` startup profile, pinned fallback, restart semantics, and explicit local-code trust boundary.

## Why
Managed DeepSeek installations need adapter `0.1.6` to load plugins explicitly installed into Sesori's dedicated profile. The adapter resolves one validated startup snapshot, reapplies mandatory Sesori runtime constraints, and falls back to its pinned in-memory graph if profile composition or plugin boot fails.

## Risk and test focus
The consumer diff is small, but it selects a security-sensitive native runtime. Focus on six-platform archive integrity and provenance, managed `0.1.5` replacement, compatible local-runtime precedence, profile fallback, mandatory sandbox/approval/storage/telemetry constraints, and intact ACP stdout framing.

Profile plugins are arbitrary trusted local in-process code with access to prompts, files, credentials, Node APIs, and the network. Sesori does not install such plugins automatically, and this local trust grant must not carry into a future cloud or otherwise managed-trust runtime.

There is no Sesori UI, client/bridge wire-contract, or database schema change. No authenticated phone/desktop E2E was run.

## Expected result
New or upgraded managed DeepSeek runtimes use adapter `0.1.6`. Plugins explicitly installed into `$DSH_HOME/profiles/sesori` load after adapter restart, while compatible user-managed `0.1.5+` adapters remain eligible and existing state isolation and ACP behavior remain unchanged.

## Verification
- Adapter PR #20 reviewed head `c392104dc4bc9c218a80b34def814c88c7f3d44f` and squash merge `b5df335478deeda5823c58542a5469e2a55e10ef` have identical trees; annotated tag `v0.1.6` points to that merge.
- [Release workflow 34704130645](https://github.com/sesori-ai/sesori-deepseek-acp/actions/runs/34704130645): cross-repository conformance, all six native package jobs, `verify-release-set`, and `publish` passed.
- Independently downloaded all six archives plus `checksums.txt`; recomputed every SHA-256 and matched GitHub asset digests. Verified safe paths/links, executable launcher/Node layout, exact direct dependencies, all 130 embedded DeepSeek Harness packages at `0.1.5-rc.2`, and exact target/source/consumer/protocol metadata without executing downloaded artifacts.
- Consumer manifest names and hashes exactly match the downloaded checksum manifest.
- `asdf exec dart analyze --fatal-infos` in `bridge/sesori_plugin_deepseek`: passed.
- DeepSeek plugin suite: **117 tests passed**.
- Dart formatting and Git whitespace checks passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the managed DeepSeek adapter to 0.1.6 so explicitly installed plugins in `$DSH_HOME/profiles/sesori` load on startup. Managed installs upgrade from 0.1.5; compatible PATH adapters at 0.1.5+ remain accepted. Adapter 0.1.6 resolves one startup profile snapshot, reapplies mandatory sandbox/approval/storage/telemetry constraints, and falls back to its pinned in-memory graph if profile composition or plugin boot fails. Profile plugins are trusted local in-process code, and this trust grant does not carry into future cloud or managed-trust runtimes. Updates all six platform archives and hashes and adds regression coverage for managed 0.1.5 replacement and compatible PATH 0.1.5. No UI, wire-contract, or database schema changes.

<sup>Written for commit 96957a208a3a4ee2c769700063ed1a3d3a16caf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

