### PR TITLE
🌿 Keep noisy projects hidden during catalog scans

### DIFF
--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -1,6 +1,6 @@
 import "dart:async";
 import "dart:collection";
-import "dart:io" show Platform;
+import "dart:io" show Directory, Platform;
 import "dart:math";
 
 import "package:path/path.dart" as p;
@@ -48,6 +48,7 @@ class CatalogImportRepository({
   static final Random _secureRandom = Random.secure();
 
   final String? _normalizedUserHomeDirectory = _resolveNormalizedUserHomeDirectory();
+  final String _normalizedTemporaryDirectory = normalizeProjectDirectory(directory: Directory.systemTemp.path);
   final StreamController<List<SessionBackendActivity>> _backendActivityController =
       StreamController<List<SessionBackendActivity>>.broadcast(sync: true);
 
@@ -743,7 +744,7 @@ class CatalogImportRepository({
 
   bool _shouldHideDiscoveredProject({required String projectPath}) {
     // Scans discover history; only Add/Open Project explicitly reveals these folders.
-    for (final temporaryDirectory in const ["/tmp", "/private/tmp"]) {
+    for (final temporaryDirectory in ["/tmp", "/private/tmp", _normalizedTemporaryDirectory]) {
       if (p.equals(temporaryDirectory, projectPath) || p.isWithin(temporaryDirectory, projectPath)) return true;
     }
     final userHomeDirectory = _normalizedUserHomeDirectory;

--- a/bridge/app/lib/src/repositories/catalog_import_repository.dart
+++ b/bridge/app/lib/src/repositories/catalog_import_repository.dart
@@ -465,8 +465,6 @@ class CatalogImportRepository({
         // extra enumeration or query is needed.
         var projectsAdded = 0;
         var sessionsAdded = 0;
-        final automaticallyHiddenProjectIds = <String>{};
-        final hideNewHiddenHomeProjects = !control.explicitImportRequested;
         for (final observation in publicationProjects.values) {
           final existing = _projectCatalogIdentityCalculator.calculate(
             projectsById: projectsById,
@@ -475,15 +473,12 @@ class CatalogImportRepository({
             observedPath: observation.path,
           );
           if (existing == null) projectsAdded++;
-          final hiddenWhenNew =
-              hideNewHiddenHomeProjects && _isUnderTopLevelHiddenHomeDirectory(projectPath: observation.path);
           final row = _mergeProjectRow(
             observation: observation,
             existing: existing,
-            hiddenWhenNew: hiddenWhenNew,
+            hiddenWhenNew: _shouldHideDiscoveredProject(projectPath: observation.path),
             importStartedAt: importStartedAt,
           );
-          if (existing == null && hiddenWhenNew) automaticallyHiddenProjectIds.add(row.projectId);
           projectRows.add(row);
           final previousPath = existing == null ? null : _normalizeRequiredPath(existing.path);
           final nextPath = _normalizeRequiredPath(row.path);
@@ -566,17 +561,6 @@ class CatalogImportRepository({
               projectionVersion: projectionVersion,
               completedAt: completedAt,
             ),
-          );
-        }
-        // An explicit scan can join while the first project write is pending.
-        // Correct only new rows this automatic import hid; existing visibility stays authoritative.
-        if (control.explicitImportRequested && automaticallyHiddenProjectIds.isNotEmpty) {
-          requireCurrentGeneration();
-          await _projectsDao.upsertProjectRows(
-            rows: [
-              for (final row in projectRows)
-                if (automaticallyHiddenProjectIds.contains(row.projectId)) row.copyWith(hidden: false),
-            ],
           );
         }
         requireCurrentGeneration();
@@ -757,7 +741,11 @@ class CatalogImportRepository({
     }
   }
 
-  bool _isUnderTopLevelHiddenHomeDirectory({required String projectPath}) {
+  bool _shouldHideDiscoveredProject({required String projectPath}) {
+    // Scans discover history; only Add/Open Project explicitly reveals these folders.
+    for (final temporaryDirectory in const ["/tmp", "/private/tmp"]) {
+      if (p.equals(temporaryDirectory, projectPath) || p.isWithin(temporaryDirectory, projectPath)) return true;
+    }
     final userHomeDirectory = _normalizedUserHomeDirectory;
     if (userHomeDirectory == null || !p.isWithin(userHomeDirectory, projectPath)) return false;
     final relativeSegments = p.split(p.relative(projectPath, from: userHomeDirectory));

--- a/bridge/app/lib/src/repositories/models/catalog_import_control.dart
+++ b/bridge/app/lib/src/repositories/models/catalog_import_control.dart
@@ -1,7 +1,7 @@
 import "package:sesori_plugin_interface/sesori_plugin_interface.dart";
 
 class CatalogImportControl({
-  required var bool explicitImportRequested,
+  required var bool rescanRequested,
   required var bool hydrationMarkerRequested,
 }) implements PluginCatalogCancellationSignal {
   bool cancellationRequested = false;

--- a/bridge/app/lib/src/routing/start_catalog_import_handler.dart
+++ b/bridge/app/lib/src/routing/start_catalog_import_handler.dart
@@ -18,7 +18,7 @@ class StartCatalogImportHandler({required final CatalogImportService _service})
     required CatalogImportRequest body,
   }) async {
     try {
-      _service.start(pluginId: body.pluginId, trigger: CatalogImportTrigger.explicit);
+      _service.start(pluginId: body.pluginId, trigger: CatalogImportTrigger.rescan);
     } on CatalogImportPluginUnknownException {
       throw buildErrorResponse(request, 404, "plugin not found");
     } on CatalogImportPluginNotEnabledException {

--- a/bridge/app/lib/src/services/catalog_import_service.dart
+++ b/bridge/app/lib/src/services/catalog_import_service.dart
@@ -5,9 +5,17 @@ import "package:sesori_shared/sesori_shared.dart";
 import "../repositories/catalog_import_repository.dart";
 import "../repositories/models/catalog_import_control.dart";
 
-enum CatalogImportTrigger() { automatic, explicit }
+/// Both triggers discover projects using the same visibility defaults.
+/// A rescan bypasses the startup hydration marker, not project hiding.
+enum CatalogImportTrigger() {
+  automatic,
+  rescan,
+}
 
-enum CatalogEmptyHydrationPolicy() { complete, retry }
+enum CatalogEmptyHydrationPolicy() {
+  complete,
+  retry,
+}
 
 class CatalogImportPluginUnknownException({required final String pluginId}) implements Exception;
 
@@ -16,14 +24,14 @@ class CatalogImportPluginNotEnabledException({required final String pluginId}) i
 class CatalogImportPluginUnavailableException({required final String pluginId}) implements Exception;
 
 class CatalogImportService({
-    required final CatalogImportRepository _repository,
-    required List<String> orderedPluginIds,
-    required Map<String, CatalogEmptyHydrationPolicy> emptyHydrationPolicies,
-  }) {
-
+  required final CatalogImportRepository _repository,
+  required List<String> orderedPluginIds,
+  required Map<String, CatalogEmptyHydrationPolicy> emptyHydrationPolicies,
+}) {
   final List<String> _orderedPluginIds = List<String>.unmodifiable(orderedPluginIds);
   final Set<String> _knownPluginIds = Set<String>.unmodifiable(orderedPluginIds);
-  final Map<String, CatalogEmptyHydrationPolicy> _emptyHydrationPolicies = Map<String, CatalogEmptyHydrationPolicy>.unmodifiable(emptyHydrationPolicies);
+  final Map<String, CatalogEmptyHydrationPolicy> _emptyHydrationPolicies =
+      Map<String, CatalogEmptyHydrationPolicy>.unmodifiable(emptyHydrationPolicies);
   final StreamController<CatalogImportProgress> _progressController = StreamController<CatalogImportProgress>.broadcast(
     sync: true,
   );
@@ -54,7 +62,7 @@ class CatalogImportService({
     }
 
     final control = CatalogImportControl(
-      explicitImportRequested: trigger != CatalogImportTrigger.automatic,
+      rescanRequested: trigger == CatalogImportTrigger.rescan,
       hydrationMarkerRequested: trigger == CatalogImportTrigger.automatic,
     );
     _controls[pluginId] = control;
@@ -98,19 +106,21 @@ class CatalogImportService({
 
   Future<void> _run({required String pluginId, required CatalogImportControl control}) async {
     try {
-      if (!control.explicitImportRequested) {
+      if (!control.rescanRequested) {
         final completion = await _repository.getHydrationCompletion(pluginId: pluginId);
         if (control.cancellationRequested) {
           _publish(CatalogImportProgress.cancelled(pluginId: pluginId));
           return;
         }
-        if (!control.explicitImportRequested && completion != null) return;
+        if (!control.rescanRequested && completion != null) return;
       }
 
       await for (final progress in _repository.importCatalog(pluginId: pluginId, control: control)) {
-        if (progress case CatalogImportCommitting(
-          sessionsSeen: 0,
-        ) when _emptyHydrationPolicies[pluginId] == CatalogEmptyHydrationPolicy.retry) {
+        if (progress
+            case CatalogImportCommitting(
+              sessionsSeen: 0,
+            )
+            when _emptyHydrationPolicies[pluginId] == CatalogEmptyHydrationPolicy.retry) {
           control.hydrationMarkerRequested = false;
         }
         _publish(progress);
@@ -129,8 +139,8 @@ class CatalogImportService({
     switch (trigger) {
       case CatalogImportTrigger.automatic:
         control.hydrationMarkerRequested = true;
-      case CatalogImportTrigger.explicit:
-        control.explicitImportRequested = true;
+      case CatalogImportTrigger.rescan:
+        control.rescanRequested = true;
     }
   }
 

--- a/bridge/app/test/repositories/catalog_import_repository_test.dart
+++ b/bridge/app/test/repositories/catalog_import_repository_test.dart
@@ -337,13 +337,16 @@ void main() {
 
     for (final rescanRequested in [false, true]) {
       test("temporary discovery stays hidden and counted (rescan: $rescanRequested)", () async {
-        const visibility = {
+        final temporaryDirectory = normalizeProjectDirectory(directory: Directory.systemTemp.path);
+        final visibility = {
           "/tmp": true,
           "/tmp/qa": true,
           "/private/tmp": true,
           "/private/tmp/qa": true,
           "/tmp-project": false,
           "/private/tmp-project": false,
+          temporaryDirectory: true,
+          p.join(temporaryDirectory, "sesori-catalog-discovery"): true,
         };
         final plugin = _NativeImportPlugin(
           projects: [

--- a/bridge/app/test/repositories/catalog_import_repository_test.dart
+++ b/bridge/app/test/repositories/catalog_import_repository_test.dart
@@ -28,12 +28,12 @@ void main() {
 
     setUp(() async {
       database = createTestDatabase();
-      directory = await Directory.systemTemp.createTemp("sesori-catalog-import-test-");
+      // Catalog fixtures are metadata-only; ordinary project paths must not live below /tmp.
+      directory = Directory(p.join(_userHomeDirectory(), "sesori-catalog-import-test"));
     });
 
     tearDown(() async {
       await database.close();
-      await directory.delete(recursive: true);
     });
 
     test("native import validates ancestry, preserves bridge state, and is idempotent", () async {
@@ -113,7 +113,7 @@ void main() {
       );
       final repository = _repository(database: database, plugin: plugin);
       final control = CatalogImportControl(
-        explicitImportRequested: false,
+        rescanRequested: false,
         hydrationMarkerRequested: true,
       );
 
@@ -163,7 +163,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -175,7 +175,7 @@ void main() {
     });
 
     test("pre-start snapshot uses the same atomic publication and tombstones", () async {
-      final projectPath = "${directory.path}/snapshot";
+      final projectPath = p.join(_userHomeDirectory(), ".sesori-test-snapshot", "project");
       await database.sessionDao.insertSessionTombstone(
         backendSessionId: "deleted",
         pluginId: "snapshot",
@@ -192,6 +192,10 @@ void main() {
                 _pluginSession(id: "deleted", directory: projectPath),
               ],
             ),
+            PluginProjectCatalogSnapshot(
+              project: const PluginProject(id: "snapshot-temporary", directory: "/private/tmp/snapshot"),
+              sessions: [_pluginSession(id: "temporary-root", directory: "/private/tmp/snapshot")],
+            ),
           ],
         ),
       );
@@ -207,7 +211,7 @@ void main() {
       final statuses = await repository
           .importCatalog(
             pluginId: "snapshot",
-            control: CatalogImportControl(explicitImportRequested: true, hydrationMarkerRequested: true),
+            control: CatalogImportControl(rescanRequested: true, hydrationMarkerRequested: true),
           )
           .toList();
 
@@ -217,12 +221,18 @@ void main() {
       expect(child?.parentSessionId, root?.sessionId);
       expect(await database.sessionDao.getSessionByBinding(pluginId: "snapshot", backendSessionId: "deleted"), isNull);
       expect(await repository.getHydrationCompletion(pluginId: "snapshot"), isNotNull);
+      expect((await database.projectsDao.getAllProjects()).map((project) => project.hidden), everyElement(isTrue));
+      expect(await database.projectsDao.getCatalogProjects(), isEmpty);
+      expect(
+        await database.sessionDao.getSessionByBinding(pluginId: "snapshot", backendSessionId: "temporary-root"),
+        isNotNull,
+      );
     });
 
-    test("explicit native import shows new projects while preserving existing visibility", () async {
+    test("rescan hides noisy new projects while preserving existing visibility", () async {
       final visiblePath = "${directory.path}/visible";
       final hiddenPath = "${directory.path}/hidden";
-      final importedPath = p.join(_userHomeDirectory(), ".sesori-test-explicit-import", "project");
+      final importedPath = p.join(_userHomeDirectory(), ".sesori-test-rescan", "project");
       await database.projectsDao.upsertProjectRows(
         rows: [
           _projectRow(id: "visible-project", path: visiblePath),
@@ -246,7 +256,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -254,10 +264,10 @@ void main() {
 
       expect((await database.projectsDao.getProject(projectId: "visible-project"))?.hidden, isFalse);
       expect((await database.projectsDao.getProject(projectId: "hidden-project"))?.hidden, isTrue);
-      expect((await database.projectsDao.getProject(projectId: "imported-project"))?.hidden, isFalse);
+      expect((await database.projectsDao.getProject(projectId: "imported-project"))?.hidden, isTrue);
       expect(
         (await database.projectsDao.getCatalogProjects()).map((project) => project.projectId),
-        unorderedEquals(["visible-project", "imported-project"]),
+        ["visible-project"],
       );
       expect(
         (await database.sessionDao.getSessionByBinding(
@@ -280,7 +290,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: false,
+              rescanRequested: false,
               hydrationMarkerRequested: true,
             ),
           )
@@ -313,7 +323,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: false,
+              rescanRequested: false,
               hydrationMarkerRequested: true,
             ),
           )
@@ -325,33 +335,91 @@ void main() {
       expect((await database.projectsDao.getProject(projectId: "existing-project"))?.hidden, isFalse);
     });
 
-    test("an explicit import joining an automatic project write keeps the new project visible", () async {
-      final projectPath = p.join(_userHomeDirectory(), ".sesori-test-joined-explicit", "project");
-      final plugin = _NativeImportPlugin(
-        projects: [PluginProject(id: "joined-explicit-project", directory: projectPath)],
-        rootsByProject: const {},
-        childrenByParent: const {},
-      );
-      final projectsDao = _BlockingProjectWriteDao(database: database);
-      final repository = CatalogImportRepository(
-        runtime: createTestPluginRuntime(plugins: [plugin]),
-        projectsDao: projectsDao,
-        sessionDao: database.sessionDao,
-        catalogHydrationsDao: database.catalogHydrationsDao,
-        projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
-      );
-      final control = CatalogImportControl(
-        explicitImportRequested: false,
-        hydrationMarkerRequested: true,
-      );
-      final publication = repository.importCatalog(pluginId: plugin.id, control: control).drain<void>();
-      await projectsDao.firstWriteStarted.future;
+    for (final rescanRequested in [false, true]) {
+      test("temporary discovery stays hidden and counted (rescan: $rescanRequested)", () async {
+        const visibility = {
+          "/tmp": true,
+          "/tmp/qa": true,
+          "/private/tmp": true,
+          "/private/tmp/qa": true,
+          "/tmp-project": false,
+          "/private/tmp-project": false,
+        };
+        final plugin = _NativeImportPlugin(
+          projects: [
+            for (final path in visibility.keys) PluginProject(id: path, directory: path),
+          ],
+          rootsByProject: {
+            for (final path in visibility.keys) path: [_pluginSession(id: "root-$path", directory: path)],
+          },
+          childrenByParent: {
+            "root-/tmp/qa": [_pluginSession(id: "temporary-child", directory: "/tmp/qa/child")],
+          },
+        );
+        final statuses = await _repository(database: database, plugin: plugin)
+            .importCatalog(
+              pluginId: plugin.id,
+              control: CatalogImportControl(
+                rescanRequested: rescanRequested,
+                hydrationMarkerRequested: !rescanRequested,
+              ),
+            )
+            .toList();
+        final completed = statuses.whereType<CatalogImportCompleted>().single;
 
-      control.explicitImportRequested = true;
-      projectsDao.releaseFirstWrite();
-      await publication;
+        for (final entry in visibility.entries) {
+          expect((await database.projectsDao.getProject(projectId: entry.key))?.hidden, entry.value);
+        }
+        expect(completed.projectsImported, visibility.length);
+        expect(completed.sessionsImported, visibility.length + 1);
+        expect(completed.newItems, CatalogImportNewItems(projects: visibility.length, sessions: visibility.length + 1));
+        expect(
+          (await database.sessionDao.getSessionByBinding(
+            pluginId: plugin.id,
+            backendSessionId: "temporary-child",
+          ))?.projectId,
+          "/tmp/qa",
+        );
 
-      expect((await database.projectsDao.getProject(projectId: "joined-explicit-project"))?.hidden, isFalse);
+        final repeated = await _importCompletion(database: database, plugin: plugin);
+        expect(repeated.newItems, const CatalogImportNewItems(projects: 0, sessions: 0));
+        expect((await database.projectsDao.getProject(projectId: "/tmp/qa"))?.hidden, isTrue);
+
+        await database.projectsDao.recordOpenedProject(
+          projectId: "/tmp/qa",
+          path: "/tmp/qa",
+          displayName: null,
+          createdAt: 1,
+          updatedAt: 100,
+        );
+        await _importCompletion(database: database, plugin: plugin);
+        expect((await database.projectsDao.getProject(projectId: "/tmp/qa"))?.hidden, isFalse);
+      });
+    }
+
+    test("derived scans hide noisy launch and session projects without dropping history", () async {
+      final hiddenHomePath = p.join(_userHomeDirectory(), ".sesori-test-derived", "project");
+      final plugin = _DerivedImportPlugin(
+        launchDirectory: "/tmp/launch",
+        sessions: [
+          _pluginSession(id: "temporary-root", directory: "/private/tmp/session"),
+          _pluginSession(id: "temporary-child", parentId: "temporary-root", directory: "/private/tmp/child"),
+          _pluginSession(id: "hidden-home-root", directory: hiddenHomePath),
+        ],
+      );
+
+      final completed = await _importCompletion(database: database, plugin: plugin);
+
+      expect(completed.newItems, const CatalogImportNewItems(projects: 3, sessions: 3));
+      expect((await database.projectsDao.getAllProjects()).map((project) => project.hidden), everyElement(isTrue));
+      expect(await database.projectsDao.getCatalogProjects(), isEmpty);
+      expect(
+        (await database.sessionDao.getSessionByBinding(
+          pluginId: plugin.id,
+          backendSessionId: "temporary-child",
+        ))?.projectId,
+        "/private/tmp/session",
+      );
     });
 
     test("native import gives an exact project id precedence during a move", () async {
@@ -375,7 +443,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -398,7 +466,7 @@ void main() {
           .importCatalog(
             pluginId: derived.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -415,7 +483,7 @@ void main() {
           .importCatalog(
             pluginId: native.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -460,7 +528,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -498,7 +566,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -555,7 +623,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -630,7 +698,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -706,7 +774,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -741,7 +809,7 @@ void main() {
           .importCatalog(
             pluginId: "native",
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -867,7 +935,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -900,7 +968,7 @@ void main() {
       );
       final repository = _repository(database: database, plugin: plugin);
       final control = CatalogImportControl(
-        explicitImportRequested: true,
+        rescanRequested: true,
         hydrationMarkerRequested: false,
       );
       final result = repository.importCatalog(pluginId: plugin.id, control: control).toList();
@@ -924,7 +992,7 @@ void main() {
         projectCatalogIdentityCalculator: const ProjectCatalogIdentityCalculator(),
       );
       final control = CatalogImportControl(
-        explicitImportRequested: true,
+        rescanRequested: true,
         hydrationMarkerRequested: true,
       );
       final statuses = <CatalogImportProgress>[];
@@ -965,7 +1033,7 @@ void main() {
           .importCatalog(
             pluginId: "snapshot",
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: true,
             ),
           )
@@ -991,7 +1059,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -1028,7 +1096,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: true,
+              rescanRequested: true,
               hydrationMarkerRequested: false,
             ),
           )
@@ -1074,7 +1142,7 @@ void main() {
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: false,
+              rescanRequested: false,
               hydrationMarkerRequested: true,
             ),
           )
@@ -1123,7 +1191,7 @@ void main() {
             .importCatalog(
               pluginId: plugin.id,
               control: CatalogImportControl(
-                explicitImportRequested: false,
+                rescanRequested: false,
                 hydrationMarkerRequested: true,
               ),
             )
@@ -1230,26 +1298,6 @@ class _BlockingProjectsDao({required AppDatabase database}) extends ProjectsDao 
   }
 }
 
-class _BlockingProjectWriteDao({required AppDatabase database}) extends ProjectsDao {
-  this : super(database);
-
-  final Completer<void> firstWriteStarted = Completer<void>();
-  final Completer<void> _firstWriteGate = Completer<void>();
-  var _firstWriteReleased = false;
-
-  void releaseFirstWrite() => _firstWriteGate.complete();
-
-  @override
-  Future<void> upsertProjectRows({required List<ProjectDto> rows}) async {
-    if (!_firstWriteReleased) {
-      _firstWriteReleased = true;
-      firstWriteStarted.complete();
-      await _firstWriteGate.future;
-    }
-    await super.upsertProjectRows(rows: rows);
-  }
-}
-
 class _RecordingSessionDao({
   required AppDatabase database,
   required final int? failOnWriteCall,
@@ -1316,7 +1364,7 @@ class _TrackingProjectCatalogIdentityCalculator({required final String firstProj
   }
 }
 
-/// Runs one explicit import and returns its completion status.
+/// Runs one catalog rescan and returns its completion status.
 Future<CatalogImportCompleted> _importCompletion({
   required AppDatabase database,
   required BridgePluginApi plugin,
@@ -1325,7 +1373,7 @@ Future<CatalogImportCompleted> _importCompletion({
       .importCatalog(
         pluginId: plugin.id,
         control: CatalogImportControl(
-          explicitImportRequested: true,
+          rescanRequested: true,
           hydrationMarkerRequested: false,
         ),
       )

--- a/bridge/app/test/routing/catalog_import_handlers_test.dart
+++ b/bridge/app/test/routing/catalog_import_handlers_test.dart
@@ -26,7 +26,7 @@ void main() {
   }
 
   group("catalog import handlers", () {
-    test("POST starts the selected import and GET returns its latest status", () async {
+    test("POST rescans despite a hydration marker and GET returns its latest status", () async {
       final repository = _HandlerCatalogImportRepository();
       final service = createService(repository);
       addTearDown(service.dispose);
@@ -49,6 +49,8 @@ void main() {
       final decoded = CatalogImportStatusesResponse.fromJson(jsonDecodeMap(getResponse.body!));
       expect(decoded.statuses.single, isA<CatalogImportCompleted>());
       expect(repository.importCalls, 1);
+      expect(repository.control?.rescanRequested, isTrue);
+      expect(repository.control?.hydrationMarkerRequested, isFalse);
     });
 
     test("POST and DELETE map an unselected plugin to 404", () async {
@@ -73,7 +75,7 @@ void main() {
       final service = createService(repository);
       addTearDown(service.dispose);
       final cancelled = service.progress.firstWhere((status) => status is CatalogImportCancelled);
-      service.start(pluginId: "selected", trigger: CatalogImportTrigger.explicit);
+      service.start(pluginId: "selected", trigger: CatalogImportTrigger.rescan);
       await repository.started.future;
 
       final response = await CancelCatalogImportHandler(service: service).routeForTest(
@@ -110,7 +112,11 @@ class _HandlerCatalogImportRepository({final Completer<void>? release}) implemen
   Set<String> get importEligiblePluginIds => const {"selected"};
 
   @override
-  Future<CatalogHydrationDto?> getHydrationCompletion({required String pluginId}) async => null;
+  Future<CatalogHydrationDto?> getHydrationCompletion({required String pluginId}) async => CatalogHydrationDto(
+    pluginId: pluginId,
+    projectionVersion: CatalogImportRepository.projectionVersion,
+    completedAt: 1,
+  );
 
   @override
   Stream<CatalogImportProgress> importCatalog({

--- a/bridge/app/test/services/catalog_import_service_test.dart
+++ b/bridge/app/test/services/catalog_import_service_test.dart
@@ -36,7 +36,7 @@ void main() {
       );
 
       expect(
-        () => service.start(pluginId: "other", trigger: CatalogImportTrigger.explicit),
+        () => service.start(pluginId: "other", trigger: CatalogImportTrigger.rescan),
         throwsA(isA<CatalogImportPluginNotEnabledException>()),
       );
       expect(() => service.cancel(pluginId: "other"), throwsA(isA<CatalogImportPluginNotEnabledException>()));
@@ -76,7 +76,7 @@ void main() {
       expect(service.latestStatuses, isEmpty);
     });
 
-    test("overlapping automatic and explicit starts join and combine control", () async {
+    test("overlapping automatic and rescan starts join and combine control", () async {
       final hydrationGate = Completer<CatalogHydrationDto?>();
       final releaseImport = Completer<void>();
       final repository = _FakeCatalogImportRepository(
@@ -95,7 +95,7 @@ void main() {
       final completed = service.progress.firstWhere((status) => status is CatalogImportCompleted);
 
       service.start(pluginId: "selected", trigger: CatalogImportTrigger.automatic);
-      service.start(pluginId: "selected", trigger: CatalogImportTrigger.explicit);
+      service.start(pluginId: "selected", trigger: CatalogImportTrigger.rescan);
       hydrationGate.complete(
         const CatalogHydrationDto(
           pluginId: "selected",
@@ -106,7 +106,7 @@ void main() {
       await repository.importStarted.future;
 
       expect(repository.importCalls, 1);
-      expect(repository.lastControl?.explicitImportRequested, isTrue);
+      expect(repository.lastControl?.rescanRequested, isTrue);
       expect(repository.lastControl?.hydrationMarkerRequested, isTrue);
       releaseImport.complete();
       await completed;
@@ -129,7 +129,7 @@ void main() {
       addTearDown(service.dispose);
       final cancelled = service.progress.firstWhere((status) => status is CatalogImportCancelled);
 
-      service.start(pluginId: "selected", trigger: CatalogImportTrigger.explicit);
+      service.start(pluginId: "selected", trigger: CatalogImportTrigger.rescan);
       await repository.importStarted.future;
       service.cancel(pluginId: "selected");
       releaseImport.complete();
@@ -155,7 +155,7 @@ void main() {
         policy: CatalogEmptyHydrationPolicy.complete,
       );
       final cancelled = service.progress.firstWhere((status) => status is CatalogImportCancelled);
-      service.start(pluginId: "selected", trigger: CatalogImportTrigger.explicit);
+      service.start(pluginId: "selected", trigger: CatalogImportTrigger.rescan);
       await repository.importStarted.future;
 
       eligiblePluginIds.remove("selected");
@@ -191,7 +191,7 @@ void main() {
       final subscription = service.progress.listen(statuses.add);
       addTearDown(subscription.cancel);
 
-      service.start(pluginId: "selected", trigger: CatalogImportTrigger.explicit);
+      service.start(pluginId: "selected", trigger: CatalogImportTrigger.rescan);
       await service.progress.firstWhere((status) => status is CatalogImportFailed);
 
       expect(statuses.whereType<CatalogImportFailed>(), hasLength(1));
@@ -268,7 +268,7 @@ void main() {
         repository: repository,
         policy: CatalogEmptyHydrationPolicy.complete,
       );
-      service.start(pluginId: "selected", trigger: CatalogImportTrigger.explicit);
+      service.start(pluginId: "selected", trigger: CatalogImportTrigger.rescan);
       await repository.importStarted.future;
 
       final first = service.dispose();

--- a/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
+++ b/bridge/app/tool/benchmarks/catalog_import_event_soak.dart
@@ -196,7 +196,7 @@ class const _CatalogImportEventSoak({required final _BenchmarkConfiguration _con
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: false,
+              rescanRequested: false,
               hydrationMarkerRequested: true,
             ),
           )

--- a/bridge/app/tool/benchmarks/import_concurrency_benchmark.dart
+++ b/bridge/app/tool/benchmarks/import_concurrency_benchmark.dart
@@ -111,7 +111,7 @@ class const _ImportConcurrencyBenchmark({required final _BenchmarkConfiguration 
           .importCatalog(
             pluginId: plugin.id,
             control: CatalogImportControl(
-              explicitImportRequested: false,
+              rescanRequested: false,
               hydrationMarkerRequested: true,
             ),
           )

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -31,8 +31,9 @@ state.
   while a navigated directory loads or reports an access failure. Hiding delists
   without destroying sessions or history. Every catalog scan preserves the stored
   visibility of existing projects. Newly discovered ordinary projects appear
-  immediately; projects at or below `/tmp` or `/private/tmp`, or whose first
-  directory entry below the resolved user home starts with `.`, start hidden.
+  immediately; projects at or below the host's system temporary directory,
+  `/tmp`, or `/private/tmp`, or whose first directory entry below the resolved
+  user home starts with `.`, start hidden.
   Both `~/.tool` and its descendants qualify; a dot directory nested below a
   visible home entry does not. Automatic hydration, Deep Scan/full refresh, and
   scans from harness settings share these defaults. They still import and count
@@ -377,8 +378,9 @@ For list-row swipes, alternate iOS, Android gesture navigation, Android button
 navigation, and a non-mobile platform; begin drags inside and just outside each
 10% edge buffer.
 For catalog scanning, vary automatic hydration, Deep Scan, and harness-settings
-rescans. Compare a direct home dot directory, its descendants, `/tmp` and
-`/private/tmp` projects, similarly prefixed ordinary paths, a dot directory nested
+rescans. Compare a direct home dot directory, its descendants, the host's system
+temporary directory, `/tmp` and `/private/tmp` projects, similarly prefixed
+ordinary paths, a dot directory nested
 below a visible home entry, and an existing project's stored visibility. Reveal
 a hidden folder through Add/Open Project and confirm rescanning preserves it. Use the mobile component playbook to compare every scan
 row state and meaningful count variant in light/dark themes, iPhone/Android

--- a/docs/regression/projects-and-sessions.md
+++ b/docs/regression/projects-and-sessions.md
@@ -29,15 +29,18 @@ state.
   up arrow moves to the parent, while Home and Root shortcuts jump to the host
   user's home directory and filesystem root. Those controls remain available
   while a navigated directory loads or reports an access failure. Hiding delists
-  without destroying sessions or history. A catalog import lists newly inserted
-  projects immediately and preserves the stored visibility of every existing
-  project; it does not infer why an existing row is hidden. A new project found
-  by automatic hydration starts hidden when the first directory entry below the
-  resolved user home starts with `.`: both `~/.tool` and its descendants qualify.
-  Explicit catalog imports and manual project opens remain visible by default,
-  while a dot directory nested below a visible home entry does not qualify. No
-  existing project is backfilled or reclassified. Import is explicit, per plugin,
-  atomic, non-destructive, cancellable, and attributes progress.
+  without destroying sessions or history. Every catalog scan preserves the stored
+  visibility of existing projects. Newly discovered ordinary projects appear
+  immediately; projects at or below `/tmp` or `/private/tmp`, or whose first
+  directory entry below the resolved user home starts with `.`, start hidden.
+  Both `~/.tool` and its descendants qualify; a dot directory nested below a
+  visible home entry does not. Automatic hydration, Deep Scan/full refresh, and
+  scans from harness settings share these defaults. They still import and count
+  every project and session, including hidden temporary projects; rescanning an
+  unchanged catalog reports nothing new. Only deliberately selecting a folder
+  through Add/Open Project reveals it, and later scans preserve that choice.
+  No existing project is backfilled or reclassified. Catalog scans are per plugin,
+  atomic, non-destructive, cancellable, and attribute progress.
 - A completed import reports both the totals it published and, separately, how
   much of that was new. The two are not interchangeable: a re-import of an
   unchanged catalog still publishes every row, so the totals stay at the full
@@ -49,14 +52,14 @@ state.
   the producer omits the delta. An automatic hydration request whose completion
   marker is already current runs no import and emits no progress or completion
   line.
-- A user can start an import from the app. The three list surfaces — the
+- A user can start a catalog rescan from the app. The three list surfaces — the
   project list, the full-screen session list, and the wide split-view pane —
   offer it as a second, deeper stage of their pull, which invites itself with a
   caption once the ordinary trigger is passed and commits at the deeper one
   while the finger is still down. It covers every harness the bridge reports as
   routable, which is not the same as enabled: a blocked or failed harness is
   refused by the bridge and is left out. The harness settings surface offers the
-  same import for one named harness.
+  same rescan for one named harness.
 - A dormant OpenCode import first attempts a direct metadata-only SQLite snapshot. A
   successful snapshot must not resolve or start an OpenCode runtime, server, health
   probe, CLI session listing, or REST API. It reads projects, project-directory
@@ -268,24 +271,24 @@ state.
 - DeepSeek child reads merge persisted and live direct children, with persisted
   metadata winning. Live descendants inherit the tracked root's project before
   their headers reach persistence; only activity rolls up to the root.
-- DeepSeek explicit import enumerates only adapter-owned session headers below
+- DeepSeek catalog import enumerates only adapter-owned session headers below
   the isolated plugin state. It derives projects from normalized session `cwd`,
   preserves parent/child metadata, and never scans or imports normal
   `DSH_HOME/sessions`. Ordinary project/session list reads remain bridge-database
   reads after import; adapter JSONL is not a second normal catalog source.
-- Antigravity explicit import uses the isolated profile's bounded read-only `.meta` records to recover only UUID
+- Antigravity catalog import uses the isolated profile's bounded read-only `.meta` records to recover only UUID
   session IDs and canonical absolute working directories. It never scans ordinary catalog reads, parses private SQLite
   or brain content, reads tokens, mutates Google history, or replaces authoritative bridge/live attribution. The
   plugin's one recovery batch is prepared once per cold live connection and existing bridge tombstones keep locally
   deleted rows out of later import.
-- GitHub Copilot explicit import follows standard ACP `session/list` pagination,
+- GitHub Copilot catalog import follows standard ACP `session/list` pagination,
   up to the bounded page limit, attributes committed rows to `copilot`, and then
   returns to bridge-database reads for ordinary listing. Sesori never scans
   Copilot's configuration or history directories. Cancellation or a first-page
   failure leaves the prior catalog intact. A later-page failure logs the error
   and commits the pages gathered so far as a fail-soft partial observation;
   missing previously imported rows remain because import is non-destructive.
-- Grok explicit import uses bounded standard ACP `session/list` for roots, then
+- Grok catalog import uses bounded standard ACP `session/list` for roots, then
   enriches each reported root from its local
   `~/.grok/sessions/<encoded cwd>/<session id>/` summary and update records.
   Persisted and not-yet-flushed live sub-agents appear under the root through the
@@ -342,8 +345,8 @@ state.
 | Level | Additional coverage |
 |---|---|
 | L1 Smoke | Headless bridge, representative plugin: project list and one project's session list return committed data with plugin attribution. |
-| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new and lists its newly inserted projects, while preserving an existing project's stored visibility. Focused import coverage proves automatic hydration hides new projects at and below a top-level home dot directory, leaves a dot directory below a visible home entry visible, and lets an explicit import—including one joining an in-flight automatic write—remain visible; a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. An automatic hydration request with a current marker does not enumerate or publish progress. Focused client coverage holds pre-commit list reads through a completion, ignores a zero-count hydration completion, proves the post-commit snapshot wins and a second completion gets a trailing snapshot, retains a failed snapshot for the next refresh, proves an interrupted full-screen load and pull surface the winning failure while retaining session PR-data waiting, and covers a completion after immediate cancellation. Focused shared-presentation and shell tests cover project/session empty and row states, split-pane behavior, mobile CLI recovery, both desktop disconnected variants using supervised Start without CLI copy, and desktop list-to-detail plus child-session routing with unsupported detail controls omitted. Focused client coverage also proves the deeper pull starts one scan however far it travels, that a pull which fired it runs no ordinary refresh and raises no confirmation while an ordinary pull still does, that the row keeps one height from starting through running to its result, that its loader and beam follow the coordinated timeline and reduced-motion rest frame, that terminal tones, platform corners, localized count branches, and Cancel/Dismiss semantics remain exact, and that a scan started from harness settings is announced there while one started elsewhere is not. |
-| L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; Copilot exhausts a multi-page standard ACP catalog and exposes one newly imported session without a second manual refresh; Grok explicitly imports a persisted session with `grok` attribution, then an unchanged re-import leaves the committed catalog intact; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render; project and session row swipes stay inert from the iOS back edge and both Android gesture-navigation edges while remaining active at unreserved edges and under Android button navigation. A catalog scan started by the deeper pull renders its row through starting, running, and its result on one mobile platform and in the wide split-view pane, which drives its pull through a different scroll owner; two *routable* harnesses at once, so the fan-out has two members and a partial failure is reachable at all — enabled is not enough, since a blocked or failed harness is enabled and still left out; one native-ownership and one bridge-derived harness, which count new projects differently; and one run that genuinely imports a new session, visible in the list without a second manual refresh. |
+| L2 Routine | Headless bridge, representative plugin: open, rename, hide; create a session and see it listed before metadata, then observe generated title and eligible branch refinement through the existing session update without unseen change; unseen otherwise advances and clears; the existing activity marker appears in REST and live list-state projections; statuses report idle/busy. A first import reports every published row as new and lists its newly inserted ordinary projects, while preserving an existing project's stored visibility. Focused native, snapshot, and derived import coverage proves startup hydration and rescans hide new home dot-directory and temporary projects without omitting their sessions or changing their import counts, leave ordinary and nested-dot projects visible, and preserve a folder revealed through Add/Open Project; a re-import of an unchanged catalog reports the same totals with a zero delta, and a completion whose delta is absent reports its totals without claiming nothing changed. An automatic hydration request with a current marker does not enumerate or publish progress. Focused client coverage holds pre-commit list reads through a completion, ignores a zero-count hydration completion, proves the post-commit snapshot wins and a second completion gets a trailing snapshot, retains a failed snapshot for the next refresh, proves an interrupted full-screen load and pull surface the winning failure while retaining session PR-data waiting, and covers a completion after immediate cancellation. Focused shared-presentation and shell tests cover project/session empty and row states, split-pane behavior, mobile CLI recovery, both desktop disconnected variants using supervised Start without CLI copy, and desktop list-to-detail plus child-session routing with unsupported detail controls omitted. Focused client coverage also proves the deeper pull starts one scan however far it travels, that a pull which fired it runs no ordinary refresh and raises no confirmation while an ordinary pull still does, that the row keeps one height from starting through running to its result, that its loader and beam follow the coordinated timeline and reduced-motion rest frame, that terminal tones, platform corners, localized count branches, and Cancel/Dismiss semantics remain exact, and that a scan started from harness settings is announced there while one started elsewhere is not. |
+| L3 Release | Client end to end (phone): every supporting production plugin still covers native/derived ownership, import, and child resolution; Pi imports configured/default/known roots with explicit names and resolvable lineage; Copilot exhausts a multi-page standard ACP catalog and exposes one newly imported session without a second manual refresh; Grok scans a persisted session into the catalog with `grok` attribution, then an unchanged re-import leaves the committed catalog intact; one representative plugin proves two running roots and two projects with running roots reorder after committed user-side activity, inactive session/project order is unchanged, a live patch reorders without another status event or project summary, and omitted ordering facts use updated-time fallbacks. Focused ACP protocol and client ordering tests prove the exact awaiting-only state is not promoted because normal production root prompts remain running while awaiting input. Lists and unseen badges render; project and session row swipes stay inert from the iOS back edge and both Android gesture-navigation edges while remaining active at unreserved edges and under Android button navigation. A catalog scan started by the deeper pull renders its row through starting, running, and its result on one mobile platform and in the wide split-view pane, which drives its pull through a different scroll owner; two *routable* harnesses at once, so the fan-out has two members and a partial failure is reachable at all — enabled is not enough, since a blocked or failed harness is enabled and still left out; one native-ownership and one bridge-derived harness, which count new projects differently; and one run that genuinely imports a new session, visible in the list without a second manual refresh. |
 | L4 Extended | Relay integration, every supporting production plugin: bridge and plugin restart preserve identity and overrides; a moved backend-native project keeps them while a moved bridge-derived project is discovered as new without mutating the old catalog; a cancelled or first-page failed import leaves the prior catalog intact; reads during import stay consistent; an unavailable plugin is reported while others keep listing. Copilot later-page failure commits gathered pages as a non-destructive fail-soft partial observation. Scanning against older and interrupted peers: a bridge that omits its new-item delta falls back to totals rather than reporting nothing new; a supported bridge with no import route at all reports that it cannot scan, and so does one that has the import route but not the management route the app needs to learn its harnesses — two different bridge versions reaching the same state by different paths; a bridge holding terminal import statuses is reconnected to without announcing a stale success; a disconnect mid-scan reconnects and settles without claiming a summary; and a bridge whose harnesses are all blocked reports that there is nothing to scan. |
 | L5 Full | Client end to end, every supporting production plugin: multiple clients observe consistent listings and unseen transitions; large catalogs and paged listings behave; unattributed payloads resolve to the historical identity. |
 
@@ -373,10 +376,11 @@ updated-time versus archive-time buckets, and missing-timestamp headings.
 For list-row swipes, alternate iOS, Android gesture navigation, Android button
 navigation, and a non-mobile platform; begin drags inside and just outside each
 10% edge buffer.
-For catalog scanning, vary automatic hydration against explicit import and
-compare a direct home dot directory, its descendants, a dot directory nested
-below a visible home entry, and an existing project whose stored visibility must
-remain unchanged. Use the mobile component playbook to compare every scan
+For catalog scanning, vary automatic hydration, Deep Scan, and harness-settings
+rescans. Compare a direct home dot directory, its descendants, `/tmp` and
+`/private/tmp` projects, similarly prefixed ordinary paths, a dot directory nested
+below a visible home entry, and an existing project's stored visibility. Reveal
+a hidden folder through Add/Open Project and confirm rescanning preserves it. Use the mobile component playbook to compare every scan
 row state and meaningful count variant in light/dark themes, iPhone/Android
 viewports, and reduced motion. Then vary the number of enabled harnesses,
 whether any is blocked or failed, and which surface starts the run — each of
@@ -418,9 +422,9 @@ leave the surface that started one. Restore harness eligibility afterwards.
   completion changes its read/unread state or last user-message marker.
 - Unseen never clears, clears without viewing, or an unavailable plugin is idle.
 - Hiding destroys sessions, a cancelled import destroys the committed catalog,
-  automatic hydration exposes a newly discovered project below a top-level home
-  dot directory, or explicit import or an existing visibility choice is silently
-  hidden.
+  any scan exposes a new home dot-directory or temporary project, hidden projects'
+  sessions are omitted or counted as new again on an unchanged rescan, or a folder
+  deliberately revealed through Add/Open Project is hidden again.
 - Desktop wide navigation recreates the session inventory on each selected
   detail/diff route, loses selection, or narrow navigation renders both panes.
 - Antigravity import parses SQLite/brain/token content, writes Google files, scans during an ordinary catalog read,
@@ -504,7 +508,7 @@ leave the surface that started one. Restore harness eligibility afterwards.
 - An old bridge cannot provide per-running-root ordering facts in
   `projects.summary`, so the current app falls back to project updated time.
 - Untested Hermes gap (remove this entry once verified): a failed or cancelled
-  in-flight Hermes import was never exercised; only completed explicit imports
+  in-flight Hermes import was never exercised; only completed catalog imports
   and non-destructive re-imports were verified.
 
 ## Sources


### PR DESCRIPTION
## Complexity

🌿 Straightforward — localized catalog visibility policy, clearer internal scan intent, and focused regression coverage.

## What

- Apply the same new-project visibility defaults to startup hydration, Deep Scan/full refresh, and harness-settings rescans.
- Default projects at or below the host's system temporary directory, `/tmp`, `/private/tmp`, and top-level home dot-directories to hidden. Ordinary project folders still appear.
- Retain every discovered project and session in the database, including temporary history, so import totals remain truthful and unchanged rescans report no new items.
- Remove the scan-specific reveal override and rename internal `explicit` import intent to `rescan`; rescans still bypass completed startup hydration markers.
- Preserve Add/Open Project as the deliberate reveal flow and keep existing visibility authoritative.

## Why

Deep Scan discovers history; it does not mean the user deliberately selected every discovered directory as a project. The previous explicit-scan exception bypassed hiding and surfaced tool-owned folders. Keeping temporary projects hidden rather than excluding them avoids extra filtering logic and misleading discovery counts.

## Risk and test focus

Low risk. The shared bridge publication path applies the policy across all harnesses, without plugin-specific changes. Focus is native/snapshot/derived discovery, host-temp and POSIX path-boundary matching, retained session lineage and counts, rescan marker bypass, and preserving a folder revealed through Add/Open Project.

Database impact: only the existing `hidden` value on newly discovered noisy projects. Existing rows are not reclassified or cleaned up. No schema migration, wire change, or compatibility shim; the replaced visibility behavior was unreleased.

## Expected result

Startup and user-triggered scans no longer add new tool/temp projects to the visible project list. Their sessions remain imported. Add/Open Project reveals the chosen folder, and later scans preserve that choice. Ordinary repositories remain visible.

## Verification

- `cd bridge && asdf exec dart pub get --enforce-lockfile`
- `cd bridge/app && asdf exec dart test --reporter=expanded test/repositories/catalog_import_repository_test.dart test/services/catalog_import_service_test.dart test/routing/catalog_import_handlers_test.dart test/bridge/routing/open_project_handler_test.dart` — passed
- `cd bridge/app && asdf exec dart analyze --fatal-infos` — no issues
- Dart formatting and `git diff --check` — passed
- Updated `docs/regression/projects-and-sessions.md`.
- Production local catalog was inspected read-only; no local project visibility or session data was changed.
