### PR TITLE
🌱 Show the tool action beside its title on chat cards

### DIFF
--- a/bridge/app/test/bridge/acp_tool_projection_test.dart
+++ b/bridge/app/test/bridge/acp_tool_projection_test.dart
@@ -187,7 +187,8 @@ void main() {
         );
         expect(state.shellCommand, isNull);
         // The agent's title stays a display label; it never becomes a command.
-        expect(state.title, evidence["title"]);
+        // A title-only call drops it because it already names the tool.
+        expect(state.title, evidence.containsKey("kind") ? evidence["title"] : null);
         expect(state.output, isNull);
         expect(state.error, isNull);
         expect(state.status, ToolStatus.error);

--- a/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_event_mapper.dart
@@ -1235,7 +1235,7 @@ class AcpEventMapper({
         tool: state.tool,
         state: PluginToolState(
           status: state.status,
-          title: state.title,
+          title: _contentMapper.toolTitle(tool: state.tool, title: state.title),
           shellCommand: state.shellCommand,
           output: content.output,
           error: state.status == PluginToolStatus.error ? content.output : null,

--- a/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
+++ b/bridge/sesori_plugin_acp/lib/src/acp_session_loader.dart
@@ -566,7 +566,7 @@ class AcpReplayCollector({
       tool: tool.tool,
       state: PluginToolState(
         status: tool.status,
-        title: tool.title,
+        title: _contentMapper.toolTitle(tool: tool.tool, title: tool.title),
         shellCommand: tool.shellCommand,
         output: content.output,
         error: tool.status == PluginToolStatus.error ? content.output : null,

--- a/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
+++ b/bridge/sesori_plugin_acp/lib/src/repositories/mappers/acp_content_mapper.dart
@@ -104,6 +104,10 @@ final class const AcpContentMapper() {
     return "tool";
   }
 
+  /// The agent's display title, or null when [toolName] fell back to that same
+  /// title (no `kind`): the card would otherwise read `Read file Read file`.
+  String? toolTitle({required String tool, required String? title}) => title == tool ? null : title;
+
   PluginToolStatus? toolStatus({required Object? status}) {
     return switch (status) {
       "pending" => PluginToolStatus.pending,

--- a/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
+++ b/bridge/sesori_plugin_acp/test/acp_event_mapper_test.dart
@@ -644,10 +644,9 @@ void main() {
           "status": "pending",
         }),
       );
-      expect(
-        emptyKind.whereType<BridgeSseMessagePartUpdated>().single.part.tool,
-        "Search files",
-      );
+      final emptyKindPart = emptyKind.whereType<BridgeSseMessagePartUpdated>().single.part;
+      expect(emptyKindPart.tool, "Search files");
+      expect(emptyKindPart.state.title, isNull, reason: "a title that became the tool name is not repeated");
 
       final nonStringKind = mapper.map(
         update({

--- a/bridge/sesori_plugin_antigravity/test/antigravity_protocol_mapper_updates_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_protocol_mapper_updates_test.dart
@@ -469,7 +469,7 @@ void main() {
     );
     expect(protocol.normalizeSessionUpdate(params: params), same(params));
     final state = _parity(params: params);
-    expect(state.title, "Fallback");
+    expect(state.title, isNull, reason: "the title already names the tool when kind is malformed");
     expect(state.output, "standard output");
     expect(state.status, PluginToolStatus.completed);
   });

--- a/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
+++ b/bridge/sesori_plugin_cursor/test/cursor_task_replay_tracker_test.dart
@@ -81,6 +81,7 @@ void main() {
       expect((tile.sessionID, tile.messageID), (_sessionId, message.info.id));
       expect((tile.prompt, tile.description, tile.agent), ("Inspect code", "Inspect", "unspecified"));
       expect(tile.childSessionID, isNull);
+      // The title-only call names its tool by that title, so the title is not repeated.
       expect(
         (
           tile.taskState?.status,
@@ -88,7 +89,7 @@ void main() {
           tile.taskState?.output,
           tile.taskState?.attachments.length,
         ),
-        (PluginToolStatus.completed, "Task: Inspect", "final report", 1),
+        (PluginToolStatus.completed, null, "final report", 1),
       );
       expect(message.parts.whereType<PluginMessagePartTool>(), isEmpty);
     });

--- a/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
+++ b/bridge/sesori_plugin_deepseek/test/deepseek_subagent_test.dart
@@ -283,7 +283,8 @@ void main() {
       expect(tools, hasLength(1));
       expect(tools.single.state.status, PluginToolStatus.error);
       expect(tools.last.state.output, "terminal failure");
-      expect(tools.last.state.title, "Delegation startup");
+      expect(tools.last.tool, "Delegation startup");
+      expect(tools.last.state.title, isNull, reason: "the deferred title already names the tool");
       expect(tools.last.state.error, "terminal failure");
     });
 

--- a/client/module_app_ui/lib/src/features/session_detail/widgets/tool_part_widget.dart
+++ b/client/module_app_ui/lib/src/features/session_detail/widgets/tool_part_widget.dart
@@ -15,8 +15,10 @@ class const ToolPartWidget({super.key, required final MessagePartTool part}) ext
     final prego = context.prego;
     final loc = context.loc;
     final state = part.state;
-    final toolName =
-        state.shellCommand ?? state.title ?? (part.tool.isEmpty ? loc.sessionDetailToolUnknown : part.tool);
+    final toolName = part.tool.isEmpty ? loc.sessionDetailToolUnknown : part.tool;
+    // The action stays visible; the command or title (file path, pattern,
+    // skill) follows it in a lighter style.
+    final detail = state.shellCommand ?? state.title;
     final status = state.status;
     final output = status == ToolStatus.completed ? state.output : null;
     final errorText = status == ToolStatus.error ? state.error : null;
@@ -39,8 +41,19 @@ class const ToolPartWidget({super.key, required final MessagePartTool part}) ext
                   _statusIcon(status: status, prego: prego),
                   const SizedBox(width: 8),
                   Expanded(
-                    child: Text(
-                      toolName,
+                    child: Text.rich(
+                      TextSpan(
+                        text: toolName,
+                        children: [
+                          if (detail != null)
+                            TextSpan(
+                              text: " $detail",
+                              style: prego.textTheme.textSm.regular.copyWith(
+                                color: prego.colors.textSecondary,
+                              ),
+                            ),
+                        ],
+                      ),
                       style: prego.textTheme.textSm.regular.copyWith(
                         fontWeight: FontWeight.w500,
                       ),

--- a/client/module_app_ui/test/features/session_detail/widgets/file_part_widget_test.dart
+++ b/client/module_app_ui/test/features/session_detail/widgets/file_part_widget_test.dart
@@ -1463,7 +1463,7 @@ void main() {
 
     await tester.pumpWidget(_app(child: const ToolPartWidget(part: part)));
 
-    expect(find.text("git status --short"), findsOneWidget);
+    expect(find.text("shell git status --short"), findsOneWidget);
     expect(find.text(" M file.dart"), findsOneWidget);
   });
 

--- a/docs/HARNESS_CAPABILITIES.md
+++ b/docs/HARNESS_CAPABILITIES.md
@@ -58,7 +58,7 @@ harnesses without a dedicated skill tool, so the read path is the skill signal.
 | Pi | ✅ Tool-call arguments `pattern`, then `path`; live from `toolcall_end`/`message_end` and replay. `toolcall_start` carries no arguments, so the title first appears with the running or terminal update. |
 | OpenCode | ✅ Native tool part `title`. |
 | Codex | ✅ Argument-derived title (`cmd`, `command`, `path`, `filePath`, `query`, else bounded raw arguments). |
-| Grok, Antigravity, Copilot, Cursor, OMP, Hermes, DeepSeek | ✅ Agent-supplied ACP `tool_call` title, when the agent sends one; Sesori does not derive titles from ACP inputs. |
+| Grok, Antigravity, Copilot, Cursor, OMP, Hermes, DeepSeek | ✅ Agent-supplied ACP `tool_call` title, when the agent sends one; Sesori does not derive titles from ACP inputs. A call without `kind` uses its title as the tool name and drops the title, so the card does not say it twice. |
 
 ## Managed runtime
 

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -19,6 +19,8 @@ sub-agent parts, plus the signal that a tool changed files.
   (`skill`, `file_path`, `notebook_path`, `pattern`, `path`, `url`, `query`), Pi from the
   tool-call arguments (`pattern`, then `path`), Codex from its argument-derived
   title, and OpenCode and ACP harnesses pass the harness-supplied title through.
+  An ACP call without `kind` uses its title as the tool name and drops the
+  title, so the card never repeats it.
   Skills that load through a file read of `SKILL.md` are visible by that path.
   Pi learns the title at `toolcall_end`, so a card announced by `toolcall_start`
   shows it from the running or terminal update onward, live and after replay.

--- a/docs/regression/tools-and-file-changes.md
+++ b/docs/regression/tools-and-file-changes.md
@@ -22,6 +22,8 @@ sub-agent parts, plus the signal that a tool changed files.
   Skills that load through a file read of `SKILL.md` are visible by that path.
   Pi learns the title at `toolcall_end`, so a card announced by `toolcall_start`
   shows it from the running or terminal update onward, live and after replay.
+  The client card header shows the tool name followed by the title, or by the
+  shell command for shell tools, so the action and its target are both visible.
 - Plugin and shared message parts are sealed variants, so text, tool, subtask,
   file, agent, and retry data cannot be combined with unrelated part types. The
   shared variants retain the released `type` values and normalize known payloads
@@ -182,7 +184,7 @@ guarantee.
 - Shell output exceeds the bound, truncates mid-character, or differs between
   live streaming and replay; non-shell snippets reach the client; or a
   completed read/edit/skill card shows only the tool name without its path,
-  pattern, or skill.
+  pattern, or skill, or only the path without the tool name.
 - A tool stays running after the backend finished, or an error renders as a
   completion.
 - Backend naming or payload shape reaches the client unnormalized, or a local


### PR DESCRIPTION
## Complexity
🌱 Trivial: one header change in the client tool card, a one-line ACP title normalization at the plugin's two emission points, adjusted tests, and doc lines.

## What
- The session tool card header renders the tool name followed by its detail (the shell command, or the bounded title such as a file path, pattern, or skill) in a lighter style on the same single line. Previously the header showed `shellCommand ?? title ?? tool`, so any tool that carried a title hid its own name.
- ACP harnesses (Grok, Antigravity, Copilot, Cursor, OMP, Hermes, DeepSeek): a `tool_call` without `kind` already uses its title as the tool name; the plugin now drops that title from the tool state, live and on replay, so the card does not read `Read file Read file`. Normalized in the plugin rather than the shared widget, as `client/AGENTS.md` requires.

## Why
After #1450 restored bounded titles, tool cards showed only the file path with no indication of the action (read, edit, write, skill load). Reported on the Pi harness; the cause is the client rendering rule, so the fix applies to every harness.

## Risk and test focus
Client rendering plus a cosmetic ACP tool-state title change. No wire contract change (the title field stays nullable) and no database impact; older clients render `title ?? tool` and show the same text either way. Focus on the card header for shell tools (`bash git status --short`), ordinary tools with a title (`read lib/main.dart`), tools without a title (`browser`), the unknown-tool fallback, and title-only ACP calls (the name once, no repeated title). Long paths still ellipsize on one line.

## Expected result
Every tool card shows the action and its target together, for example `read bridge/app/lib/src/services/plugin_lifecycle_service.dart` with the path in the secondary text color. A title-only ACP call shows its title once, as the action.

## Verification
- `flutter test test/features/session_detail/widgets/file_part_widget_test.dart` in `client/module_app_ui`: 35 passed
- `flutter analyze` in `client/module_app_ui`: no issues
- `dart test` for the ACP live mapper, replay loader, and tool content suites: 115 passed; bridge tool projection suites: 34 passed; Antigravity update mapper and DeepSeek sub-agent suites: passed
- `dart analyze` in `bridge/sesori_plugin_acp`: no issues
- `dart format --set-exit-if-changed` on the touched files: unchanged
