### PR TITLE
🌱 Centralize PR sizing and substantial-change planning

### DIFF
--- a/.agents/skills/sesori-plan-maker/SKILL.md
+++ b/.agents/skills/sesori-plan-maker/SKILL.md
@@ -50,15 +50,10 @@ the role, a plan, or a reviewer as a reason to overrule a confirmed decision.
   such as `3.a` / `3.b`, map them to PR ordinals, and synchronize dependencies,
   tracker and series titles/totals. Clean splits of approved work never need
   permission; substantive scope expansion still does.
-- Target ~1,500 changed lines per PR as a soft cap, counting additions plus
-  deletions, generated code, tests, and docs. Prefer considerably smaller PRs for
-  complex changes; allow larger coherent diffs when most churn is generated
-  boilerplate, such as Drift output exceeding 1,000 lines for one new table.
-  Record generated versus authored churn and explain substantial overages when
-  no clean split is practical. Keep generated output with its source.
-  Every push restarts AI review of the entire PR; small coherent PRs avoid costly
-  fix/re-review loops and merge sooner. Follow the plan worker's PR Sizing and
-  Step Splitting rules during execution.
+- Follow the repository-wide `PR Sizing And Review Convergence` policy in
+  `AGENTS.md` when estimating PR boundaries. Record significant expected
+  exceptions in durable plans; execution-specific substep bookkeeping remains
+  in the plan worker skill.
 - For durable planned work, the first PR step always raises the plan under
   `.plan/active/<slug>/` before implementation begins. The penultimate step
   reconciles and completes the affected feature documents under

--- a/.agents/skills/sesori-plan-maker/SKILL.md
+++ b/.agents/skills/sesori-plan-maker/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: sesori-plan-maker
 description: >-
-  Create or update practical, code-informed plans and trackers. Load before
-  every substantial change, even when implementation fits one step and one PR.
-  Skip only clearly targeted simple bug fixes and simple UI changes.
+  Create or update practical, code-informed plans and trackers. Use before every
+  substantial change as required by AGENTS.md, including work that fits one step
+  and one PR; planning output may be ephemeral or durable.
 ---
 
 # Plan Maker
@@ -14,15 +14,12 @@ work. Prefer a short useful plan over a large planning system.
 
 ## Required Use And Plan Durability
 
-- Use this skill before every substantial change. Substantial work includes new
-  features, meaningful refactors, cross-layer or cross-package behavior, and
-  persistence, transport, lifecycle, concurrency, security, or material
-  PR-boundary decisions.
-- Skip it only for a clearly targeted simple bug fix or clearly targeted simple
-  UI change. Do not skip planning merely because substantial work happens to fit
-  one implementation step or one PR.
-- For substantial single-step work, make a concise ephemeral plan in chat or a
-  temporary file outside the repository, then continue with one normal PR. Do
+- `AGENTS.md` is the source of truth for when substantial-change planning is
+  required and which targeted changes may skip it. Do not redefine that threshold
+  in this skill.
+- When this skill is required for single-step work, make a concise ephemeral
+  plan in chat or a temporary file outside the repository, then continue with
+  one normal PR. Do
   not commit the plan or add plan-only, regression-doc, and retirement PR steps
   merely because this skill was used.
 - Create a durable plan under `.plan/active/<slug>/` when implementation needs

--- a/.agents/skills/sesori-plan-maker/SKILL.md
+++ b/.agents/skills/sesori-plan-maker/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: sesori-plan-maker
-description: Create or update practical, code-informed plans and trackers. Use ONLY when the user explicitly asks to make or change a plan or tracker. It may also self-invoke while planning a new feature, larger refactor, or other large effort that would benefit from multiple steps or PR splits. Do not self-invoke for routine implementation, small fixes, or ordinary single-step work.
+description: >-
+  Create or update practical, code-informed plans and trackers. Load before
+  every substantial change, even when implementation fits one step and one PR.
+  Skip only clearly targeted simple bug fixes and simple UI changes.
 ---
 
 # Plan Maker
@@ -9,21 +12,31 @@ When this skill is loaded, turn a user's goal into a practical implementation
 plan grounded in the current codebase. Keep the process proportional to the
 work. Prefer a short useful plan over a large planning system.
 
