### PR TITLE
⚙️ [path-runtime-authority-split] foundation: centralize executable and command control [step 2/9]

### DIFF
--- a/.plan/active/path-runtime-authority-split/TRACKER.md
+++ b/.plan/active/path-runtime-authority-split/TRACKER.md
@@ -5,16 +5,16 @@
 - Slug: `path-runtime-authority-split`
 - Base: `main` at `4854865eedf6`
 - Preserved source: PR #1458 at `0caf101b9a`
-- Current step: 1/9 — plan replacement sequence
-- Open replacement implementation PRs: none
+- Current step: 2/9 — centralize executable and command control
+- Open replacement implementation PRs: Step 2 pending publication
 - Architecture review: approved 2026-09-13 after exact ownership clarification; Step 8 core edits stay selector-only
 
 ## Steps
 
 | Step | Status | PR | Changed-line ceiling |
 |---|---|---|---:|
-| 1. Plan replacement sequence | In progress | Pending | 650 |
-| 2. Centralize executable and command control | Not started | — | 700 |
+| 1. Plan replacement sequence | Merged | #1462 | 650 |
+| 2. Centralize executable and command control | In progress | Pending | 700 |
 | 3. Settle commands and terminate process trees | Not started | — | 1,000 |
 | 4. Make PATH authoritative for managed copies | Not started | — | 1,450 |
 | 5. Report outdated PATH runtimes and safe updaters | Not started | — | 1,400 |
@@ -67,14 +67,34 @@ Exact files, constructor collaborators, dependency flows, compatibility defaults
 - [x] Map all latest review findings to replacement slices.
 - [x] Complete architecture-plan review and apply valid findings.
 - [x] Validate plan/tracker formatting and changed-line budget.
-- [ ] Commit, push, and open Step 1 PR.
-- [ ] Reply on #1458 with replacement provenance and close it without deleting the branch.
-- [ ] Start PR monitor for Step 1.
+- [x] Commit, push, and open Step 1 PR.
+- [x] Reply on #1458 with replacement provenance and close it without deleting the branch.
+- [x] Start PR monitor for Step 1.
 
-## Verification Evidence
+## Step 1 Evidence
 
+- PR #1462 merged at `27cd7c76fa`.
 - Architecture-plan review: APPROVED on permitted second pass; no blocking findings.
-- `git diff --check`: passes.
+- `git diff --check`: passed.
 - Added-line width: zero lines over 120 Unicode characters or UTF-8 bytes.
 - Step 1 content: 524 lines, below its 650-line ceiling.
 - No Dart/Flutter suites required for plan-only changes.
+
+## Step 2 Checklist
+
+- [x] Add injectable concrete `IoHostExecutableLocator`; retain no one-to-one interface.
+- [x] Centralize locale-independent process-missing and positive PATH-absence classification.
+- [x] Add abortable `HostProcessCommandExecutor` execution with observed termination.
+- [x] Add direct host lookup, classification, timeout, abort, and termination tests.
+- [x] Run focused Foundation tests and strict analysis.
+- [x] Complete architecture-implementation review and apply valid findings.
+- [x] Measure the full Step 2 diff against its 700-line ceiling.
+- [ ] Commit, push, and open Step 2 PR.
+- [ ] Start PR monitor for Step 2.
+
+## Step 2 Evidence
+
+- Focused Foundation tests: 11 passed.
+- `dart analyze --fatal-infos`: no issues.
+- Architecture implementation review: APPROVED with no violations.
+- Full Step 2 diff: 526 changed lines, below the 700-line ceiling.

--- a/bridge/sesori_bridge_foundation/lib/sesori_bridge_foundation.dart
+++ b/bridge/sesori_bridge_foundation/lib/sesori_bridge_foundation.dart
@@ -9,6 +9,7 @@ export "src/binary_download_client.dart";
 export "src/browser_noop.dart";
 export "src/checksum_validator.dart";
 export "src/command_executor.dart";
+export "src/host_executable_locator.dart";
 export "src/host_process_command_executor.dart";
 export "src/os_version_formatter.dart";
 export "src/parallel_lock.dart";

