### PR TITLE
🌿 [all-harness-runtime-refresh] runtime: validate Antigravity and Cursor exact builds [step 3/9]

### DIFF
--- a/.agents/skills/update-backend-runtimes/SKILL.md
+++ b/.agents/skills/update-backend-runtimes/SKILL.md
@@ -175,6 +175,9 @@ Record planned versus completed checks distinctly. A target refresh requires
 official release evidence, integrity checks for **every managed asset**, isolated
 current-host production installation/identity/protocol checks, and focused owning
 package tests/analyzer. Use the harness reference for exceptions and extra gates.
+Apply every named required gate in the approved plan, including detailed harness
+prose; a shorter summary table does not silently replace it. Resolve contradictory
+requirements with the owner before marking a pin Pass. A merge is not a waiver.
 
 - Download and hash every managed asset as opaque bytes. Compare published
   digests and checksum lists where provided; distinguish metadata agreement from
@@ -211,6 +214,11 @@ package tests/analyzer. Use the harness reference for exceptions and extra gates
   credentials and network scope. Do not borrow the user's live session. Record
   required-but-unavailable checks as blocked; mocks or version output do not
   prove live behavior. Preserve useful source findings while pinning is blocked.
+- For lifecycle gates without a real-auth requirement, a controlled loopback
+  model fixture may drive the actual candidate. Never fabricate runtime events
+  as native evidence. Separate exercised production seams from merely inspected
+  code, and distinguish a replayed current prompt from persisted history. Record
+  controller wait budgets honestly: `Future.timeout` does not cancel its source.
 - Keep reports/commits free of secrets, prompts, transcripts, user-local paths,
   account identifiers and raw provider payloads. Record bounded outcomes and
   immutable public source links instead; preserve diagnostic detail in local

--- a/.plan/active/all-harness-runtime-refresh/PLAN.md
+++ b/.plan/active/all-harness-runtime-refresh/PLAN.md
@@ -16,7 +16,7 @@
 - **Planning baseline:** branch `update-target-runtime-all-harnesses`, commit
   `8879ea1a62cc52104509c4483fe611c7eb0287bf`.
 - **Scope:** ten registered harnesses. DeepSeek remains registered for
-  reconciliation only and is explicitly excluded/unchanged.
+  inventory reconciliation only and is explicitly excluded from this series' audit and changes.
 - **Implementation branch:** `all-harness-runtime-refresh-step-3`, based on
   Step 2 merge `ba3264eab93a1775d4e4c24e7672cab8bebe2d67`. This series preserves
   floors, layout/platform policy, launch behavior, and Sesori database/wire
@@ -63,7 +63,7 @@ contains 11 entries. This pre-series baseline reconciles all 11, including the
 excluded row; [TRACKER.md](TRACKER.md) records current branch targets and gate
 status. Release links alone are not completed implementation gates.
 