+## Required Use And Plan Durability
+
+- Use this skill before every substantial change. Substantial work includes new
+  features, meaningful refactors, cross-layer or cross-package behavior, and
+  persistence, transport, lifecycle, concurrency, security, or material
+  PR-boundary decisions.
+- Skip it only for a clearly targeted simple bug fix or clearly targeted simple
+  UI change. Do not skip planning merely because substantial work happens to fit
+  one implementation step or one PR.
+- For substantial single-step work, make a concise ephemeral plan in chat or a
+  temporary file outside the repository, then continue with one normal PR. Do
+  not commit the plan or add plan-only, regression-doc, and retirement PR steps
+  merely because this skill was used.
+- Create a durable plan under `.plan/active/<slug>/` when implementation needs
+  multiple tracked steps or PRs, durable decisions, handoff, or ongoing status,
+  or when the user explicitly requests committed planning artifacts.
+
 ## User Direction
 
-The user has final authority. Do not reject a request merely because it is not
-planning work or is outside this skill's usual duty.
-
-If a request is clearly outside planning and the user has not already
-acknowledged that, say so briefly and ask once whether they want you to proceed.
-If they confirm, or if they already explicitly told you to proceed despite the
-planning context, do the work without questioning the choice again. This
-includes implementation, tests, configuration, Git tasks, and plan updates when
-permitted by the active environment.
-
-Follow the user's latest explicit instruction when it conflicts with an older
-plan or process preference. Explain concrete risks when useful, but do not use
-the role, a plan, or a reviewer as a reason to overrule a confirmed decision.
+The user has final authority. When this skill is self-invoked for substantial
+implementation, do not ask whether planning is wanted: plan proportionally and
+continue the requested work unless the user asked for a plan only. Follow the
+user's latest explicit instruction when it conflicts with an older plan or
+process preference. Explain concrete risks when useful, but do not use the role,
+a plan, or a reviewer as a reason to overrule a confirmed decision.
 
 ## Planning
 
@@ -33,8 +46,9 @@ the role, a plan, or a reviewer as a reason to overrule a confirmed decision.
   from available context. Avoid exhaustive interviews and arbitrary checklists.
 - Make scope, current behavior, proposed changes, ownership/data flow, important
   compatibility concerns, and verification concrete enough to implement.
-- Scale detail to the task. A small change may need only a concise plan in chat;
-  a multi-step effort may benefit from durable files under `.plan/active/<slug>/`.
+- Scale detail to the task. Substantial single-step work may need only a concise
+  ephemeral plan; multi-step work may benefit from durable files under
+  `.plan/active/<slug>/`.
 - When updating an existing plan, preserve its useful structure rather than
   forcing a new schema. Keep its tracker or execution state in sync when needed.
 - Do not invent stages, waves, PR boundaries, worktrees, or process artifacts

--- a/.agents/skills/sesori-plan-worker/SKILL.md
+++ b/.agents/skills/sesori-plan-worker/SKILL.md
@@ -21,8 +21,8 @@ guide, not a boundary on what you may do.
   better implementation path is acceptable; ask the user before making a
   considerable divergence, then update durable plan truth as appropriate.
   Cleanly splitting approved work into more PRs is not such a divergence and
-  never needs permission; follow repository sizing policy and Planned Step
-  Splitting below.
+  never needs permission; follow `PR Sizing And Review Convergence` in
+  `AGENTS.md` and Planned Step Splitting below.
 - Ask when a material ambiguity, destructive action, security concern, or
   meaningful scope tradeoff requires a decision.
 

--- a/.agents/skills/sesori-plan-worker/SKILL.md
+++ b/.agents/skills/sesori-plan-worker/SKILL.md
@@ -21,7 +21,8 @@ guide, not a boundary on what you may do.
   better implementation path is acceptable; ask the user before making a
   considerable divergence, then update durable plan truth as appropriate.
   Cleanly splitting approved work into more PRs is not such a divergence and
-  never needs permission; follow PR Sizing and Step Splitting below.
+  never needs permission; follow repository sizing policy and Planned Step
+  Splitting below.
 - Ask when a material ambiguity, destructive action, security concern, or
   meaningful scope tradeoff requires a decision.
 
@@ -78,42 +79,18 @@ add the slug/step wrapper to a single-PR task. In the workflow above, “success
 means the next executable step or substep, including `3.a` → `3.b`, not literal
 arithmetic on the original step number.
 
-## PR Sizing and Step Splitting
+## Planned Step Splitting
 