--- a/bridge/sesori_bridge_foundation/lib/src/host_executable_locator.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/host_executable_locator.dart
@@ -1,0 +1,138 @@
+import "dart:io";
+
+import "package:path/path.dart" as p;
+
+/// Whether the executable path a host process would resolve is present.
+enum HostExecutablePresence() {
+  present,
+  absent,
+  unknown,
+}
+
+/// Read-only host lookup used to distinguish an absent command from a present
+/// but unlaunchable shim or broken symbolic link.
+///
+/// This concrete class is injectable directly; Dart test fakes may implement it
+/// without requiring a one-to-one interface.
+class const IoHostExecutableLocator({required final bool? platformIsWindows}) {
+  bool get isWindows => platformIsWindows ?? Platform.isWindows;
+
+  /// Whether [error] is the host's unambiguous command-not-found result.
+  ///
+  /// POSIX error code 3 has unrelated meanings, while Windows uses it for a
+  /// missing path.
+  bool isProcessMissingError({required ProcessException error}) =>
+      error.errorCode == 2 || (isWindows && error.errorCode == 3);
+
+  /// Whether host lookup positively proves [executable] is absent.
+  ///
+  /// Unknown lookup results remain authoritative and therefore return false.
+  bool isPathCommandAbsent({
+    required String executable,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+  }) =>
+      locate(executable: executable, environment: environment, workingDirectory: workingDirectory) ==
+      HostExecutablePresence.absent;
+
+  HostExecutablePresence locate({
+    required String executable,
+    required Map<String, String>? environment,
+    required String? workingDirectory,
+  }) {
+    if (executable.contains("/") || executable.contains(r"\")) {
+      final resolvedExecutable = workingDirectory != null && !p.isAbsolute(executable)
+          ? p.join(workingDirectory, executable)
+          : executable;
+      return _inspectCandidates([resolvedExecutable]);
+    }
+
+    final extensions = isWindows && p.extension(executable).isEmpty
+        ? (_environmentValue(environment: environment, name: "PATHEXT") ??
+                  _environmentValue(environment: Platform.environment, name: "PATHEXT") ??
+                  ".COM;.EXE;.BAT;.CMD")
+              .split(";")
+              .where((extension) => extension.isNotEmpty)
+              .toList(growable: false)
+        : const [""];
+    final candidates = <String>[];
+    if (isWindows) {
+      _addCandidates(
+        candidates: candidates,
+        directory: workingDirectory ?? Directory.current.path,
+        executable: executable,
+        extensions: extensions,
+      );
+    }
+
+    final pathValue =
+        _environmentValue(environment: environment, name: "PATH") ??
+        _environmentValue(environment: Platform.environment, name: "PATH");
+    if (pathValue == null) {
+      final currentDirectoryPresence = _inspectCandidates(candidates);
+      return currentDirectoryPresence == HostExecutablePresence.present
+          ? HostExecutablePresence.present
+          : HostExecutablePresence.unknown;
+    }
+
+    for (final rawDirectory in pathValue.split(isWindows ? ";" : ":")) {
+      final directory = _unquote(rawDirectory.trim());
+      _addCandidates(
+        candidates: candidates,
+        directory: directory.isEmpty ? workingDirectory ?? Directory.current.path : directory,
+        executable: executable,
+        extensions: extensions,
+      );
+    }
+    return _inspectCandidates(candidates);
+  }
+
+  void _addCandidates({
+    required List<String> candidates,
+    required String directory,
+    required String executable,
+    required List<String> extensions,
+  }) {
+    for (final extension in extensions) {
+      candidates.add(p.join(directory, "$executable$extension"));
+    }
+  }
+
+  HostExecutablePresence _inspectCandidates(List<String> candidates) {
+    var hadUnknown = false;
+    for (final candidate in candidates) {
+      if (candidate.contains("\u0000")) {
+        hadUnknown = true;
+        continue;
+      }
+      try {
+        if (FileSystemEntity.typeSync(candidate, followLinks: false) != FileSystemEntityType.notFound) {
+          return HostExecutablePresence.present;
+        }
+      } on FileSystemException {
+        hadUnknown = true;
+      }
+    }
+    return hadUnknown ? HostExecutablePresence.unknown : HostExecutablePresence.absent;
+  }
+
+  String? _environmentValue({
+    required Map<String, String>? environment,
+    required String name,
+  }) {
+    if (environment == null) return null;
+    if (!isWindows) return environment[name];
+    final normalizedName = name.toLowerCase();
+    for (final entry in environment.entries) {
+      if (entry.key.toLowerCase() == normalizedName) return entry.value;
+    }
+    return null;
+  }
+
+  String _unquote(String value) {
+    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+      return value.substring(1, value.length - 1);
+    }
+    return value;
+  }
+}