-| Harness | Current target / floor or exact policy | Candidate and evidence | Distribution / status |
+| Harness | Pre-series target / floor or exact policy | Candidate and evidence | Distribution / status |
 |---|---|---|---|
 | OpenCode | `1.18.19` / `1.14.0` | [`v1.18.30`](https://github.com/anomalyco/opencode/releases/tag/v1.18.30) | Six managed single-binary archives; recommended after gates |
 | Antigravity | Registry package `1.0.0`; exact server `agy_acp_server_20260818_01_RC01`, ACP 1; no semantic floor | Registry [`v2026.09.12-d30bc9a`](https://github.com/agentclientprotocol/registry/releases/tag/v2026.09.12-d30bc9a), package `1.1.1`; observed server `agy_acp_server_1.1.1` | Five ZIP hashes and macOS ARM64 install/initialize/cleanup accepted in Step 3 |
@@ -150,8 +150,11 @@ floor. OMP Windows ARM64 is an approved platform mapping, not a floor change.
   Source-to-binary association is optional evidence, not a signed or
   source-attestation gate. Preserve `--no-auto-update agent --no-leader stdio`,
   floor `1.0.5`, and current scoped-stop policy.
-- **DeepSeek:** no candidate audit or producer work. Keep target/minimum `0.1.5`,
-  six assets, capabilities, regressions, and historical evidence untouched.
+- **DeepSeek:** no candidate audit or producer work. The `0.1.5` target/minimum
+  and six assets in the inventory and `AUDIT.md` are historical pre-series
+  observations, not a requirement to freeze or restore the current upstream
+  target. Do not audit, modify, or revert unrelated DeepSeek changes; its current
+  target is intentionally not assessed by this series.
 
 No safe simplification was found. OMP native settlement and Hermes empty-shell
 behavior affect cleanup/ordering but do not authorize removing bridge queue,

--- a/.plan/active/all-harness-runtime-refresh/PLAN.md
+++ b/.plan/active/all-harness-runtime-refresh/PLAN.md
@@ -6,9 +6,13 @@
 - **Status:** [plan PR #1453](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1453)
   and [Step 2 PR #1455](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1455)
   merged. Four targets are verified, including the required Pi/Claude lifecycle
-  follow-up accepted after merge. Codex/OMP remain unchanged and blocked;
-  Step 3 Antigravity/Cursor verification is active. See
-  [Step 2 verification](STEP-2-VERIFICATION.md).
+  follow-up accepted after merge. Step 3 verifies and applies Antigravity
+  package `1.1.1` / server `agy_acp_server_1.1.1` on this branch: all five archive
+  records, native install/initialize, actual production validator, teardown and
+  focused checks pass. Cursor remains unchanged because configured
+  load/replay/model/mode gates are blocked; Codex/OMP also remain blocked. See
+  [Step 2 verification](STEP-2-VERIFICATION.md) and
+  [Step 3 verification](STEP-3-VERIFICATION.md).
 - **Planning baseline:** branch `update-target-runtime-all-harnesses`, commit
   `8879ea1a62cc52104509c4483fe611c7eb0287bf`.
 - **Scope:** ten registered harnesses. DeepSeek remains registered for
@@ -62,7 +66,7 @@ status. Release links alone are not completed implementation gates.
 | Harness | Current target / floor or exact policy | Candidate and evidence | Distribution / status |
 |---|---|---|---|
 | OpenCode | `1.18.19` / `1.14.0` | [`v1.18.30`](https://github.com/anomalyco/opencode/releases/tag/v1.18.30) | Six managed single-binary archives; recommended after gates |
-| Antigravity | Registry package `1.0.0`; exact server `agy_acp_server_20260818_01_RC01`, ACP 1; no semantic floor | Registry [`v2026.09.12-d30bc9a`](https://github.com/agentclientprotocol/registry/releases/tag/v2026.09.12-d30bc9a), package `1.1.1`; exact server pending | Five package-directory ZIPs; probe-first exact-pair validation |
+| Antigravity | Registry package `1.0.0`; exact server `agy_acp_server_20260818_01_RC01`, ACP 1; no semantic floor | Registry [`v2026.09.12-d30bc9a`](https://github.com/agentclientprotocol/registry/releases/tag/v2026.09.12-d30bc9a), package `1.1.1`; observed server `agy_acp_server_1.1.1` | Five ZIP hashes and macOS ARM64 install/initialize/cleanup accepted in Step 3 |
 | Codex | `0.153.4` / `0.139.0` | [`rust-v0.154.0`](https://github.com/openai/codex/releases/tag/rust-v0.154.0) | Six canonical package tarballs; recommended after both transports pass |
 | GitHub Copilot | `1.0.80` / `1.0.78` | [`v1.0.83`](https://github.com/github/copilot-cli/releases/tag/v1.0.83) | Six single-binary archives; recommended after ACP/install gates |
 | Cursor | `2026.08.11-e8db854` / date floor `2026.07.16` | [official installer](https://cursor.com/install), exact `2026.09.10-fd3934a` | Four package tarballs; probe-first content/hash/install gate |
@@ -93,6 +97,8 @@ floor. OMP Windows ARM64 is an approved platform mapping, not a floor change.
   sibling `agy_acp_server`/`localharness_external` members, exact initialize
   identity, ACP 1, auth methods, and teardown pass. No OAuth/session probe or
   native delegation matrix lift; package version is not server identity.
+  Step 3 observed `agy_acp_server_1.1.1` from the candidate and applied only
+  release facts; the manifest already derives its package target from them.
 - **Codex:** update `codex_runtime_manifest.dart` and six canonical package
   assets after independent WebSocket and stdio app-server checks. Keep helpers,
   resources, capability opt-outs, rollout tailer, approvals, queue, history,
@@ -398,7 +404,7 @@ matrix/retirement decision.
 |---|---|---|
 | 1/9 | `🌱 [all-harness-runtime-refresh] docs: publish runtime refresh plan [step 1/9]` | Publish this plan, tracker, audit, and verified reference corrections; no production changes |
 | 2/9 | `🌿 [all-harness-runtime-refresh] runtime: refresh mechanical targets [step 2/9]` | OpenCode, Codex, Copilot, Claude, Pi, and OMP target/assets refreshes with independent release/install/protocol/tests; OMP uses seven existing assets |
-| 3/9 | `⚙️ [all-harness-runtime-refresh] runtime: validate Antigravity and Cursor exact builds [step 3/9]` | Antigravity exact package/server pair and Cursor exact installer build, content, hashes, layout, and ACP gates |
+| 3/9 | `🌿 [all-harness-runtime-refresh] runtime: validate Antigravity and Cursor exact builds [step 3/9]` | Antigravity exact package/server pair and Cursor exact installer build, content, hashes, layout, and ACP gates |
 | 4/9 | `⚙️ [all-harness-runtime-refresh] runtime(hermes): resolve cleanup and refresh target [step 4/9]` | Narrow empty-session cleanup prerequisite; pin `0.21.2` only after cleanup and target gates |
 | 5/9 | `🌿 [all-harness-runtime-refresh] runtime(grok): refresh target [step 5/9]` | Stable-channel `1.0.30`, normalized ACP namespace, exact launch/protocol gates; no source-binary gate |
 | 6/9 | `⚙️ [all-harness-runtime-refresh] runtime(omp): add Windows arm64 asset [step 6/9]` | Approved eighth executable, manifest/platform tests, native Windows gate, and platform regression/capability docs |

--- a/.plan/active/all-harness-runtime-refresh/PLAN.md
+++ b/.plan/active/all-harness-runtime-refresh/PLAN.md
@@ -4,15 +4,19 @@
 
 - **Plan slug:** `all-harness-runtime-refresh`.
 - **Status:** [plan PR #1453](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1453)
-  merged. Step 2/9 applies four independently verified targets; Codex and OMP
-  remain unchanged and blocked. See [Step 2 verification](STEP-2-VERIFICATION.md).
+  and [Step 2 PR #1455](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1455)
+  merged. Four targets are verified, including the required Pi/Claude lifecycle
+  follow-up accepted after merge. Codex/OMP remain unchanged and blocked;
+  Step 3 Antigravity/Cursor verification is active. See
+  [Step 2 verification](STEP-2-VERIFICATION.md).
 - **Planning baseline:** branch `update-target-runtime-all-harnesses`, commit
   `8879ea1a62cc52104509c4483fe611c7eb0287bf`.
 - **Scope:** ten registered harnesses. DeepSeek remains registered for
   reconciliation only and is explicitly excluded/unchanged.
-- **Implementation branch:** `all-harness-runtime-refresh-step-2`, based on
-  plan merge `a644652e0c1a03232dc33184b522124703636988`. Floors, layout/platform
-  policy, launch behavior, and Sesori database/wire contracts are unchanged.
+- **Implementation branch:** `all-harness-runtime-refresh-step-3`, based on
+  Step 2 merge `ba3264eab93a1775d4e4c24e7672cab8bebe2d67`. This series preserves
+  floors, layout/platform policy, launch behavior, and Sesori database/wire
+  contracts; unrelated upstream changes are not part of this refresh.
 - **Evidence:** [AUDIT.md](AUDIT.md) preserves the pre-implementation source
   snapshot. Step reports distinguish completed runtime gates from outstanding
   verification; unexecuted candidates remain provisional.
@@ -62,9 +66,9 @@ status. Release links alone are not completed implementation gates.
 | Codex | `0.153.4` / `0.139.0` | [`rust-v0.154.0`](https://github.com/openai/codex/releases/tag/rust-v0.154.0) | Six canonical package tarballs; recommended after both transports pass |
 | GitHub Copilot | `1.0.80` / `1.0.78` | [`v1.0.83`](https://github.com/github/copilot-cli/releases/tag/v1.0.83) | Six single-binary archives; recommended after ACP/install gates |
 | Cursor | `2026.08.11-e8db854` / date floor `2026.07.16` | [official installer](https://cursor.com/install), exact `2026.09.10-fd3934a` | Four package tarballs; probe-first content/hash/install gate |
-| Claude Code | `2.1.237` / `2.1.221` | [`v2.1.269`](https://github.com/anthropics/claude-code/releases/tag/v2.1.269); npm `latest` agrees | Direct configured/PATH CLI, zero managed assets; recommended after stream gate |
+| Claude Code | `2.1.237` / `2.1.221` | [`v2.1.269`](https://github.com/anthropics/claude-code/releases/tag/v2.1.269); npm `latest` agrees | Direct configured/PATH CLI, zero managed assets; recommended after stream/approval/replay/interrupt gates |
 | Hermes Agent | `0.20.4` / `0.20.0` | [`v2026.9.11`](https://github.com/NousResearch/hermes-agent/releases/tag/v2026.9.11), CLI `0.21.2` | Direct `hermes acp`; blocked by cleanup seam |
-| Pi | `0.84.4` / `0.84.1` | [`v0.85.1`](https://github.com/earendil-works/pi/releases/tag/v0.85.1); npm package `@earendil-works/pi-coding-agent` | Six package archives; recommended after RPC gate; compaction not reverified |
+| Pi | `0.84.4` / `0.84.1` | [`v0.85.1`](https://github.com/earendil-works/pi/releases/tag/v0.85.1); npm package `@earendil-works/pi-coding-agent` | Six package archives; recommended after RPC, settlement, and manual-compaction abort/ordering gates |
 | Oh My Pi (OMP) | `17.3.8` / `17.2.13` | [`v18.1.18`](https://github.com/can1357/oh-my-pi/releases/tag/v18.1.18), published 2026-09-11 | Seven assets in current Sesori manifest; official candidate has eight including Windows ARM64; approved separate platform step |
 | Grok Build | `1.0.5` / `1.0.5` | [xAI stable channel](https://x.ai/cli/stable), channel `1.0.30` | Direct official CLI; recommended after channel/ACP gate |
 | DeepSeek (excluded) | `0.1.5` / `0.1.5` | None assessed | Existing six managed assets remain untouched; excluded/unchanged |
@@ -321,9 +325,9 @@ Required target and configured gates are:
 | Codex | Package/helpers plus independent WebSocket and stdio initialize/list/correlation/teardown | None | Account prompt/history/approval |
 | Copilot | Install/version, exact ACP launch, initialize and `copilot-login` method without prompting | None | Entitlement/session/options/tool E2E |
 | Cursor | Four archive hashes; current-host package layout, exact build, ACP initialize/model/mode, teardown | Configured load/replay fixture; missing fixture blocks pin | Broad provider/model/cancel exploration |
-| Claude | Isolated version/help, all launch flags, stream-json startup/teardown | None | Provider/auth/queue/child terminal fixture |
+| Claude | Isolated version/help, all launch flags, stream-json startup, approval/replay/interrupt/teardown with a controlled provider | None | Real-provider/auth/queue/child terminal fixture |
 | Hermes | Tagged isolated `hermes acp` version/initialize/list/session-list plus scratch cleanup | Configured new/load fixture; missing fixture blocks pin | Provider/catalog/replay exploration |
-| Pi | Package/version, RPC launch/get_state/correlation/teardown, compaction ordering | None | Provider-backed prompt/catalog/history |
+| Pi | Package/version, RPC launch/get_state/correlation/teardown, settlement and manual-compaction abort/ordering with a controlled provider | None | Real-provider prompt/catalog/history |
 | OMP | Managed direct placement, `omp/<version>`, ACP initialize and bounded queue/cancel smoke | Configured `authenticate(agent)`, list/new/load, persisted cleanup; missing fixture blocks pin | Authenticated turn, plan UX, MCP, sub-agents |
 | Grok | Direct version/exact launch, ACP identity/list/resume/namespace/teardown | Reference-required authenticated new/prompt/replay/model-selection/close probes; missing fixture blocks pin | Optional broad provider/model/child exploration |
 

--- a/.plan/active/all-harness-runtime-refresh/STEP-2-LIFECYCLE-VERIFICATION.md
+++ b/.plan/active/all-harness-runtime-refresh/STEP-2-LIFECYCLE-VERIFICATION.md
@@ -1,0 +1,104 @@
+# Step 2 — Supplemental lifecycle verification
+
+Date: 2026-09-12. Follow-up to
+[PR #1455](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1455).
+
+## Why this follow-up exists
+
+The first Step 2 report established startup, integrity, installation, and
+focused package checks, but did not establish all Pi/Claude lifecycle gates
+named in the plan. Review caught that gap. The owner chose to complete the
+additional checks, not weaken the requirements. PR #1455 merged while those
+review threads were still open; this accepted follow-up closes that evidence
+gap after merge. The merge itself was not a gate waiver.
+
+Both candidates now pass the additional gates below on **macOS ARM64**. The
+actual candidate runtimes ran against controlled loopback model responses;
+no Pi RPC or Claude control/stream events were fabricated. No real credentials,
+live account/profile, external provider network, or production source changes
+were needed. This is not a live-provider authentication or model-quality claim.
+
+## Pi 0.85.1
+
+Used the verified installed candidate through
+`PiPlugin -> PiSessionService -> PiSessionProcessRepository -> PiRpcClient`.
+Public production calls covered catalog/options refresh, session creation,
+prompting, the native `compact` command, `abortSession`, history, and shutdown.
+
+| Required observation | Result |
+|---|---|
+| Native settlement | `agent_start -> agent_end -> agent_settled`; production consumes settlement, then emits idle status and `BridgeSseSessionIdle` |
+| Manual compaction entry | Native `compaction_start` and a production running `compact` tool part after ten synthetic history messages |
+| Abort during held provider request | Native `compaction_end(aborted: true, willRetry: false)`; no successful-compaction event |
+| Production cleanup ordering | Running compact part -> compaction message removal -> idle status -> session idle, at event indexes 87–90 |
+| Post-abort state/history | Idle work/session state; no compact tool entry retained |
+| Reuse | A follow-up on the same production session ID launches the normal resumed-session process and settles successfully |
+| Automatic teardown | Production idle reap and shutdown observed all four owned candidate exits; fixture also stopped and exited |
+
+Disposable project compaction retention was reduced so the small synthetic
+history entered real compaction. The held fixture response was released after
+abort was requested; native cancellation, not a fabricated provider abort
+event, determined the outcome. Successful compaction output, automatic retry,
+and real-provider behavior were not tested.
+
+`PiLaunchSpec` already supplies `--approve` for its RPC launches. The probe used
+that existing production project-trust policy; this refresh adds no launch
+flag or permission-policy change.
+
+## Claude Code 2.1.269
+
+The real candidate used the `ClaudeLaunchSpec` launch vector under normal
+manual permission policy. Captured native frames were parsed with production
+`ClaudeStreamMessage` types. `ClaudeEventDispatcher.mapPromptReplay`,
+`ClaudeTranscriptApi`, `ClaudeTranscriptCatalogRepository`, and
+`ClaudeHistoryMapper` processed the actual replay/history evidence. This does
+not claim a full `ClaudeSessionService`/approval-registry integration run.
+
+| Required observation | Result |
+|---|---|
+| Stdio permission allow | Correlated native `can_use_tool`; allowed harmless owned-project action created its marker and completed |
+| Stdio permission deny | Correlated denial; one permission denial reported and denied marker absent |
+| Resident reuse | Two completed turns on the same candidate process |
+| Persisted resume/history | Seed turn persisted; `--resume` continued the session; native records and production history both ordered user/assistant/user/assistant |
+| Replay/correlation | Current-user replay echo preceded resumed assistant output; production replay mapping preserved prompt correlation |
+| Active interrupt | Partial output preceded the request; correlated interrupt ACK preceded distinct terminal `error_during_execution` / `aborted_streaming` |
+| No late admission | No late permission request or action marker after interrupt |
+| Reuse after interrupt | Normal resumed-session follow-up completed successfully |
+| Teardown | All owned candidate/fixture handles reaped; final owned-process scan empty |
+
+The replay echo is the current submitted prompt, not a claim that old transcript
+history is replayed over stdio. Persisted history was checked separately through
+the native transcript and production history mapper. The resumed provider
+request contained three messages versus one for the seed request.
+
+## Bounds and evidence
+
+Fresh synthetic profiles/projects, allowlisted environments, and restrictive
+macOS sandboxes prevented access to user data and external network. Candidate
+network access was confined to the owned loopback fixture. Trusted controllers
+outside the candidate sandbox owned process groups, bounded operations, and
+performed automatic cleanup; no denied in-sandbox presence check was used as
+proof of exit.
+
+All observed scenarios completed within the 120-second controller budget.
+Pi's production/native event sequence occupied about 1.55 seconds, followed by
+about 2.32 seconds of automatic cleanup; Claude scenarios took approximately
+0.97, 1.17, and 1.41 seconds. Deadline-expiry fault injection was not tested;
+Pi's outer `Future.timeout` is a wait budget, not cancellation of its underlying
+future. The reported passing evidence includes actual process exits and cleanup,
+not an inference from that timeout.
+
+Local authoritative artifacts, relative to `.dart_tool/runtime-refresh-validation/`:
+
+- `pi/LIFECYCLE-REPORT.md`
+- `pi/lifecycle/run-1789233459476/{result,production-events,native-events}.json`
+- `pi/lifecycle/lifecycle_driver.dart` and `fixture_server.dart`
+- `claude/LIFECYCLE-REPORT.md`
+- `claude/lifecycle/runs/gate-validation.json`
+- `claude/lifecycle/runs/{permission,replay,interrupt}/summary.json`
+- `claude/lifecycle/run_lifecycle.py`, `fixture_server.py`, and `production_seam_probe.dart`
+
+The worktree advanced from `fd2d4d8` to merged `ba3264ea` during verification;
+Pi/Claude and their relevant runtime/shared/toolchain inputs did not change.
+Earlier successful asset/install checks and the 349 post-pin tests were not
+rerun. Codex/OMP blockers and all later target/feature gates remain unchanged.

--- a/.plan/active/all-harness-runtime-refresh/STEP-2-VERIFICATION.md
+++ b/.plan/active/all-harness-runtime-refresh/STEP-2-VERIFICATION.md
@@ -5,11 +5,17 @@ Date: 2026-09-12. Base: plan merge `a644652e0c1a03232dc33184b522124703636988`
 
 ## Disposition
 
-Four independently gated candidates are applied in this branch. Two remain
-unchanged and blocked; this is not completion of every target or the series.
-All independent floors, platform mappings, layouts, and launch policies remain
-unchanged. DeepSeek is excluded. No new production classes, generated files,
-wire contracts, or Sesori database changes are introduced.
+Four targets merged in [PR #1455](https://github.com/sesori-ai/sesori_apps_monorepo/pull/1455)
+as `ba3264eab93a1775d4e4c24e7672cab8bebe2d67`. Review identified missing
+Pi/Claude lifecycle evidence; the owner chose to complete those gates, not
+relax them. Their [supplemental verification](STEP-2-LIFECYCLE-VERIFICATION.md)
+was accepted after merge. The results below include that follow-up.
+
+Two targets remain unchanged and blocked; this is not completion of every
+target or the series. All independent floors, platform mappings, layouts, and
+launch policies remain unchanged. DeepSeek is excluded from this series.
+No new production classes, generated files, wire contracts, or Sesori database
+changes are introduced.
 
 | Harness | Previous target → branch target | Floor | Result |
 |---|---|---|---|
@@ -93,13 +99,18 @@ were not exposed. Network was denied except loopback where required.
   initialization passed, including ACP v1 and `copilot-login`. No login/provider
   turn ran; teardown left no candidate process.
 - **Pi:** exact version and reference RPC launch returned correlated successful
-  `get_state` with object data. Shutdown completed within two seconds. Provider
-  turns, settlement, retry, and compaction behavior were not reverified.
+  `get_state` with object data. Startup shutdown completed within two seconds.
+  The supplemental native/production-plugin run verified settlement, manual
+  compaction abort/ordering, cleared state, resumed reuse, and automatic cleanup
+  with a controlled loopback provider. Successful compaction, retry, and real
+  provider behavior remain untested.
 - **Claude:** official current-host archive integrity, exact version, production
   launch flags, and correlated stream-json initialization passed. The matching
-  SDK vector and isolated synthetic-session resume also initialized. No live
-  provider/replay-order/partial-delta/permission-exchange claim is made. This
-  direct CLI has no managed-asset pin or automatic installation change.
+  SDK vector and initial synthetic-session resume also initialized. Supplemental
+  native permission allow/deny, persisted resume/history and replay correlation,
+  active interrupt/terminal distinction, reuse, and cleanup passed with production
+  parsing/mapping checks. No live external-provider claim is made. This direct
+  CLI has no managed-asset pin or automatic installation change.
 
 Other platforms are integrity-checked but **not natively tested**. No UI,
 authenticated-provider, Windows ARM64 feature, or multi-select gate is claimed.

--- a/.plan/active/all-harness-runtime-refresh/STEP-3-VERIFICATION.md
+++ b/.plan/active/all-harness-runtime-refresh/STEP-3-VERIFICATION.md
@@ -1,0 +1,208 @@
+# Step 3 — Antigravity and Cursor exact builds
+
+## Decision and scope
+
+- **Antigravity: adopt** registry package `1.1.1`, exact server identity
+  `agy_acp_server_1.1.1`, ACP 1. Archive/install/initialize, actual production
+  validator, teardown and focused checks pass. The five existing platform
+  mappings remain.
+- **Cursor: blocked, unchanged** at `2026.08.11-e8db854`. Candidate
+  `2026.09.10-fd3934a` passed its no-credential checks, but required configured
+  load/replay and model/mode checks are incomplete.
+- Every independent minimum remains unchanged. Antigravity's `minPathVersion`
+  follows the exact package identity; it is not an independent semantic floor.
+  Its earlier server pair no longer passes the exact check. Explicit binaries
+  remain authoritative and must be replaced as a complete pair.
+- No authentication policy, capability, platform, wire/database contract,
+  generated production model, or analytics event is added. DeepSeek and
+  unrelated upstream changes remain outside this series.
+
+## Antigravity release and integrity
+
+Official registry commit `d30bc9a7c011b522e8502281d5fbcfca51abd5ff`, release
+`v2026.09.12-d30bc9a`, declares package `1.1.1` and five Google-hosted ZIPs.
+Each selected archive was independently downloaded and SHA-256 hashed. HTTP
+content lengths and local sizes agreed. These are local integrity records,
+not publisher checksum attestations or source-to-binary proofs.
+
+| Platform | Archive bytes | SHA-256 |
+|---|---:|---|
+| macOS arm64 | 316014828 | `fdfa915652cdb7ba8085cc8fffed072cbe009251aa2c951aabdda07a8c28a189` |
+| Linux arm64 | 656572786 | `ed69e64b308fcb123ab54bf3277bf9cb0d651064f885ea5aab0ff520c7175398` |
+| Linux x64 | 681969407 | `38f62d01b32deb0907b3d39a71ec301fd36369f6ffd1cf262d4af385177f79df` |
+| Windows arm64 | 468521191 | `35f4b1f47ba6a3fea7b0a3e30010df5ea73a64b4f0e7cf991cddc673ddfbcafc` |
+| Windows x64 | 468238392 | `47cb50eef14f0a4655d78cfcfda869bcea7aaee5f9787e936bc2935ea612c3b8` |
+
+All five static ZIP inspections found the expected server/harness siblings.
+Archive URLs, hashes, archive sizes, and both member sizes were reconciled
+against the production release constants by platform, not copied from prose.
+The macOS ARM64 installed members additionally match:
+
+- Server SHA-256: `9d900b93031fc42397f88206e14eba4193729bbef631a70b18e7a19631a6dfac`.
+- Harness SHA-256: `e0a8ef9d80a1ffb178f945159dda33f73d4a5be65516642542352584b834fa2a`.
+
+The exact URLs and byte counts live in
+`bridge/sesori_plugin_antigravity/lib/src/foundation/antigravity_release.dart`.
+No macOS x64 mapping is introduced. Linux/Windows native execution remains
+**Untested**; static archive inspection is not native platform verification.
+
+## Antigravity native boundary
+
+The macOS ARM64 candidate ran in fresh synthetic project/state directories
+under a restrictive OS sandbox with filtered environment, no ambient
+credentials, and no external network. Production managed installation,
+checksum validation, extraction, staging and placement used the independently
+captured bytes through an exact-URL-checking local download adapter.
+
+Candidate-aware manifest/validator projections were necessary while the
+production constants still selected `1.0.0`. Native probing exercised
+`AntigravityRuntimeStorage`, `AntigravityRuntimeRepository`,
+`AntigravityAcpApi`, `AntigravityLaunchSpecBuilder`, and
+`AntigravityEnvironmentBuilder`. This is not a claim that the unmodified
+old-pin `AntigravityRuntimeVersionValidator` accepted the new identity.
+Post-pin unit checks separately cover that production validator. A bounded
+native follow-up on 2026-09-13 also passed the actual production path, reusing
+the installed candidate without downloading or reinstalling it:
+
+`AntigravityRuntimeVersionValidator.validate` →
+`AntigravityRuntimeService.validateManagedCandidate` →
+`AntigravityRuntimeRepository.inspectPair/probe` →
+`AntigravityAcpApi.initializeOnly`.
+
+Recording wrappers called production `super` methods. No custom final
+predicate, fake frame or recorded-snapshot replay was substituted.
+
+Its first launch failed before Dart `main()` with current-directory access
+denied by the sandbox; no candidate started and no validator result was
+produced. The outer controller exited 255 after 0.586 seconds, without timeout,
+and recorded no survivors. One same-protocol retry explicitly used an allowed
+scratch cwd and an unchanged wrapper copy inside the existing read grant.
+The compiled helper and sandbox policy were unchanged.
+
+That retry entered `AntigravityRuntimeVersionValidator.validate` and
+`AntigravityRuntimeService.validateManagedCandidate`, but production pair
+inspection failed at `FileSystemEntity.resolveSymbolicLinksSync` with
+`Operation not permitted`. The service returned `AntigravityRuntimeStorageFailed`
+and the validator returned `false`; repository probe, ACP initialize and native
+candidate spawn were never reached. This is not candidate rejection evidence.
+The helper exited 2 after 0.13 seconds, without timeout or surviving owned
+processes. The owner then authorized one minimal read-only path-resolution
+correction and same-protocol retry. A new profile added only exact
+metadata/existence literals for `/` and the owned validation tree's
+`antigravity/install-state` and `antigravity/install-state/antigravity` ancestors.
+No additional file-content, write, execute, signal or network access was granted;
+the original profile, helper and wrapper were preserved unchanged.
+
+That final attempt reached native initialize and returned validator `true`
+with the selected managed contract `agy_acp_server_1.1.1`. Native exit `-15`
+was observed through production teardown. The outer controller exited 0 in
+**1.434 seconds**, did not time out, and recorded no surviving owned processes.
+These were infrastructure corrections, not a candidate rejection or gate waiver.
+
+Initial discovery, candidate-aware validation and final production-validator
+initialize observations agree on:
+
+- Agent `antigravity-acp`, version `agy_acp_server_1.1.1`, protocol 1.
+- Session load/list/resume advertised; standard close absent.
+- Authentication logout advertised; methods `oauth-personal`, `oauth-business`,
+  `gemini-api-key`, and `agent-platform`.
+- No OAuth, session creation, prompt, model operation, or authenticated probe.
+  Sesori still exposes **personal OAuth only**.
+
+The production install retained both siblings, correct permissions and the
+archive-digest sentinel, with no symlinks or validation staging residue.
+Production launch kept the sibling harness path and isolated profile behavior;
+Linux `--uid=` and Windows filename policies were not changed.
+
+Both initial install/probe native processes exited with `-15` during normal teardown.
+The trusted outer controller completed with exit 0 in **38.603 seconds**, did
+not time out, and recorded an empty final owned-process scan. An in-sandbox
+presence denial is not evidence of absence. Deadline-expiry fault injection
+was not performed.
+
+## Cursor candidate boundary and blocker
+
+The official installer at `https://cursor.com/install` was captured, not
+executed. Its exact candidate URLs use
+`https://downloads.cursor.com/lab/2026.09.10-fd3934a/` followed by
+`{darwin|linux}/{arm64|x64}/agent-cli-package.tar.gz`.
+
+| Platform | Archive bytes | SHA-256 |
+|---|---:|---|
+| macOS arm64 | 174178929 | `aec0b01ae056de48a02fe315fbf0580eb91377752d993307499988cbe0285423` |
+| macOS x64 | 181409095 | `964cc72e88125c6b48ecaaebef68bf7cb752eb7b9d010a5535cf9f8e677dcf83` |
+| Linux arm64 | 177655979 | `e0494438b01c37bc34848491d1f3478ef469494c56caf020de11796d146db64a` |
+| Linux x64 | 179673253 | `27997c8391ad853a5a732b1845db8ef82a8ba6afb0f7829cc739464f8966e96e` |
+
+All four records come from independently downloaded bytes; no publisher
+checksum or source attestation is claimed. Native evidence is macOS ARM64 only:
+
+- Production installer/extractor/staging/checksum/version validation through
+  candidate metadata and an exact-URL-checking local byte adapter.
+- Complete package retained: 568 entries, no symlinks, executable entrypoint,
+  matching sentinel, and no staging residue. Worker/runtime/native-module
+  siblings were not reduced to a single binary.
+- Exact `--version` succeeded; production `cursor-agent acp` launch initialized
+  ACP 1, advertising `cursor_login`, load/list and parameterized model picker.
+  No endpoint override, authentication, session or model/mode request was made.
+- Restricted OS sandbox, synthetic state/project and filtered environment;
+  external network and ambient credentials were unavailable.
+- Candidate exit 143 was observed. Trusted outer cleanup handled an owned
+  orphaned `rg --files` descendant and confirmed an empty final group. It
+  passed in **6.929 seconds**, within the 120-second deadline, without timeout.
+
+Configured persisted-session load/replay remains required before pinning;
+model/mode checks are also `BLOCKED_AUTH_REQUIRED`. Completion needs explicit
+owner authorization for an isolated disposable Cursor login/profile or scoped
+API credential, the normal Cursor endpoint, one persisted synthetic-project
+session, and bounded list/load/replay/model/mode/cleanup operations. No ambient
+profile, credentials or provider access may be inferred from “continue”.
+
+Cursor's date floor, explicit-binary precedence, full package layout, endpoint
+behavior, and Darwin/Linux-only support remain unchanged. Its source and
+post-pin tests are untouched because no Cursor pin was applied.
+
+## Post-pin verification and recovery
+
+Pinned Dart **3.13.3** completed Antigravity's owning analyzer with
+`analyze --fatal-infos`. Formatting all five changed Dart files made no changes.
+**68 distinct tests across nine files passed**, using the latest execution of
+each affected suite rather than counting retries as additional coverage:
+
+- Release/launch, historical initialize fixture, runtime manifest, storage,
+  version validator, runtime service, descriptor, plugin, authentication composer.
+- The first eight-file run exposed two descriptor failures: its current-runtime
+  fake reused the historical `1.0.0` initialize capture. The descriptor and
+  authentication composer now use a separate, explicitly synthetic current
+  fixture. The historical capture remains unchanged and its decoder test checks
+  its historical identity. The affected 19 tests passed on the focused follow-up;
+  the seven unchanged passing suites were not rerun.
+
+No production classes, ownership, launch policy or internal/wire contracts
+changed, so a new architecture review was not required. Full repository tests
+and analysis remain CI-owned. No initial download/install/protocol probe was
+repeated for a documentation-only change or handoff recovery.
+
+The parent async runner disappeared before writing its result, independently
+of the successful native controller outcomes. Both completed reports survived,
+were preserved, and were recovered through their retained native child sessions.
+Recovery performed no candidate execution, stale-PID signaling or tracked/Git
+mutation. Parent reconciliation accepted the raw evidence and completed the actual
+production-validator follow-up before accepting Antigravity's target. Runner failure was neither a candidate regression
+nor permission to weaken the candidate sandbox.
+
+Private supporting records remain beneath
+`.dart_tool/runtime-refresh-validation/`:
+
+- `antigravity/metadata/{integrity-summary,archive-layout}.json`;
+  `antigravity/logs/final-probe{.controller,-summary}.json`;
+  `antigravity/probe/antigravity_candidate_probe.dart`; `antigravity/post-pin/`;
+  `antigravity/production-validator/retry-2/` report, native result, controller
+  result, permission diff and ownership records.
+- `cursor/official/selected-assets.tsv`; `cursor/probe/runs/install-protocol/`
+  install/ACP/outer-owner/outer-result records; both lane reports and preserved
+  handoff copies.
+
+These records contain local diagnostic context and are not uploaded wholesale.
+The public evidence above contains no credentials, prompts, provider payloads,
+account identifiers, or user-local absolute paths.

--- a/.plan/active/all-harness-runtime-refresh/TRACKER.md
+++ b/.plan/active/all-harness-runtime-refresh/TRACKER.md
@@ -52,7 +52,7 @@
 | Pi | `0.85.1` | `0.84.1` unchanged | `0.85.1` | Pass: six hashes/install/RPC, native production-plugin settlement/manual-compaction abort/ordering/reuse/cleanup; tests/analyzer |
 | Oh My Pi | `17.3.8` | `17.2.13` unchanged | `18.1.18` | Blocked: seven hashes/install/initialize pass; authorized authenticate/list/new/load/cleanup fixture absent |
 | Grok Build | `1.0.5` | `1.0.5` unchanged | stable channel `1.0.30` | Blocked; reference-required authenticated new/prompt/replay/model-selection/close probes pending |
-| DeepSeek | Upstream main | Outside this series | None | Explicitly excluded; unrelated upstream changes are neither audited nor modified here |
+| DeepSeek | Not assessed (excluded) | Outside this series | None | Explicitly excluded; historical baseline is not a current-target claim, and unrelated upstream changes are neither audited nor modified here |
 
 ## Approved and deferred decisions
 

--- a/.plan/active/all-harness-runtime-refresh/TRACKER.md
+++ b/.plan/active/all-harness-runtime-refresh/TRACKER.md
@@ -2,7 +2,7 @@
 
 ## Current state
 
-- **Series:** nine top-level steps; Steps 1–2 merged, Step 3 verification active.
+- **Series:** nine top-level steps; Steps 1–2 merged, Step 3 verified and ready for review.
 - **Branch/base:** `all-harness-runtime-refresh-step-3` /
   `ba3264eab93a1775d4e4c24e7672cab8bebe2d67`.
 - **Delivered scope:** PR #1455 merged four target updates, 18 managed digests,
@@ -12,10 +12,16 @@
 - **Approved scope:** mechanical target refreshes, OMP Windows ARM64 mapping,
   and OMP-backed shared ACP multi-select questions. Floors remain unchanged;
   DeepSeek and unrelated upstream changes remain outside this series.
-- **Next:** accept independent Antigravity/Cursor release/install/protocol
-  evidence and apply only passing targets. Codex teardown proof and required
-  configured/authenticated fixtures remain blocking only for their respective
-  pins. See [Step 2 verification](STEP-2-VERIFICATION.md) and its
+- **Current branch:** Antigravity package `1.1.1` / server `agy_acp_server_1.1.1`
+  applied after five-asset integrity, macOS ARM64 installation, actual production
+  validator/initialize and cleanup gates. All 68 distinct tests across nine files
+  and the owning analyzer pass. Cursor remains unchanged.
+- **Next:** publish and monitor Step 3, then advance independently actionable work.
+  No credential/profile access, provider networking, or expanded feature scope
+  is authorized by the completed read-only sandbox correction.
+  Codex teardown proof and required configured/authenticated fixtures remain
+  blocking only for their respective pins. See [Step 3 verification](STEP-3-VERIFICATION.md),
+  [Step 2 verification](STEP-2-VERIFICATION.md), and its
   [lifecycle follow-up](STEP-2-LIFECYCLE-VERIFICATION.md).
 
 ## Delivery ledger
@@ -24,7 +30,7 @@
 |---|---|---|---|
 | [x] | 1/9 | `🌱 [all-harness-runtime-refresh] docs: publish runtime refresh plan [step 1/9]` | PR #1453 merged as a644652e0c; no production changes |
 | [x] | 2/9 | `🌿 [all-harness-runtime-refresh] runtime: refresh mechanical targets [step 2/9]` | PR #1455 merged as ba3264eab9; four targets verified including post-merge Pi/Claude follow-up; Codex/OMP remain blocked and unchanged |
-| [ ] | 3/9 | `⚙️ [all-harness-runtime-refresh] runtime: validate Antigravity and Cursor exact builds [step 3/9]` | Independent exact-pair/build/hash/install probes running; no target applied yet |
+| [ ] | 3/9 | `🌿 [all-harness-runtime-refresh] runtime: validate Antigravity and Cursor exact builds [step 3/9]` | Antigravity verified/applied, including actual production-validator native gate; Cursor configured gates block its pin; review pending |
 | [ ] | 4/9 | `⚙️ [all-harness-runtime-refresh] runtime(hermes): resolve cleanup and refresh target [step 4/9]` | Blocked on empty-session cleanup seam |
 | [ ] | 5/9 | `🌿 [all-harness-runtime-refresh] runtime(grok): refresh target [step 5/9]` | Channel/ACP probe pending; namespace/provenance policy corrected |
 | [ ] | 6/9 | `⚙️ [all-harness-runtime-refresh] runtime(omp): add Windows arm64 asset [step 6/9]` | Approved eighth asset; hash/mapping/native Windows ARM64 install-version-ACP smoke/documentation gates pending |
@@ -37,10 +43,10 @@
 | Harness | Branch target | Floor/exact policy | Candidate | Status |
 |---|---:|---|---:|---|
 | OpenCode | `1.18.30` | `1.14.0` unchanged | `1.18.30` | Pass: six hashes, install, REST/SSE, read-only catalog, focused tests/analyzer |
-| Antigravity | package `1.0.0`; server `agy_acp_server_20260818_01_RC01` | Exact package/server/ACP 1; no semantic floor | package `1.1.1`; server pending | Probe-first |
+| Antigravity | package `1.1.1`; server `agy_acp_server_1.1.1` | Exact package/server/ACP 1; no semantic floor | package `1.1.1`; server `agy_acp_server_1.1.1` | Pass: five hashes, macOS ARM64 install/actual production validator/initialize/cleanup, focused tests/analyzer |
 | Codex | `0.153.4` | `0.139.0` unchanged | `0.154.0` | Partial / blocked: assets/install/both transports pass; scratch sandbox group teardown fails after one focused retry |
 | GitHub Copilot | `1.0.83` | `1.0.78` unchanged | `1.0.83` | Pass: six hashes, install, ACP initialize, focused tests/analyzer |
-| Cursor | `2026.08.11-e8db854` | date floor `2026.07.16` unchanged | `2026.09.10-fd3934a` | Probe-first; four content hashes and configured load/replay fixture pending; missing fixture blocks pin |
+| Cursor | `2026.08.11-e8db854` | date floor `2026.07.16` unchanged | `2026.09.10-fd3934a` | Blocked: four hashes and macOS ARM64 install/initialize/cleanup pass; configured load/replay and model/mode evidence absent |
 | Claude Code | `2.1.269` | `2.1.221` unchanged | `2.1.269` | Pass: CLI/SDK launch, native controlled-provider approval/replay/interrupt/reuse/cleanup plus production parsing/history mapping; tests/analyzer |
 | Hermes Agent | `0.20.4` | `0.20.0` unchanged | `0.21.2` | Blocked; cleanup and configured new/load fixture prerequisites |
 | Pi | `0.85.1` | `0.84.1` unchanged | `0.85.1` | Pass: six hashes/install/RPC, native production-plugin settlement/manual-compaction abort/ordering/reuse/cleanup; tests/analyzer |
@@ -55,7 +61,7 @@
   ACP array `items.anyOf` forms for OMP through shared mapping and existing UI.
 - **Still prerequisite:** Hermes narrow not-found cleanup treatment must be
   confirmed by candidate source/probe before pinning. Required configured gates
-  are also pin-blocking: Cursor load/replay; OMP authenticate/list/new/load and
+  are also pin-blocking: Cursor load/replay/model/mode; OMP authenticate/list/new/load and
   persisted cleanup; Hermes new/load; and Grok authenticated
   new/prompt/replay/model-selection/close. Missing fixtures block their
   respective pins; optional broad provider/model/catalog/child exploration is
@@ -80,7 +86,7 @@ These gates are tracked independently from the target-only L2 matrix.
 
 | Feature/gate | Minimum sufficient scope | Required evidence | Status |
 |---|---|---|---|
-| Cursor configured load/replay | Pin-blocking configured fixture | Authorized isolated configured load/replay; missing fixture blocks Cursor pin | Blocked |
+| Cursor configured lifecycle/options | Pin-blocking configured fixture | Authorized isolated load/replay/model/mode; missing fixture blocks Cursor pin | Blocked |
 | OMP configured lifecycle | Pin-blocking configured fixture | `authenticate(agent)`, list/new/load, persisted cleanup; missing fixture blocks OMP pin | Blocked |
 | Hermes configured lifecycle | Pin-blocking configured fixture | Configured new/load; missing fixture blocks Hermes pin | Blocked |
 | Grok authenticated seam | Pin-blocking authenticated fixture | New/prompt/replay/model-selection/close; missing fixture blocks Grok pin | Blocked |
@@ -116,6 +122,31 @@ These gates are tracked independently from the target-only L2 matrix.
   through the production plugin, and Claude native approval/replay/interrupt
   with production parsing/history mapping. Controlled loopback providers only;
   real-provider behavior and deadline-expiry fault injection are not claimed.
+- Step 3 recovered both completed native-lane reports after an independent
+  parent-runner failure, without re-execution or an execution-mode fallback.
+  Antigravity's five hashes/member sizes and Cursor's four hashes were reconciled
+  against machine-readable records. Only Antigravity's verified exact pair was
+  applied after the actual production-validator native follow-up passed.
+  Other platforms remain natively untested; no authenticated or
+  broader capability claim is added. See [Step 3 verification](STEP-3-VERIFICATION.md).
+- The production-validator helper first failed before Dart `main()` due to cwd
+  access. One same-protocol retry used an allowed cwd and an unchanged wrapper
+  copy inside existing grants; it reached the production validator but returned
+  `false` through `AntigravityRuntimeStorageFailed` during symbolic-link
+  resolution. No candidate or ACP process started in either attempt. Both
+  controllers reaped their helpers with no survivors; no sandbox permissions
+  changed in those attempts. After owner approval, three exact metadata/existence
+  literals repaired path resolution without additional file-content, write,
+  execution, signal or network permissions. The actual production validator then
+  returned `true` for the real `agy_acp_server_1.1.1` candidate; native exit `-15`,
+  controller exit 0 in 1.434 seconds, no timeout and no surviving owned processes
+  were observed. Original profiles/reports and dirty diffs remain preserved.
+- Antigravity post-pin checks cover 68 distinct cases across nine files. Two
+  initial descriptor failures identified historical `1.0.0` data reused as a
+  current-runtime fake; separate synthetic current data fixed descriptor and
+  authentication-composer fixtures without rewriting the historical capture.
+  The affected 19 cases and owning analyzer passed; unchanged passing suites
+  and native probes were not repeated.
 - No real credentials or live profiles were used. Required configured fixtures,
   multi-select, and Windows ARM64 native gates remain blocked; other non-macOS
   native paths remain untested. Full evidence and limits are in

--- a/.plan/active/all-harness-runtime-refresh/TRACKER.md
+++ b/.plan/active/all-harness-runtime-refresh/TRACKER.md
@@ -2,27 +2,29 @@
 
 ## Current state
 
-- **Series:** nine top-level steps; Step 1 merged, Step 2 verified locally.
-- **Branch/base:** `all-harness-runtime-refresh-step-2` /
-  `a644652e0c1a03232dc33184b522124703636988`.
-- **Publication scope:** four target updates, 18 managed digests, and focused
-  target fixtures. No new capabilities, generated files, wire/database changes,
-  or product release. Branch targets below are not yet a merged release claim.
+- **Series:** nine top-level steps; Steps 1–2 merged, Step 3 verification active.
+- **Branch/base:** `all-harness-runtime-refresh-step-3` /
+  `ba3264eab93a1775d4e4c24e7672cab8bebe2d67`.
+- **Delivered scope:** PR #1455 merged four target updates, 18 managed digests,
+  and focused target fixtures. Its additional Pi/Claude lifecycle evidence was
+  accepted after merge; no required gate was waived. No new capabilities,
+  generated files, wire/database changes, or product release were introduced.
 - **Approved scope:** mechanical target refreshes, OMP Windows ARM64 mapping,
   and OMP-backed shared ACP multi-select questions. Floors remain unchanged;
-  DeepSeek remains excluded.
-- **Next:** publish and monitor Step 2, then begin the Antigravity/Cursor
-  successor. Codex teardown proof and configured/authenticated fixtures remain
-  blocking only for their respective pins; none is waived. See
-  [Step 2 verification](STEP-2-VERIFICATION.md) for completed and blocked gates.
+  DeepSeek and unrelated upstream changes remain outside this series.
+- **Next:** accept independent Antigravity/Cursor release/install/protocol
+  evidence and apply only passing targets. Codex teardown proof and required
+  configured/authenticated fixtures remain blocking only for their respective
+  pins. See [Step 2 verification](STEP-2-VERIFICATION.md) and its
+  [lifecycle follow-up](STEP-2-LIFECYCLE-VERIFICATION.md).
 
 ## Delivery ledger
 
 | Done | Step | Exact PR title | Status |
 |---|---|---|---|
 | [x] | 1/9 | `🌱 [all-harness-runtime-refresh] docs: publish runtime refresh plan [step 1/9]` | PR #1453 merged as a644652e0c; no production changes |
-| [ ] | 2/9 | `🌿 [all-harness-runtime-refresh] runtime: refresh mechanical targets [step 2/9]` | OpenCode/Copilot/Claude/Pi verified and applied locally; Codex/OMP remain blocked and unchanged |
-| [ ] | 3/9 | `⚙️ [all-harness-runtime-refresh] runtime: validate Antigravity and Cursor exact builds [step 3/9]` | Exact ACP pair and Cursor build/content gates pending |
+| [x] | 2/9 | `🌿 [all-harness-runtime-refresh] runtime: refresh mechanical targets [step 2/9]` | PR #1455 merged as ba3264eab9; four targets verified including post-merge Pi/Claude follow-up; Codex/OMP remain blocked and unchanged |
+| [ ] | 3/9 | `⚙️ [all-harness-runtime-refresh] runtime: validate Antigravity and Cursor exact builds [step 3/9]` | Independent exact-pair/build/hash/install probes running; no target applied yet |
 | [ ] | 4/9 | `⚙️ [all-harness-runtime-refresh] runtime(hermes): resolve cleanup and refresh target [step 4/9]` | Blocked on empty-session cleanup seam |
 | [ ] | 5/9 | `🌿 [all-harness-runtime-refresh] runtime(grok): refresh target [step 5/9]` | Channel/ACP probe pending; namespace/provenance policy corrected |
 | [ ] | 6/9 | `⚙️ [all-harness-runtime-refresh] runtime(omp): add Windows arm64 asset [step 6/9]` | Approved eighth asset; hash/mapping/native Windows ARM64 install-version-ACP smoke/documentation gates pending |
@@ -39,12 +41,12 @@
 | Codex | `0.153.4` | `0.139.0` unchanged | `0.154.0` | Partial / blocked: assets/install/both transports pass; scratch sandbox group teardown fails after one focused retry |
 | GitHub Copilot | `1.0.83` | `1.0.78` unchanged | `1.0.83` | Pass: six hashes, install, ACP initialize, focused tests/analyzer |
 | Cursor | `2026.08.11-e8db854` | date floor `2026.07.16` unchanged | `2026.09.10-fd3934a` | Probe-first; four content hashes and configured load/replay fixture pending; missing fixture blocks pin |
-| Claude Code | `2.1.269` | `2.1.221` unchanged | `2.1.269` | Pass: direct CLI/SDK launch and isolated stream initialization; descriptor tests/analyzer |
+| Claude Code | `2.1.269` | `2.1.221` unchanged | `2.1.269` | Pass: CLI/SDK launch, native controlled-provider approval/replay/interrupt/reuse/cleanup plus production parsing/history mapping; tests/analyzer |
 | Hermes Agent | `0.20.4` | `0.20.0` unchanged | `0.21.2` | Blocked; cleanup and configured new/load fixture prerequisites |
-| Pi | `0.85.1` | `0.84.1` unchanged | `0.85.1` | Pass: six package hashes, install, correlated RPC get_state, focused tests/analyzer; compaction not reverified |
+| Pi | `0.85.1` | `0.84.1` unchanged | `0.85.1` | Pass: six hashes/install/RPC, native production-plugin settlement/manual-compaction abort/ordering/reuse/cleanup; tests/analyzer |
 | Oh My Pi | `17.3.8` | `17.2.13` unchanged | `18.1.18` | Blocked: seven hashes/install/initialize pass; authorized authenticate/list/new/load/cleanup fixture absent |
 | Grok Build | `1.0.5` | `1.0.5` unchanged | stable channel `1.0.30` | Blocked; reference-required authenticated new/prompt/replay/model-selection/close probes pending |
-| DeepSeek | `0.1.5` | `0.1.5` unchanged | None | Explicitly excluded/unchanged |
+| DeepSeek | Upstream main | Outside this series | None | Explicitly excluded; unrelated upstream changes are neither audited nor modified here |
 
 ## Approved and deferred decisions
 
@@ -108,6 +110,12 @@ These gates are tracked independently from the target-only L2 matrix.
   passed. All four owning analyzers and formatting for nine Dart files passed
   with pinned Dart 3.13.3. Older compatible PATH fixtures and historical protocol
   observations remain unchanged.
+- Review caught missing named Pi/Claude lifecycle evidence. The owner chose to
+  complete it, not relax the plan. PR #1455 merged with those threads still
+  open; the subsequent accepted checks verify Pi settlement/compaction abort
+  through the production plugin, and Claude native approval/replay/interrupt
+  with production parsing/history mapping. Controlled loopback providers only;
+  real-provider behavior and deadline-expiry fault injection are not claimed.
 - No real credentials or live profiles were used. Required configured fixtures,
   multi-select, and Windows ARM64 native gates remain blocked; other non-macOS
   native paths remain untested. Full evidence and limits are in

--- a/bridge/sesori_plugin_antigravity/lib/src/foundation/antigravity_release.dart
+++ b/bridge/sesori_plugin_antigravity/lib/src/foundation/antigravity_release.dart
@@ -11,10 +11,10 @@ final class const AntigravityReleaseArtifact({
 
 /// Public facts pinned from Google's official ACP registry release.
 abstract final class AntigravityRelease() {
-  static const String registryCommit = "536e378b70a7a6d5f078a9160180e3569a23253c";
-  static const String registryPackageVersion = "1.0.0";
+  static const String registryCommit = "d30bc9a7c011b522e8502281d5fbcfca51abd5ff";
+  static const String registryPackageVersion = "1.1.1";
   static const int protocolVersion = 1;
-  static const String agentVersion = "agy_acp_server_20260818_01_RC01";
+  static const String agentVersion = "agy_acp_server_1.1.1";
 
   static const String personalOauthMethodId = "oauth-personal";
   static const Set<String> advertisedAuthenticationMethodIds = {
@@ -37,58 +37,58 @@ abstract final class AntigravityRelease() {
       PlatformArch.arm64: AntigravityReleaseArtifact(
         archiveUrl:
             "https://dl.google.com/agy-extensions/releases/macos/"
-            "agy-acp-server-agy_acp_server_20260818_01_RC01-darwin-arm64.zip",
-        archiveSha256: "f122ca7e7030a27f9649da4cf1a7d80e12c48c5f6118ff35affc34d56cbf83dd",
-        archiveBytes: 314500221,
-        serverBytes: 792105680,
-        harnessBytes: 101551680,
+            "agy-acp-server-agy_acp_server_1.1.1-darwin-arm64.zip",
+        archiveSha256: "fdfa915652cdb7ba8085cc8fffed072cbe009251aa2c951aabdda07a8c28a189",
+        archiveBytes: 316014828,
+        serverBytes: 802163856,
+        harnessBytes: 116766704,
       ),
     },
     PlatformOs.linux: {
       PlatformArch.x64: AntigravityReleaseArtifact(
         archiveUrl:
             "https://dl.google.com/agy-extensions/releases/linux/"
-            "agy-acp-server-agy_acp_server_20260818_01_RC01-linux-x86_64.zip",
-        archiveSha256: "ce3f09628575b25497cf5a3c19d073b49acb80f1dab1ff8592919e9c9b8799e1",
-        archiveBytes: 543411011,
-        serverBytes: 1529513909,
-        harnessBytes: 117532520,
+            "agy-acp-server-agy_acp_server_1.1.1-linux-x86_64.zip",
+        archiveSha256: "38f62d01b32deb0907b3d39a71ec301fd36369f6ffd1cf262d4af385177f79df",
+        archiveBytes: 681969407,
+        serverBytes: 1880360328,
+        harnessBytes: 128966920,
       ),
       PlatformArch.arm64: AntigravityReleaseArtifact(
         archiveUrl:
             "https://dl.google.com/agy-extensions/releases/linux/"
-            "agy-acp-server-agy_acp_server_20260818_01_RC01-linux-arm64.zip",
-        archiveSha256: "70fcdac70684de60f7a0eb16ea497d6cc4498728420f060e0850cfc9a9329b40",
-        archiveBytes: 524995159,
-        serverBytes: 1519373648,
-        harnessBytes: 110601552,
+            "agy-acp-server-agy_acp_server_1.1.1-linux-arm64.zip",
+        archiveSha256: "ed69e64b308fcb123ab54bf3277bf9cb0d651064f885ea5aab0ff520c7175398",
+        archiveBytes: 656572786,
+        serverBytes: 1862073131,
+        harnessBytes: 122158704,
       ),
     },
     PlatformOs.windows: {
       PlatformArch.x64: AntigravityReleaseArtifact(
         archiveUrl:
             "https://dl.google.com/agy-extensions/releases/windows/"
-            "agy-acp-server-agy_acp_server_20260818_01_RC01-windows-x86_64.zip",
-        archiveSha256: "35c7dd169c2794172ce02e9444a6db4a8ed4bb11398be07976cac2ee494f44e6",
-        archiveBytes: 331985114,
-        serverBytes: 297200088,
-        harnessBytes: 122038424,
+            "agy-acp-server-agy_acp_server_1.1.1-windows-x86_64.zip",
+        archiveSha256: "47cb50eef14f0a4655d78cfcfda869bcea7aaee5f9787e936bc2935ea612c3b8",
+        archiveBytes: 468238392,
+        serverBytes: 430801616,
+        harnessBytes: 130971800,
       ),
       PlatformArch.arm64: AntigravityReleaseArtifact(
         archiveUrl:
             "https://dl.google.com/agy-extensions/releases/windows/"
-            "agy-acp-server-agy_acp_server_20260818_01_RC01-windows-arm64.zip",
-        archiveSha256: "1522056748d45fbc34d0be72b41b99b0637be1b4caad0b34d37eb16d04ccb9c4",
-        archiveBytes: 332484576,
-        serverBytes: 301449928,
-        harnessBytes: 114173080,
+            "agy-acp-server-agy_acp_server_1.1.1-windows-arm64.zip",
+        archiveSha256: "35f4b1f47ba6a3fea7b0a3e30010df5ea73a64b4f0e7cf991cddc673ddfbcafc",
+        archiveBytes: 468521191,
+        serverBytes: 435075816,
+        harnessBytes: 122455704,
       ),
     },
   };
 
-  // Step 2 also independently hashed the extracted macOS members.
-  static const String macosArm64ServerSha256 = "6d700b48eaaab70b1083b4d18d63e81b6d8cdc1da1c4670db29f5986f9d484ef";
-  static const String macosArm64HarnessSha256 = "34d78dd5fd0e24a628ed6487bc6a042ff9419f7122f5f761b001d218f2c9d026";
+  // The extracted macOS ARM64 siblings are also independently hashed.
+  static const String macosArm64ServerSha256 = "9d900b93031fc42397f88206e14eba4193729bbef631a70b18e7a19631a6dfac";
+  static const String macosArm64HarnessSha256 = "e0a8ef9d80a1ffb178f945159dda33f73d4a5be65516642542352584b834fa2a";
 
   static AntigravityReleaseArtifact? artifactFor({required PlatformTarget target}) =>
       artifacts[target.os]?[target.arch];

--- a/bridge/sesori_plugin_antigravity/test/antigravity_authentication_composer_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_authentication_composer_test.dart
@@ -133,7 +133,7 @@ void main() {
     File(p.join(directory.path, AntigravityRelease.harnessFileName(target: target)))
         .writeAsStringSync("synthetic sibling");
     final fixture =
-        jsonDecode(File("test/fixtures/official_initialize_1_0_0.json").readAsStringSync()) as Map<String, dynamic>;
+        jsonDecode(File("test/fixtures/synthetic_current_initialize.json").readAsStringSync()) as Map<String, dynamic>;
     final processes = _Processes(initialize: fixture);
     final store = _Store();
     final http = _Http();

--- a/bridge/sesori_plugin_antigravity/test/antigravity_initialize_fixture_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_initialize_fixture_test.dart
@@ -13,7 +13,8 @@ void main() {
     expect(dto.protocolVersion, AntigravityRelease.protocolVersion);
     expect(dto.agentInfo?.name, AntigravityIdentity.upstreamAgentName);
     expect(dto.agentInfo?.title, "Google Antigravity");
-    expect(dto.agentInfo?.version, AntigravityRelease.agentVersion);
+    // This historical observation is not the currently accepted runtime identity.
+    expect(dto.agentInfo?.version, "agy_acp_server_20260818_01_RC01");
     expect(dto.agentCapabilities?.loadSession, isTrue);
     expect(dto.agentCapabilities?.sessionCapabilities?.list, isTrue);
     expect(dto.agentCapabilities?.sessionCapabilities?.resume, isTrue);

--- a/bridge/sesori_plugin_antigravity/test/antigravity_plugin_descriptor_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_plugin_descriptor_test.dart
@@ -223,7 +223,7 @@ class _DownloadHttp({required final Object failure}) extends http.BaseClient {
 }
 
 Map<String, dynamic> _initialize() =>
-    jsonDecode(File("test/fixtures/official_initialize_1_0_0.json").readAsStringSync()) as Map<String, dynamic>;
+    jsonDecode(File("test/fixtures/synthetic_current_initialize.json").readAsStringSync()) as Map<String, dynamic>;
 
 ({String server, String harness}) _writePair({required Directory directory}) {
   final server = p.join(directory.path, AntigravityRelease.serverFileName(target: _target));

--- a/bridge/sesori_plugin_antigravity/test/antigravity_release_and_launch_test.dart
+++ b/bridge/sesori_plugin_antigravity/test/antigravity_release_and_launch_test.dart
@@ -22,29 +22,29 @@ void main() {
       (
         "antigravity",
         "antigravity-acp",
-        "536e378b70a7a6d5f078a9160180e3569a23253c",
-        "1.0.0",
-        "agy_acp_server_20260818_01_RC01",
+        "d30bc9a7c011b522e8502281d5fbcfca51abd5ff",
+        "1.1.1",
+        "agy_acp_server_1.1.1",
       ),
     );
     final macArtifact = AntigravityRelease.artifactFor(target: macArm)!;
     expect(
       (macArtifact.archiveBytes, macArtifact.serverBytes, macArtifact.harnessBytes),
-      (314500221, 792105680, 101551680),
+      (316014828, 802163856, 116766704),
     );
     expect(
       macArtifact.archiveUrl,
       "https://dl.google.com/agy-extensions/releases/macos/"
-      "agy-acp-server-agy_acp_server_20260818_01_RC01-darwin-arm64.zip",
+      "agy-acp-server-agy_acp_server_1.1.1-darwin-arm64.zip",
     );
-    expect(macArtifact.archiveSha256, "f122ca7e7030a27f9649da4cf1a7d80e12c48c5f6118ff35affc34d56cbf83dd");
+    expect(macArtifact.archiveSha256, "fdfa915652cdb7ba8085cc8fffed072cbe009251aa2c951aabdda07a8c28a189");
     expect(
       AntigravityRelease.macosArm64ServerSha256,
-      "6d700b48eaaab70b1083b4d18d63e81b6d8cdc1da1c4670db29f5986f9d484ef",
+      "9d900b93031fc42397f88206e14eba4193729bbef631a70b18e7a19631a6dfac",
     );
     expect(
       AntigravityRelease.macosArm64HarnessSha256,
-      "34d78dd5fd0e24a628ed6487bc6a042ff9419f7122f5f761b001d218f2c9d026",
+      "e0a8ef9d80a1ffb178f945159dda33f73d4a5be65516642542352584b834fa2a",
     );
     expect(
       AntigravityRelease.advertisedAuthenticationMethodIds,
@@ -56,38 +56,38 @@ void main() {
     final expected = <PlatformTarget, (String, String, int, int, int)>{
       macArm: (
         "darwin-arm64.zip",
-        "f122ca7e7030a27f9649da4cf1a7d80e12c48c5f6118ff35affc34d56cbf83dd",
-        314500221,
-        792105680,
-        101551680,
+        "fdfa915652cdb7ba8085cc8fffed072cbe009251aa2c951aabdda07a8c28a189",
+        316014828,
+        802163856,
+        116766704,
       ),
       linuxX64: (
         "linux-x86_64.zip",
-        "ce3f09628575b25497cf5a3c19d073b49acb80f1dab1ff8592919e9c9b8799e1",
-        543411011,
-        1529513909,
-        117532520,
+        "38f62d01b32deb0907b3d39a71ec301fd36369f6ffd1cf262d4af385177f79df",
+        681969407,
+        1880360328,
+        128966920,
       ),
       linuxArm: (
         "linux-arm64.zip",
-        "70fcdac70684de60f7a0eb16ea497d6cc4498728420f060e0850cfc9a9329b40",
-        524995159,
-        1519373648,
-        110601552,
+        "ed69e64b308fcb123ab54bf3277bf9cb0d651064f885ea5aab0ff520c7175398",
+        656572786,
+        1862073131,
+        122158704,
       ),
       winX64: (
         "windows-x86_64.zip",
-        "35c7dd169c2794172ce02e9444a6db4a8ed4bb11398be07976cac2ee494f44e6",
-        331985114,
-        297200088,
-        122038424,
+        "47cb50eef14f0a4655d78cfcfda869bcea7aaee5f9787e936bc2935ea612c3b8",
+        468238392,
+        430801616,
+        130971800,
       ),
       winArm: (
         "windows-arm64.zip",
-        "1522056748d45fbc34d0be72b41b99b0637be1b4caad0b34d37eb16d04ccb9c4",
-        332484576,
-        301449928,
-        114173080,
+        "35f4b1f47ba6a3fea7b0a3e30010df5ea73a64b4f0e7cf991cddc673ddfbcafc",
+        468521191,
+        435075816,
+        122455704,
       ),
     };
     for (final entry in expected.entries) {

--- a/bridge/sesori_plugin_antigravity/test/fixtures/synthetic_current_initialize.json
+++ b/bridge/sesori_plugin_antigravity/test/fixtures/synthetic_current_initialize.json
@@ -1,0 +1,24 @@
+{
+  "protocolVersion": 1,
+  "agentInfo": {
+    "name": "antigravity-acp",
+    "title": "Google Antigravity",
+    "version": "agy_acp_server_1.1.1"
+  },
+  "agentCapabilities": {
+    "loadSession": true,
+    "sessionCapabilities": {
+      "list": {},
+      "resume": {}
+    },
+    "auth": {
+      "logout": {}
+    }
+  },
+  "authMethods": [
+    {"id": "oauth-personal"},
+    {"id": "oauth-business"},
+    {"id": "gemini-api-key"},
+    {"id": "agent-platform"}
+  ]
+}

--- a/docs/ANTIGRAVITY.md
+++ b/docs/ANTIGRAVITY.md
@@ -9,8 +9,8 @@ before downloading or authenticating. Installing the runtime does not grant Goog
 
 | Item | Supported contract |
 |---|---|
-| ACP registry package | `1.0.0` |
-| Exact ACP runtime identity | `agy_acp_server_20260818_01_RC01` |
+| ACP registry package | `1.1.1` |
+| Exact ACP runtime identity | `agy_acp_server_1.1.1` |
 | Bridge hosts | macOS arm64; Linux x64/arm64; Windows x64/arm64 |
 | Unsupported host | macOS x64, including an explicit binary path |
 | Authentication | Personal Google OAuth (`oauth-personal`) only |
@@ -18,7 +18,9 @@ before downloading or authenticating. Installing the runtime does not grant Goog
 Business/Enterprise OAuth, Gemini API keys and Agent Platform authentication are not exposed by this integration.
 The [pinned release facts](../bridge/sesori_plugin_antigravity/lib/src/foundation/antigravity_release.dart) contain the
 five official archive URLs, checksums and file sizes. Registry package version and ACP runtime identity are different:
-managed version directories use `1.0.0`, while validation checks the exact runtime identity above.
+managed version directories use `1.1.1`, while validation checks the exact runtime identity above.
+A pair reporting the earlier `agy_acp_server_20260818_01_RC01` identity no longer passes that exact check.
+An explicit binary path remains authoritative, so replace its complete pair rather than expecting managed fallback.
 
 ## Install or supply the pair
 
@@ -118,9 +120,10 @@ needs no browser of its own, but does need a current connected client for initia
 ## Verification status and further contracts
 
 Implementation is not a claim of completed cross-platform end-to-end verification. Official archive integrity was
-checked for all five targets. Native initialize-only and managed-pipeline correctness has been exercised on macOS arm64
-in disposable state. One bounded authenticated ACP probe verified only the generic sub-agent projection described
-above. Native Linux/Windows installation, real personal OAuth, authenticated discovery-session creation/resume, full
+checked for all five targets of package `1.1.1`. Native initialize-only and managed-pipeline correctness has been exercised
+on macOS arm64 in disposable state. The earlier bounded authenticated ACP probe against package `1.0.0` verified only
+the generic sub-agent projection described above; that observation was not rerun for `1.1.1`.
+Native Linux/Windows installation, real personal OAuth, authenticated discovery-session creation/resume, full
 ordinary session/image/history flows and the final cumulative L1–L5 matrix remain unverified. Missing test
 infrastructure is a blocked result, not a pass.
 

--- a/docs/regression/antigravity-descriptor-and-setup.md
+++ b/docs/regression/antigravity-descriptor-and-setup.md
@@ -14,6 +14,8 @@ contract, see [Google Antigravity in Sesori](../ANTIGRAVITY.md).
   does not create files, read token contents, spawn/probe a process, prepare a browser command or authenticate.
 - Runtime precedence is authoritative explicit pair, then PATH, then the installed managed-layout location. Empty POSIX
   PATH entries continue to mean the current directory. Static inspection does not claim a validated runtime version.
+  The current exact pair is package `1.1.1` / server `agy_acp_server_1.1.1`, ACP 1. After a target refresh, an explicit
+  pair reporting the previous identity must be rejected, never silently replaced through managed fallback.
 - Missing/rejected/unsupported/boundary outcomes map to honest setup statuses and current-client authentication hints.
   macOS x64 reports unsupported-platform guidance without constructing a managed filename, preparing a profile or
   launching a process, including when an explicit binary option is supplied.
@@ -58,6 +60,8 @@ preserve local diagnostics and settle as `ProvisionFailed`; explicit startup abo
 - **L1/L2:** app `plugin_registry_test.dart` and `run_command_catalog_import_test.dart` cover the exact registered ID,
   display name, plugin-owned identity, current-target management capabilities, OpenCode default, inert
   declaration and namespaced CLI option. `antigravity_plugin_descriptor_test.dart` owns target/override gating.
+  Active-runtime descriptor/authentication tests use a synthetic current-release initialize fixture; the historical
+  `1.0.0` capture remains a decoder observation, not evidence that the old runtime identity is currently accepted.
   Client `harnesses_settings_screen_test.dart` covers overview-to-detail navigation without an install request and
   visible missing/invalid-runtime guidance before explicit installation. `antigravity_runtime_manifest_test.dart` covers the official five-target
   assets, checksums, package-directory layout, conservative two-minute archive-command budget, version directory and
@@ -71,7 +75,7 @@ preserve local diagnostics and settle as `ProvisionFailed`; explicit startup abo
   browser-noop invocation, abort, exit reset/reconnect and shutdown. `antigravity_runtime_service_test.dart` covers
   recovered PATH storage diagnostics and inert managed fallback. `antigravity_plugin_test.dart` covers exact
   whitespace-bearing live/replay stamping and cold-reset resume before strict dispatch.
-- **L5 Full:** the managed macOS arm64 pipeline has run against the cached independently rehashed official archive in
+- **L5 Full:** the package `1.1.1` managed macOS arm64 pipeline has run against independently hashed official bytes in
   disposable state, preserving both siblings and completing isolated initialize-only validation/cleanup before result.
   Native Linux/Windows managed installs, real personal OAuth, cross-target launch/permissions, bridge import and
   tombstone behavior remain unverified. Automated registration/composition evidence does not replace them.


### PR DESCRIPTION
## Complexity
🌿 Straightforward — one plugin's release facts and localized fixtures, with verification documentation; no architectural or lifecycle-code changes.

## What
- Advance Antigravity to registry package `1.1.1` / exact server `agy_acp_server_1.1.1`, ACP 1, using five independently downloaded archive hashes and verified member facts.
- Preserve exact-pair/platform/layout/launch policy and personal-OAuth-only support. Separate synthetic current-runtime test data from the unchanged historical `1.0.0` capture.
- Keep Cursor at `2026.08.11-e8db854`: its candidate passed integrity/install/initialize/cleanup, but required configured load/replay/model/mode gates remain blocked.
- Publish Step 3 evidence and the completed post-merge Pi/Claude lifecycle supplement for Step 2. Record the remaining per-harness blockers without waiving them.

## Why
Adopt only candidates whose named gates pass. This completes Antigravity's actual production-validator check rather than treating a candidate-specific validation predicate as equivalent evidence.

## Risk and test focus
Moderate integration risk: incorrect release facts or exact identity matching could block Antigravity installation/startup. All five archive records were reconciled; macOS ARM64 exercised installation and the actual production validator with real native initialize and teardown.

Linux/Windows native execution and real Antigravity OAuth/session flows remain unverified. Previous explicit Antigravity pairs must be replaced as complete pairs; there is no silent managed fallback. Independent minimums remain unchanged; Antigravity's package-version alias retains its exact-pair policy. DeepSeek and unrelated upstream changes are excluded.

## Expected result
Eligible managed Antigravity installations use `1.1.1`; current native identity is accepted and prior explicit identities are rejected under the existing exact policy. Cursor and other blocked pins remain unchanged. No UI feature, Sesori database/schema/wire change, generated-model change, new analytics event, or product release.

## Verification
- 68 distinct Antigravity tests across nine files passed, including the focused fixture follow-up; owning `dart analyze --fatal-infos` passed with Dart 3.13.3. Formatting five changed Dart files produced no changes.
- Actual `AntigravityRuntimeVersionValidator` → runtime service → repository → ACP initialize returned `true` for the real candidate; native exit `-15`, outer exit 0 in 1.434 seconds, no timeout or surviving owned processes.
- Sandbox startup/path-resolution issues were repaired through the same native lane. Owner-approved changes added only metadata/existence access to three exact ancestor paths; no file-content, write, execution, signal or network permissions were added, and credentials remained inaccessible.
- No accepted downloads/install probes or unchanged passing package checks were rerun for documentation or handoff recovery. Full repository matrix remains CI-owned.

Evidence and limits:
- [Step 3 verification](https://github.com/sesori-ai/sesori_apps_monorepo/blob/84723df9183031c0d8f18a83075768d17ee5f4d7/.plan/active/all-harness-runtime-refresh/STEP-3-VERIFICATION.md)
- [Step 2 lifecycle supplement](https://github.com/sesori-ai/sesori_apps_monorepo/blob/84723df9183031c0d8f18a83075768d17ee5f4d7/.plan/active/all-harness-runtime-refresh/STEP-2-LIFECYCLE-VERIFICATION.md)
- [Series tracker](https://github.com/sesori-ai/sesori_apps_monorepo/blob/74c026302cf31671c3cd137a82c678acd97f6ffb/.plan/active/all-harness-runtime-refresh/TRACKER.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Antigravity's exact runtime pair to package `1.1.1` / server `agy_acp_server_1.1.1` after validating the real candidate through the production validator on macOS ARM64. Cursor remains on `2026.08.11-e8db854` because its `2026.09.10-fd3934a` candidate still needs configured load/replay and model/mode gates.

**Behavior changes**
- The old Antigravity server identity no longer passes exact validation, so explicit pairs must be replaced as complete pairs; there is no silent managed fallback.
- Test fixtures now use a synthetic current-runtime initialize capture instead of treating the historical `1.0.0` observation as current.
- Adds Step 3 verification docs and the post-merge Step 2 lifecycle supplement.
- DeepSeek's `0.1.5` record is now explicitly a historical pre-series baseline, not a current-target claim.

**Verification**
- All five Antigravity archives were independently hashed and reconciled against release constants.
- Native macOS ARM64 install, production validator/initialize, and teardown passed with no surviving processes.
- 68 Antigravity tests across nine files pass; owning analyzer and formatting pass.
- Linux/Windows native execution and real Antigravity OAuth/session flows remain unverified.
- No analytics events, generated models, or database/wire changes are introduced.

<sup>Written for commit 74c026302cf31671c3cd137a82c678acd97f6ffb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sesori-ai/sesori_apps_monorepo/pull/1457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