-Target **~1,500 changed lines per PR as a soft cap**, counting additions plus
-deletions across production code, tests, docs, and generated files. Count the
-whole diff against its merge base, but assess authored complexity separately:
-
-- Aim considerably lower for complex lifecycle, concurrency, security, or
-  cross-layer changes. Line count is not a quota to fill.
-- Larger coherent PRs are acceptable when most churn is generated boilerplate,
-  such as Drift output that can exceed 1,000 lines for one new table. Report
-  generated versus authored churn and explain substantial overages; never hide
-  generated files from the total or split generated outputs from their source.
-- Prefer smaller independently valid PRs whenever a clean split exists. Each
-  should compile, have focused verification, and be reviewable on its own without
-  artificial compatibility code solely to bridge the split.
-
-**Clean PR splits are always approved and encouraged. Never ask permission just
-to split**, including when new work is discovered, review feedback grows the
-change, or the original estimate was wrong. This approval covers delivery shape,
-not unrelated features, considerable refactors, or other substantive scope
-changes that still require the user's decision.
+Follow the repository-wide `PR Sizing And Review Convergence` policy in
+`AGENTS.md`. Its soft cap, standing approval for clean splits, and oversized-PR
+review-loop rules apply to every planned step.
 
 Split a growing Step `3` into `3.a`, `3.b`, and further substeps as needed. Update
-`PLAN.md`, `TRACKER.md`, step files, dependencies, estimates, complexity and PR
+`PLAN.md`, `TRACKER.md`, step files, dependencies, estimates, complexity, and PR
 boundaries together. Keep the series slug, recompute the shared PR total, and
 synchronize planned and published series titles. Map durable substep IDs to PR
 ordinals explicitly; preserve completed-step/PR links rather than losing history.
 Apply the same one-open-PR/one-local-successor workflow to the revised sequence.
-If a PR is already open, preserve reviewed work and explain the replacement or
-extraction; do not rewrite published history or force-push to manufacture a split.
-
-Every new pushed commit starts another AI review wave over the **entire PR**.
-Large diffs encourage fresh findings on each pass, creating fix/push/re-review
-loops, more latency, and repeated review cost. Smaller coherent PRs converge,
-get approved, and merge sooner. Reassess boundaries before pushing a growing
-fix batch instead of feeding that loop indefinitely.
 
 ## PR Complexity and Communication
 

--- a/.agents/skills/update-backend-runtimes/SKILL.md
+++ b/.agents/skills/update-backend-runtimes/SKILL.md
@@ -163,9 +163,10 @@ plan under `.plan/active/<slug>/`. It must contain:
 Do not pin production versions, publish adapters, or implement optional findings
 merely to finish planning. An explicit implementation request authorizes its
 stated scope; execute through [sesori-plan-worker](../sesori-plan-worker/SKILL.md)
-after planning and applicable gates. Follow its ~1,500-line soft cap, smaller
-complex PRs, generated-boilerplate allowance, and pre-approved clean step splits.
-Splitting never needs another permission request; adding unapproved behavior does.
+after planning and applicable gates. Follow the repository-wide `PR Sizing And
+Review Convergence` policy in `AGENTS.md`; execution-specific step sequencing
+remains in the plan worker. Splitting never needs another permission request;
+adding unapproved behavior does.
 Respect the current workspace restrictions for separate-repo dependencies: record
 an authorized handoff/blocker rather than creating a forbidden checkout.
 

--- a/.claude/skills/sesori-plan-maker/SKILL.md
+++ b/.claude/skills/sesori-plan-maker/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: sesori-plan-maker
-description: Create or update practical, code-informed plans and trackers. Use ONLY when the user explicitly asks to make or change a plan or tracker. It may also self-invoke while planning a new feature, larger refactor, or other large effort that would benefit from multiple steps or PR splits. Do not self-invoke for routine implementation, small fixes, or ordinary single-step work.
+description: >-
+  Create or update practical, code-informed plans and trackers. Use before every
+  substantial change as required by AGENTS.md, including work that fits one step
+  and one PR; planning output may be ephemeral or durable.
 ---
 
 # sesori-plan-maker (Claude Code shim)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,17 @@ eagerly "just in case."
 
 - Prefer the smallest change that fully solves the demonstrated problem. Do not
   add machinery for hypothetical consumers, rare timing windows, or future work.