--- a/bridge/sesori_bridge_foundation/lib/src/host_process_command_executor.dart
+++ b/bridge/sesori_bridge_foundation/lib/src/host_process_command_executor.dart
@@ -1,7 +1,8 @@
 import "dart:async";
 import "dart:convert";
 
-import "package:sesori_plugin_interface/sesori_plugin_interface.dart" show HostProcessService, Log, SpawnedProcess;
+import "package:sesori_plugin_interface/sesori_plugin_interface.dart"
+    show HostProcessService, Log, PluginStartAbortedException, SpawnedProcess, StartAbortSignal;
 
 import "command_executor.dart";
 
@@ -12,7 +13,8 @@ import "command_executor.dart";
 /// acquisition primitives (archive extraction, version probing) run their
 /// short-lived helper commands (`tar`, `unzip`, `<bin> --version`) through this
 /// adapter. It drains stdout/stderr from spawn so a chatty child cannot block on
-/// a full pipe, and force-kills a child that outlives the timeout.
+/// a full pipe, and force-kills a child that outlives the timeout. Forced
+/// termination is not considered complete until the child exit is observed.
 class HostProcessCommandExecutor({
   required final HostProcessService _processes,
   required final bool _runInShell,
@@ -33,7 +35,42 @@ class HostProcessCommandExecutor({
     String? workingDirectory,
     Map<String, String>? environment,
     Duration? timeout,
+  }) => _run(
+    executable: executable,
+    arguments: arguments,
+    workingDirectory: workingDirectory,
+    environment: environment,
+    timeout: timeout,
+    abortSignal: null,
+  );
+
+  /// Runs a mutation command whose process must be force-stopped when bridge
+  /// shutdown wins the race.
+  Future<CommandResult> runAbortable({
+    required String executable,
+    required List<String> arguments,
+    required String? workingDirectory,
+    required Map<String, String>? environment,
+    required Duration? timeout,
+    required StartAbortSignal abortSignal,
+  }) => _run(
+    executable: executable,
+    arguments: arguments,
+    workingDirectory: workingDirectory,
+    environment: environment,
+    timeout: timeout,
+    abortSignal: abortSignal,
+  );
+
+  Future<CommandResult> _run({
+    required String executable,
+    required List<String> arguments,
+    required String? workingDirectory,
+    required Map<String, String>? environment,
+    required Duration? timeout,
+    required StartAbortSignal? abortSignal,
   }) async {
+    if (abortSignal?.isAborted ?? false) throw const PluginStartAbortedException();
     final SpawnedProcess process = await _processes.spawn(
       includeParentEnvironment: _includeParentEnvironment,
       executable: executable,
@@ -68,7 +105,14 @@ class HostProcessCommandExecutor({
     final Future<void> stdoutDone = stdoutSub.asFuture<void>();
     final Future<void> stderrDone = stderrSub.asFuture<void>();
     try {
-      final int exitCode = await process.exitCode.timeout(timeout ?? _defaultTimeout);
+      final exit = process.exitCode;
+      final effectiveTimeout = timeout ?? _defaultTimeout;
+      final int exitCode = abortSignal == null
+          ? await exit.timeout(effectiveTimeout)
+          : await Future.any<int>([
+              exit,
+              abortSignal.whenAborted.then<int>((_) => throw const PluginStartAbortedException()),
+            ]).timeout(effectiveTimeout);
       // Wait for the output streams to finish before reading the buffers, so a
       // command whose stdout/stderr is still buffered at exit (e.g. a fast
       // `--version` or a `tar -tzf` listing) is not captured truncated. Bounded
@@ -87,18 +131,47 @@ class HostProcessCommandExecutor({
         stdout: stdoutBuffer.toString(),
         stderr: stderrBuffer.toString(),
       );
+    } on PluginStartAbortedException {
+      await _kill(process: process, executable: executable, reason: "aborted");
+      rethrow;
     } on TimeoutException {
-      try {
-        await _processes.signalForce(pid: process.pid);
-      } on Object catch (error, stackTrace) {
-        Log.w("HostProcessCommandExecutor: failed to kill timed-out '$executable'", error, stackTrace);
-      }
+      await _kill(process: process, executable: executable, reason: "timed-out");
       rethrow;
     } finally {
       // Isolate each cancel: a cancel failure must neither mask the in-flight
       // command result/error nor skip the other subscription's teardown.
       await _cancelQuietly(stdoutSub, stream: "stdout", executable: executable);
       await _cancelQuietly(stderrSub, stream: "stderr", executable: executable);
+    }
+  }
+
+  Future<void> _kill({
+    required SpawnedProcess process,
+    required String executable,
+    required String reason,
+  }) async {
+    Object? signalError;
+    StackTrace? signalStackTrace;
+    try {
+      await _processes.signalForce(pid: process.pid);
+    } on Object catch (error, stackTrace) {
+      signalError = error;
+      signalStackTrace = stackTrace;
+      Log.w("HostProcessCommandExecutor: failed to kill $reason '$executable'", error, stackTrace);
+    }
+
+    try {
+      await process.exitCode.timeout(const Duration(seconds: 5));
+    } on Object catch (error, stackTrace) {
+      Log.w(
+        "HostProcessCommandExecutor: failed to confirm termination of $reason '$executable'",
+        error,
+        stackTrace,
+      );
+      if (signalError case final error?) {
+        Error.throwWithStackTrace(error, signalStackTrace ?? StackTrace.current);
+      }
+      rethrow;
     }
   }
 

--- a/bridge/sesori_bridge_foundation/test/host_executable_locator_test.dart
+++ b/bridge/sesori_bridge_foundation/test/host_executable_locator_test.dart
@@ -1,0 +1,130 @@
+import "dart:io";
+
+import "package:path/path.dart" as p;
+import "package:sesori_bridge_foundation/sesori_bridge_foundation.dart";
+import "package:test/test.dart";
+
+void main() {
+  late Directory temporaryDirectory;
+
+  setUp(() {
+    temporaryDirectory = Directory.systemTemp.createTempSync("host-executable-locator");
+  });
+
+  tearDown(() {
+    if (temporaryDirectory.existsSync()) temporaryDirectory.deleteSync(recursive: true);
+  });
+
+  test("finds a PATH file even when launching it could fail", () {
+    File(p.join(temporaryDirectory.path, "runtime")).writeAsStringSync("#!/missing-interpreter\n");
+    const locator = IoHostExecutableLocator(platformIsWindows: false);
+
+    expect(
+      locator.locate(
+        executable: "runtime",
+        environment: {"PATH": temporaryDirectory.path},
+        workingDirectory: null,
+      ),
+      HostExecutablePresence.present,
+    );
+  });
+
+  test("reports an absent POSIX PATH command", () {
+    const locator = IoHostExecutableLocator(platformIsWindows: false);
+
+    expect(
+      locator.locate(
+        executable: "runtime",
+        environment: {"PATH": temporaryDirectory.path},
+        workingDirectory: null,
+      ),
+      HostExecutablePresence.absent,
+    );
+    expect(
+      locator.isPathCommandAbsent(
+        executable: "runtime",
+        environment: {"PATH": temporaryDirectory.path},
+        workingDirectory: null,
+      ),
+      isTrue,
+    );
+  });
+
+  test("does not treat present or indeterminate PATH entries as absent", () {
+    File(p.join(temporaryDirectory.path, "runtime")).writeAsStringSync("runtime");
+    const locator = IoHostExecutableLocator(platformIsWindows: false);
+
+    expect(
+      locator.isPathCommandAbsent(
+        executable: "runtime",
+        environment: {"PATH": temporaryDirectory.path},
+        workingDirectory: null,
+      ),
+      isFalse,
+    );
+    expect(
+      locator.isPathCommandAbsent(
+        executable: "runtime",
+        environment: const {"PATH": "\u0000"},
+        workingDirectory: null,
+      ),
+      isFalse,
+    );
+  });
+
+  test("classifies command-not-found process errors by platform", () {
+    const posixLocator = IoHostExecutableLocator(platformIsWindows: false);
+    const windowsLocator = IoHostExecutableLocator(platformIsWindows: true);
+    const errorCodeTwo = ProcessException("runtime", [], "missing", 2);
+    const errorCodeThree = ProcessException("runtime", [], "missing", 3);
+    const permissionDenied = ProcessException("runtime", [], "denied", 13);
+
+    expect(posixLocator.isProcessMissingError(error: errorCodeTwo), isTrue);
+    expect(posixLocator.isProcessMissingError(error: errorCodeThree), isFalse);
+    expect(windowsLocator.isProcessMissingError(error: errorCodeTwo), isTrue);
+    expect(windowsLocator.isProcessMissingError(error: errorCodeThree), isTrue);
+    expect(windowsLocator.isProcessMissingError(error: permissionDenied), isFalse);
+  });
+
+  test("uses case-insensitive Windows environment keys and PATHEXT", () {
+    File(p.join(temporaryDirectory.path, "runtime.CMD")).writeAsStringSync("@echo off");
+    const locator = IoHostExecutableLocator(platformIsWindows: true);
+
+    expect(
+      locator.locate(
+        executable: "runtime",
+        environment: {"Path": temporaryDirectory.path, "PathExt": ".CMD;.EXE"},
+        workingDirectory: null,
+      ),
+      HostExecutablePresence.present,
+    );
+  });
+
+  test("checks the Windows working directory before PATH", () {
+    final pathDirectory = Directory.systemTemp.createTempSync("host-executable-path");
+    addTearDown(() {
+      if (pathDirectory.existsSync()) pathDirectory.deleteSync(recursive: true);
+    });
+    File(p.join(temporaryDirectory.path, "runtime.CMD")).writeAsStringSync("@echo off");
+    const locator = IoHostExecutableLocator(platformIsWindows: true);
+
+    expect(
+      locator.locate(
+        executable: "runtime",
+        environment: {"PATH": pathDirectory.path, "PATHEXT": ".CMD;.EXE"},
+        workingDirectory: temporaryDirectory.path,
+      ),
+      HostExecutablePresence.present,
+    );
+  });
+
+  test("inspects an explicit path directly", () {
+    final executable = File(p.join(temporaryDirectory.path, "runtime"))..writeAsStringSync("runtime");
+    const locator = IoHostExecutableLocator(platformIsWindows: false);
+
+    expect(
+      locator.locate(executable: executable.path, environment: const {}, workingDirectory: null),
+      HostExecutablePresence.present,
+    );
+  });
+}

--- a/bridge/sesori_bridge_foundation/test/host_process_command_executor_test.dart
+++ b/bridge/sesori_bridge_foundation/test/host_process_command_executor_test.dart
@@ -1,3 +1,4 @@
+import "dart:async";
 import "dart:convert";
 import "dart:io";
 
@@ -25,9 +26,98 @@ void main() {
     expect(process.stdoutChunksDelivered, 2);
     expect(process.stderrChunksDelivered, 2);
   });
+
+  test("timeout force-stops a running command before settling", () async {
+    final processes = _FakeHostProcessService(process: _HangingSpawnedProcess());
+    final executor = HostProcessCommandExecutor(
+      includeParentEnvironment: true,
+      processes: processes,
+      runInShell: false,
+      maxCapturedOutputCharactersPerStream: 6,
+    );
+
+    await expectLater(
+      executor.runAbortable(
+        executable: "updater",
+        arguments: const ["update"],
+        workingDirectory: null,
+        environment: const {},
+        timeout: const Duration(milliseconds: 10),
+        abortSignal: StartAbortSignal.never,
+      ),
+      throwsA(isA<TimeoutException>()),
+    );
+    expect(processes.forceSignals, [42]);
+  });
+
+  test("abort force-stops a running command before settling", () async {
+    final processes = _FakeHostProcessService(process: _HangingSpawnedProcess());
+    final executor = HostProcessCommandExecutor(
+      includeParentEnvironment: true,
+      processes: processes,
+      runInShell: false,
+      maxCapturedOutputCharactersPerStream: 6,
+    );
+    final aborted = StartAbortController();
+
+    final run = executor.runAbortable(
+      executable: "updater",
+      arguments: const ["update"],
+      workingDirectory: null,
+      environment: const {},
+      timeout: const Duration(minutes: 1),
+      abortSignal: aborted.signal,
+    );
+    await Future<void>.delayed(Duration.zero);
+    aborted.abort();
+
+    await expectLater(run, throwsA(isA<PluginStartAbortedException>()));
+    expect(processes.forceSignals, [42]);
+  });
+
+  test("an unsuccessful force signal does not settle before the process exits", () async {
+    final process = _HangingSpawnedProcess();
+    final processes = _FakeHostProcessService(
+      process: process,
+      forceSignalWasRequested: false,
+      completeExitOnForceSignal: false,
+    );
+    final executor = HostProcessCommandExecutor(
+      includeParentEnvironment: true,
+      processes: processes,
+      runInShell: false,
+      maxCapturedOutputCharactersPerStream: 6,
+    );
+    final aborted = StartAbortController();
+    var settled = false;
+
+    final run = executor.runAbortable(
+      executable: "updater",
+      arguments: const ["update"],
+      workingDirectory: null,
+      environment: const {},
+      timeout: const Duration(minutes: 1),
+      abortSignal: aborted.signal,
+    );
+    unawaited(run.then<void>((_) => settled = true, onError: (Object _, StackTrace _) => settled = true));
+    await Future<void>.delayed(Duration.zero);
+    aborted.abort();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(processes.forceSignals, [42]);
+    expect(settled, isFalse);
+
+    process.completeExit(-9);
+    await expectLater(run, throwsA(isA<PluginStartAbortedException>()));
+  });
 }
 
-class const _FakeHostProcessService({required final SpawnedProcess process}) implements HostProcessService {
+class _FakeHostProcessService({
+  required final SpawnedProcess process,
+  final bool forceSignalWasRequested = true,
+  final bool completeExitOnForceSignal = true,
+}) implements HostProcessService {
+  final forceSignals = <int>[];
   @override
   Future<SpawnedProcess> spawn({
     required String executable,
@@ -45,10 +135,46 @@ class const _FakeHostProcessService({required final SpawnedProcess process}) imp
   Future<ProcessIdentity?> inspect({required int pid}) async => null;
 
   @override
-  Future<SignalResult> signalForce({required int pid}) => throw UnsupportedError("not used");
+  Future<SignalResult> signalForce({required int pid}) async {
+    forceSignals.add(pid);
+    if (completeExitOnForceSignal) {
+      final spawnedProcess = process;
+      if (spawnedProcess is _HangingSpawnedProcess) spawnedProcess.completeExit(-9);
+    }
+    return SignalResult(
+      pid: pid,
+      requestedSignal: ShutdownSignal.force,
+      deliveredSignal: ProcessSignal.sigkill,
+      wasRequested: forceSignalWasRequested,
+      attemptedAt: DateTime.now(),
+    );
+  }
 
   @override
   Future<SignalResult> signalGraceful({required int pid}) => throw UnsupportedError("not used");
+}
+
+class _HangingSpawnedProcess() implements SpawnedProcess {
+  final Completer<int> _exit = Completer<int>();
+
+  void completeExit(int exitCode) {
+    if (!_exit.isCompleted) _exit.complete(exitCode);
+  }
+
+  @override
+  Future<int> get exitCode => _exit.future;
+
+  @override
+  int get pid => 42;
+
+  @override
+  Stream<List<int>> get stderr => const Stream.empty();
+
+  @override
+  Stream<List<int>> get stdout => const Stream.empty();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class _FakeSpawnedProcess({required final List<List<int>> stdoutChunks, required final List<List<int>> stderrChunks})


### PR DESCRIPTION
## Complexity

⚙️ Moderate — introduces shared host-process primitives and termination semantics, but activates no plugin or client behavior.

## What

- Adds injectable concrete `IoHostExecutableLocator` with no one-to-one interface.
- Classifies executable presence through platform-qualified POSIX/Windows paths, including Windows working-directory precedence, relative PATH resolution, POSIX whitespace fidelity, and PATH/PATHEXT handling for bare and explicit commands.
- Centralizes process-missing and positively-proven PATH-absence decisions for later descriptor consumers.
- Applies timeout and cancellation during process spawning while retaining bounded cleanup of any late child.
- Adds abortable `HostProcessCommandExecutor.runAbortable`, output draining, bounded termination confirmation, and continued late-spawn retirement.
- Adds focused lookup, classification, spawn, timeout, abort, output-drain, and termination tests.
- Advances the durable replacement tracker to Step 2 with reproducible immutable sizing evidence.

## Why

The preserved implementation in #1458 needed one locale-independent Foundation owner for executable evidence and one bounded command runner for global updater processes. Landing these neutral primitives first prevents every harness from copying shell-error policy and gives later slices a verified process-lifetime boundary.

## Risk and test focus

Moderate internal risk around Windows command lookup, broken or unreadable PATH entries, timeout/abort races during spawn and execution, stream draining, and process-exit observation. No plugin behavior, wire contract, UI, database, persisted state, authentication, or backend startup changes in this slice.

## Expected result

Foundation consumers can distinguish proven absence from present or ambiguous commands. Helper-command timeout and abort remain bounded, termination-confirmation failures remain observable, and a child returned after the caller's cleanup bound is still force-stopped asynchronously. Existing product behavior remains unchanged until later series steps adopt these primitives.

## Verification

- Focused Foundation tests: 21 passed
- Cursor hung-version-probe CI regression: passed
- `dart analyze --fatal-infos` in `bridge/sesori_bridge_foundation`: no issues
- Architecture implementation review: approved with no violations
- `git diff --check`
- 825 authored changed lines across 7 files; zero generated churn
- Review-adjusted Step 2 ceiling: 850 lines (originally 700)