+- Load and use `sesori-plan-maker` before every substantial change. Skip it only
+  for a clearly targeted simple bug fix or clearly targeted simple UI change.
+  Treat new features, meaningful refactors, cross-layer/package work, and
+  persistence, transport, lifecycle, concurrency, security, or material
+  PR-boundary decisions as substantial.
+- Plan-maker use does not require a durable plan or multiple PRs. When substantial
+  work is one implementation step that fits one coherent PR, make a proportional
+  ephemeral plan in chat or outside the repository, then implement the single PR.
+  Do not commit or merge a plan file for that case. Use `.plan/active/` only when
+  durable multi-step tracking, decisions, handoff, or a PR series will provide
+  ongoing value, or when the user explicitly requests a committed plan.
 - Strive for feature parity across harnesses. Treat every feature request as
   applying to all backend plugins whose harness can support it; do not enhance
   a single harness unless the user explicitly scopes the request to it. When

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,6 +149,35 @@ eagerly "just in case."
   wrapper's presentation privacy-safe when the original may contain sensitive
   payload data.
 
+## PR Sizing And Review Convergence
+
+- Target **~1,500 changed lines per PR as a soft cap**. Count additions plus
+  deletions across the whole diff against its merge base, including production
+  code, tests, docs, and generated files. Line count is not a quota to fill.
+- Aim considerably lower for lifecycle, concurrency, security, cross-layer, or
+  otherwise complex changes.
+- Larger coherent PRs are acceptable when most churn is generated boilerplate,
+  such as Drift output that can exceed 1,000 lines for one new table. Report
+  generated versus authored churn, explain substantial overages, and keep
+  generated output with its source.
+- Prefer smaller independently valid PRs whenever a clean split exists. Each
+  split should compile, have focused verification, and remain reviewable without
+  artificial compatibility code created only to bridge the split.
+- Clean PR splits are always approved and encouraged. Never ask permission only
+  to split approved work, including when review feedback grows the change or an
+  estimate was wrong. This approval does not cover unrelated features,
+  considerable refactors, or other substantive scope expansion.
+- Every pushed commit starts another AI review wave over the **entire PR**, not
+  only the new commit. Oversized diffs invite fresh findings in already-reviewed
+  areas and can create a costly fix/push/full-re-review loop instead of
+  converging.
+- Measure before the first push and reassess before each follow-up push. When an
+  open PR significantly exceeds the soft cap and a clean decomposition exists,
+  stop feeding the review loop with more fix commits. Preserve published and
+  reviewed history, explain the replacement or extraction, and move remaining
+  work into smaller coherent PRs. Never rewrite published history or force-push
+  solely to manufacture a split.
+
 ## Code Quality And Change Risk
 
 - Leave touched code cleaner and simpler than you found it when the


### PR DESCRIPTION
## Complexity

🌱 Trivial — repository instruction and skill-reference changes only.

## What

- Adds repository-wide PR sizing and review-convergence policy to `AGENTS.md`.
- Sets ~1,500 changed lines as soft cap, with lower targets for complex work and a generated-code exception.
- Documents that every push triggers AI review of the entire PR and that oversized diffs can enter fix/push/full-re-review loops.
- Requires `sesori-plan-maker` before every substantial change while exempting only clearly targeted simple bug fixes and simple UI changes.
- Allows substantial single-step work to use an ephemeral plan and ship as one normal PR without committed planning artifacts.
- Moves generic sizing guidance out of planning skills; those skills now reference repository policy and retain workflow-specific rules.
- Keeps the Claude Code plan-maker discovery shim aligned with the canonical skill.

## Why

Large PRs attract repeated findings across already-reviewed code after every pushed commit. Planning substantial work early makes clean PR boundaries more likely, while ephemeral plans avoid unnecessary repository ceremony when the implementation remains one coherent step.

## Risk and test focus

Low risk. Instruction-only change; no production, user-visible, database, transport, or generated-code impact. Review focus: policy clarity, proportional plan durability, consistency across skill references, and avoidance of stale duplicate sizing rules.

## Expected result

Agents use plan-maker for substantial changes, use ephemeral planning for coherent single-step work, and create durable plan files only when ongoing tracking adds value. They measure full PR churn against merge base, target about 1,500 changed lines or less, split approved work without asking permission, and stop feeding significantly oversized PRs with repeated review-fix commits when clean decomposition exists.

## Verification

- `git diff --check`
- Added lines stay within 120 characters
- 143 total changed lines across five instruction/skill files
- No Dart or Flutter suites run; repository rules require only relevant validation for instruction changes
